### PR TITLE
Implement unified time testing with controllable app_now() function

### DIFF
--- a/monoscope.cabal
+++ b/monoscope.cabal
@@ -119,6 +119,7 @@ extra-source-files:
     static/migrations/0091_drop_redacted_fields.sql
     static/migrations/0092_anomalies_endpoint_metadata.sql
     static/migrations/0093_log_patterns_is_error.sql
+    static/migrations/0094_app_now_function.sql
 
 source-repository head
   type: git
@@ -204,6 +205,7 @@ library
       Pkg.SchemaLearning.Catalog
       Pkg.SchemaLearning.Hot
       Pkg.SchemaLearning.Worker
+      Pkg.TestClock
       Pkg.TestUtils
       Pkg.TraceSessionCache
       ProcessMessage

--- a/src/Pkg/TestClock.hs
+++ b/src/Pkg/TestClock.hs
@@ -9,15 +9,15 @@
 -- through 'syncConnectionTime' before issuing time-sensitive SQL and the
 -- triggers / stored procedures will see the same clock as the Haskell
 -- effect.
-module Pkg.TestClock
-  ( TestClock (..)
-  , newTestClock
-  , advanceTime
-  , setTestTime
-  , getTestTime
-  , runMutableTime
-  , syncConnectionTime
-  ) where
+module Pkg.TestClock (
+  TestClock (..),
+  newTestClock,
+  advanceTime,
+  setTestTime,
+  getTestTime,
+  runMutableTime,
+  syncConnectionTime,
+) where
 
 import Data.Time (NominalDiffTime, UTCTime, addUTCTime, defaultTimeLocale, formatTime)
 import Database.PostgreSQL.Simple (Connection)

--- a/src/Pkg/TestClock.hs
+++ b/src/Pkg/TestClock.hs
@@ -1,0 +1,78 @@
+-- | Mutable test clock for unified time testing.
+--
+-- Provides a controllable, advanceable clock backed by an 'IORef UTCTime'.
+-- In tests, use 'runMutableTime' instead of 'runFrozenTime' to get a clock
+-- that can be fast-forwarded with 'advanceTime'.
+--
+-- The companion migration 0094_app_now_function.sql defines a PostgreSQL
+-- @app_now()@ that reads the @app.current_time@ GUC. Pass a test connection
+-- through 'syncConnectionTime' before issuing time-sensitive SQL and the
+-- triggers / stored procedures will see the same clock as the Haskell
+-- effect.
+module Pkg.TestClock
+  ( TestClock (..)
+  , newTestClock
+  , advanceTime
+  , setTestTime
+  , getTestTime
+  , runMutableTime
+  , syncConnectionTime
+  ) where
+
+import Data.Time (NominalDiffTime, UTCTime, addUTCTime, defaultTimeLocale, formatTime)
+import Database.PostgreSQL.Simple (Connection)
+import Database.PostgreSQL.Simple qualified as PGS
+import Effectful (Eff, IOE, (:>))
+import Effectful.Dispatch.Dynamic (interpret)
+import Effectful.Time (Time (..))
+import GHC.Clock (getMonotonicTime)
+import Relude
+
+
+-- | A mutable clock backed by an 'IORef'. Create with 'newTestClock',
+-- advance with 'advanceTime', and use 'runMutableTime' to interpret
+-- the 'Time' effect.
+newtype TestClock = TestClock {unTestClock :: IORef UTCTime}
+
+
+-- | Create a new test clock starting at the given time.
+newTestClock :: UTCTime -> IO TestClock
+newTestClock t = TestClock <$> newIORef t
+
+
+-- | Advance the test clock forward by the given duration.
+advanceTime :: TestClock -> NominalDiffTime -> IO ()
+advanceTime (TestClock ref) dt = modifyIORef' ref (addUTCTime dt)
+
+
+-- | Set the test clock to an absolute time.
+setTestTime :: TestClock -> UTCTime -> IO ()
+setTestTime (TestClock ref) = writeIORef ref
+
+
+-- | Read the current time from the test clock.
+getTestTime :: TestClock -> IO UTCTime
+getTestTime (TestClock ref) = readIORef ref
+
+
+-- | Run the 'Time' effect using a mutable test clock.
+-- 'CurrentTime' reads from the IORef (advanceable).
+-- 'MonotonicTime' uses the real monotonic clock (unchanged).
+runMutableTime :: IOE :> es => TestClock -> Eff (Time ': es) a -> Eff es a
+runMutableTime clock = interpret $ \_ -> \case
+  CurrentTime -> liftIO $ getTestTime clock
+  MonotonicTime -> liftIO getMonotonicTime
+
+
+-- | Sync a PostgreSQL connection's @app.current_time@ GUC to the test
+-- clock's current value. Uses @set_config(_, _, true)@ so the setting is
+-- transaction-scoped and resets when the connection returns to the pool.
+--
+-- Call this on every connection that needs to see the test clock from
+-- inside triggers / stored procedures / DDL defaults that go through
+-- @app_now()@.
+syncConnectionTime :: TestClock -> Connection -> IO ()
+syncConnectionTime clock conn = do
+  t <- getTestTime clock
+  let timeStr = formatTime defaultTimeLocale "%F %T%Q+00" t
+  void $ PGS.execute conn "SELECT set_config('app.current_time', ?, true)" (PGS.Only timeStr)

--- a/src/Pkg/TestUtils.hs
+++ b/src/Pkg/TestUtils.hs
@@ -604,7 +604,7 @@ runTestEffect pool hpool logger tp action = do
 -- that go through @app_now()@ on a connection that's been synced via
 -- 'syncConnectionTime' see the same clock too.
 runTestBg :: UTCTime -> TestResources -> ATBackgroundCtx a -> IO a
-runTestBg t TestResources{..} = \action -> do
+runTestBg t TestResources{..} action = do
   setTestTime trTestClock t
   (notifications, result) <- runTestBackgroundWithClock trTestClock trLogger trATCtx action
   logNotifications trATCtx trLogger notifications

--- a/src/Pkg/TestUtils.hs
+++ b/src/Pkg/TestUtils.hs
@@ -112,7 +112,6 @@ import Effectful.Labeled (runLabeled)
 import Effectful.Log (Log)
 import Effectful.Reader.Static qualified
 import Effectful.Time (Time, runTime)
-import Pkg.TestClock (TestClock, advanceTime, getTestTime, newTestClock, runMutableTime, setTestTime, syncConnectionTime)
 import Hasql.Pool qualified as HPool
 import Log qualified
 import Log.Backend.StandardOutput.Bulk qualified as LogBulk
@@ -135,6 +134,7 @@ import Pages.Settings qualified as Api
 import Pkg.DeriveUtils (AesonText (..), DB, UUIDId (..), mkHasqlPool)
 import Pkg.ExtractionWorker qualified as ExtractionWorker
 import Pkg.SchemaLearning.Worker qualified as SchemaWorker
+import Pkg.TestClock (TestClock, advanceTime, getTestTime, newTestClock, runMutableTime, setTestTime, syncConnectionTime)
 import Pkg.TraceSessionCache qualified as TSC
 import ProcessMessage qualified
 import Proto.Opentelemetry.Proto.Collector.Logs.V1.LogsService qualified as LS

--- a/src/Pkg/TestUtils.hs
+++ b/src/Pkg/TestUtils.hs
@@ -27,6 +27,13 @@ module Pkg.TestUtils (
   runQueryEffect,
   runHasqlEffect,
   frozenTime,
+  -- Mutable test clock — advance time within a single spec to exercise
+  -- time-dependent behaviour without re-creating the AuthContext / pool.
+  advanceTestTime,
+  advanceMinutes,
+  advanceHours,
+  advanceDays,
+  getTestTime,
   -- Helper functions for tests
   drainExtractionWorker,
   processMessagesAndBackgroundJobs,
@@ -83,7 +90,7 @@ import Data.HashMap.Strict qualified as HM
 import Data.Pool (Pool, defaultPoolConfig, destroyAllResources, newPool, withResource)
 import Data.ProtoLens (defMessage)
 import Data.Text qualified as T
-import Data.Time (UTCTime, getCurrentTime)
+import Data.Time (NominalDiffTime, UTCTime, getCurrentTime)
 import Data.Time.Clock.POSIX (utcTimeToPOSIXSeconds)
 import Data.UUID qualified as UUID
 import Data.UUID.V4 (nextRandom)
@@ -104,7 +111,8 @@ import Effectful.Ki qualified as Ki
 import Effectful.Labeled (runLabeled)
 import Effectful.Log (Log)
 import Effectful.Reader.Static qualified
-import Effectful.Time (Time, runFrozenTime, runTime)
+import Effectful.Time (Time, runTime)
+import Pkg.TestClock (TestClock, advanceTime, getTestTime, newTestClock, runMutableTime, setTestTime, syncConnectionTime)
 import Hasql.Pool qualified as HPool
 import Log qualified
 import Log.Backend.StandardOutput.Bulk qualified as LogBulk
@@ -528,9 +536,23 @@ runTestBackground t authCtx action = LogBulk.withBulkStdOutLogger \logger ->
   runTestBackgroundWithLogger t logger authCtx action
 
 
--- | Run background context and return both notifications and result
+-- | Run background context and return both notifications and result.
+--
+-- Backwards-compatible signature: takes a 'UTCTime' which is used to /seed/
+-- a fresh mutable clock for this run. Code that wants to advance time
+-- inside the run should switch to 'runTestBgClock' and the 'TestClock'
+-- helpers ('advanceMinutes', etc.).
 runTestBackgroundWithNotifications :: UTCTime -> Log.Logger -> Config.AuthContext -> ATBackgroundCtx a -> IO ([Data.Effectful.Notify.Notification], a)
 runTestBackgroundWithNotifications t logger appCtx process = do
+  clock <- newTestClock t
+  runTestBackgroundWithClock clock logger appCtx process
+
+
+-- | Like 'runTestBackgroundWithNotifications' but takes an externally-managed
+-- 'TestClock' so callers can advance time across multiple runs in the same
+-- spec.
+runTestBackgroundWithClock :: TestClock -> Log.Logger -> Config.AuthContext -> ATBackgroundCtx a -> IO ([Data.Effectful.Notify.Notification], a)
+runTestBackgroundWithClock clock logger appCtx process = do
   tp <- getGlobalTracerProvider
   notifRef <- newIORef []
   result <-
@@ -539,7 +561,7 @@ runTestBackgroundWithNotifications t logger appCtx process = do
       & Effectful.Reader.Static.runReader appCtx
       & runHasqlPool appCtx.hasqlPool
       & runLabeled @"timefusion" (runHasqlPool appCtx.hasqlTimefusionPool)
-      & runFrozenTime t
+      & runMutableTime clock
       & Logging.runLog ("background-job:" <> show appCtx.config.environment) logger appCtx.config.logLevel
       & Tracing.runTracing tp
       & runUUID
@@ -555,25 +577,7 @@ runTestBackgroundWithNotifications t logger appCtx process = do
 runTestBackgroundWithLogger :: UTCTime -> Log.Logger -> Config.AuthContext -> ATBackgroundCtx a -> IO a
 runTestBackgroundWithLogger t logger appCtx process = do
   (notifications, result) <- runTestBackgroundWithNotifications t logger appCtx process
-  -- Log the notifications that would have been sent
-  forM_ notifications \notification -> do
-    let notifInfo = case notification of
-          Data.Effectful.Notify.EmailNotification emailData ->
-            ("Email" :: Text, Data.Effectful.Notify.receiver emailData, Just (Data.Effectful.Notify.subject emailData))
-          Data.Effectful.Notify.SlackNotification slackData ->
-            ("Slack" :: Text, slackData.channelId, Nothing :: Maybe Text)
-          Data.Effectful.Notify.DiscordNotification discordData ->
-            ("Discord" :: Text, discordData.channelId, Nothing :: Maybe Text)
-          Data.Effectful.Notify.WhatsAppNotification whatsappData ->
-            ("WhatsApp" :: Text, Data.Effectful.Notify.to whatsappData, Just (Data.Effectful.Notify.template whatsappData))
-          Data.Effectful.Notify.PagerdutyNotification pdData ->
-            ("PagerDuty" :: Text, pdData.dedupKey, Just pdData.summary)
-    Log.logInfo "Notification" notifInfo
-      & Logging.runLog ("background-job:" <> show appCtx.config.environment) logger appCtx.config.logLevel
-      & Effectful.runEff
-    Log.logTrace "Notification payload" notification
-      & Logging.runLog ("background-job:" <> show appCtx.config.environment) logger appCtx.config.logLevel
-      & Effectful.runEff
+  logNotifications appCtx logger notifications
   pure result
 
 
@@ -592,9 +596,43 @@ runTestEffect pool hpool logger tp action = do
     & runEff
 
 
--- | Run a background job action using TestResources
+-- | Run a background job action using TestResources.
+--
+-- Seeds the shared 'trTestClock' to @t@ before running so subsequent
+-- 'advanceTestTime' / 'advanceMinutes' / etc. calls (and any further
+-- 'runTestBg' in the same spec) observe the advanced clock. SQL queries
+-- that go through @app_now()@ on a connection that's been synced via
+-- 'syncConnectionTime' see the same clock too.
 runTestBg :: UTCTime -> TestResources -> ATBackgroundCtx a -> IO a
-runTestBg t TestResources{..} = runTestBackgroundWithLogger t trLogger trATCtx
+runTestBg t TestResources{..} = \action -> do
+  setTestTime trTestClock t
+  (notifications, result) <- runTestBackgroundWithClock trTestClock trLogger trATCtx action
+  logNotifications trATCtx trLogger notifications
+  pure result
+
+
+-- | Log out notifications gathered during a background run. Lifted out
+-- of 'runTestBackgroundWithLogger' so 'runTestBg' can share the format.
+logNotifications :: Config.AuthContext -> Log.Logger -> [Data.Effectful.Notify.Notification] -> IO ()
+logNotifications appCtx logger notifications =
+  forM_ notifications \notification -> do
+    let notifInfo = case notification of
+          Data.Effectful.Notify.EmailNotification emailData ->
+            ("Email" :: Text, Data.Effectful.Notify.receiver emailData, Just (Data.Effectful.Notify.subject emailData))
+          Data.Effectful.Notify.SlackNotification slackData ->
+            ("Slack" :: Text, slackData.channelId, Nothing :: Maybe Text)
+          Data.Effectful.Notify.DiscordNotification discordData ->
+            ("Discord" :: Text, discordData.channelId, Nothing :: Maybe Text)
+          Data.Effectful.Notify.WhatsAppNotification whatsappData ->
+            ("WhatsApp" :: Text, Data.Effectful.Notify.to whatsappData, Just (Data.Effectful.Notify.template whatsappData))
+          Data.Effectful.Notify.PagerdutyNotification pdData ->
+            ("PagerDuty" :: Text, pdData.dedupKey, Just pdData.summary)
+    Log.logInfo "Notification" notifInfo
+      & Logging.runLog ("background-job:" <> show appCtx.config.environment) logger appCtx.config.logLevel
+      & Effectful.runEff
+    Log.logTrace "Notification payload" notification
+      & Logging.runLog ("background-job:" <> show appCtx.config.environment) logger appCtx.config.logLevel
+      & Effectful.runEff
 
 
 -- New type to hold all our resources
@@ -612,7 +650,35 @@ data TestResources = TestResources
   -- bucket exists, and the AuthContext has been configured against it.
   -- Tests that exercise S3 paths should call `requireMinio` to skip
   -- gracefully (`pendingWith`) when this is False.
+  , trTestClock :: TestClock
+  -- ^ Mutable clock that drives the 'Time' effect inside test runs. Starts
+  -- at 'frozenTime'; advance with 'advanceTestTime' / 'advanceMinutes' /
+  -- 'advanceHours' / 'advanceDays' to exercise time-dependent behaviour.
+  -- @runTestBg t tr@ resets the clock to @t@ at entry so existing tests
+  -- that pin a specific time continue to work unchanged.
   }
+
+
+-- | Advance the test clock by an arbitrary duration. The next 'currentTime'
+-- inside an effect run (including SQL queries that call @app_now()@ on a
+-- synced connection) sees the new value.
+advanceTestTime :: TestResources -> NominalDiffTime -> IO ()
+advanceTestTime tr = advanceTime tr.trTestClock
+
+
+-- | @advanceMinutes tr n@ — convenience for @advanceTestTime tr (n * 60)@.
+advanceMinutes :: TestResources -> Int -> IO ()
+advanceMinutes tr n = advanceTestTime tr (fromIntegral n * 60)
+
+
+-- | @advanceHours tr n@ — convenience for @advanceTestTime tr (n * 3600)@.
+advanceHours :: TestResources -> Int -> IO ()
+advanceHours tr n = advanceTestTime tr (fromIntegral n * 3600)
+
+
+-- | @advanceDays tr n@ — convenience for @advanceTestTime tr (n * 86400)@.
+advanceDays :: TestResources -> Int -> IO ()
+advanceDays tr n = advanceTestTime tr (fromIntegral n * 86400)
 
 
 -- | Probe a MinIO endpoint and ensure the test bucket exists. Returns the
@@ -733,6 +799,7 @@ withTestResources f = withSetup $ \pool cstr -> LogBulk.withBulkStdOutLogger \lo
               }
           )
   uuidRef <- newIORef (map (UUID.fromWords 0 0 0) [1 .. 100000])
+  testClock <- newTestClock frozenTime
   f
     TestResources
       { trPool = pool
@@ -743,21 +810,17 @@ withTestResources f = withSetup $ \pool cstr -> LogBulk.withBulkStdOutLogger \lo
       , trTracerProvider = tp
       , trUUIDRef = uuidRef
       , trMinioAvailable = minioReady
+      , trTestClock = testClock
       }
 
 
-toServantResponse
-  :: AuthContext
-  -> Servant.Headers '[Servant.Header "Set-Cookie" SetCookie] Projects.Session
-  -> Log.Logger
-  -> ATAuthCtx (RespHeaders a)
-  -> IO (RespHeaders a, a)
-toServantResponse trATCtx trSessAndHeader trLogger k = do
+toServantResponse :: TestResources -> ATAuthCtx (RespHeaders a) -> IO (RespHeaders a, a)
+toServantResponse TestResources{..} k = do
   tp <- getGlobalTracerProvider
   uuidRef <- freshUUIDRef
   headersResp <-
     ( atAuthToBase trSessAndHeader k
-        & effToServantHandlerTest uuidRef trATCtx trLogger tp
+        & effToServantHandlerTest trTestClock uuidRef trATCtx trLogger tp
         & ServantS.runHandler
     )
       <&> fromRightShow
@@ -765,7 +828,7 @@ toServantResponse trATCtx trSessAndHeader trLogger k = do
 
 
 testServant :: TestResources -> ATAuthCtx (RespHeaders a) -> IO (RespHeaders a, a)
-testServant tr = toServantResponse tr.trATCtx tr.trSessAndHeader tr.trLogger
+testServant = toServantResponse
 
 
 -- | Like testServant but also captures notifications sent during handler execution
@@ -776,7 +839,7 @@ testServantWithNotifications TestResources{..} k = do
   notifRef <- newIORef []
   headersResp <-
     ( atAuthToBaseTest notifRef trSessAndHeader k
-        & effToServantHandlerTest uuidRef trATCtx trLogger tp
+        & effToServantHandlerTest trTestClock uuidRef trATCtx trLogger tp
         & ServantS.runHandler
     )
       <&> fromRightShow
@@ -787,16 +850,12 @@ testServantWithNotifications TestResources{..} k = do
 -- | Run a base context handler (like webhookPostH, replayPostH) in test context.
 -- Each call gets a fresh UUID pool; use `runAsBase` when you need IDs persisted
 -- across multiple handler invocations within the same test.
-toBaseServantResponse
-  :: AuthContext
-  -> Log.Logger
-  -> ATBaseCtx a
-  -> IO a
-toBaseServantResponse trATCtx trLogger k = do
+toBaseServantResponse :: TestResources -> ATBaseCtx a -> IO a
+toBaseServantResponse TestResources{..} k = do
   tp <- getGlobalTracerProvider
   uuidRef <- freshUUIDRef
   ( k
-      & effToServantHandlerTest uuidRef trATCtx trLogger tp
+      & effToServantHandlerTest trTestClock uuidRef trATCtx trLogger tp
       & ServantS.runHandler
     )
     <&> fromRightShow
@@ -809,7 +868,7 @@ runAsBase :: TestResources -> ATBaseCtx a -> IO a
 runAsBase TestResources{..} k = do
   tp <- getGlobalTracerProvider
   k
-    & effToServantHandlerTest trUUIDRef trATCtx trLogger tp
+    & effToServantHandlerTest trTestClock trUUIDRef trATCtx trLogger tp
     & ServantS.runHandler
     >>= either (fail . ("Servant error: " <>) . show) pure
 
@@ -829,7 +888,7 @@ runQueryEffect TestResources{..} action = do
       & runErrorNoCallStack @ServantS.ServerError
       & Effectful.Reader.Static.runReader trATCtx
       & runHasqlPool trATCtx.hasqlPool
-      & runFrozenTime (Unsafe.read "2025-01-01 00:00:00 UTC" :: UTCTime)
+      & runMutableTime trTestClock
       & Logging.runLog "test" logger trATCtx.config.logLevel
       & Tracing.runTracing tp
       & runEff
@@ -843,7 +902,7 @@ runHasqlEffect TestResources{..} action = do
     & runErrorNoCallStack @ServantS.ServerError
     & Effectful.Reader.Static.runReader trATCtx
     & runHasqlPool trATCtx.hasqlPool
-    & runFrozenTime (Unsafe.read "2025-01-01 00:00:00 UTC" :: UTCTime)
+    & runMutableTime trTestClock
     & runEff
     <&> fromRightShow
 
@@ -1139,7 +1198,7 @@ createTestSpans TestResources{..} projectId numRequestsPerEndpoint = do
 -- | Helper to create an API key for testing using handler
 createTestAPIKey :: TestResources -> Projects.ProjectId -> Text -> IO Text
 createTestAPIKey tr projectId keyName = do
-  (_, result) <- toServantResponse tr.trATCtx tr.trSessAndHeader tr.trLogger $ Api.apiPostH projectId (Api.GenerateAPIKeyForm keyName Nothing)
+  (_, result) <- toServantResponse tr $ Api.apiPostH projectId (Api.GenerateAPIKeyForm keyName Nothing)
   case result of
     Api.ApiPost _ _ (Just (_, keyText)) -> pure keyText
     _ -> error "Failed to create API key via handler"

--- a/src/System/Types.hs
+++ b/src/System/Types.hs
@@ -33,7 +33,6 @@ import Data.Effectful.Notify qualified
 import Data.Effectful.UUID (UUIDEff, runStaticUUIDRef, runUUID)
 import Data.Effectful.Wreq (HTTP, runHTTPGolden, runHTTPWreq)
 import Data.Map qualified as Map
-import Data.Time (UTCTime)
 import Data.UUID qualified as UUID
 import Effectful
 import Effectful.Concurrent.Async (Concurrent, runConcurrent)
@@ -43,7 +42,8 @@ import Effectful.Labeled (Labeled, runLabeled)
 import Effectful.Log (Log)
 import Effectful.Reader.Static qualified
 import Effectful.State.Static.Local qualified as State
-import Effectful.Time (Time, runFrozenTime, runTime)
+import Effectful.Time (Time, runTime)
+import Pkg.TestClock (TestClock, runMutableTime)
 import Log qualified
 import Models.Projects.Projects qualified as Sessions
 import OpenTelemetry.Trace (TracerProvider)
@@ -148,11 +148,13 @@ effToServantHandler env logger tp app =
 
 
 -- | `effToServantHandler` exists specifically to be used in tests,
--- so the UUID and Time effects are fixed to constants. The IORef holds a
+-- so the UUID effect is fixed to a deterministic pool. The IORef holds a
 -- pre-populated pool of deterministic UUIDs shared across multiple handler
 -- invocations in the same test (so creates in a loop get distinct ids).
-effToServantHandlerTest :: IORef [UUID.UUID] -> AuthContext -> Log.Logger -> TracerProvider -> ATBaseCtx a -> Servant.Handler a
-effToServantHandlerTest uuidRef env logger tp app =
+-- The 'TestClock' drives the 'Time' effect and is shared across handler
+-- invocations so tests can advance time between calls.
+effToServantHandlerTest :: TestClock -> IORef [UUID.UUID] -> AuthContext -> Log.Logger -> TracerProvider -> ATBaseCtx a -> Servant.Handler a
+effToServantHandlerTest clock uuidRef env logger tp app =
   app
     & ELLM.runLLMGolden "./tests/golden/"
     & Effectful.Reader.Static.runReader env
@@ -160,7 +162,7 @@ effToServantHandlerTest uuidRef env logger tp app =
     & runHTTPGolden "./tests/golden/"
     & runHasqlPool env.hasqlPool
     & runLabeled @"timefusion" (runHasqlPool env.hasqlTimefusionPool)
-    & runFrozenTime (Unsafe.read "2025-01-01 00:00:00 UTC" :: UTCTime)
+    & runMutableTime clock
     & Logging.runLog (show env.config.environment) logger env.config.logLevel
     & Tracing.runTracing tp
     & runConcurrent

--- a/src/System/Types.hs
+++ b/src/System/Types.hs
@@ -43,11 +43,11 @@ import Effectful.Log (Log)
 import Effectful.Reader.Static qualified
 import Effectful.State.Static.Local qualified as State
 import Effectful.Time (Time, runTime)
-import Pkg.TestClock (TestClock, runMutableTime)
 import Log qualified
 import Models.Projects.Projects qualified as Sessions
 import OpenTelemetry.Trace (TracerProvider)
 import Pkg.DeriveUtils (DB)
+import Pkg.TestClock (TestClock, runMutableTime)
 import Relude
 import Relude.Unsafe qualified as Unsafe
 import Servant (AuthProtect, Header, Headers, ServerError, addHeader, noHeader)

--- a/static/migrations/0094_app_now_function.sql
+++ b/static/migrations/0094_app_now_function.sql
@@ -1,0 +1,159 @@
+-- Unified time testing: app_now() function for controllable time in
+-- triggers and stored procedures. Companion module: src/Pkg/TestClock.hs.
+--
+-- app_now() reads the custom GUC 'app.current_time'. When set (test
+-- connections, via syncConnectionTime), it returns that time. When unset
+-- (production), it falls back to NOW(). Tests can therefore fast-forward
+-- time even inside triggers / DDL defaults / scheduled-job procs, which
+-- the Haskell-side Time effect alone can't reach.
+CREATE OR REPLACE FUNCTION app_now() RETURNS TIMESTAMPTZ AS $$
+BEGIN
+  RETURN COALESCE(
+    NULLIF(current_setting('app.current_time', true), '')::timestamptz,
+    NOW()
+  );
+END;
+$$ LANGUAGE plpgsql STABLE;
+
+
+-- set_updated_at: swap current_timestamp → app_now() so triggered
+-- updated_at stamps follow the controllable clock in tests.
+-- (Original definition: migration 0001.)
+CREATE OR REPLACE FUNCTION set_updated_at() RETURNS trigger AS $$
+BEGIN
+  IF (
+    NEW IS DISTINCT FROM OLD AND
+    NEW.updated_at IS NOT DISTINCT FROM OLD.updated_at
+  ) THEN NEW.updated_at := app_now();
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+
+-- new_anomaly_proc: swap now() → app_now() while preserving the
+-- one-hour batching delay introduced in migration 0049.
+CREATE OR REPLACE FUNCTION apis.new_anomaly_proc() RETURNS trigger AS $$
+DECLARE
+  anomaly_type apis.anomaly_type;
+  anomaly_action apis.anomaly_action;
+  should_record_anomaly BOOLEAN := true;
+  existing_job_id INT;
+  existing_target_hashes JSONB;
+BEGIN
+  IF TG_WHEN <> 'AFTER' THEN
+    RAISE EXCEPTION 'apis.new_anomaly_proc() may only run as an AFTER trigger';
+  END IF;
+
+  anomaly_type := TG_ARGV[0];
+  anomaly_action := TG_ARGV[1];
+
+  IF array_length(TG_ARGV, 1) >= 3 AND TG_ARGV[2] = 'skip_anomaly_record' THEN
+    should_record_anomaly := false;
+  END IF;
+
+  IF should_record_anomaly THEN
+    INSERT INTO apis.anomalies (
+      project_id, anomaly_type, action, target_hash
+    ) VALUES (
+      NEW.project_id, anomaly_type, anomaly_action, NEW.hash
+    ) ON CONFLICT (project_id, target_hash) DO NOTHING;
+  END IF;
+
+  SELECT id, payload->'targetHashes'
+  INTO existing_job_id, existing_target_hashes
+  FROM background_jobs
+  WHERE payload->>'tag' = 'NewAnomaly'
+    AND payload->>'projectId' = NEW.project_id::TEXT
+    AND payload->>'anomalyType' = anomaly_type::TEXT
+    AND status = 'queued'
+  ORDER BY run_at ASC
+  LIMIT 1;
+
+  IF existing_job_id IS NOT NULL THEN
+    UPDATE background_jobs SET payload = jsonb_build_object(
+      'tag', 'NewAnomaly',
+      'projectId', NEW.project_id,
+      'createdAt', to_jsonb(NEW.created_at),
+      'anomalyType', anomaly_type::TEXT,
+      'anomalyAction', anomaly_action::TEXT,
+      'targetHashes', existing_target_hashes || to_jsonb(NEW.hash)
+    ) WHERE id = existing_job_id;
+  ELSE
+    INSERT INTO background_jobs (run_at, status, payload)
+    VALUES (
+      app_now() + INTERVAL '1 hour',
+      'queued',
+      jsonb_build_object(
+        'tag', 'NewAnomaly',
+        'projectId', NEW.project_id,
+        'createdAt', to_jsonb(NEW.created_at),
+        'anomalyType', anomaly_type::TEXT,
+        'anomalyAction', anomaly_action::TEXT,
+        'targetHashes', jsonb_build_array(NEW.hash)
+      )
+    );
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+
+-- check_triggered_query_monitors: swap NOW() → app_now() so monitor
+-- evaluation jobs schedule against the controllable clock.
+-- (Original definition: migration 0021.)
+CREATE OR REPLACE PROCEDURE monitors.check_triggered_query_monitors(job_id int, config jsonb)
+LANGUAGE PLPGSQL AS $$
+BEGIN
+    INSERT INTO background_jobs (run_at, status, payload)
+    VALUES (app_now(), 'queued', jsonb_build_object('tag', 'QueryMonitorsCheck'));
+    RAISE NOTICE 'Background job queued for job_id: %', job_id;
+EXCEPTION
+    WHEN OTHERS THEN
+        RAISE EXCEPTION 'Failed to queue background job: %', SQLERRM;
+END;
+$$;
+
+
+-- check_tests_to_trigger: swap NOW() → app_now() for the procedure's
+-- internal curr_time variable.
+-- (Original definition: migration 0001.)
+CREATE OR REPLACE PROCEDURE tests.check_tests_to_trigger(job_id int, config JSONB) LANGUAGE PLPGSQL AS $$
+DECLARE
+    collection_record RECORD;
+    curr_time TIMESTAMPTZ := app_now();
+    next_run_at TIMESTAMPTZ;
+    num_schedules INT;
+BEGIN
+    FOR collection_record IN
+        SELECT id, schedule, last_run
+        FROM tests.collections
+        WHERE is_scheduled AND
+              (last_run IS NULL
+               OR (
+                   (last_run + schedule)::timestamptz < (curr_time + INTERVAL '10 minutes')::timestamptz
+                  )
+              )
+    LOOP
+        num_schedules := 10 / (EXTRACT(EPOCH FROM collection_record.schedule) / 60);
+
+        FOR i IN 0..num_schedules LOOP
+            next_run_at := curr_time + (i * collection_record.schedule || ' minutes')::INTERVAL;
+            IF next_run_at < collection_record.last_run THEN
+                CONTINUE;
+            END IF;
+
+            INSERT INTO background_jobs (run_at, status, payload)
+            VALUES (curr_time + (i * collection_record.schedule || ' minutes')::INTERVAL, 'queued',
+                    jsonb_build_object('tag', 'RunCollectionTests', 'contents', collection_record.id));
+        END LOOP;
+
+        IF next_run_at < collection_record.last_run THEN
+            UPDATE tests.collections
+            SET last_run = next_run_at
+            WHERE id = collection_record.id;
+        END IF;
+    END LOOP;
+END;
+$$;

--- a/test/integration/Opentelemetry/GrpcIngestionSpec.hs
+++ b/test/integration/Opentelemetry/GrpcIngestionSpec.hs
@@ -43,7 +43,7 @@ testTimeRange = (toText $ iso8601Show $ addUTCTime (-3600) frozenTime, toText $ 
 queryLogs :: TestResources -> Maybe Text -> IO Log.LogsGet
 queryLogs tr queryM = do
   let (timeFrom, timeTo) = testTimeRange
-  (_, result) <- toServantResponse tr.trATCtx tr.trSessAndHeader tr.trLogger
+  (_, result) <- toServantResponse tr
     $ Log.apiLogH pid queryM Nothing Nothing Nothing (Just timeFrom) (Just timeTo) Nothing (Just "spans") Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing (Just "true") Nothing Nothing Nothing Nothing Nothing
   pure result
 
@@ -54,7 +54,7 @@ queryLogsViz tr queryM vizType = queryLogsVizSorted tr queryM vizType Nothing
 queryLogsVizSorted :: TestResources -> Maybe Text -> Text -> Maybe Text -> IO Log.LogsGet
 queryLogsVizSorted tr queryM vizType sortByM = do
   let (timeFrom, timeTo) = testTimeRange
-  (_, result) <- toServantResponse tr.trATCtx tr.trSessAndHeader tr.trLogger
+  (_, result) <- toServantResponse tr
     $ Log.apiLogH pid queryM Nothing Nothing Nothing (Just timeFrom) (Just timeTo) Nothing (Just "spans") Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing (Just "true") (Just vizType) Nothing Nothing Nothing sortByM
   pure result
 
@@ -316,7 +316,7 @@ spec = aroundAll withTestResources do
           ingestSessionEvent tr key ("GET /expand/" <> show i) [("session.id", "expand-sess"), ("user.id", "eu1")] False frozenTime
         void $ runAllBackgroundJobs frozenTime tr.trATCtx
         let (timeFrom, timeTo) = testTimeRange
-        (_, expandResult) <- toServantResponse tr.trATCtx tr.trSessAndHeader tr.trLogger
+        (_, expandResult) <- toServantResponse tr
           $ Log.apiLogExpandH pid (Just "session") (Just "expand-sess") Nothing Nothing Nothing (Just timeFrom) (Just timeTo)
         let field k = case expandResult of AE.Object o -> KM.lookup (fromText k) o; _ -> Nothing
             rows = fromMaybe [] $ AE.decode @[AE.Value] . AE.encode =<< field "rows"
@@ -328,14 +328,14 @@ spec = aroundAll withTestResources do
 
       it "Test 11.5: expand endpoint rejects missing key with 400" $ \tr -> do
         let (timeFrom, timeTo) = testTimeRange
-        (do (h, _) <- toServantResponse tr.trATCtx tr.trSessAndHeader tr.trLogger
+        (do (h, _) <- toServantResponse tr
               (Log.apiLogExpandH pid (Just "session") Nothing Nothing Nothing Nothing (Just timeFrom) (Just timeTo))
             evaluate h >> pass)
           `shouldThrow` \(ErrorCall msg) -> "400" `isInfixOf` msg
 
       it "Test 11.6: expand endpoint rejects invalid kind with 400" $ \tr -> do
         let (timeFrom, timeTo) = testTimeRange
-        (do (h, _) <- toServantResponse tr.trATCtx tr.trSessAndHeader tr.trLogger
+        (do (h, _) <- toServantResponse tr
               (Log.apiLogExpandH pid (Just "invalid") (Just "some-key") Nothing Nothing Nothing (Just timeFrom) (Just timeTo))
             evaluate h >> pass)
           `shouldThrow` \(ErrorCall msg) -> "400" `isInfixOf` msg
@@ -388,7 +388,7 @@ spec = aroundAll withTestResources do
         -- Expanding the shared session with the external-email filter must
         -- also return zero rows (fetchEventExamples path).
         let (timeFrom, timeTo) = testTimeRange
-        (_, expandResult) <- toServantResponse tr.trATCtx tr.trSessAndHeader tr.trLogger
+        (_, expandResult) <- toServantResponse tr
           $ Log.apiLogExpandH pid (Just "session") (Just leakSess)
               Nothing
               (Just ("attributes.user.email == \"" <> leakEmail <> "\""))
@@ -439,7 +439,7 @@ spec = aroundAll withTestResources do
                   (session_id, project_id, last_event_at, user_id, user_email, user_name)
                 VALUES (?, ?, ?, 'leaked-user', 'leaked@external.com', 'Leaked Name') |]
           (sharedSessionId, otherPid, frozenTime)
-        (_, result) <- toServantResponse tr.trATCtx tr.trSessAndHeader tr.trLogger
+        (_, result) <- toServantResponse tr
           $ Replay.replaySessionGetH pid sharedSessionId
         let lookupKey k = case result of AE.Object o -> KM.lookup (fromText k) o; _ -> Nothing
         lookupKey "userEmail" `shouldSatisfy` (`elem` [Nothing, Just AE.Null])

--- a/test/integration/Pages/Bots/BotTestHelpers.hs
+++ b/test/integration/Pages/Bots/BotTestHelpers.hs
@@ -81,7 +81,6 @@ import Effectful.Concurrent (runConcurrent)
 import Effectful.Ki qualified as Ki
 import Effectful.Labeled (runLabeled)
 import Effectful.Reader.Static qualified as Effectful.Reader
-import Effectful.Time (runFrozenTime)
 import Models.Apis.Integrations qualified as Slack
 import Models.Projects.ProjectMembers qualified as ProjectMembers
 import Models.Projects.Projects qualified as Projects

--- a/test/integration/Pages/Bots/DiscordSpec.hs
+++ b/test/integration/Pages/Bots/DiscordSpec.hs
@@ -19,7 +19,7 @@ spec = aroundAll withTestResources do
         let (body, sig, ts) = signDiscordPayload discordPingPayload "1706745600"
             testConfig = tr.trATCtx.env{Config.discordPublicKey = testDiscordPublicKeyHex}
             testCtx = tr.trATCtx{Config.env = testConfig}
-        result <- toBaseServantResponse testCtx tr.trLogger $ discordInteractionsH body (Just sig) (Just ts)
+        result <- toBaseServantResponse tr{trATCtx = testCtx} $ discordInteractionsH body (Just sig) (Just ts)
         getDiscordResponseType result `shouldBe` Just 1
 
     describe "/here command" do
@@ -31,7 +31,7 @@ spec = aroundAll withTestResources do
             testConfig = tr.trATCtx.env{Config.discordPublicKey = testDiscordPublicKeyHex}
             testCtx = tr.trATCtx{Config.env = testConfig}
 
-        result <- toBaseServantResponse testCtx tr.trLogger $ discordInteractionsH body (Just sig) (Just ts)
+        result <- toBaseServantResponse tr{trATCtx = testCtx} $ discordInteractionsH body (Just sig) (Just ts)
         getDiscordResponseType result `shouldBe` Just 4
 
       it "matches golden file format" \tr -> do
@@ -42,7 +42,7 @@ spec = aroundAll withTestResources do
             testConfig = tr.trATCtx.env{Config.discordPublicKey = testDiscordPublicKeyHex}
             testCtx = tr.trATCtx{Config.env = testConfig}
 
-        result <- toBaseServantResponse testCtx tr.trLogger $ discordInteractionsH body (Just sig) (Just ts)
+        result <- toBaseServantResponse tr{trATCtx = testCtx} $ discordInteractionsH body (Just sig) (Just ts)
         assertJsonGolden "discord/here_response.json" result
 
     describe "/monoscope command" do
@@ -54,7 +54,7 @@ spec = aroundAll withTestResources do
             testConfig = tr.trATCtx.env{Config.discordPublicKey = testDiscordPublicKeyHex}
             testCtx = tr.trATCtx{Config.env = testConfig}
 
-        result <- toBaseServantResponse testCtx tr.trLogger $ discordInteractionsH body (Just sig) (Just ts)
+        result <- toBaseServantResponse tr{trATCtx = testCtx} $ discordInteractionsH body (Just sig) (Just ts)
         isEmptyResponse result `shouldBe` True
 
       it "handles thread context for conversations" \tr -> do
@@ -69,7 +69,7 @@ spec = aroundAll withTestResources do
             (body, sig, ts) = signDiscordPayload payload "1706745607"
             testConfig = tr.trATCtx.env{Config.discordPublicKey = testDiscordPublicKeyHex}
             testCtx = tr.trATCtx{Config.env = testConfig}
-        result <- toBaseServantResponse testCtx tr.trLogger $ discordInteractionsH body (Just sig) (Just ts)
+        result <- toBaseServantResponse tr{trATCtx = testCtx} $ discordInteractionsH body (Just sig) (Just ts)
         result `shouldSatisfy` isValidJsonResponse
 
     describe "Response format" do
@@ -79,7 +79,7 @@ spec = aroundAll withTestResources do
             (body, sig, ts) = signDiscordPayload payload "1706745603"
             testConfig = tr.trATCtx.env{Config.discordPublicKey = testDiscordPublicKeyHex}
             testCtx = tr.trATCtx{Config.env = testConfig}
-        result <- toBaseServantResponse testCtx tr.trLogger $ discordInteractionsH body (Just sig) (Just ts)
+        result <- toBaseServantResponse tr{trATCtx = testCtx} $ discordInteractionsH body (Just sig) (Just ts)
         hasComponentsV2Flag result `shouldBe` True
 
       it "/here response has container component" \tr -> do
@@ -88,7 +88,7 @@ spec = aroundAll withTestResources do
             (body, sig, ts) = signDiscordPayload payload "1706745604"
             testConfig = tr.trATCtx.env{Config.discordPublicKey = testDiscordPublicKeyHex}
             testCtx = tr.trATCtx{Config.env = testConfig}
-        result <- toBaseServantResponse testCtx tr.trLogger $ discordInteractionsH body (Just sig) (Just ts)
+        result <- toBaseServantResponse tr{trATCtx = testCtx} $ discordInteractionsH body (Just sig) (Just ts)
         hasContainerComponent result `shouldBe` True
 
       it "/here response has text content components" \tr -> do
@@ -97,5 +97,5 @@ spec = aroundAll withTestResources do
             (body, sig, ts) = signDiscordPayload payload "1706745605"
             testConfig = tr.trATCtx.env{Config.discordPublicKey = testDiscordPublicKeyHex}
             testCtx = tr.trATCtx{Config.env = testConfig}
-        result <- toBaseServantResponse testCtx tr.trLogger $ discordInteractionsH body (Just sig) (Just ts)
+        result <- toBaseServantResponse tr{trATCtx = testCtx} $ discordInteractionsH body (Just sig) (Just ts)
         countTextComponents result `shouldSatisfy` (>= 3)

--- a/test/integration/Pages/Bots/SlackSpec.hs
+++ b/test/integration/Pages/Bots/SlackSpec.hs
@@ -21,7 +21,7 @@ spec = aroundAll withTestResources do
       it "sets notification channel and saves golden response" \tr -> do
         setupSlackData tr testPid "T01HEREA9X"
         let interaction = slackInteraction "/monoscope-here" "" "T01HEREA9X"
-        result <- toBaseServantResponse tr.trATCtx tr.trLogger $ slackInteractionsH interaction
+        result <- toBaseServantResponse tr $ slackInteractionsH interaction
 
         assertJsonGolden "slack/here_response.json" result
         extractResponseType result `shouldBe` Just "in_channel"
@@ -35,7 +35,7 @@ spec = aroundAll withTestResources do
       it "returns correct block structure" \tr -> do
         setupSlackData tr testPid "T02BLOCKB8Y"
         let interaction = slackInteraction "/monoscope-here" "" "T02BLOCKB8Y"
-        result <- toBaseServantResponse tr.trATCtx tr.trLogger $ slackInteractionsH interaction
+        result <- toBaseServantResponse tr $ slackInteractionsH interaction
 
         case extractSlackBlocks result of
           Just (AE.Array blocks) -> do
@@ -48,7 +48,7 @@ spec = aroundAll withTestResources do
       it "returns loading message immediately" \tr -> do
         setupSlackData tr testPid "T03MONOSC0P"
         let interaction = slackInteraction "/monoscope" "show error rate" "T03MONOSC0P"
-        result <- toBaseServantResponse tr.trATCtx tr.trLogger $ slackInteractionsH interaction
+        result <- toBaseServantResponse tr $ slackInteractionsH interaction
 
         assertJsonGolden "slack/monoscope_loading_response.json" result
         extractResponseText result `shouldSatisfy` isJust
@@ -57,14 +57,14 @@ spec = aroundAll withTestResources do
 
       it "handles missing slack data gracefully" \tr -> do
         let interaction = slackInteraction "/monoscope" "show errors" "T99NONEXIST"
-        result <- toBaseServantResponse tr.trATCtx tr.trLogger $ slackInteractionsH interaction
+        result <- toBaseServantResponse tr $ slackInteractionsH interaction
         result `shouldSatisfy` isValidJsonResponse
 
     describe "/dashboard command" do
       it "returns error when no dashboards exist" \tr -> do
         setupSlackData tr testPid "T04DASHEMTY"
         let interaction = slackInteraction "/dashboard" "" "T04DASHEMTY"
-        result <- try $ toBaseServantResponse tr.trATCtx tr.trLogger $ slackInteractionsH interaction
+        result <- try $ toBaseServantResponse tr $ slackInteractionsH interaction
         case result of
           Left (e :: SomeException) -> T.isInfixOf "dashboards" (toText $ show e) `shouldBe` True
           Right _ -> pass
@@ -82,7 +82,7 @@ spec = aroundAll withTestResources do
         setupSlackData tr testPid "T06ANOMQRY2"
 
         let interaction = slackInteraction "/monoscope" "show me recent anomalies" "T06ANOMQRY2"
-        result <- toBaseServantResponse tr.trATCtx tr.trLogger $ slackInteractionsH interaction
+        result <- toBaseServantResponse tr $ slackInteractionsH interaction
 
         isValidJsonResponse result `shouldBe` True
         extractResponseText result `shouldSatisfy` isJust
@@ -91,7 +91,7 @@ spec = aroundAll withTestResources do
       it "/here command adds channel to @everyone team" \tr -> do
         setupSlackData tr testPid "T07HERETEAM"
         let interaction = slackInteraction "/monoscope-here" "" "T07HERETEAM"
-        void $ toBaseServantResponse tr.trATCtx tr.trLogger $ slackInteractionsH interaction
+        void $ toBaseServantResponse tr $ slackInteractionsH interaction
 
         slackDataM <- runTestBg frozenTime tr $ Slack.getSlackDataByTeamId "T07HERETEAM"
         case slackDataM of
@@ -105,8 +105,8 @@ spec = aroundAll withTestResources do
       it "/here command does not duplicate channels in @everyone team" \tr -> do
         setupSlackData tr testPid "T08HEREDUP"
         let interaction = slackInteraction "/monoscope-here" "" "T08HEREDUP"
-        void $ toBaseServantResponse tr.trATCtx tr.trLogger $ slackInteractionsH interaction
-        void $ toBaseServantResponse tr.trATCtx tr.trLogger $ slackInteractionsH interaction
+        void $ toBaseServantResponse tr $ slackInteractionsH interaction
+        void $ toBaseServantResponse tr $ slackInteractionsH interaction
 
         slackDataM <- runTestBg frozenTime tr $ Slack.getSlackDataByTeamId "T08HEREDUP"
         case slackDataM of
@@ -122,7 +122,7 @@ spec = aroundAll withTestResources do
       it "/here updates both default channel_id and @everyone team" \tr -> do
         setupSlackData tr testPid "T09HEREBOTH"
         let interaction = slackInteraction "/monoscope-here" "" "T09HEREBOTH"
-        void $ toBaseServantResponse tr.trATCtx tr.trLogger $ slackInteractionsH interaction
+        void $ toBaseServantResponse tr $ slackInteractionsH interaction
 
         slackDataM <- runTestBg frozenTime tr $ Slack.getSlackDataByTeamId "T09HEREBOTH"
         case slackDataM of
@@ -138,7 +138,7 @@ spec = aroundAll withTestResources do
         setupSlackData tr testPid "T10HEREWELC"
         let interaction = slackInteraction "/monoscope-here" "" "T10HEREWELC"
         -- First call should add channel and attempt to send welcome message
-        void $ toBaseServantResponse tr.trATCtx tr.trLogger $ slackInteractionsH interaction
+        void $ toBaseServantResponse tr $ slackInteractionsH interaction
 
         slackDataM <- runTestBg frozenTime tr $ Slack.getSlackDataByTeamId "T10HEREWELC"
         case slackDataM of
@@ -153,9 +153,9 @@ spec = aroundAll withTestResources do
         setupSlackData tr testPid "T11HERENODUP"
         let interaction = slackInteraction "/monoscope-here" "" "T11HERENODUP"
         -- First call adds channel
-        void $ toBaseServantResponse tr.trATCtx tr.trLogger $ slackInteractionsH interaction
+        void $ toBaseServantResponse tr $ slackInteractionsH interaction
         -- Second call should not send welcome message (channel already exists)
-        void $ toBaseServantResponse tr.trATCtx tr.trLogger $ slackInteractionsH interaction
+        void $ toBaseServantResponse tr $ slackInteractionsH interaction
 
         slackDataM <- runTestBg frozenTime tr $ Slack.getSlackDataByTeamId "T11HERENODUP"
         case slackDataM of

--- a/test/integration/Pages/Bots/WhatsappSpec.hs
+++ b/test/integration/Pages/Bots/WhatsappSpec.hs
@@ -33,7 +33,7 @@ spec = aroundAll withTestResources do
     describe "Project lookup" do
       it "handles unknown phone number gracefully" \tr -> do
         let msg = twilioWhatsAppPrompt tr "+19999999999" "show errors"
-        result <- toBaseServantResponse tr.trATCtx tr.trLogger $ whatsappIncomingPostH msg
+        result <- toBaseServantResponse tr $ whatsappIncomingPostH msg
         isEmptyJsonObject result `shouldBe` True
 
       it "processes message for linked phone number" \tr -> do
@@ -41,7 +41,7 @@ spec = aroundAll withTestResources do
         setupWhatsappNumber tr testPid testPhone
 
         let msg = twilioWhatsAppPrompt tr testPhone "/dashboard"
-        result <- toBaseServantResponse tr.trATCtx tr.trLogger $ whatsappIncomingPostH msg
+        result <- toBaseServantResponse tr $ whatsappIncomingPostH msg
         result `shouldSatisfy` isValidJsonResponse
 
     describe "Body type detection" do
@@ -72,5 +72,5 @@ spec = aroundAll withTestResources do
         setupWhatsappNumber tr testPid testPhone
 
         let msg = twilioWhatsAppPrompt tr testPhone "what's my error rate?"
-        result <- toBaseServantResponse tr.trATCtx tr.trLogger $ whatsappIncomingPostH msg
+        result <- toBaseServantResponse tr $ whatsappIncomingPostH msg
         result `shouldSatisfy` isValidJsonResponse

--- a/test/integration/Pages/Bots/WorkflowsSpec.hs
+++ b/test/integration/Pages/Bots/WorkflowsSpec.hs
@@ -23,7 +23,7 @@ spec = aroundAll withTestResources do
         let interaction = slackInteraction "/monoscope" "show errors" "T_WF_SLACK"
 
         -- Get immediate loading response
-        loadingResp <- toBaseServantResponse tr.trATCtx tr.trLogger $ slackInteractionsH interaction
+        loadingResp <- toBaseServantResponse tr $ slackInteractionsH interaction
         loadingResp `shouldSatisfy` isValidJsonResponse
         let loadingText = fromMaybe "" $ extractResponseText loadingResp
         (T.isInfixOf "Analyzing" loadingText || T.isInfixOf "⏳" loadingText) `shouldBe` True
@@ -38,7 +38,7 @@ spec = aroundAll withTestResources do
             testConfig = tr.trATCtx.env{Config.discordPublicKey = testDiscordPublicKeyHex}
             testCtx = tr.trATCtx{Config.env = testConfig}
 
-        result <- toBaseServantResponse testCtx tr.trLogger $ discordInteractionsH signedPayload (Just sig) (Just ts)
+        result <- toBaseServantResponse tr{trATCtx = testCtx} $ discordInteractionsH signedPayload (Just sig) (Just ts)
         result `shouldSatisfy` isValidJsonResponse
         getDiscordResponseType result `shouldSatisfy` isJust
 
@@ -47,13 +47,13 @@ spec = aroundAll withTestResources do
         setupWhatsappNumber tr testPid testPhone
         let msg = twilioWhatsAppPrompt tr testPhone "show me errors in the last hour"
 
-        result <- toBaseServantResponse tr.trATCtx tr.trLogger $ whatsappIncomingPostH msg
+        result <- toBaseServantResponse tr $ whatsappIncomingPostH msg
         result `shouldSatisfy` isValidJsonResponse
 
     describe "Error Handling Workflows" do
       it "Slack: handles missing team data gracefully" \tr -> do
         let interaction = slackInteraction "/monoscope" "show errors" "T_NONEXISTENT"
-        result <- toBaseServantResponse tr.trATCtx tr.trLogger $ slackInteractionsH interaction
+        result <- toBaseServantResponse tr $ slackInteractionsH interaction
         result `shouldSatisfy` isValidJsonResponse
 
       -- NOTE: Invalid signature test removed - handler correctly throws 401 for invalid signatures
@@ -62,7 +62,7 @@ spec = aroundAll withTestResources do
 
       it "WhatsApp: handles unknown phone number" \tr -> do
         let msg = twilioWhatsAppPrompt tr "+19999999999" "show errors"
-        result <- toBaseServantResponse tr.trATCtx tr.trLogger $ whatsappIncomingPostH msg
+        result <- toBaseServantResponse tr $ whatsappIncomingPostH msg
         result `shouldSatisfy` isValidJsonResponse
 
     describe "Platform-Specific Commands" do
@@ -70,7 +70,7 @@ spec = aroundAll withTestResources do
         setupSlackData tr testPid "T_HERE_WF"
         let interaction = slackInteraction "/monoscope-here" "" "T_HERE_WF"
 
-        result <- toBaseServantResponse tr.trATCtx tr.trLogger $ slackInteractionsH interaction
+        result <- toBaseServantResponse tr $ slackInteractionsH interaction
         result `shouldSatisfy` isValidJsonResponse
         hasSuccessBlock result `shouldBe` True
 
@@ -85,7 +85,7 @@ spec = aroundAll withTestResources do
         let (signedPayload, sig, ts) = signDiscordPayload discordPingPayload "1700000000"
             testConfig = tr.trATCtx.env{Config.discordPublicKey = testDiscordPublicKeyHex}
             testCtx = tr.trATCtx{Config.env = testConfig}
-        result <- toBaseServantResponse testCtx tr.trLogger $ discordInteractionsH signedPayload (Just sig) (Just ts)
+        result <- toBaseServantResponse tr{trATCtx = testCtx} $ discordInteractionsH signedPayload (Just sig) (Just ts)
 
         result `shouldSatisfy` isValidJsonResponse
         getDiscordResponseType result `shouldBe` Just 1
@@ -95,7 +95,7 @@ spec = aroundAll withTestResources do
         setupWhatsappNumber tr testPid testPhone
         let msg = twilioWhatsAppDashboard tr testPhone
 
-        result <- toBaseServantResponse tr.trATCtx tr.trLogger $ whatsappIncomingPostH msg
+        result <- toBaseServantResponse tr $ whatsappIncomingPostH msg
         result `shouldSatisfy` isValidJsonResponse
 
     describe "Thread/Conversation Context" do
@@ -106,7 +106,7 @@ spec = aroundAll withTestResources do
         let threadedEventJson = slackThreadedEvent "T_THREAD_WF" "C_THREAD_CHANNEL" "follow up question" "1700000002.000" "1700000001.000"
         case AE.fromJSON threadedEventJson of
           AE.Success threadedEvent -> do
-            result <- toBaseServantResponse tr.trATCtx tr.trLogger $ slackEventsPostH threadedEvent
+            result <- toBaseServantResponse tr $ slackEventsPostH threadedEvent
             result `shouldSatisfy` isValidJsonResponse
           AE.Error err -> expectationFailure $ "Failed to decode event: " <> err
 
@@ -117,7 +117,7 @@ spec = aroundAll withTestResources do
             testConfig = tr.trATCtx.env{Config.discordPublicKey = testDiscordPublicKeyHex}
             testCtx = tr.trATCtx{Config.env = testConfig}
 
-        result <- toBaseServantResponse testCtx tr.trLogger $ discordInteractionsH signedPayload (Just sig) (Just ts)
+        result <- toBaseServantResponse tr{trATCtx = testCtx} $ discordInteractionsH signedPayload (Just sig) (Just ts)
         result `shouldSatisfy` isValidJsonResponse
 
     describe "Multi-Platform Integration" do
@@ -129,7 +129,7 @@ spec = aroundAll withTestResources do
 
         -- Test Slack
         let slackInt = slackInteraction "/monoscope" "show status" "T_MULTI_SLACK"
-        slackResp <- toBaseServantResponse tr.trATCtx tr.trLogger $ slackInteractionsH slackInt
+        slackResp <- toBaseServantResponse tr $ slackInteractionsH slackInt
         slackResp `shouldSatisfy` isValidJsonResponse
 
         -- Test Discord
@@ -137,19 +137,19 @@ spec = aroundAll withTestResources do
             (signedPayload, sig, ts) = signDiscordPayload discordPayload "1700000000"
             testConfig = tr.trATCtx.env{Config.discordPublicKey = testDiscordPublicKeyHex}
             testCtx = tr.trATCtx{Config.env = testConfig}
-        discordResp <- toBaseServantResponse testCtx tr.trLogger $ discordInteractionsH signedPayload (Just sig) (Just ts)
+        discordResp <- toBaseServantResponse tr{trATCtx = testCtx} $ discordInteractionsH signedPayload (Just sig) (Just ts)
         discordResp `shouldSatisfy` isValidJsonResponse
 
         -- Test WhatsApp
         let whatsappMsg = twilioWhatsAppPrompt tr testPhone "show status"
-        whatsappResp <- toBaseServantResponse tr.trATCtx tr.trLogger $ whatsappIncomingPostH whatsappMsg
+        whatsappResp <- toBaseServantResponse tr $ whatsappIncomingPostH whatsappMsg
         whatsappResp `shouldSatisfy` isValidJsonResponse
 
     describe "Response Format Validation" do
       it "Slack responses have correct structure" \tr -> do
         setupSlackData tr testPid "T_FORMAT_SLACK"
         let interaction = slackInteraction "/monoscope-here" "" "T_FORMAT_SLACK"
-        result <- toBaseServantResponse tr.trATCtx tr.trLogger $ slackInteractionsH interaction
+        result <- toBaseServantResponse tr $ slackInteractionsH interaction
 
         extractResponseType result `shouldSatisfy` isJust
         extractSlackBlocks result `shouldSatisfy` isJust
@@ -160,7 +160,7 @@ spec = aroundAll withTestResources do
             (signedPayload, sig, ts) = signDiscordPayload payload "1700000000"
             testConfig = tr.trATCtx.env{Config.discordPublicKey = testDiscordPublicKeyHex}
             testCtx = tr.trATCtx{Config.env = testConfig}
-        result <- toBaseServantResponse testCtx tr.trLogger $ discordInteractionsH signedPayload (Just sig) (Just ts)
+        result <- toBaseServantResponse tr{trATCtx = testCtx} $ discordInteractionsH signedPayload (Just sig) (Just ts)
 
         getDiscordResponseType result `shouldSatisfy` isJust
 
@@ -168,6 +168,6 @@ spec = aroundAll withTestResources do
         let testPhone = getTestPhoneNumber tr
         setupWhatsappNumber tr testPid testPhone
         let msg = twilioWhatsAppPrompt tr testPhone "test query"
-        result <- toBaseServantResponse tr.trATCtx tr.trLogger $ whatsappIncomingPostH msg
+        result <- toBaseServantResponse tr $ whatsappIncomingPostH msg
 
         result `shouldSatisfy` isValidJsonResponse

--- a/test/integration/Pages/BusinessFlowsSpec.hs
+++ b/test/integration/Pages/BusinessFlowsSpec.hs
@@ -253,7 +253,7 @@ lemonSqueezyWebhookTests = do
       it testDesc $ \TestContext{tcResources = tr, tcProjectId = testPid} -> do
         let payload = payloadFn testPid
         let rawBody = BL.toStrict (AE.encode payload)
-        let callWebhook = void $ toBaseServantResponse tr.trATCtx tr.trLogger $ LemonSqueezy.webhookPostH Nothing rawBody
+        let callWebhook = void $ toBaseServantResponse tr $ LemonSqueezy.webhookPostH Nothing rawBody
         testFn testPid tr.trPool callWebhook
 
 
@@ -371,7 +371,7 @@ replayTests = do
             , userName = Nothing
             }
 
-    result <- toBaseServantResponse tr.trATCtx tr.trLogger $ Replay.replayPostH testPid replayData
+    result <- toBaseServantResponse tr $ Replay.replayPostH testPid replayData
 
     case result of
       AE.Object obj -> do
@@ -397,7 +397,7 @@ replayTests = do
             , userName = Nothing
             }
 
-    result <- toBaseServantResponse tr.trATCtx tr.trLogger $ Replay.replayPostH testPid replayData
+    result <- toBaseServantResponse tr $ Replay.replayPostH testPid replayData
 
     case result of
       AE.Object obj -> do

--- a/test/integration/Pages/BusinessFlowsSpec.hs
+++ b/test/integration/Pages/BusinessFlowsSpec.hs
@@ -43,7 +43,7 @@ data TestContext = TestContext
 -- Create a new project for testing and provide it along with test resources
 withTestProject :: (TestContext -> IO ()) -> IO ()
 withTestProject action = withTestResources $ \tr -> do
-  headers <- (atAuthToBase tr.trSessAndHeader CreateProject.projectOnboardingH & effToServantHandlerTest tr.trUUIDRef tr.trATCtx tr.trLogger tr.trTracerProvider & ServantS.runHandler) <&> fromRightShow
+  headers <- (atAuthToBase tr.trSessAndHeader CreateProject.projectOnboardingH & effToServantHandlerTest tr.trTestClock tr.trUUIDRef tr.trATCtx tr.trLogger tr.trTracerProvider & ServantS.runHandler) <&> fromRightShow
   case lookupResponseHeader @"Location" headers of
     Header location -> do
       let pidText = T.takeWhile (/= '/') $ T.drop 3 location

--- a/test/integration/Pages/GitSyncSpec.hs
+++ b/test/integration/Pages/GitSyncSpec.hs
@@ -325,7 +325,7 @@ spec = do
         setupSync tr GitHubTestConfig{pat = "fake", owner = "o", repo = "r", branch = "main"} Nothing
         clearJobs tr
         dashId <- UUIDId <$> liftIO UUID.nextRandom
-        _ <- toBaseServantResponse tr.trATCtx tr.trLogger $ atAuthToBase tr.trSessAndHeader $ GitSyncPage.queueGitSyncPush testPid dashId
+        _ <- toBaseServantResponse tr $ atAuthToBase tr.trSessAndHeader $ GitSyncPage.queueGitSyncPush testPid dashId
         jobs <- getPendingBackgroundJobs tr.trATCtx
         V.length (V.filter isGitSyncPush jobs) `shouldSatisfy` (>= 1)
 
@@ -333,7 +333,7 @@ spec = do
         void $ testServant tr $ GitSyncPage.gitSyncSettingsDeleteH testPid
         clearJobs tr
         dashId <- UUIDId <$> liftIO UUID.nextRandom
-        _ <- toBaseServantResponse tr.trATCtx tr.trLogger $ atAuthToBase tr.trSessAndHeader $ GitSyncPage.queueGitSyncPush testPid dashId
+        _ <- toBaseServantResponse tr $ atAuthToBase tr.trSessAndHeader $ GitSyncPage.queueGitSyncPush testPid dashId
         jobs <- getPendingBackgroundJobs tr.trATCtx
         V.length (V.filter isGitSyncPush jobs) `shouldBe` 0
 
@@ -346,21 +346,21 @@ spec = do
               , repository = Just $ GitHubRepo "webhook-owner/webhook-repo" "webhook-repo" (GitHubOwner "webhook-owner" Nothing)
               , pusher = Nothing, commits = Nothing
               }
-        _ <- toBaseServantResponse tr.trATCtx tr.trLogger $ GitSyncPage.githubWebhookPostH Nothing (Just "push") (toStrict $ AE.encode payload)
+        _ <- toBaseServantResponse tr $ GitSyncPage.githubWebhookPostH Nothing (Just "push") (toStrict $ AE.encode payload)
         jobs <- getPendingBackgroundJobs tr.trATCtx
         V.length (V.filter isGitSyncFromRepo jobs) `shouldSatisfy` (>= 1)
 
       it "ignores non-push events" \tr -> do
         clearJobs tr
         let payload = GitHubWebhookPayload{ref = Nothing, repository = Just $ GitHubRepo "o/r" "r" (GitHubOwner "o" Nothing), pusher = Nothing, commits = Nothing}
-        _ <- toBaseServantResponse tr.trATCtx tr.trLogger $ GitSyncPage.githubWebhookPostH Nothing (Just "ping") (toStrict $ AE.encode payload)
+        _ <- toBaseServantResponse tr $ GitSyncPage.githubWebhookPostH Nothing (Just "ping") (toStrict $ AE.encode payload)
         jobs <- getPendingBackgroundJobs tr.trATCtx
         V.length (V.filter isGitSyncFromRepo jobs) `shouldBe` 0
 
       it "ignores untracked repos" \tr -> do
         clearJobs tr
         let payload = GitHubWebhookPayload{ref = Just "refs/heads/main", repository = Just $ GitHubRepo "unknown/repo" "repo" (GitHubOwner "unknown" Nothing), pusher = Nothing, commits = Nothing}
-        _ <- toBaseServantResponse tr.trATCtx tr.trLogger $ GitSyncPage.githubWebhookPostH Nothing (Just "push") (toStrict $ AE.encode payload)
+        _ <- toBaseServantResponse tr $ GitSyncPage.githubWebhookPostH Nothing (Just "push") (toStrict $ AE.encode payload)
         jobs <- getPendingBackgroundJobs tr.trATCtx
         V.length (V.filter isGitSyncFromRepo jobs) `shouldBe` 0
 
@@ -381,7 +381,7 @@ spec = do
             path <- uniquePath "push-create"
             dashId <- createDash tr "Push Create Test" ["e2e"]
             _ <- runTestBg frozenTime tr $ GitSync.updateDashboardGitInfo dashId path ""  -- set path, empty sha = new file
-            _ <- toBaseServantResponse tr.trATCtx tr.trLogger $ atAuthToBase tr.trSessAndHeader $ GitSyncPage.queueGitSyncPush testPid dashId
+            _ <- toBaseServantResponse tr $ atAuthToBase tr.trSessAndHeader $ GitSyncPage.queueGitSyncPush testPid dashId
             runSyncJobs tr
             exists <- ghFileExists cfg path
             exists `shouldBe` True
@@ -399,7 +399,7 @@ spec = do
             dashId <- createDash tr "Updated Title" ["updated"]
             _ <- runTestBg frozenTime tr $ GitSync.updateDashboardGitInfo dashId path sha1
             clearJobs tr
-            _ <- toBaseServantResponse tr.trATCtx tr.trLogger $ atAuthToBase tr.trSessAndHeader $ GitSyncPage.queueGitSyncPush testPid dashId
+            _ <- toBaseServantResponse tr $ atAuthToBase tr.trSessAndHeader $ GitSyncPage.queueGitSyncPush testPid dashId
             runSyncJobs tr
             (content, _) <- fromRightShow <$> ghGetFile cfg path
             BS.isInfixOf "Updated Title" content `shouldBe` True
@@ -409,7 +409,7 @@ spec = do
             setupSync tr cfg Nothing
             dashId <- createDash tr "SHA Test" []
             let expectedPath = "dashboards/sha-test.yaml"
-            _ <- toBaseServantResponse tr.trATCtx tr.trLogger $ atAuthToBase tr.trSessAndHeader $ GitSyncPage.queueGitSyncPush testPid dashId
+            _ <- toBaseServantResponse tr $ atAuthToBase tr.trSessAndHeader $ GitSyncPage.queueGitSyncPush testPid dashId
             runSyncJobs tr
             dashM <- runTestBg frozenTime tr $ Dashboards.getDashboardById dashId
             let dash = fromJust dashM
@@ -489,7 +489,7 @@ spec = do
             -- Create and push
             dashId <- createDash tr "Round Trip Original" ["local"]
             _ <- runTestBg frozenTime tr $ GitSync.updateDashboardGitInfo dashId path ""  -- set path for push
-            _ <- toBaseServantResponse tr.trATCtx tr.trLogger $ atAuthToBase tr.trSessAndHeader $ GitSyncPage.queueGitSyncPush testPid dashId
+            _ <- toBaseServantResponse tr $ atAuthToBase tr.trSessAndHeader $ GitSyncPage.queueGitSyncPush testPid dashId
             runSyncJobs tr
             -- Verify in GitHub
             (content1, sha1) <- fromRightShow <$> ghGetFile cfg path
@@ -534,7 +534,7 @@ spec = do
             setupSync tr cfg (Just "test-prefix")
             dashId <- createDash tr "Prefixed Push" []
             let path = "test-prefix/dashboards/prefixed-push.yaml"
-            _ <- toBaseServantResponse tr.trATCtx tr.trLogger $ atAuthToBase tr.trSessAndHeader $ GitSyncPage.queueGitSyncPush testPid dashId
+            _ <- toBaseServantResponse tr $ atAuthToBase tr.trSessAndHeader $ GitSyncPage.queueGitSyncPush testPid dashId
             runSyncJobs tr
             exists <- ghFileExists cfg path
             exists `shouldBe` True
@@ -552,7 +552,7 @@ spec = do
             -- Create dashboard with wrong SHA
             dashId <- createDash tr "Conflict Test" []
             _ <- runTestBg frozenTime tr $ GitSync.updateDashboardGitInfo dashId path "wrong-sha-12345"
-            _ <- toBaseServantResponse tr.trATCtx tr.trLogger $ atAuthToBase tr.trSessAndHeader $ GitSyncPage.queueGitSyncPush testPid dashId
+            _ <- toBaseServantResponse tr $ atAuthToBase tr.trSessAndHeader $ GitSyncPage.queueGitSyncPush testPid dashId
             -- Should not crash, just log error
             runSyncJobs tr
             -- Original file unchanged

--- a/test/integration/Web/ApiV1Spec.hs
+++ b/test/integration/Web/ApiV1Spec.hs
@@ -145,7 +145,7 @@ spec = aroundAll withTestResources do
       it "rejects API requests with no auth and no demo project header" $ \tr -> do
         let mkTopApp =
               genericServeTWithContext
-                (effToServantHandlerTest tr.trUUIDRef tr.trATCtx tr.trLogger tr.trTracerProvider)
+                (effToServantHandlerTest tr.trTestClock tr.trUUIDRef tr.trATCtx tr.trLogger tr.trTracerProvider)
                 (Routes.server tr.trLogger tr.trATCtx tr.trTracerProvider)
                 (Routes.genAuthServerContext tr.trLogger tr.trATCtx)
             req = WT.setPath Wai.defaultRequest "/api/v1/schema"
@@ -155,7 +155,7 @@ spec = aroundAll withTestResources do
       it "allows unauthenticated access when X-Project-Id is the demo project" $ \tr -> do
         let mkTopApp =
               genericServeTWithContext
-                (effToServantHandlerTest tr.trUUIDRef tr.trATCtx tr.trLogger tr.trTracerProvider)
+                (effToServantHandlerTest tr.trTestClock tr.trUUIDRef tr.trATCtx tr.trLogger tr.trTracerProvider)
                 (Routes.server tr.trLogger tr.trATCtx tr.trTracerProvider)
                 (Routes.genAuthServerContext tr.trLogger tr.trATCtx)
             req =
@@ -184,7 +184,7 @@ spec = aroundAll withTestResources do
     describe "Events endpoint" do
       it "returns valid LogResult with expected JSON structure" $ \tr -> do
         result <-
-          toBaseServantResponse tr.trATCtx tr.trLogger
+          toBaseServantResponse tr
             $ Log.queryEvents testPid (Just "") (Just "1h") Nothing Nothing Nothing Nothing Nothing
         let json = AE.toJSON result
         (json ^? key "logsData" . _Array) `shouldSatisfy` isJust
@@ -195,10 +195,7 @@ spec = aroundAll withTestResources do
         (json ^? key "hasMore") `shouldSatisfy` isJust
 
       it "returns 400 for malformed query" $ \tr -> do
-        ( toBaseServantResponse
-            tr.trATCtx
-            tr.trLogger
-            (Log.queryEvents testPid (Just "|| invalid {{") (Just "1h") Nothing Nothing Nothing Nothing Nothing)
+        ( toBaseServantResponse tr (Log.queryEvents testPid (Just "|| invalid {{") (Just "1h") Nothing Nothing Nothing Nothing Nothing)
             >>= evaluateWHNF_
           )
           `shouldThrow` anyException
@@ -206,7 +203,7 @@ spec = aroundAll withTestResources do
     describe "Metrics endpoint" do
       it "returns valid MetricsData for count query with JSON round-trip" $ \tr -> do
         result <-
-          toBaseServantResponse tr.trATCtx tr.trLogger
+          toBaseServantResponse tr
             $ Charts.queryMetrics Nothing (Just Charts.DTMetric) (Just testPid) (Just "summarize count(*) by bin_auto(timestamp)") Nothing (Just "1h") Nothing Nothing (Just "spans") []
         result.rowsCount `shouldSatisfy` (>= 0)
         AE.eitherDecode @MetricsData (AE.encode result) `shouldSatisfy` isRight
@@ -324,7 +321,7 @@ spec = aroundAll withTestResources do
     describe "Events body query" do
       it "accepts EventsQuery payload and returns LogResult" $ \tr -> do
         result <-
-          toBaseServantResponse tr.trATCtx tr.trLogger
+          toBaseServantResponse tr
             $ ApiH.apiEventsQuery testPid (def :: ApiT.EventsQuery){ApiT.query = Just "", ApiT.since = Just "1h"}
         let json = AE.toJSON result
         (json ^? key "logsData" . _Array) `shouldSatisfy` isJust
@@ -359,10 +356,10 @@ spec = aroundAll withTestResources do
         let q = "attributes.wc.marker == \"" <> marker <> "\""
             base = (def :: ApiT.EventsQuery){ApiT.query = Just q, ApiT.since = Just "1h"}
 
-        rDefault <- toBaseServantResponse tr.trATCtx tr.trLogger $ ApiH.apiEventsQuery testPid base
+        rDefault <- toBaseServantResponse tr $ ApiH.apiEventsQuery testPid base
         V.length rDefault.logsData `shouldBe` 1 -- only A matches the predicate
 
-        rWith <- toBaseServantResponse tr.trATCtx tr.trLogger
+        rWith <- toBaseServantResponse tr
           $ ApiH.apiEventsQuery testPid base{ApiT.withChildren = Just True}
         -- A + B + C. D is in the same trace but lives under E, not A — the
         -- old buggy behaviour would have included it; the descendant filter
@@ -507,7 +504,7 @@ spec = aroundAll withTestResources do
           dummyApp _ = error "dummyApp invoked unexpectedly"
           buildTestApp tr pid =
             genericServeTWithContext
-              (effToServantHandlerTest tr.trUUIDRef tr.trATCtx tr.trLogger tr.trTracerProvider)
+              (effToServantHandlerTest tr.trTestClock tr.trUUIDRef tr.trATCtx tr.trLogger tr.trTracerProvider)
               (apiV1Server tr.trLogger tr.trATCtx tr.trTracerProvider pid)
               Servant.EmptyContext
           -- Top-level Servant app for the e2e tests below — same wiring as
@@ -515,7 +512,7 @@ spec = aroundAll withTestResources do
           -- /api/v1/mcp through this exercises auth + JSON-RPC + dispatch.
           mkTopApp tr =
             genericServeTWithContext
-              (effToServantHandlerTest tr.trUUIDRef tr.trATCtx tr.trLogger tr.trTracerProvider)
+              (effToServantHandlerTest tr.trTestClock tr.trUUIDRef tr.trATCtx tr.trLogger tr.trTracerProvider)
               (Routes.server tr.trLogger tr.trATCtx tr.trTracerProvider)
               (Routes.genAuthServerContext tr.trLogger tr.trATCtx)
           mcpHttp tr authHdr body =

--- a/test/integration/Web/ClientMetadataSpec.hs
+++ b/test/integration/Web/ClientMetadataSpec.hs
@@ -39,7 +39,7 @@ spec = aroundAll withTestResources do
 
       response <-
         clientMetadataH (Just apiKey)
-          & effToServantHandlerTest trUUIDRef trATCtx trLogger trTracerProvider
+          & effToServantHandlerTest trTestClock trUUIDRef trATCtx trLogger trTracerProvider
           & ServantS.runHandler
           <&> fromRightShow
       response.projectId `shouldBe` expectedClientMetadata.projectId
@@ -50,7 +50,7 @@ spec = aroundAll withTestResources do
       let invalidApiKey = Just "invalid-api-key"
       response <-
         clientMetadataH invalidApiKey
-          & effToServantHandlerTest trUUIDRef trATCtx trLogger trTracerProvider
+          & effToServantHandlerTest trTestClock trUUIDRef trATCtx trLogger trTracerProvider
           & ServantS.runHandler
 
       response `shouldSatisfy` isLeft


### PR DESCRIPTION
## Summary
This PR introduces a unified time testing system that allows tests to control time across both Haskell effects and PostgreSQL triggers/defaults. It replaces the frozen time approach with a mutable, advanceable test clock that syncs with PostgreSQL's `app_now()` function via a custom GUC variable.

## Key Changes

### Database Migration
- Added `static/migrations/0033_app_now_function.sql` which:
  - Creates `app_now()` function that reads from `app.current_time` GUC variable, falling back to `NOW()` in production
  - Updates `set_updated_at()` trigger to use `app_now()`
  - Updates `new_anomaly_proc()`, `check_triggered_query_monitors()`, and `check_tests_to_trigger()` procedures to use `app_now()` for background job scheduling

### New Test Clock Module
- Created `src/Pkg/TestClock.hs` providing:
  - `TestClock` type backed by an `IORef UTCTime`
  - `advanceTime` and `setTestTime` for controlling the test clock
  - `runMutableTime` to interpret the `Time` effect from a mutable clock
  - `syncConnectionTime` to sync the test clock to PostgreSQL's GUC on each connection checkout
  - `runWithTimeSyncedPool` to wrap connection pools with automatic time synchronization

### Test Infrastructure Updates
- Updated `Pkg.TestUtils` to:
  - Accept `TestClock` parameter in background job runners
  - Export time advancement helpers (`advanceTestTime`, `advanceMinutes`, `advanceHours`, `advanceDays`)
  - Create and manage `TestClock` in `TestResources`
  - Use `runMutableTime` and `runWithTimeSyncedPool` instead of `runFrozenTime`

### Query Updates for Time Consistency
- Updated multiple query functions to accept `Time :> es` constraint and use `Time.currentTime` instead of `NOW()`:
  - `Models.Apis.RequestDumps`: `getRequestDumpForReports`, `getRequestDumpsForPreviousReportPeriod`
  - `Models.Telemetry.Telemetry`: `getDataPointsData`, `getMetricChartListData`
  - `Models.Apis.Anomalies`: `countAnomalies`, `acknowledgeAnomalies`
  - `Models.Apis.Issues`: `updateIssueWithNewAnomaly`, `updateIssueEnhancement`
  - `Models.Apis.LogPatterns`: `acknowledgeLogPatterns`
  - `Models.Apis.Monitors`: `updateQMonitorTriggeredState`
  - `Models.Projects.Projects`: `projectCacheById`
  - `Models.Projects.ProjectMembers` and `Models.Projects.ProjectApiKeys`: Similar updates

### Test Updates
- Updated integration tests to:
  - Pass `TestClock` to background job runners and response handlers
  - Use `getTestTime` instead of `getCurrentTime` for test assertions
  - Remove dependency on `runFrozenTime` in favor of mutable clock

## Implementation Details
- The test clock is synced to PostgreSQL connections via `set_config('app.current_time', ?, true)` which makes the setting transaction-scoped and auto-resets when connections return to the pool
- All time-dependent queries now explicitly use the test clock's time rather than relying on database-side `NOW()` calls
- This ensures consistent time behavior across Haskell effects, background job scheduling, and database triggers during testing

https://claude.ai/code/session_019Mn7XLed4oq6j7dWqciekH