### PR TITLE
Add lenient UTF-8 handling for protobuf message decoding

### DIFF
--- a/src/Opentelemetry/OtlpServer.hs
+++ b/src/Opentelemetry/OtlpServer.hs
@@ -34,6 +34,8 @@ import Data.List qualified as L
 import Data.List.Extra (chunksOf)
 import Data.Map qualified as Map
 import Data.ProtoLens.Encoding (decodeMessage)
+import Data.ProtoLens.Encoding.Bytes (runBuilder, runParser)
+import Data.ProtoLens.Encoding.Wire (TaggedValue (..), WireValue (..), buildFieldSet, parseFieldSet)
 import Data.Scientific (fromFloatDigits)
 import Data.Text qualified as T
 import Data.Time (UTCTime, diffUTCTime, getCurrentTime)
@@ -121,6 +123,45 @@ instance ParseMetadata OtlpRequestMetadata where
 wireTypeErrorsRef :: IORef (HashMap Text (Int, AE.Value))
 {-# NOINLINE wireTypeErrorsRef #-}
 wireTypeErrorsRef = unsafePerformIO $ newIORef HashMap.empty
+
+
+-- | Try to decode a protobuf message with lenient UTF-8 handling.
+-- On UTF-8 decode errors, sanitizes the wire format by replacing invalid UTF-8 bytes
+-- with '?' in length-delimited fields, then retries decoding.
+decodeMessageLenient :: Message msg => ByteString -> Either String msg
+decodeMessageLenient bs =
+  case decodeMessage bs of
+    Right msg -> Right msg
+    Left err
+      | "Cannot decode byte" `L.isInfixOf` err -> decodeMessage (sanitizeProtobufUtf8 bs)
+      | otherwise -> Left err
+
+
+-- | Sanitize a protobuf ByteString by walking the wire format and replacing
+-- invalid UTF-8 bytes in length-delimited fields with '?'.
+sanitizeProtobufUtf8 :: ByteString -> ByteString
+sanitizeProtobufUtf8 bs =
+  case runParser parseFieldSet bs of
+    Left _ -> bs
+    Right fields -> runBuilder (buildFieldSet (map sanitizeTaggedValue fields))
+
+
+sanitizeTaggedValue :: TaggedValue -> TaggedValue
+sanitizeTaggedValue (TaggedValue tag (Lengthy content))
+  | BS.null content = TaggedValue tag (Lengthy content)
+  | otherwise =
+      case runParser parseFieldSet content of
+        Right subFields@(_ : _) ->
+          -- Content parses as a nested protobuf message; recursively sanitize its fields
+          TaggedValue tag (Lengthy (runBuilder (buildFieldSet (map sanitizeTaggedValue subFields))))
+        _ ->
+          -- Content is a string or bytes field; replace invalid UTF-8 bytes with '?'
+          TaggedValue tag (Lengthy (sanitizeUtf8Bytes content))
+sanitizeTaggedValue other = other
+
+
+sanitizeUtf8Bytes :: ByteString -> ByteString
+sanitizeUtf8Bytes content = encodeUtf8 (decodeUtf8With (\_ _ -> Just '?') content)
 
 
 -- | Initialize periodic error logging
@@ -298,7 +339,7 @@ processBatchPipeline !label msgs appCtx fallbackTime extractKeys extractIds conv
   checkpoint (cp "") $ do
     processingStartTime <- liftIO getCurrentTime
     let !msgsCount = length msgs
-        !decodedMsgs = [(ackId, decodeMessage msg :: Either String req) | (ackId, msg) <- msgs] `using` parList rpar
+        !decodedMsgs = [(ackId, decodeMessageLenient msg :: Either String req) | (ackId, msg) <- msgs] `using` parList rpar
         !allProjectKeys = V.force $ V.concat [extractKeys req | (_, Right req) <- decodedMsgs]
         !uniqueProjectKeys = V.force $ V.fromList $ L.nub $ V.toList allProjectKeys
         !atIds = concatMap extractIds [req | (_, Right req) <- decodedMsgs]


### PR DESCRIPTION
## Summary
This PR adds lenient UTF-8 decoding for protobuf messages to gracefully handle malformed UTF-8 sequences in incoming data. Instead of failing on invalid UTF-8 bytes, the decoder now sanitizes the wire format by replacing invalid bytes with '?' characters and retries decoding.

## Key Changes
- Added `decodeMessageLenient` function that attempts standard decoding first, then falls back to sanitized decoding on UTF-8 errors
- Implemented `sanitizeProtobufUtf8` to walk the protobuf wire format and sanitize length-delimited fields
- Added `sanitizeTaggedValue` to recursively handle nested protobuf messages while sanitizing string/bytes fields
- Added `sanitizeUtf8Bytes` utility to replace invalid UTF-8 sequences with '?' characters
- Updated `processBatchPipeline` to use `decodeMessageLenient` instead of `decodeMessage` for all incoming messages
- Added necessary imports from `Data.ProtoLens.Encoding` modules

## Implementation Details
The sanitization process:
1. Parses the protobuf wire format into tagged values
2. For length-delimited fields, attempts to parse them as nested messages
3. If successful, recursively sanitizes the nested fields
4. If not a message, treats the content as a string/bytes field and replaces invalid UTF-8 bytes with '?'
5. Rebuilds the wire format with sanitized content

This approach ensures that valid protobuf structures are preserved while gracefully handling encoding issues in string and bytes fields.

https://claude.ai/code/session_01MmF2VFF2zfknCJNUzgJACT