### PR TITLE
Collapse log-pattern clusters in Inbox and auto-archive stale issues

### DIFF
--- a/scripts/archive-noisy-log-pattern-issues.sh
+++ b/scripts/archive-noisy-log-pattern-issues.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+#
+# One-off cleanup: archive (do not delete) open log_pattern /
+# log_pattern_rate_change issues that match known noise patterns.
+#
+# Paired with:
+#   - src/BackgroundJobs.hs: widened detector log-level gate
+#     (only ERROR/WARN/FATAL/CRITICAL produce rate-change issues)
+#   - src/BackgroundJobs.hs: pruneStaleLogPatterns now auto-archives
+#     opens older than staleLogPatternIssueDays (14 days)
+#
+# Noise predicates — a row must satisfy at least one to be archived:
+#   (a) issue_type='log_pattern' with no updated_at activity in 7 days
+#   (b) issue_type='log_pattern_rate_change' with a pre-0075 title shape
+#       ("Log Pattern Drop" prefix, or stray ";badge-info" markup)
+#   (c) issue_type='log_pattern_rate_change' with severity='low' — these
+#       are already auto-demoted silent drops (Issues.hs:865-868); the
+#       Inbox hides them but they linger on Acknowledged/Archived tabs
+#       and inflate counts.
+#   (d) issue_type='log_pattern_rate_change' whose direction is 'drop',
+#       current rate collapsed to 0, and no updates for 7d. Deploy/
+#       pod-restart noise.
+#
+# Rows are only archived if they are still open
+# (acknowledged_at IS NULL AND archived_at IS NULL), preserving audit.
+#
+# Usage:
+#   DATABASE_URL=postgres://… ./scripts/archive-noisy-log-pattern-issues.sh dry-run
+#   DATABASE_URL=postgres://… ./scripts/archive-noisy-log-pattern-issues.sh write
+#
+# Safety:
+#   - Default mode prints counts only; archival requires the `write` arg.
+#   - The write path is wrapped in BEGIN/COMMIT so a connection drop leaves
+#     the table untouched.
+
+set -euo pipefail
+
+MODE="${1:-dry-run}"
+
+if [[ -z "${DATABASE_URL:-}" ]]; then
+  echo "DATABASE_URL is required (set it in your env or source .env)" >&2
+  exit 1
+fi
+
+if ! command -v psql >/dev/null 2>&1; then
+  echo "psql not found on PATH" >&2
+  exit 1
+fi
+
+PREDICATE=$(cat <<'SQL'
+  acknowledged_at IS NULL
+  AND archived_at IS NULL
+  AND (
+    -- (a) New-pattern zombies: no activity in 7d.
+    (issue_type = 'log_pattern'
+      AND updated_at < NOW() - INTERVAL '7 days')
+    OR
+    -- (b) Rate-change rows from the pre-0075 detector (legacy title shape).
+    (issue_type = 'log_pattern_rate_change'
+      AND (title ILIKE '%Log Pattern Drop%'
+        OR title ILIKE '%badge-info%'))
+    OR
+    -- (c) Auto-demoted silent drops (severity='low' set by
+    -- createLogPatternRateChangeIssue for drops on unknown services).
+    (issue_type = 'log_pattern_rate_change' AND severity = 'low')
+    OR
+    -- (d) Drops where volume collapsed to 0 and no updates for 7d.
+    (issue_type = 'log_pattern_rate_change'
+      AND (issue_data->>'change_direction') = 'drop'
+      AND COALESCE((issue_data->>'current_rate_per_hour')::float, 0) = 0
+      AND updated_at < NOW() - INTERVAL '7 days')
+  )
+SQL
+)
+
+case "$MODE" in
+  dry-run)
+    echo "DRY RUN — no rows will be changed. Counts per (project_id, issue_type):"
+    echo
+    psql "$DATABASE_URL" -v ON_ERROR_STOP=1 <<SQL
+SELECT project_id,
+       issue_type,
+       COUNT(*) AS candidate_count
+FROM apis.issues
+WHERE $PREDICATE
+GROUP BY project_id, issue_type
+ORDER BY candidate_count DESC;
+
+SELECT '-- total candidate rows' AS label, COUNT(*) AS total
+FROM apis.issues
+WHERE $PREDICATE;
+SQL
+    echo
+    echo "Re-run with: $0 write"
+    ;;
+  write)
+    echo "WRITE mode — archiving candidate rows."
+    psql "$DATABASE_URL" -v ON_ERROR_STOP=1 <<SQL
+BEGIN;
+
+WITH archived AS (
+  UPDATE apis.issues
+  SET archived_at = NOW()
+  WHERE $PREDICATE
+  RETURNING project_id, issue_type
+)
+SELECT project_id,
+       issue_type,
+       COUNT(*) AS archived_count
+FROM archived
+GROUP BY project_id, issue_type
+ORDER BY archived_count DESC;
+
+COMMIT;
+SQL
+    echo
+    echo "Done. Re-run dry-run to confirm counts have collapsed."
+    ;;
+  *)
+    echo "Usage: $0 {dry-run|write}" >&2
+    exit 2
+    ;;
+esac

--- a/src/BackgroundJobs.hs
+++ b/src/BackgroundJobs.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE StrictData #-}
 
-module BackgroundJobs (jobsWorkerInit, jobsRunner, processBackgroundJob, BgJobs (..), jobTypeName, runHourlyJob, generateOtelFacetsBatch, throwParsePayload, checkTriggeredQueryMonitors, monitorStatus, detectSpikeOrDrop, aboveVolumeFloor, spikeZScoreThreshold, spikeMinAbsoluteDelta, spikeMinBaselineRate, dropMinBaselineRate, calculateLogPatternBaselines, detectLogPatternSpikes, processNewLogPatterns, calculateErrorBaselines, detectErrorSpikes, notifyErrorSubscriptions, sweepErrorSubscriptions, consumeNotificationToken, endpointTemplateDiscovery, patternEmbeddingAndMerge, processEagerBatch, flushDrainTask, runErrorDecayFiber, runDrainFlusher, runDrainAgeFlushTimer, runSessionBackfillTimer, getStripeSubDetails, scheduleTrialReminders, StripeSubDetails (..), errorTrendChartUrl) where
+module BackgroundJobs (jobsWorkerInit, jobsRunner, processBackgroundJob, BgJobs (..), jobTypeName, runHourlyJob, generateOtelFacetsBatch, throwParsePayload, checkTriggeredQueryMonitors, monitorStatus, detectSpikeOrDrop, aboveVolumeFloor, isAlertableLogLevel, spikeZScoreThreshold, spikeMinAbsoluteDelta, spikeMinBaselineRate, dropMinBaselineRate, calculateLogPatternBaselines, detectLogPatternSpikes, processNewLogPatterns, pruneStaleLogPatterns, calculateErrorBaselines, detectErrorSpikes, notifyErrorSubscriptions, sweepErrorSubscriptions, consumeNotificationToken, endpointTemplateDiscovery, patternEmbeddingAndMerge, processEagerBatch, flushDrainTask, runErrorDecayFiber, runDrainFlusher, runDrainAgeFlushTimer, runSessionBackfillTimer, getStripeSubDetails, scheduleTrialReminders, StripeSubDetails (..), errorTrendChartUrl) where
 
 import Control.Concurrent (threadDelay)
 import Control.Concurrent.Async (async)
@@ -2934,12 +2934,17 @@ monitorStatus triggerLessThan warnThreshold alertThreshold alertRecovery warnRec
 -- ============================================================================
 
 -- Tuning knobs for log pattern baseline and spike detection
-baselineWindowHours, baselinePageSize, maxNewPatternsPerRun, stalePatternDays, staleNewPatternDays :: Int
+baselineWindowHours, baselinePageSize, maxNewPatternsPerRun, stalePatternDays, staleNewPatternDays, staleLogPatternIssueDays :: Int
 baselineWindowHours = 48 -- 2 days
 baselinePageSize = 1000
 maxNewPatternsPerRun = 500
 stalePatternDays = 30 -- prune acknowledged patterns older than this
 staleNewPatternDays = 7 -- auto-acknowledge 'new' patterns older than this
+-- Auto-archive open log_pattern / log_pattern_rate_change issues with no
+-- `updated_at` activity in this many days. `insertIssue` bumps updated_at on
+-- conflict, so still-firing patterns never age out. Well clear of the 24h ack
+-- cooldown and 2h pending-anomaly TTL.
+staleLogPatternIssueDays = 14
 
 
 minEventsForNewPatternAlerts :: Int64
@@ -3015,6 +3020,15 @@ aboveVolumeFloor sr = case sr.direction of
   Issues.Drop -> sr.mean >= dropMinBaselineRate
 
 
+-- | Whitelist of log levels that can produce a rate-change issue. Case-insensitive.
+-- Nothing is explicitly rejected: a pattern with no level is not a reliable
+-- incident signal, and was the single biggest source of historical noise.
+isAlertableLogLevel :: Maybe Text -> Bool
+isAlertableLogLevel = \case
+  Just lvl -> T.toUpper lvl `elem` ["ERROR", "WARN", "WARNING", "FATAL", "CRITICAL"]
+  Nothing -> False
+
+
 dirText :: Issues.RateChangeDirection -> Text
 dirText Issues.Spike = "spike"
 dirText Issues.Drop = "drop"
@@ -3024,7 +3038,9 @@ dirText Issues.Drop = "drop"
 -- Projects partial-hour counts to hourly rate for sub-hourly detection.
 --
 -- Gating stack (applied in order):
---   1. Ignore INFO/TRACE logs and patterns without an established baseline.
+--   1. Whitelist ERROR/WARN/FATAL/CRITICAL (case-insensitive) via
+--      `isAlertableLogLevel`; reject Nothing and everything else.
+--      Also require an established baseline.
 --   2. Baseline volume floor (spikeMinBaselineRate / dropMinBaselineRate) —
 --      anything below is expected silence, not signal.
 --   3. Persistence gate: first detection writes a pending marker on the
@@ -3043,8 +3059,12 @@ detectLogPatternSpikes pid scheduledTime authCtx = do
   patternsWithRates <- LogPatterns.getPatternsWithCurrentRates pid scheduledTime
 
   -- Step 1+2: per-pattern anomaly detection with floor check.
+  -- Gate: whitelist known error/warn levels (case-insensitive). Nothing is
+  -- rejected — unknown level is not a reliable incident signal, and projects
+  -- that don't attach `log.level` were the largest source of Inbox noise.
+  -- Mirrors the shape of `isIssueWorthy` for the new-pattern path.
   let classify lpRate =
-        guard (lpRate.logLevel `notElem` [Just "INFO", Just "TRACE" :: Maybe Text])
+        guard (isAlertableLogLevel lpRate.logLevel)
           *> case (lpRate.baselineState, lpRate.baselineMean, lpRate.baselineMad) of
             (BSEstablished, Just mean, Just mad) -> do
               let projectedCount = round (fromIntegral lpRate.currentHourCount * scaleFactor)
@@ -3133,15 +3153,30 @@ isIssueWorthy lp
 
 
 -- | Prune acknowledged patterns not seen in 30 days, auto-acknowledge stale 'new' patterns,
--- and delete old hourly stats beyond the baseline window.
+-- delete old hourly stats beyond the baseline window, and archive open
+-- log_pattern/log_pattern_rate_change issues that have had no updates in 14
+-- days (dead signal — actively-firing patterns bump @updated_at@ via
+-- @insertIssue@ on conflict).
 pruneStaleLogPatterns :: Projects.ProjectId -> ATBackgroundCtx ()
 pruneStaleLogPatterns pid = do
   now <- Time.currentTime
   autoAcked <- LogPatterns.autoAcknowledgeStaleNewPatterns pid now staleNewPatternDays
   pruned <- LogPatterns.pruneStalePatterns pid now stalePatternDays
   statsPruned <- LogPatterns.pruneOldHourlyStats pid now (baselineWindowHours + 24)
-  Relude.when (autoAcked > 0 || pruned > 0 || statsPruned > 0)
-    $ Log.logTrace "Pruned stale log patterns and old stats" (pid, "autoAcked" :: Text, autoAcked, "pruned" :: Text, pruned, "statsPruned" :: Text, statsPruned)
+  autoArchived <- Issues.autoArchiveStaleLogPatternIssues pid now staleLogPatternIssueDays
+  Relude.when (autoAcked > 0 || pruned > 0 || statsPruned > 0 || autoArchived > 0)
+    $ Log.logTrace
+      "Pruned stale log patterns and old stats"
+      ( pid
+      , "autoAcked" :: Text
+      , autoAcked
+      , "pruned" :: Text
+      , pruned
+      , "statsPruned" :: Text
+      , statsPruned
+      , "autoArchived" :: Text
+      , autoArchived
+      )
 
 
 calculateErrorBaselines :: Projects.ProjectId -> ATBackgroundCtx ()

--- a/src/Models/Apis/Issues.hs
+++ b/src/Models/Apis/Issues.hs
@@ -41,6 +41,7 @@ module Models.Apis.Issues (
   isInCooldown,
   setAckState,
   setArchiveState,
+  autoArchiveStaleLogPatternIssues,
   selectIssueByHash,
   selectLatestIssueByHash,
   reopenIssue,
@@ -151,7 +152,7 @@ data IssueType
   | QueryAlert
   | LogPattern
   | LogPatternRateChange
-  deriving stock (Bounded, Enum, Eq, Generic, Read, Show)
+  deriving stock (Bounded, Enum, Eq, Generic, Ord, Read, Show)
   deriving anyclass (NFData)
   deriving (AE.FromJSON, AE.ToJSON, Display, FromField, FromHttpApiData, HI.DecodeValue, HI.EncodeValue, ToField, ToSchema) via WrappedEnumSC "" IssueType
 
@@ -635,6 +636,25 @@ setArchiveState pid iids mTs
           UPDATE apis.issues
           SET archived_at = #{mTs}, updated_at = COALESCE(#{mTs}, updated_at)
           WHERE project_id = #{pid} AND id = ANY(#{iids}::uuid[]) |]
+
+
+-- | Archive open @log_pattern@ / @log_pattern_rate_change@ issues whose
+-- @updated_at@ is older than @days@. @insertIssue@ bumps @updated_at@ on
+-- conflict, so an actively-firing pattern never ages out — only dead signal
+-- does. The predicate runs against OLD @updated_at@ before the
+-- @set_updated_at@ trigger fires, so the cutoff is evaluated on the
+-- pre-archive value.
+autoArchiveStaleLogPatternIssues :: DB es => Projects.ProjectId -> UTCTime -> Int -> Eff es Int64
+autoArchiveStaleLogPatternIssues pid now days =
+  Hasql.interpExecute
+    [HI.sql|
+      UPDATE apis.issues
+      SET archived_at = #{now}
+      WHERE project_id = #{pid}
+        AND acknowledged_at IS NULL
+        AND archived_at IS NULL
+        AND issue_type IN ('log_pattern'::apis.issue_type, 'log_pattern_rate_change'::apis.issue_type)
+        AND updated_at < #{now} - (INTERVAL '1 day' * #{days}) |]
 
 
 -- | Scoped lookup: returns Nothing if the issue belongs to a different project.

--- a/src/Pages/Anomalies.hs
+++ b/src/Pages/Anomalies.hs
@@ -1139,7 +1139,16 @@ anomalyListGetH pid layoutM filterTM sortM timeFilter pageM perPageM loadM endpo
           }
   let serviceMenu = FilterMenu{label = "Service", paramName = "service", multiSelect = True, options = map (\s -> FilterOption{label = s, value = s, isActive = s `elem` serviceFilters}) availableServices}
       typeMenu = FilterMenu{label = "Type", paramName = "type", multiSelect = True, options = map (\t -> FilterOption{label = t, value = t, isActive = t `elem` typeFilters}) availableTypes}
-      issuesVM = V.fromList $ map (IssueVM False False currTime filterV) issues
+      -- Only the Inbox tab applies log-pattern clustering. Acknowledged /
+      -- Archived stay flat so operators can inspect every row. Groups also
+      -- dissolve when the user explicitly filters by service (no value in
+      -- collapsing a single service into itself).
+      applyGrouping = currentFilterTab == "Inbox" && null serviceFilters
+      issuesVM =
+        V.fromList
+          $ if applyGrouping
+            then collapseLogPatternGroups pid currTime period issues
+            else map (IssueVM False False currTime filterV) issues
       tableActions =
         TableHeaderActions
           { baseUrl
@@ -1163,7 +1172,7 @@ anomalyListGetH pid layoutM filterTM sortM timeFilter pageM perPageM loadM endpo
           , rows = issuesVM
           , features =
               def
-                { rowId = Just \(IssueVM _ _ _ _ issue) -> Issues.issueIdText issue.id
+                { rowId = Just issueRowId
                 , rowAttrs = Just issueRowAttrs
                 , bulkActions =
                     [ BulkAction{icon = Just "check", title = "Acknowledge", uri = "/p/" <> pid.toText <> "/issues/bulk_actions/acknowledge"}
@@ -1207,7 +1216,7 @@ anomalyListGetH pid layoutM filterTM sortM timeFilter pageM perPageM loadM endpo
                   }
           }
   addRespHeaders $ case (layoutM, hxRequestM, hxBoostedM, loadM) of
-    (_, _, _, Just "true") -> ALRows $ TableRows{columns = issueColumns pid period, rows = issuesVM, emptyState = Nothing, renderAsTable = True, rowId = Just \(IssueVM _ _ _ _ issue) -> Issues.issueIdText issue.id, rowAttrs = Just issueRowAttrs, pagination = if totalCount > 0 then Just paginationConfig else Nothing}
+    (_, _, _, Just "true") -> ALRows $ TableRows{columns = issueColumns pid period, rows = issuesVM, emptyState = Nothing, renderAsTable = True, rowId = Just issueRowId, rowAttrs = Just issueRowAttrs, pagination = if totalCount > 0 then Just paginationConfig else Nothing}
     _ -> ALPage $ PageCtx bwconf issuesTable
 
 
@@ -1233,6 +1242,17 @@ issueRowAttrs (IssueVM _ _ _ _ issue) =
       "critical" -> "bg-fillError-weak"
       "warning" -> "bg-fillWarning-weak"
       _ -> ""
+issueRowAttrs IssueGroup{} = [class_ "group/row hover:bg-fillWeaker bg-fillWeaker/40"]
+
+
+issueRowId :: IssueVM -> Text
+issueRowId (IssueVM _ _ _ _ issue) = Issues.issueIdText issue.id
+issueRowId (IssueGroup _ ty svcM _ _ _ _) = "group:" <> tyText <> ":" <> Issues.serviceLabel svcM
+  where
+    tyText = case ty of
+      Issues.LogPattern -> "log_pattern"
+      Issues.LogPatternRateChange -> "log_pattern_rate_change"
+      _ -> "other"
 
 
 -- | (icon, iconStyle, colorClass, tooltip) — uses shape+color so status isn't color-only
@@ -1244,8 +1264,67 @@ anomalyStatusIndicator False False "warning" = ("triangle-alert", "regular", "te
 anomalyStatusIndicator False False _ = ("circle-alert", "regular", "text-textWeak", "Active")
 
 
-data IssueVM = IssueVM Bool Bool UTCTime Text Issues.IssueL
+-- | Row type rendered by the Issues list. 'IssueVM' is the normal per-issue
+-- row; 'IssueGroup' is a synthetic collapsed row used only in the Inbox tab to
+-- fold large clusters of log-pattern issues into a single expandable entry.
+data IssueVM
+  = IssueVM Bool Bool UTCTime Text Issues.IssueL
+  | -- | IssueGroup projectId issueType service count currTime lastSeen (period label)
+    IssueGroup Projects.ProjectId Issues.IssueType (Maybe Text) Int UTCTime UTCTime Text
   deriving stock (Show)
+
+
+-- | Minimum number of log-pattern rows sharing (issue_type, service) before
+-- they collapse into a single group header in the Inbox. Below this, the
+-- normal per-row listing is clearer than a group wrapper.
+logPatternGroupThreshold :: Int
+logPatternGroupThreshold = 5
+
+
+-- | Collapse log-pattern / log-pattern-rate-change rows that share
+-- (issue_type, service) into 'IssueGroup' headers when the cluster hits
+-- 'logPatternGroupThreshold'. Non-log-pattern rows and small clusters render
+-- through the normal 'IssueVM' path. Only active on the Inbox tab so
+-- Acknowledged / Archived views stay inspectable.
+--
+-- Issues arrive in an arbitrary sort order (default is created_at DESC) so
+-- grouping runs over two passes: aggregate counts + last-seen per
+-- (type, service) first, then stream the original list emitting an
+-- 'IssueGroup' header at the first occurrence of a clusterable key and
+-- skipping the rest. Ordering of the first representative is preserved.
+collapseLogPatternGroups :: Projects.ProjectId -> UTCTime -> Text -> [Issues.IssueL] -> [IssueVM]
+collapseLogPatternGroups pid currTime period issues =
+  go issues Map.empty
+  where
+    isLogPattern :: Issues.IssueType -> Bool
+    isLogPattern Issues.LogPattern = True
+    isLogPattern Issues.LogPatternRateChange = True
+    isLogPattern _ = False
+
+    keyOf :: Issues.IssueL -> (Issues.IssueType, Maybe Text)
+    keyOf i = (i.issueType, i.service)
+
+    aggregates :: Map.Map (Issues.IssueType, Maybe Text) (Int, UTCTime)
+    aggregates =
+      Map.fromListWith combine
+        [ (keyOf i, (1, zonedTimeToUTC i.updatedAt))
+        | i <- issues
+        , isLogPattern i.issueType
+        ]
+      where
+        combine (c1, t1) (c2, t2) = (c1 + c2, max t1 t2)
+
+    go :: [Issues.IssueL] -> Map.Map (Issues.IssueType, Maybe Text) () -> [IssueVM]
+    go [] _ = []
+    go (i : rest) emitted
+      | isLogPattern i.issueType
+      , let k = keyOf i
+      , Just (count, lastSeen) <- Map.lookup k aggregates
+      , count >= logPatternGroupThreshold =
+          if Map.member k emitted
+            then go rest emitted
+            else IssueGroup pid (fst k) (snd k) count currTime lastSeen period : go rest (Map.insert k () emitted)
+      | otherwise = IssueVM False False currTime period i : go rest emitted
 
 
 issueColumns :: Projects.ProjectId -> Text -> [Column IssueVM]
@@ -1272,17 +1351,24 @@ renderIssueEventsCol (IssueVM _ isWidget _ _ issue) =
       | n >= 100 = "text-sm text-fillError-strong"
       | n >= 10 = "text-sm text-fillWarning-strong"
       | otherwise = "text-sm text-textStrong"
+renderIssueEventsCol (IssueGroup _ _ _ count _ _ _) =
+  span_ [class_ "tabular-nums font-medium text-sm text-textStrong"]
+    $ toHtml
+    $ formatWithCommas (fromIntegral count)
 
 
 renderIssueDateCol :: IssueVM -> Html ()
 renderIssueDateCol (IssueVM _ _ currTime _ issue) =
   span_ [class_ "text-xs text-textWeak"] $ toHtml $ compactTimeAgo $ toText $ prettyTimeAuto currTime $ zonedTimeToUTC issue.createdAt
+renderIssueDateCol (IssueGroup _ _ _ _ currTime lastSeen _) =
+  span_ [class_ "text-xs text-textWeak"] $ toHtml $ compactTimeAgo $ toText $ prettyTimeAuto currTime lastSeen
 
 
 renderIssueChartCol :: IssueVM -> Html ()
 renderIssueChartCol (IssueVM _ _ _ _ issue) = sparkline_ buckets
   where
     PGArray buckets = issue.activityBuckets
+renderIssueChartCol IssueGroup{} = pass
 
 
 highlightJsHead_ :: Monad m => HtmlT m ()
@@ -1393,6 +1479,36 @@ renderIssueMainCol pid (IssueVM _ _ currTime period issue) = do
     inlineBtn tip icon hxAction extraAttrs =
       button_ ([type_ "button", term "data-tippy-content" tip, class_ "cursor-pointer hover:text-textBrand transition-colors tap-target", hxSwap_ "outerHTML", hxTarget_ "closest .itemsListItem", hxAction] <> extraAttrs)
         $ faSprite_ icon "regular" "h-3.5 w-3.5"
+renderIssueMainCol pid (IssueGroup _ ty svcM count currTime lastSeen period) = do
+  let typeNoun = case ty of
+        Issues.LogPatternRateChange -> "log pattern rate changes"
+        Issues.LogPattern -> "new log patterns"
+        _ -> "issues"
+      svcLabel = Issues.serviceLabel svcM
+      typeParam = case ty of
+        Issues.LogPatternRateChange -> "log_pattern_rate_change"
+        Issues.LogPattern -> "log_pattern"
+        _ -> ""
+      expandUrl =
+        "/p/"
+          <> pid.toText
+          <> "/issues?filter=Inbox&period="
+          <> period
+          <> "&type="
+          <> typeParam
+          <> "&service="
+          <> svcLabel
+  div_ [class_ "flex items-center gap-2 py-1 min-w-0"] do
+    span_ [class_ "inline-flex shrink-0 text-textWeak"] $ faSprite_ "layer-group" "regular" "w-3.5 h-3.5"
+    span_ [class_ "text-sm text-textStrong font-medium"] $ toHtml $ show count <> " " <> typeNoun
+    span_ [class_ "text-xs text-textWeak"] "in"
+    span_ [class_ "cbadge-sm badge-neutral"] $ toHtml svcLabel
+    span_ [class_ "text-xs text-textWeak ml-auto"] $ toHtml $ "last seen " <> toText (prettyTimeAuto currTime lastSeen)
+    a_
+      [ href_ expandUrl
+      , class_ "text-xs text-textBrand hover:underline shrink-0"
+      ]
+      "Expand →"
 
 
 issueCardCompact_ :: Projects.ProjectId -> UTCTime -> Issues.IssueL -> Html ()

--- a/src/Pages/Anomalies.hs
+++ b/src/Pages/Anomalies.hs
@@ -1306,7 +1306,8 @@ collapseLogPatternGroups pid currTime period issues =
 
     aggregates :: Map.Map (Issues.IssueType, Maybe Text) (Int, UTCTime)
     aggregates =
-      Map.fromListWith combine
+      Map.fromListWith
+        combine
         [ (keyOf i, (1, zonedTimeToUTC i.updatedAt))
         | i <- issues
         , isLogPattern i.issueType

--- a/test/integration/Pages/AnomaliesSpec.hs
+++ b/test/integration/Pages/AnomaliesSpec.hs
@@ -136,7 +136,7 @@ spec = aroundAll withTestResources do
         AnomalyList.anomalyListGetH testPid Nothing (Just "Acknowledged") Nothing Nothing Nothing Nothing Nothing Nothing Nothing [] [] Nothing Nothing
       case pg of
         AnomalyList.ALPage (PageCtx _ tbl) -> do
-          let acknowledgedApiChangeIssues = V.filter (\(AnomalyList.IssueVM _ _ _ _ c) -> c.issueType == Issues.ApiChange) tbl.rows
+          let acknowledgedApiChangeIssues = V.filter (isApiChangeSingleRow Issues.ApiChange) tbl.rows
           V.length acknowledgedApiChangeIssues `shouldSatisfy` (> 0)
         _ -> error "Unexpected response"
 
@@ -214,7 +214,7 @@ spec = aroundAll withTestResources do
 
       -- Get updated anomaly list
       anomalies <- getAnomalies tr
-      let formatApiChangeIssues = V.filter (\(AnomalyList.IssueVM _ _ _ _ c) -> c.issueType == Issues.ApiChange) anomalies
+      let formatApiChangeIssues = V.filter (isApiChangeSingleRow Issues.ApiChange) anomalies
 
       -- In the new Issues system, format anomalies are part of API changes
       length formatApiChangeIssues `shouldSatisfy` (>= 1)
@@ -226,12 +226,19 @@ spec = aroundAll withTestResources do
       case pg of
         AnomalyList.ALPage (PageCtx _ tbl) -> do
           -- Acknowledged anomalies should include API changes
-          let acknowledgedApiChangeIssues = V.filter (\(AnomalyList.IssueVM _ _ _ _ c) -> c.issueType == Issues.ApiChange) tbl.rows
+          let acknowledgedApiChangeIssues = V.filter (isApiChangeSingleRow Issues.ApiChange) tbl.rows
 
           -- We acknowledged at least one API change issue in the previous test
           length acknowledgedApiChangeIssues `shouldSatisfy` (>= 1)
           length tbl.rows `shouldSatisfy` (> 0)
         _ -> error "Unexpected response"
+
+
+-- | Row predicate for API-change singles; ignores 'IssueGroup' placeholders.
+isApiChangeSingleRow :: Issues.IssueType -> AnomalyList.IssueVM -> Bool
+isApiChangeSingleRow ty = \case
+  AnomalyList.IssueVM _ _ _ _ c -> c.issueType == ty
+  _ -> False
 
 
 -- Same endpoint as msg1 but with different request body shape, to test shape anomaly detection

--- a/test/integration/Pages/LogPatternsSpec.hs
+++ b/test/integration/Pages/LogPatternsSpec.hs
@@ -214,6 +214,61 @@ spec = aroundAll withTestResources do
       issuesAfter <- countIssues tr Issues.LogPatternRateChange
       issuesAfter `shouldSatisfy` (> issuesBefore)
 
+    it "4d. Rate-change gate rejects lowercase INFO, DEBUG, and unknown log levels" \tr -> do
+      -- Builds three patterns with identical spike conditions but different
+      -- log levels. Only ERROR / WARN / FATAL / CRITICAL should produce an
+      -- issue — Phase 2 widened the gate to be case-insensitive and reject
+      -- null levels (the biggest historical source of Inbox noise).
+      let srcField = "summary"
+          mkGatedPattern h lvl = do
+            void $ runTestBg frozenTime tr $ LogPatterns.upsertLogPattern LogPatterns.UpsertPattern
+              { projectId = pid, logPattern = "Gate test " <> h <> " <*>", hash = h
+              , sourceField = srcField, serviceName = Just "test-svc", logLevel = lvl
+              , traceId = Nothing, sampleMessage = Just "Gate test", eventCount = 100
+              }
+            forM_ ([-48 .. -1] :: [Int]) \hr ->
+              insertHourlyStat tr srcField h (addUTCTime (fromIntegral hr * 3600) frozenTime) 600
+          spikeCount = 600 :: Int64 -- projected = 600*4 = 2400 — far above baseline mean ~600 + 3*mad
+
+      mkGatedPattern "gate-info-lc" (Just "info")
+      mkGatedPattern "gate-debug" (Just "DEBUG")
+      mkGatedPattern "gate-null" Nothing
+      mkGatedPattern "gate-error" (Just "ERROR")
+
+      runTestBg frozenTime tr $ BackgroundJobs.calculateLogPatternBaselines pid
+
+      forM_ ["gate-info-lc", "gate-debug", "gate-null", "gate-error"] \h ->
+        insertHourlyStat tr srcField h frozenTime spikeCount
+
+      -- Detector runs twice: persistence gate requires two consecutive windows.
+      runTestBg frozenTime tr $ BackgroundJobs.detectLogPatternSpikes pid frozenTime tr.trATCtx
+      let secondRun = addUTCTime 900 frozenTime -- 15 min later, still within TTL
+      insertHourlyStat tr srcField "gate-info-lc" secondRun spikeCount
+      insertHourlyStat tr srcField "gate-debug" secondRun spikeCount
+      insertHourlyStat tr srcField "gate-null" secondRun spikeCount
+      insertHourlyStat tr srcField "gate-error" secondRun spikeCount
+      runTestBg secondRun tr $ BackgroundJobs.detectLogPatternSpikes pid secondRun tr.trATCtx
+
+      -- Only the ERROR pattern should have produced a rate-change issue.
+      forM_ ["gate-info-lc", "gate-debug", "gate-null"] \h -> do
+        cnt <- withResource tr.trPool \conn -> do
+          [PGS.Only n] <- PGS.query conn
+            [sql| SELECT COUNT(*)::INT FROM apis.issues
+                  WHERE project_id = ? AND issue_type = 'log_pattern_rate_change'
+                    AND target_hash = ? |]
+            (pid, h) :: IO [PGS.Only Int]
+          pure n
+        cnt `shouldBe` 0
+
+      errorCnt <- withResource tr.trPool \conn -> do
+        [PGS.Only n] <- PGS.query conn
+          [sql| SELECT COUNT(*)::INT FROM apis.issues
+                WHERE project_id = ? AND issue_type = 'log_pattern_rate_change'
+                  AND target_hash = 'gate-error' |]
+          (PGS.Only pid) :: IO [PGS.Only Int]
+        pure n
+      errorCnt `shouldSatisfy` (>= 1)
+
     it "4b. getLogPatternTexts excludes merged member patterns" \tr -> do
       let canonHash = "canon-drain-001"
           memberHash = "member-drain-001"
@@ -353,6 +408,54 @@ spec = aroundAll withTestResources do
       -- Verify stale hourly stats are also prunable
       statsPruned <- runTestBg frozenTime tr $ LogPatterns.pruneOldHourlyStats pid frozenTime 72
       statsPruned `shouldSatisfy` (>= 1)
+
+    it "7a. pruneStaleLogPatterns auto-archives open log_pattern issues older than 14 days" \tr -> do
+      -- Seed two open log_pattern issues — one stale (20d), one fresh (5d) —
+      -- plus a stale log_pattern_rate_change to cover both types. Archiving
+      -- is keyed on updated_at; insertIssue bumps it on conflict, so only
+      -- dead signal ages out.
+      let stalePatRow = ("autoarchive-stale-pat" :: Text, "log_pattern" :: Text, 20 :: Int)
+          freshPatRow = ("autoarchive-fresh-pat" :: Text, "log_pattern" :: Text, 5 :: Int)
+          staleRcRow = ("autoarchive-stale-rc" :: Text, "log_pattern_rate_change" :: Text, 20 :: Int)
+          rows = [stalePatRow, freshPatRow, staleRcRow]
+      -- Use frozenTime for row timestamps so the auto-archive cutoff
+      -- (frozenTime - 14 days) sees the stale rows as older.
+      withResource tr.trPool \conn -> forM_ rows \(tgt, ty, daysOld) -> do
+        iid <- UUID.nextRandom
+        let title = ("t" :: Text) <> tgt
+        void $ PGS.execute conn
+          [sql| INSERT INTO apis.issues
+                  (id, project_id, issue_type, target_hash, endpoint_hash, title,
+                   severity, critical, affected_requests, affected_clients,
+                   issue_data, updated_at, created_at)
+                VALUES (?, ?, ?::apis.issue_type, ?, ?, ?, 'warning', false,
+                        1, 1, '{}'::jsonb,
+                        ?::timestamptz - (INTERVAL '1 day' * ?),
+                        ?::timestamptz - (INTERVAL '1 day' * ?)) |]
+          (iid, pid, ty, tgt, tgt, title, frozenTime, daysOld, frozenTime, daysOld)
+
+      -- Sanity: all three rows are open pre-prune.
+      openBefore <- withResource tr.trPool \conn -> do
+        rs <- PGS.query conn
+          [sql| SELECT target_hash FROM apis.issues
+                WHERE project_id = ? AND archived_at IS NULL
+                  AND target_hash = ANY(?) |]
+          (pid, V.fromList ["autoarchive-stale-pat", "autoarchive-fresh-pat", "autoarchive-stale-rc" :: Text])
+        pure $ V.fromList (map (PGS.fromOnly :: PGS.Only Text -> Text) rs)
+      V.length openBefore `shouldBe` 3
+
+      runTestBg frozenTime tr $ BackgroundJobs.pruneStaleLogPatterns pid
+
+      archivedAfter <- withResource tr.trPool \conn -> do
+        rs <- PGS.query conn
+          [sql| SELECT target_hash FROM apis.issues
+                WHERE project_id = ? AND archived_at IS NOT NULL
+                  AND target_hash = ANY(?) |]
+          (pid, V.fromList ["autoarchive-stale-pat", "autoarchive-fresh-pat", "autoarchive-stale-rc" :: Text])
+        pure $ V.fromList (map (PGS.fromOnly :: PGS.Only Text -> Text) rs)
+      V.toList archivedAfter `shouldSatisfy` elem "autoarchive-stale-pat"
+      V.toList archivedAfter `shouldSatisfy` elem "autoarchive-stale-rc"
+      V.toList archivedAfter `shouldSatisfy` (not . elem "autoarchive-fresh-pat")
 
     it "8. logCanMerge gate correctly filters pairs" \_ -> do
       -- Similar patterns (share meaningful tokens) → should pass

--- a/test/unit/BackgroundJobs/SpikeDetectionSpec.hs
+++ b/test/unit/BackgroundJobs/SpikeDetectionSpec.hs
@@ -1,6 +1,6 @@
 module BackgroundJobs.SpikeDetectionSpec (spec) where
 
-import BackgroundJobs (aboveVolumeFloor, detectSpikeOrDrop, dropMinBaselineRate, spikeMinAbsoluteDelta, spikeMinBaselineRate, spikeZScoreThreshold)
+import BackgroundJobs (aboveVolumeFloor, detectSpikeOrDrop, dropMinBaselineRate, isAlertableLogLevel, spikeMinAbsoluteDelta, spikeMinBaselineRate, spikeZScoreThreshold)
 import Models.Apis.Issues (RateChangeDirection (..), SpikeResult (..))
 import Relude
 import Test.Hspec
@@ -62,3 +62,27 @@ spec = describe "detectSpikeOrDrop" do
       -- 1000 is plenty for a spike but too small for a drop
       aboveVolumeFloor (mkSpike 1000) `shouldBe` True
       aboveVolumeFloor (mkDrop 1000) `shouldBe` False
+
+
+  describe "isAlertableLogLevel" do
+    it "accepts ERROR / WARN / WARNING / FATAL / CRITICAL (any case)" do
+      isAlertableLogLevel (Just "ERROR") `shouldBe` True
+      isAlertableLogLevel (Just "error") `shouldBe` True
+      isAlertableLogLevel (Just "Warn") `shouldBe` True
+      isAlertableLogLevel (Just "warning") `shouldBe` True
+      isAlertableLogLevel (Just "FATAL") `shouldBe` True
+      isAlertableLogLevel (Just "critical") `shouldBe` True
+
+    it "rejects INFO / DEBUG / TRACE / NOTICE (any case)" do
+      isAlertableLogLevel (Just "INFO") `shouldBe` False
+      isAlertableLogLevel (Just "info") `shouldBe` False
+      isAlertableLogLevel (Just "DEBUG") `shouldBe` False
+      isAlertableLogLevel (Just "debug") `shouldBe` False
+      isAlertableLogLevel (Just "TRACE") `shouldBe` False
+      isAlertableLogLevel (Just "notice") `shouldBe` False
+
+    it "rejects unknown level (Nothing) — largest source of historical noise" do
+      isAlertableLogLevel Nothing `shouldBe` False
+
+    it "rejects empty string" do
+      isAlertableLogLevel (Just "") `shouldBe` False


### PR DESCRIPTION
## Summary

This PR improves the Inbox experience for log-pattern issues by introducing collapsible group headers for large clusters of similar issues, and adds automatic archival of stale log-pattern issues to reduce noise.

## Key Changes

- **Log-pattern grouping in Inbox**: Issues of type `LogPattern` and `LogPatternRateChange` that share the same (issue_type, service) pair are collapsed into a single expandable `IssueGroup` header when the cluster reaches 5+ issues. This only applies to the Inbox tab; Acknowledged and Archived tabs remain flat for inspection. Groups dissolve when filtering by service (no value in collapsing a single service into itself).

- **Stricter log-level gating**: Added `isAlertableLogLevel` function that whitelists only ERROR, WARN, WARNING, FATAL, and CRITICAL (case-insensitive). Patterns with no log level or unknown levels are now rejected during spike detection, eliminating a major source of historical noise.

- **Auto-archival of stale issues**: Implemented `autoArchiveStaleLogPatternIssues` to automatically archive open log-pattern issues with no activity for 14+ days. Since `insertIssue` bumps `updated_at` on conflict, actively-firing patterns never age out—only dead signal does.

- **New IssueVM variant**: Added `IssueGroup` constructor to represent collapsed clusters, with dedicated rendering for group headers showing count, service, and last-seen timestamp with an expand link.

- **Refactored row ID generation**: Extracted `issueRowId` function to handle both `IssueVM` and `IssueGroup` cases, generating unique IDs for groups using the pattern `group:<type>:<service>`.

- **One-off cleanup script**: Added `scripts/archive-noisy-log-pattern-issues.sh` to archive known noise patterns (legacy detector output, auto-demoted silent drops, etc.) with dry-run and write modes.

## Implementation Details

- Grouping uses a two-pass algorithm: first aggregates counts and last-seen timestamps per (type, service), then streams the original list emitting group headers at first occurrence and skipping duplicates to preserve ordering.
- Group rendering includes a filtered link to expand the cluster with pre-filled type and service parameters.
- Tests added for log-level gating and stale issue auto-archival.
- Existing tests updated to handle the new `IssueGroup` variant in row filtering.

https://claude.ai/code/session_012mpbQgAFGEXNSyGVsmAghh