### PR TITLE
fix(packaging): align cabal with AGPL LICENSE, add fmt pre-commit

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Format staged Haskell files with fourmolu before commit.
+# Activate locally: git config core.hooksPath .githooks
+# Skip ad-hoc: SKIP_FOURMOLU=1 git commit ...
+
+set -euo pipefail
+
+if [ "${SKIP_FOURMOLU:-0}" = "1" ]; then
+    exit 0
+fi
+
+if ! command -v fourmolu >/dev/null 2>&1; then
+    echo "pre-commit: fourmolu not on PATH — skipping format check." >&2
+    echo "            install with: cabal install fourmolu  (or ghcup/stack)" >&2
+    exit 0
+fi
+
+mapfile -t HS_FILES < <(git diff --cached --name-only --diff-filter=ACM -z \
+    | tr '\0' '\n' \
+    | grep -E '\.hs$' || true)
+
+if [ ${#HS_FILES[@]} -eq 0 ]; then
+    exit 0
+fi
+
+# Only touch files that are fully staged; bail if a file has unstaged changes
+# on top of the staged version, since reformatting + re-adding would silently
+# swallow the working-tree edits.
+UNSAFE=()
+for f in "${HS_FILES[@]}"; do
+    if ! git diff --quiet -- "$f"; then
+        UNSAFE+=("$f")
+    fi
+done
+
+if [ ${#UNSAFE[@]} -gt 0 ]; then
+    echo "pre-commit: refusing to format — these staged files have unstaged" >&2
+    echo "            changes on top (commit or stash them first):" >&2
+    printf '              %s\n' "${UNSAFE[@]}" >&2
+    exit 1
+fi
+
+fourmolu --mode inplace "${HS_FILES[@]}"
+git add -- "${HS_FILES[@]}"

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -103,7 +103,7 @@ cabal run monoscope-server
 
 ```bash
 # Code formatter
-brew install ormolu
+brew install fourmolu        # or: cabal install fourmolu
 
 # Linter
 brew install hlint
@@ -118,6 +118,17 @@ make fmt
 # Run linter
 make lint
 ```
+
+**Auto-format on commit:**
+
+A versioned pre-commit hook in `.githooks/pre-commit` runs `fourmolu` on staged
+`.hs` files. Activate it once per clone:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+To bypass for a single commit: `SKIP_FOURMOLU=1 git commit ...`.
 
 ### Automatic Recompilation with ghcid
 

--- a/monoscope.cabal
+++ b/monoscope.cabal
@@ -1,4 +1,4 @@
-cabal-version: 2.0
+cabal-version: 2.2
 
 -- This file has been generated from package.yaml by hpack version 0.38.1.
 --
@@ -6,13 +6,13 @@ cabal-version: 2.0
 
 name:           monoscope
 version:        0.1.0.0
-description:    Please see the README on GitHub at <https://github.com/githubuser/monoscope#readme>
-homepage:       https://github.com/githubuser/monoscope#readme
-bug-reports:    https://github.com/githubuser/monoscope/issues
-author:         Author name here
-maintainer:     example@example.com
-copyright:      2021 Author name here
-license:        BSD3
+description:    Please see the README on GitHub at <https://github.com/monoscope-tech/monoscope#readme>
+homepage:       https://github.com/monoscope-tech/monoscope#readme
+bug-reports:    https://github.com/monoscope-tech/monoscope/issues
+author:         Monoscope
+maintainer:     hello@monoscope.tech
+copyright:      2021-2026 Monoscope
+license:        AGPL-3.0-only
 license-file:   LICENSE
 build-type:     Custom
 extra-source-files:

--- a/package.yaml
+++ b/package.yaml
@@ -1,10 +1,11 @@
 name: monoscope
 version: 0.1.0.0
-github: 'githubuser/monoscope'
-license: BSD3
-author: 'Author name here'
-maintainer: 'example@example.com'
-copyright: '2021 Author name here'
+github: 'monoscope-tech/monoscope'
+license: AGPL-3.0-only
+license-file: LICENSE
+author: 'Monoscope'
+maintainer: 'hello@monoscope.tech'
+copyright: '2021-2026 Monoscope'
 language: GHC2024
 spec-version: 0.36.0
 


### PR DESCRIPTION
## Summary
- **License mismatch (legal bug).** `monoscope.cabal` and `package.yaml`
  declared `BSD3` while `LICENSE` and the README publish the project under
  AGPL-3.0. Aligns both to `AGPL-3.0-only` (SPDX), bumps
  `cabal-version: 2.0 → 2.2` since SPDX expressions require it.
- **Restore real package metadata.** Replaces hpack defaults
  (`author: Author name here`, `maintainer: example@example.com`,
  `github: githubuser/monoscope`, `copyright: 2021 Author name here`) with
  `Monoscope` / `hello@monoscope.tech` / `monoscope-tech/monoscope` /
  `2021-2026 Monoscope`. Fixes the derived `homepage` and `bug-reports`
  URLs that pointed to a non-existent repo.
- **Auto-format on commit.** Adds versioned `.githooks/pre-commit` that
  runs `fourmolu --mode inplace` on staged `.hs` files (skips cleanly if
  `fourmolu` isn't installed; refuses to format files with unstaged
  edits to avoid swallowing working-tree changes). Documents activation
  in `docs/DEVELOPMENT.md` and fixes a stale `brew install ormolu` →
  `fourmolu` in the same section. Goal: stop the recurring
  `Auto-format code with fourmolu` follow-up commits.
