### PR TITLE
docs(docker): expand override example with persistent storage and MinIO options

### DIFF
--- a/docker-compose.override.yml.example
+++ b/docker-compose.override.yml.example
@@ -27,3 +27,39 @@ services:
     environment:
       - ENVIRONMENT=DEV
       - LOG_LEVEL=debug
+
+  # Optional: Enable persistent storage for development (default is tmpfs)
+  # Uncomment the volumes section below to use persistent volumes instead of tmpfs.
+  # This is useful when you need data to survive container restarts during development.
+  #
+  # timescaledb:
+  #   tmpfs: []  # Remove tmpfs to use persistent volume
+  #   volumes:
+  #     - timescale_data:/var/lib/postgresql/data
+
+  # Optional: MinIO for local S3-compatible storage (required for trace/metric ingestion)
+  # Uncomment to enable local object storage alongside the database.
+  # After enabling, set MINIO_ENDPOINT=http://minio:9000,
+  # MINIO_ACCESS_KEY, MINIO_SECRET_KEY, and MINIO_BUCKET in your .env file.
+  #
+  # minio:
+  #   image: bitnami/minio:latest
+  #   ports:
+  #     - '9000:9000'
+  #     - '9001:9001'
+  #   environment:
+  #     - MINIO_ROOT_USER=minioadmin
+  #     - MINIO_ROOT_PASSWORD=minioadmin
+  #     - MINIO_DEFAULT_BUCKETS=monoscope-dev
+  #   healthcheck:
+  #     test: ["CMD", "curl", "-fsS", "http://localhost:9000/minio/health/live"]
+  #     interval: 5s
+  #     timeout: 3s
+  #     retries: 10
+  #   networks:
+  #     - monoscope-network
+
+# Add persistent volume reference if using non-tmpfs storage above
+# volumes:
+#   timescale_data:
+#     driver: local


### PR DESCRIPTION
## Summary

Expand docker-compose.override.yml.example with two new commented sections that address common local development needs:

1. **Persistent TimescaleDB storage** — opt-in replacement for tmpfs storage. Useful when you need data to survive container restarts during extended development sessions.

2. **Local MinIO instance** — a commented-out MinIO service with a proper healthcheck (). This enables local S3-compatible storage for trace and metric ingestion without requiring an external S3 bucket.

## Why this matters

New contributors often struggle with local MinIO setup for trace/metric workflows. The override example already covered the monoscope service but had no guidance for persistent storage or MinIO. Adding commented examples with the correct healthcheck timing makes the dev environment much easier to bootstrap.

## Changes

- docker-compose.override.yml.example: +37 lines of commented examples

## Testing

Checked that YAML is valid (docker-compose config --quiet exits 0).

## Risk

Low — purely additive documentation in an .example file.