### PR TITLE
docs: add bug report and feature request issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,69 @@
+name: Bug Report
+description: Report something that is not working correctly
+title: "bug: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for reporting a bug! Please fill out all applicable sections to help us reproduce and fix the issue quickly.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear description of the bug. What did you expect to happen, and what actually happened?
+      placeholder: |
+        Short summary of the bug.
+        What were you trying to do?
+        What happened instead?
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to Reproduce
+      description: Exact steps to reproduce the bug, in order.
+      placeholder: |
+        1. Go to '...'
+        2. Click on '...'
+        3. Scroll down to '...'
+        4. See error
+    validations:
+      required: true
+
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      description: |
+        Include your setup: OS, Docker version, Monoscope version (or commit hash),
+        and how you are running Monoscope (Docker Compose, binary, etc.).
+      placeholder: "e.g., macOS 14, Docker 26, Monoscope v1.2.3 via docker-compose"
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant Logs
+      description: |
+        Paste any relevant error messages, stack traces, or log output.
+        If running in Docker, include output from `docker-compose logs monoscope`.
+      render: shell
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Anything else that might be relevant (screenshots, workaround, frequency of occurrence)
+      render: shell
+
+  - type: checkboxes
+    id: requirements
+    attributes:
+      label: Checklist
+      options:
+        - label: I have searched for existing issues to confirm this is not a known behavior
+          required: true
+        - label: I am using the latest stable version of Monoscope
+          required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,61 @@
+name: Feature Request
+description: Suggest a new feature or improvement
+title: "feat: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Have an idea for a new feature or improvement? We'd love to hear it!
+
+        Please fill out all applicable sections. Well-structured requests with clear use cases get prioritized.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or Pain Point
+      description: What problem does this solve? Why is this important?
+      placeholder: |
+        Describe the problem you are facing or the gap you have identified.
+        Who is affected by this?
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: Describe your proposed solution in detail.
+      placeholder: |
+        How would you like this to work? Be as specific as possible.
+        Include any API changes, UI changes, or behavioral changes.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: What other approaches have you considered?
+      placeholder: |
+        List any alternative solutions or workarounds you considered
+        and why you chose your proposed approach.
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: |
+        Any other context: mockups, diagrams, links to similar features in other tools,
+        or anything else that would help us understand the request.
+      render: shell
+
+  - type: checkboxes
+    id: requirements
+    attributes:
+      label: Checklist
+      options:
+        - label: I have searched existing issues and PRs to confirm this is not already being worked on
+          required: true
+        - label: This feature request is aligned with Monoscope's observability focus
+          required: true


### PR DESCRIPTION
## Summary

Add two GitHub issue templates:
- **Bug report** (bug_report.md): description, reproduction steps, environment, logs, context, checklist
- **Feature request** (feature_request.md): problem/pain point, proposed solution, alternatives, context

## Why this matters

Monoscope had no issue templates — users filed free-form issues with inconsistent structure, making it harder to triage and reproduce bugs. The new templates guide users to provide all the information needed to resolve issues quickly.

## Testing

Verified: templates are in the modern multi-file format (no config.yml required), branch is ahead of upstream/master, push succeeded.

## Risk

Low — purely additive documentation. No production code modified.