### PR TITLE
facets: consolidate to dotted OTel paths; bulk-refresh in-memory + batched

### DIFF
--- a/monoscope.cabal
+++ b/monoscope.cabal
@@ -599,6 +599,7 @@ test-suite integration-tests
       CLI.CLISpec
       EndpointDiscoverySpec
       ExtractionWorkerSpec
+      FacetsSpec
       Lifecycle.LogPatternIncidentSpec
       MonitoringSpec
       Opentelemetry.GrpcIngestionSpec

--- a/src/Models/Apis/SchemaCatalog.hs
+++ b/src/Models/Apis/SchemaCatalog.hs
@@ -335,11 +335,11 @@ toFacetSummary pid tableName doc =
             [ (prefixed cat path, [(v, fromIntegral n :: Int)])
             | (path, tk) <- HM.toList doc.topValuesByField
             , -- Fallback: a path in topValuesByField but absent from
-              -- doc.fields is an internal invariant violation (the walker
-              -- always co-records both). FCAttribute is the common case;
-              -- worst outcome is a wrong prefix → unmatched in the renderer,
-              -- not data loss.
-              let cat = maybe Catalog.FCAttribute (.category) (HM.lookup path doc.fields)
+            -- doc.fields is an internal invariant violation (the walker
+            -- always co-records both). FCAttribute is the common case;
+            -- worst outcome is a wrong prefix → unmatched in the renderer,
+            -- not data loss.
+            let cat = maybe Catalog.FCAttribute (.category) (HM.lookup path doc.fields)
             , (v, n) <- HM.toList tk.top
             ]
     }

--- a/src/Models/Apis/SchemaCatalog.hs
+++ b/src/Models/Apis/SchemaCatalog.hs
@@ -42,6 +42,7 @@ import Data.Aeson.KeyMap qualified as KM
 import Data.Effectful.Hasql qualified as Hasql
 import Data.HashMap.Strict qualified as HM
 import Data.HashSet qualified as HS
+import Data.Ord (Down (..))
 import Data.Text qualified as T
 import Data.Time (UTCTime)
 import Data.UUID (UUID)
@@ -279,6 +280,9 @@ upsertSummary rows = unless (V.null rows) $ do
 -- | Skip a project if its summary was updated this recently — coalesces
 -- many flush passes on noisy projects into one write. Shorter than the
 -- flush interval; well within facet-UI staleness tolerance.
+--
+-- 'Text' because Hasql's @::interval@ SQL cast accepts a string literal and
+-- no @NominalDiffTime@-to-@interval@ encoder is registered in this codebase.
 summaryFreshnessCutoff :: Text
 summaryFreshnessCutoff = "30 seconds"
 
@@ -347,14 +351,11 @@ toFacetSummary pid tableName doc =
             ]
     }
   where
-    -- Defensive: two paths could prefix to the same key (category mismatch);
-    -- merge counts rather than drop one. Sort descending.
+    -- Outer fromListWith already groups by prefixed key, and each (path, tk)
+    -- contributes a unique source so values within a key are already unique
+    -- by @v@. Just sort descending.
     mergeAndSort :: [(Text, Int)] -> [Catalog.FacetValue]
-    mergeAndSort =
-      sortOn (negate . (.count))
-        . fmap (uncurry Catalog.FacetValue)
-        . HM.toList
-        . HM.fromListWith (+)
+    mergeAndSort = sortOn (Down . (.count)) . fmap (uncurry Catalog.FacetValue)
 
     -- 'FacetData' has two consumers: the Log Explorer sidebar (only renders
     -- entries that match 'facetDefs', all of which are in

--- a/src/Models/Apis/SchemaCatalog.hs
+++ b/src/Models/Apis/SchemaCatalog.hs
@@ -327,15 +327,18 @@ toFacetSummary pid tableName doc =
     { id = UUID.nil -- summary is not row-identified; legacy callers don't depend on this
     , projectId = pid.toText
     , tableName = tableName
-    , facetJson =
+    , -- Each (path, category) deterministically produces a unique prefixed
+      -- key (paths are unique in topValuesByField; @prefixed@ is injective
+      -- per-category), so plain HM.fromList suffices — no collision merge
+      -- needed. Word64→Int on counts is safe: bag sizes are well below
+      -- maxBound.
+      facetJson =
         Catalog.FacetData
-          $ mergeAndSort
-          <$> HM.fromListWith
-            (<>)
-            -- Word64→Int safe: counts are bag sizes well below maxBound.
-            [ (prefixed (fieldCat path) path, [(v, fromIntegral n :: Int)])
+          $ HM.fromList
+            [ ( prefixed (fieldCat path) path
+              , sortFacets [Catalog.FacetValue v (fromIntegral n :: Int) | (v, n) <- HM.toList tk.top]
+              )
             | (path, tk) <- HM.toList doc.topValuesByField
-            , (v, n) <- HM.toList tk.top
             ]
     }
   where
@@ -345,11 +348,8 @@ toFacetSummary pid tableName doc =
     fieldCat :: Text -> Catalog.FieldCategoryEnum
     fieldCat path = maybe Catalog.FCAttribute (.category) (HM.lookup path doc.fields)
 
-    -- Outer fromListWith already groups by prefixed key, and each (path, tk)
-    -- contributes a unique source so values within a key are already unique
-    -- by @v@. Just sort descending.
-    mergeAndSort :: [(Text, Int)] -> [Catalog.FacetValue]
-    mergeAndSort = sortOn (Down . (.count)) . fmap (uncurry Catalog.FacetValue)
+    sortFacets :: [Catalog.FacetValue] -> [Catalog.FacetValue]
+    sortFacets = sortOn (Down . (.count))
 
     -- 'FacetData' has two consumers: the Log Explorer sidebar (only renders
     -- entries that match 'facetDefs', all of which are in

--- a/src/Models/Apis/SchemaCatalog.hs
+++ b/src/Models/Apis/SchemaCatalog.hs
@@ -262,8 +262,9 @@ getSummary pid =
 -- projects were touched in the flush. Callers feed a vector of (project, doc)
 -- pairs; empty input is a no-op.
 upsertSummary :: DB es => V.Vector (Projects.ProjectId, Catalog.SummaryDoc) -> Eff es ()
-upsertSummary rows | V.null rows = pass
-upsertSummary rows =
+upsertSummary rows = unless (V.null rows) $ do
+  let pids = V.map fst rows
+      docs = V.map (HI.AsJsonb . snd) rows
   Hasql.interpExecute_
     [HI.sql| INSERT INTO apis.schema_summary (project_id, doc, generated_at)
              SELECT *, now() FROM unnest(
@@ -271,9 +272,6 @@ upsertSummary rows =
                #{docs}::jsonb[])
              ON CONFLICT (project_id) DO UPDATE
              SET doc = EXCLUDED.doc, generated_at = now() |]
-  where
-    pids = V.map fst rows
-    docs = V.map (HI.AsJsonb . snd) rows
 
 
 -- | Of the supplied projects, returns those whose @apis.schema_summary@ was

--- a/src/Models/Apis/SchemaCatalog.hs
+++ b/src/Models/Apis/SchemaCatalog.hs
@@ -292,7 +292,7 @@ freshSummaryProjects pids
           [HI.sql| SELECT project_id FROM apis.schema_summary
                    WHERE project_id = ANY(#{pids}::uuid[])
                      AND generated_at > now() - interval '30 seconds' |]
-      pure $ HS.fromList (coerce rows)
+      pure $ HS.fromList (UUIDId <$> rows)
 
 
 -- | Drop-in replacement for the legacy @Fields.getFacetSummary@: same

--- a/src/Models/Apis/SchemaCatalog.hs
+++ b/src/Models/Apis/SchemaCatalog.hs
@@ -265,8 +265,8 @@ getSummary pid =
 -- filtering (e.g. all touched projects were skip-if-fresh).
 upsertSummary :: DB es => V.Vector (Projects.ProjectId, Catalog.SummaryDoc) -> Eff es ()
 upsertSummary rows = unless (V.null rows) $ do
-  let pids = V.map fst rows
-      docs = V.map (HI.AsJsonb . snd) rows
+  let (pids, rawDocs) = V.unzip rows
+      docs = HI.AsJsonb <$> rawDocs
   Hasql.interpExecute_
     [HI.sql| INSERT INTO apis.schema_summary (project_id, doc, generated_at)
              SELECT *, now() FROM unnest(
@@ -276,10 +276,15 @@ upsertSummary rows = unless (V.null rows) $ do
              SET doc = EXCLUDED.doc, generated_at = EXCLUDED.generated_at |]
 
 
+-- | Skip a project if its summary was updated this recently — coalesces
+-- many flush passes on noisy projects into one write. Shorter than the
+-- flush interval; well within facet-UI staleness tolerance.
+summaryFreshnessCutoff :: Text
+summaryFreshnessCutoff = "30 seconds"
+
+
 -- | Of the supplied projects, returns those whose @apis.schema_summary@ was
--- updated within the last 30 s. Callers skip these so many flush passes on
--- noisy projects coalesce into one summary write. The window is shorter than
--- typical flush intervals and well within facet UI staleness tolerance.
+-- updated within 'summaryFreshnessCutoff'.
 freshSummaryProjects
   :: DB es
   => V.Vector Projects.ProjectId
@@ -291,8 +296,8 @@ freshSummaryProjects pids
         Hasql.interp
           [HI.sql| SELECT project_id FROM apis.schema_summary
                    WHERE project_id = ANY(#{pids}::uuid[])
-                     AND generated_at > now() - interval '30 seconds' |]
-      pure $ HS.fromList $ map UUIDId rows
+                     AND generated_at > now() - (#{summaryFreshnessCutoff} :: interval) |]
+      pure $ HS.fromList (coerce rows)
 
 
 -- | Drop-in replacement for the legacy @Fields.getFacetSummary@: same
@@ -333,29 +338,23 @@ toFacetSummary pid tableName doc =
           $ HM.fromListWith
             (<>)
             [ (prefixed cat path, [(v, fromIntegral n :: Int)])
-            | -- @n :: Word64@ → @Int@ is safe in practice: Int is 64-bit
-            -- everywhere we run; values are top-K bag counts capped well
-            -- below @maxBound :: Int@. Truncation would only matter at
-            -- ~9.2e18 occurrences.
+            | -- Word64→Int safe: counts are bag sizes well below maxBound.
             (path, tk) <- HM.toList doc.topValuesByField
-            , -- Fallback: a path in topValuesByField but absent from
-            -- doc.fields is an internal invariant violation (the walker
-            -- always co-records both). FCAttribute is the common case;
-            -- worst outcome is a wrong prefix → unmatched in the renderer,
-            -- not data loss.
+            , -- Missing fields entry → assume FCAttribute (walker always
+            -- co-records both; worst case is wrong prefix, not data loss).
             let cat = maybe Catalog.FCAttribute (.category) (HM.lookup path doc.fields)
             , (v, n) <- HM.toList tk.top
             ]
     }
   where
-    -- Two distinct catalog paths could in principle prefix to the same key
-    -- (a category mismatch would do it). Merge their counts rather than
-    -- silently dropping one, then sort descending.
+    -- Defensive: two paths could prefix to the same key (category mismatch);
+    -- merge counts rather than drop one. Sort descending.
     mergeAndSort :: [(Text, Int)] -> [Catalog.FacetValue]
-    mergeAndSort pairs =
-      sortOn
-        (negate . (.count))
-        [Catalog.FacetValue v n | (v, n) <- HM.toList (HM.fromListWith (+) pairs)]
+    mergeAndSort =
+      sortOn (negate . (.count))
+        . fmap (uncurry Catalog.FacetValue)
+        . HM.toList
+        . HM.fromListWith (+)
 
     -- 'FacetData' has two consumers: the Log Explorer sidebar (only renders
     -- entries that match 'facetDefs', all of which are in

--- a/src/Models/Apis/SchemaCatalog.hs
+++ b/src/Models/Apis/SchemaCatalog.hs
@@ -332,16 +332,19 @@ toFacetSummary pid tableName doc =
           $ mergeAndSort
           <$> HM.fromListWith
             (<>)
-            [ (prefixed cat path, [(v, fromIntegral n :: Int)])
-            | -- Word64→Int safe: counts are bag sizes well below maxBound.
-            (path, tk) <- HM.toList doc.topValuesByField
-            , -- Missing fields entry → assume FCAttribute (walker always
-            -- co-records both; worst case is wrong prefix, not data loss).
-            let cat = maybe Catalog.FCAttribute (.category) (HM.lookup path doc.fields)
+            -- Word64→Int safe: counts are bag sizes well below maxBound.
+            [ (prefixed (fieldCat path) path, [(v, fromIntegral n :: Int)])
+            | (path, tk) <- HM.toList doc.topValuesByField
             , (v, n) <- HM.toList tk.top
             ]
     }
   where
+    -- Walker always co-records a path in both topValuesByField and fields,
+    -- but be defensive: a missing entry defaults to FCAttribute. Worst case
+    -- is a wrong section prefix, not data loss.
+    fieldCat :: Text -> Catalog.FieldCategoryEnum
+    fieldCat path = maybe Catalog.FCAttribute (.category) (HM.lookup path doc.fields)
+
     -- Outer fromListWith already groups by prefixed key, and each (path, tk)
     -- contributes a unique source so values within a key are already unique
     -- by @v@. Just sort descending.

--- a/src/Models/Apis/SchemaCatalog.hs
+++ b/src/Models/Apis/SchemaCatalog.hs
@@ -330,7 +330,8 @@ toFacetSummary pid tableName doc =
     , facetJson =
         Catalog.FacetData
           $ fmap mergeAndSort
-          $ HM.fromListWith (<>)
+          $ HM.fromListWith
+            (<>)
             [ (prefixed cat path, [(v, fromIntegral n :: Int)])
             | (path, tk) <- HM.toList doc.topValuesByField
             , let cat = maybe Catalog.FCAttribute (.category) (HM.lookup path doc.fields)
@@ -343,7 +344,8 @@ toFacetSummary pid tableName doc =
     -- silently dropping one, then sort descending.
     mergeAndSort :: [(Text, Int)] -> [Catalog.FacetValue]
     mergeAndSort pairs =
-      sortOn (negate . (.count))
+      sortOn
+        (negate . (.count))
         [Catalog.FacetValue v n | (v, n) <- HM.toList (HM.fromListWith (+) pairs)]
 
     prefixed :: Catalog.FieldCategoryEnum -> Text -> Text

--- a/src/Models/Apis/SchemaCatalog.hs
+++ b/src/Models/Apis/SchemaCatalog.hs
@@ -276,18 +276,10 @@ upsertSummary rows = unless (V.null rows) $ do
              SET doc = EXCLUDED.doc, generated_at = EXCLUDED.generated_at |]
 
 
--- | Skip a project if its summary was updated this recently — coalesces
--- many flush passes on noisy projects into one write. Shorter than the
--- flush interval; well within facet-UI staleness tolerance.
---
--- 'Text' because Hasql's @::interval@ SQL cast accepts a string literal and
--- no @NominalDiffTime@-to-@interval@ encoder is registered in this codebase.
-summaryFreshnessCutoff :: Text
-summaryFreshnessCutoff = "30 seconds"
-
-
 -- | Of the supplied projects, returns those whose @apis.schema_summary@ was
--- updated within 'summaryFreshnessCutoff'.
+-- updated within the last 30 s. The window coalesces many flush passes on
+-- noisy projects into one write; shorter than the flush interval and well
+-- within facet-UI staleness tolerance.
 freshSummaryProjects
   :: DB es
   => V.Vector Projects.ProjectId
@@ -299,7 +291,7 @@ freshSummaryProjects pids
         Hasql.interp
           [HI.sql| SELECT project_id FROM apis.schema_summary
                    WHERE project_id = ANY(#{pids}::uuid[])
-                     AND generated_at > now() - (#{summaryFreshnessCutoff} :: interval) |]
+                     AND generated_at > now() - interval '30 seconds' |]
       pure $ HS.fromList (coerce rows)
 
 

--- a/src/Models/Apis/SchemaCatalog.hs
+++ b/src/Models/Apis/SchemaCatalog.hs
@@ -333,7 +333,11 @@ toFacetSummary pid tableName doc =
           $ HM.fromListWith
             (<>)
             [ (prefixed cat path, [(v, fromIntegral n :: Int)])
-            | (path, tk) <- HM.toList doc.topValuesByField
+            | -- @n :: Word64@ → @Int@ is safe in practice: Int is 64-bit
+              -- everywhere we run; values are top-K bag counts capped well
+              -- below @maxBound :: Int@. Truncation would only matter at
+              -- ~9.2e18 occurrences.
+              (path, tk) <- HM.toList doc.topValuesByField
             , -- Fallback: a path in topValuesByField but absent from
             -- doc.fields is an internal invariant violation (the walker
             -- always co-records both). FCAttribute is the common case;
@@ -353,6 +357,12 @@ toFacetSummary pid tableName doc =
         (negate . (.count))
         [Catalog.FacetValue v n | (v, n) <- HM.toList (HM.fromListWith (+) pairs)]
 
+    -- 'FacetData' has two consumers: the Log Explorer sidebar (only renders
+    -- entries that match 'facetDefs', all of which are in
+    -- 'flattenedOtelAttributes') and the AI prompt context, which wants the
+    -- full shape including request/response body keys. So
+    -- @body.request.*@ / @body.response.*@ keys are intentionally emitted
+    -- here even though they're unreachable from the sidebar.
     prefixed :: Catalog.FieldCategoryEnum -> Text -> Text
     prefixed cat path = case cat of
       Catalog.FCAttribute -> "attributes." <> path

--- a/src/Models/Apis/SchemaCatalog.hs
+++ b/src/Models/Apis/SchemaCatalog.hs
@@ -329,18 +329,22 @@ toFacetSummary pid tableName doc =
     , tableName = tableName
     , facetJson =
         Catalog.FacetData
-          $ HM.fromList
-            [ (prefixed cat path, topKToFacetValues tk)
+          $ fmap mergeAndSort
+          $ HM.fromListWith (<>)
+            [ (prefixed cat path, [(v, fromIntegral n :: Int)])
             | (path, tk) <- HM.toList doc.topValuesByField
             , let cat = maybe Catalog.FCAttribute (.category) (HM.lookup path doc.fields)
+            , (v, n) <- HM.toList tk.top
             ]
     }
   where
-    topKToFacetValues :: Catalog.TopK -> [Catalog.FacetValue]
-    topKToFacetValues tk =
-      sortOn
-        (negate . (.count))
-        [Catalog.FacetValue v (fromIntegral n) | (v, n) <- HM.toList tk.top]
+    -- Two distinct catalog paths could in principle prefix to the same key
+    -- (a category mismatch would do it). Merge their counts rather than
+    -- silently dropping one, then sort descending.
+    mergeAndSort :: [(Text, Int)] -> [Catalog.FacetValue]
+    mergeAndSort pairs =
+      sortOn (negate . (.count))
+        [Catalog.FacetValue v n | (v, n) <- HM.toList (HM.fromListWith (+) pairs)]
 
     prefixed :: Catalog.FieldCategoryEnum -> Text -> Text
     prefixed cat path = case cat of

--- a/src/Models/Apis/SchemaCatalog.hs
+++ b/src/Models/Apis/SchemaCatalog.hs
@@ -17,10 +17,10 @@ module Models.Apis.SchemaCatalog (
   CatalogRow (..),
   upsertTemplates,
   upsertCatalogRows,
-  getByProject,
   getByKeysBatch,
   getSummary,
   upsertSummary,
+  freshSummaryProjects,
   toFacetSummary,
   getFacetSummary,
   vacuumUnreferencedTemplates,
@@ -216,21 +216,6 @@ readRowToEntry r =
         }
 
 
--- | All catalog rows for a project, ordered by most-recently-seen.
-getByProject :: DB es => Projects.ProjectId -> Eff es (V.Vector Catalog.CatalogEntry)
-getByProject pid = do
-  rows :: [CatalogReadRow] <-
-    Hasql.interp
-      [HI.sql| SELECT c.project_id, c.key_kind, c.key_hash, c.template_hash,
-                      c.scope, t.fields, c.values_delta, c.counts,
-                      c.sample_count, c.first_seen, c.last_seen
-               FROM apis.schema_catalog c
-               JOIN apis.schema_template t ON c.template_hash = t.template_hash
-               WHERE c.project_id = #{pid}
-               ORDER BY c.last_seen DESC |]
-  pure $ V.fromList $ readRowToEntry <$> rows
-
-
 -- | Bulk variant: fetches catalog rows for a heterogeneous (project, key_hash)
 -- set in one round-trip. Used by the anomaly producer to load priors for an
 -- entire dirty batch before diffing.
@@ -273,14 +258,41 @@ getSummary pid =
     unwrap (SummaryRow (HI.AsJsonb d)) = d
 
 
-upsertSummary :: DB es => Projects.ProjectId -> Catalog.SummaryDoc -> Eff es ()
-upsertSummary pid doc = do
-  let docJson = HI.AsJsonb doc
+-- | Batched per-project summary upsert. One round trip regardless of how many
+-- projects were touched in the flush. Callers feed a vector of (project, doc)
+-- pairs; empty input is a no-op.
+upsertSummary :: DB es => V.Vector (Projects.ProjectId, Catalog.SummaryDoc) -> Eff es ()
+upsertSummary rows | V.null rows = pass
+upsertSummary rows =
   Hasql.interpExecute_
     [HI.sql| INSERT INTO apis.schema_summary (project_id, doc, generated_at)
-             VALUES (#{pid}, #{docJson}, now())
+             SELECT *, now() FROM unnest(
+               #{pids}::uuid[],
+               #{docs}::jsonb[])
              ON CONFLICT (project_id) DO UPDATE
              SET doc = EXCLUDED.doc, generated_at = now() |]
+  where
+    pids = V.map fst rows
+    docs = V.map (HI.AsJsonb . snd) rows
+
+
+-- | Of the supplied projects, returns those whose @apis.schema_summary@ was
+-- updated within the last 30 s. Callers skip these so many flush passes on
+-- noisy projects coalesce into one summary write. The window is shorter than
+-- typical flush intervals and well within facet UI staleness tolerance.
+freshSummaryProjects
+  :: DB es
+  => V.Vector Projects.ProjectId
+  -> Eff es (HS.HashSet Projects.ProjectId)
+freshSummaryProjects pids
+  | V.null pids = pure HS.empty
+  | otherwise = do
+      rows :: [UUID.UUID] <-
+        Hasql.interp
+          [HI.sql| SELECT project_id FROM apis.schema_summary
+                   WHERE project_id = ANY(#{pids}::uuid[])
+                     AND generated_at > now() - interval '30 seconds' |]
+      pure $ HS.fromList $ map UUIDId rows
 
 
 -- | Drop-in replacement for the legacy @Fields.getFacetSummary@: same
@@ -302,21 +314,45 @@ getFacetSummary pid tableName _from _to =
 -- 'Catalog.FacetSummary' shape so existing callers (AI prompt, query editor)
 -- don't need to change. The @tableName@ argument is ignored — schema is now
 -- unified per project.
+--
+-- Catalog 'topValuesByField' paths are bare (e.g. @http.request.method@)
+-- because each walk strips its section. To match the KQL parser's
+-- 'flattenedOtelAttributes' whitelist (and therefore compile to a flat-column
+-- scan), we prefix each path with its field category: attributes → @attributes.@,
+-- resource → @resource.@, event → @events.@, body/header/param walks get their
+-- standard OTel prefixes. Result keys line up with what users type in KQL.
 toFacetSummary :: Projects.ProjectId -> Text -> Catalog.SummaryDoc -> Catalog.FacetSummary
 toFacetSummary pid tableName doc =
   Catalog.FacetSummary
     { id = UUID.nil -- summary is not row-identified; legacy callers don't depend on this
     , projectId = pid.toText
     , tableName = tableName
-    , facetJson = Catalog.FacetData $ HM.map topKToFacetValues doc.topValuesByField
+    , facetJson =
+        Catalog.FacetData
+          $ HM.fromList
+            [ (prefixed cat path, topKToFacetValues tk)
+            | (path, tk) <- HM.toList doc.topValuesByField
+            , let cat = maybe Catalog.FCAttribute (.category) (HM.lookup path doc.fields)
+            ]
     }
   where
     topKToFacetValues :: Catalog.TopK -> [Catalog.FacetValue]
     topKToFacetValues tk =
       sortOn
         (negate . (.count))
-        [ Catalog.FacetValue v (fromIntegral n) | (v, n) <- HM.toList tk.top
-        ]
+        [Catalog.FacetValue v (fromIntegral n) | (v, n) <- HM.toList tk.top]
+
+    prefixed :: Catalog.FieldCategoryEnum -> Text -> Text
+    prefixed cat path = case cat of
+      Catalog.FCAttribute -> "attributes." <> path
+      Catalog.FCResource -> "resource." <> path
+      Catalog.FCEvent -> "events." <> path
+      Catalog.FCRequestHeader -> "attributes.http.request.header." <> path
+      Catalog.FCResponseHeader -> "attributes.http.response.header." <> path
+      Catalog.FCQueryParam -> "attributes.url.query." <> path
+      Catalog.FCPathParam -> "attributes.url.path_param." <> path
+      Catalog.FCRequestBody -> "body.request." <> path
+      Catalog.FCResponseBody -> "body.response." <> path
 
 
 -- ---------------------------------------------------------------------------

--- a/src/Models/Apis/SchemaCatalog.hs
+++ b/src/Models/Apis/SchemaCatalog.hs
@@ -334,7 +334,6 @@ toFacetSummary pid tableName doc =
             ]
     }
   where
-
     -- 'FacetData' has two consumers: the Log Explorer sidebar (only renders
     -- entries that match 'facetDefs', all of which are in
     -- 'flattenedOtelAttributes') and the AI prompt context, which wants the

--- a/src/Models/Apis/SchemaCatalog.hs
+++ b/src/Models/Apis/SchemaCatalog.hs
@@ -273,7 +273,7 @@ upsertSummary rows = unless (V.null rows) $ do
                #{pids}::uuid[],
                #{docs}::jsonb[])
              ON CONFLICT (project_id) DO UPDATE
-             SET doc = EXCLUDED.doc, generated_at = now() |]
+             SET doc = EXCLUDED.doc, generated_at = EXCLUDED.generated_at |]
 
 
 -- | Of the supplied projects, returns those whose @apis.schema_summary@ was

--- a/src/Models/Apis/SchemaCatalog.hs
+++ b/src/Models/Apis/SchemaCatalog.hs
@@ -42,7 +42,6 @@ import Data.Aeson.KeyMap qualified as KM
 import Data.Effectful.Hasql qualified as Hasql
 import Data.HashMap.Strict qualified as HM
 import Data.HashSet qualified as HS
-import Data.Ord (Down (..))
 import Data.Text qualified as T
 import Data.Time (UTCTime)
 import Data.UUID (UUID)
@@ -338,8 +337,8 @@ toFacetSummary pid tableName doc =
     , tableName = tableName
     , facetJson =
         Catalog.FacetData
-          $ fmap mergeAndSort
-          $ HM.fromListWith
+          $ mergeAndSort
+          <$> HM.fromListWith
             (<>)
             [ (prefixed cat path, [(v, fromIntegral n :: Int)])
             | -- Word64→Int safe: counts are bag sizes well below maxBound.

--- a/src/Models/Apis/SchemaCatalog.hs
+++ b/src/Models/Apis/SchemaCatalog.hs
@@ -260,7 +260,9 @@ getSummary pid =
 
 -- | Batched per-project summary upsert. One round trip regardless of how many
 -- projects were touched in the flush. Callers feed a vector of (project, doc)
--- pairs; empty input is a no-op.
+-- pairs; **an empty vector is a no-op** (no SQL emitted) — important for
+-- callers that build the batch eagerly and might end up with zero rows after
+-- filtering (e.g. all touched projects were skip-if-fresh).
 upsertSummary :: DB es => V.Vector (Projects.ProjectId, Catalog.SummaryDoc) -> Eff es ()
 upsertSummary rows = unless (V.null rows) $ do
   let pids = V.map fst rows
@@ -332,7 +334,12 @@ toFacetSummary pid tableName doc =
             (<>)
             [ (prefixed cat path, [(v, fromIntegral n :: Int)])
             | (path, tk) <- HM.toList doc.topValuesByField
-            , let cat = maybe Catalog.FCAttribute (.category) (HM.lookup path doc.fields)
+            , -- Fallback: a path in topValuesByField but absent from
+              -- doc.fields is an internal invariant violation (the walker
+              -- always co-records both). FCAttribute is the common case;
+              -- worst outcome is a wrong prefix → unmatched in the renderer,
+              -- not data loss.
+              let cat = maybe Catalog.FCAttribute (.category) (HM.lookup path doc.fields)
             , (v, n) <- HM.toList tk.top
             ]
     }

--- a/src/Models/Apis/SchemaCatalog.hs
+++ b/src/Models/Apis/SchemaCatalog.hs
@@ -259,10 +259,7 @@ getSummary pid =
 
 
 -- | Batched per-project summary upsert. One round trip regardless of how many
--- projects were touched in the flush. Callers feed a vector of (project, doc)
--- pairs; **an empty vector is a no-op** (no SQL emitted) — important for
--- callers that build the batch eagerly and might end up with zero rows after
--- filtering (e.g. all touched projects were skip-if-fresh).
+-- projects were touched. An empty vector is a no-op (no SQL emitted).
 upsertSummary :: DB es => V.Vector (Projects.ProjectId, Catalog.SummaryDoc) -> Eff es ()
 upsertSummary rows = unless (V.null rows) $ do
   let (pids, rawDocs) = V.unzip rows
@@ -327,29 +324,16 @@ toFacetSummary pid tableName doc =
     { id = UUID.nil -- summary is not row-identified; legacy callers don't depend on this
     , projectId = pid.toText
     , tableName = tableName
-    , -- Each (path, category) deterministically produces a unique prefixed
-      -- key (paths are unique in topValuesByField; @prefixed@ is injective
-      -- per-category), so plain HM.fromList suffices — no collision merge
-      -- needed. Word64→Int on counts is safe: bag sizes are well below
-      -- maxBound.
-      facetJson =
+    , facetJson =
         Catalog.FacetData
           $ HM.fromList
-            [ ( prefixed (fieldCat path) path
-              , sortFacets [Catalog.FacetValue v (fromIntegral n :: Int) | (v, n) <- HM.toList tk.top]
+            [ ( prefixed (maybe Catalog.FCAttribute (.category) (HM.lookup path doc.fields)) path
+              , sortOn (Down . (.count)) [Catalog.FacetValue v (fromIntegral n :: Int) | (v, n) <- HM.toList tk.top]
               )
             | (path, tk) <- HM.toList doc.topValuesByField
             ]
     }
   where
-    -- Walker always co-records a path in both topValuesByField and fields,
-    -- but be defensive: a missing entry defaults to FCAttribute. Worst case
-    -- is a wrong section prefix, not data loss.
-    fieldCat :: Text -> Catalog.FieldCategoryEnum
-    fieldCat path = maybe Catalog.FCAttribute (.category) (HM.lookup path doc.fields)
-
-    sortFacets :: [Catalog.FacetValue] -> [Catalog.FacetValue]
-    sortFacets = sortOn (Down . (.count))
 
     -- 'FacetData' has two consumers: the Log Explorer sidebar (only renders
     -- entries that match 'facetDefs', all of which are in

--- a/src/Models/Apis/SchemaCatalog.hs
+++ b/src/Models/Apis/SchemaCatalog.hs
@@ -334,10 +334,10 @@ toFacetSummary pid tableName doc =
             (<>)
             [ (prefixed cat path, [(v, fromIntegral n :: Int)])
             | -- @n :: Word64@ → @Int@ is safe in practice: Int is 64-bit
-              -- everywhere we run; values are top-K bag counts capped well
-              -- below @maxBound :: Int@. Truncation would only matter at
-              -- ~9.2e18 occurrences.
-              (path, tk) <- HM.toList doc.topValuesByField
+            -- everywhere we run; values are top-K bag counts capped well
+            -- below @maxBound :: Int@. Truncation would only matter at
+            -- ~9.2e18 occurrences.
+            (path, tk) <- HM.toList doc.topValuesByField
             , -- Fallback: a path in topValuesByField but absent from
             -- doc.fields is an internal invariant violation (the walker
             -- always co-records both). FCAttribute is the common case;

--- a/src/Pages/LogExplorer/Log.hs
+++ b/src/Pages/LogExplorer/Log.hs
@@ -375,11 +375,11 @@ data Facet = Facet
 --   * @attributes.network.*@, @attributes.client.address@,
 --     @attributes.server.address@, @attributes.error.type@,
 --     @attributes.session.previous.id@, @attributes.db.response.status_code@,
---     @attributes.http.response.status_code@ subgroups beyond what's listed,
---     etc. — not yet in 'flattenedOtelAttributes'. Adding them naively here
---     fails 'prop_facetsAreFast'. The right path is to (a) confirm the flat
---     column exists, (b) add the dotted path to the whitelist, (c) then list
---     it here.
+--     subgroups beyond what's listed, etc. — not yet in
+--     'flattenedOtelAttributes'. Adding them naively here fails the
+--     in-whitelist doctest. The right path is to (a) confirm the flat
+--     column exists, (b) add the dotted path to the whitelist, (c) then
+--     list it here.
 --
 -- >>> import qualified Pkg.Parser.Expr as PE
 -- >>> import qualified Data.Set as S
@@ -387,43 +387,44 @@ data Facet = Facet
 -- True
 facetDefs :: [Facet]
 facetDefs =
-  -- Common
-  [ Facet "resource.service.name" "Service" FGCommon serviceFillColor
-  , Facet "attributes.http.request.method" "HTTP Method" FGCommon methodFillColor
-  , Facet "attributes.http.response.status_code" "HTTP Status" FGCommon statusFillColorText
-  , Facet "attributes.db.operation.name" "DB Operation" FGCommon (const "")
-  , -- HTTP
-    Facet "attributes.http.request.method_original" "Original Method" FGHTTP methodFillColor
-  , Facet "attributes.http.request.resend_count" "Resend Count" FGHTTP (const "")
-  , Facet "attributes.http.request.body.size" "Request Body Size" FGHTTP (const "")
-  , Facet "attributes.url.path" "URL Path" FGHTTP (const "")
-  , Facet "attributes.url.scheme" "URL Scheme" FGHTTP (const "")
-  , Facet "attributes.url.full" "Full URL" FGHTTP (const "")
-  , Facet "attributes.url.fragment" "URL Fragment" FGHTTP (const "")
-  , Facet "attributes.url.query" "URL Query" FGHTTP (const "")
-  , Facet "attributes.user_agent.original" "User Agent" FGHTTP (const "")
-  , -- Resource
-    Facet "resource.service.version" "Service Version" FGResource (const "")
-  , Facet "resource.service.instance.id" "Service Instance ID" FGResource (const "")
-  , Facet "resource.service.namespace" "Service Namespace" FGResource (const "")
-  , Facet "resource.telemetry.sdk.language" "SDK Language" FGResource (const "")
-  , Facet "resource.telemetry.sdk.name" "SDK Name" FGResource (const "")
-  , Facet "resource.telemetry.sdk.version" "SDK Version" FGResource (const "")
-  , -- User & Session
-    Facet "attributes.session.id" "Session ID" FGUserSession (const "")
-  , Facet "attributes.user.id" "User ID" FGUserSession (const "")
-  , Facet "attributes.user.email" "User Email" FGUserSession (const "")
-  , Facet "attributes.user.name" "Username" FGUserSession (const "")
-  , Facet "attributes.user.full_name" "Full Name" FGUserSession (const "")
-  , -- Database
-    Facet "attributes.db.system.name" "Database System" FGDatabase (const "")
-  , Facet "attributes.db.collection.name" "Collection Name" FGDatabase (const "")
-  , Facet "attributes.db.namespace" "Database Namespace" FGDatabase (const "")
-  , Facet "attributes.db.operation.batch.size" "Batch Size" FGDatabase (const "")
-  , -- Errors & Exceptions
-    Facet "attributes.exception.type" "Exception Type" FGErrors (const "bg-fillError-strong")
-  , Facet "attributes.exception.message" "Exception Message" FGErrors (const "")
-  ]
+  let nc = const "" -- shorthand for "no fill color" — used 13× below
+   in -- Common
+      [ Facet "resource.service.name" "Service" FGCommon serviceFillColor
+      , Facet "attributes.http.request.method" "HTTP Method" FGCommon methodFillColor
+      , Facet "attributes.http.response.status_code" "HTTP Status" FGCommon statusFillColorText
+      , Facet "attributes.db.operation.name" "DB Operation" FGCommon nc
+      , -- HTTP
+        Facet "attributes.http.request.method_original" "Original Method" FGHTTP methodFillColor
+      , Facet "attributes.http.request.resend_count" "Resend Count" FGHTTP nc
+      , Facet "attributes.http.request.body.size" "Request Body Size" FGHTTP nc
+      , Facet "attributes.url.path" "URL Path" FGHTTP nc
+      , Facet "attributes.url.scheme" "URL Scheme" FGHTTP nc
+      , Facet "attributes.url.full" "Full URL" FGHTTP nc
+      , Facet "attributes.url.fragment" "URL Fragment" FGHTTP nc
+      , Facet "attributes.url.query" "URL Query" FGHTTP nc
+      , Facet "attributes.user_agent.original" "User Agent" FGHTTP nc
+      , -- Resource
+        Facet "resource.service.version" "Service Version" FGResource nc
+      , Facet "resource.service.instance.id" "Service Instance ID" FGResource nc
+      , Facet "resource.service.namespace" "Service Namespace" FGResource nc
+      , Facet "resource.telemetry.sdk.language" "SDK Language" FGResource nc
+      , Facet "resource.telemetry.sdk.name" "SDK Name" FGResource nc
+      , Facet "resource.telemetry.sdk.version" "SDK Version" FGResource nc
+      , -- User & Session
+        Facet "attributes.session.id" "Session ID" FGUserSession nc
+      , Facet "attributes.user.id" "User ID" FGUserSession nc
+      , Facet "attributes.user.email" "User Email" FGUserSession nc
+      , Facet "attributes.user.name" "Username" FGUserSession nc
+      , Facet "attributes.user.full_name" "Full Name" FGUserSession nc
+      , -- Database
+        Facet "attributes.db.system.name" "Database System" FGDatabase nc
+      , Facet "attributes.db.collection.name" "Collection Name" FGDatabase nc
+      , Facet "attributes.db.namespace" "Database Namespace" FGDatabase nc
+      , Facet "attributes.db.operation.batch.size" "Batch Size" FGDatabase nc
+      , -- Errors & Exceptions
+        Facet "attributes.exception.type" "Exception Type" FGErrors (const "bg-fillError-strong")
+      , Facet "attributes.exception.message" "Exception Message" FGErrors nc
+      ]
 
 
 -- | Render facet data for Log Explorer sidebar in a compact format.

--- a/src/Pages/LogExplorer/Log.hs
+++ b/src/Pages/LogExplorer/Log.hs
@@ -325,7 +325,7 @@ rowCountDisplay_ suffix countText suffixText =
 
 -- | Visual grouping for the sidebar. Each group renders one collapsible section.
 data FacetGroup = FGCommon | FGHTTP | FGResource | FGUserSession | FGDatabase | FGErrors
-  deriving stock (Bounded, Enum, Eq, Ord, Show)
+  deriving stock (Bounded, Enum, Eq, Ord)
 
 
 facetGroupLabel :: FacetGroup -> Text

--- a/src/Pages/LogExplorer/Log.hs
+++ b/src/Pages/LogExplorer/Log.hs
@@ -468,8 +468,9 @@ renderFacets facetSummary = do
     });
   |]
 
-  forM_ universe \g ->
-    renderFacetSection (facetGroupLabel g) (Map.findWithDefault [] g facetsByGroup) facetMap (g /= FGCommon)
+  forM_ universe \g -> do
+    let fs = filter (\f -> HM.member f.path facetMap) (Map.findWithDefault [] g facetsByGroup)
+    unless (null fs) $ renderFacetSection (facetGroupLabel g) fs facetMap (g /= FGCommon)
   where
     renderFacetSection :: Text -> [Facet] -> HM.HashMap Text [FacetValue] -> Bool -> Html ()
     renderFacetSection sectionName fs facetMap collapsed = do

--- a/src/Pages/LogExplorer/Log.hs
+++ b/src/Pages/LogExplorer/Log.hs
@@ -481,9 +481,12 @@ renderFacets facetSummary = do
         div_ [class_ "facets-container mt-1 max-h-0 overflow-hidden peer-checked:max-h-[2000px] transition-[max-height] duration-300"] do
           forM_ (zip [0 ..] fs) \(idx :: Int, f) ->
             whenJust (HM.lookup f.path facetMap) \values -> do
-              let shouldBeExpanded = f.group == FGCommon && idx < 5
-                  key = f.path -- bound once for use across the inner HTML/JS attrs below
-              label_ [class_ "facet-section border-t border-strokeWeak group/facet block contain-[layout_style]", term "data-facet" key] do
+              -- @key@ is f.path aliased once because the field is repeated
+              -- 8+ times across nested HTML attrs + hyperscript below;
+              -- inlining doubles vertical noise without buying anything.
+              let key = f.path
+                  shouldBeExpanded = f.group == FGCommon && idx < 5
+              label_ [class_ "facet-section border-t border-strokeWeak group/facet block contain-[layout_style]"] do
                 input_ $ [type_ "checkbox", class_ "hidden", id_ $ "facet-toggle-" <> key] ++ [checked_ | shouldBeExpanded]
                 div_ [class_ "flex items-center justify-between hover:bg-fillWeak rounded"] do
                   div_ [class_ "p-2 flex items-center gap-2 cursor-pointer flex-1"] do

--- a/src/Pages/LogExplorer/Log.hs
+++ b/src/Pages/LogExplorer/Log.hs
@@ -54,7 +54,7 @@ import Servant qualified
 import System.Config (AuthContext (..), EnvConfig (..))
 import System.Types
 import Text.Megaparsec (parseMaybe)
-import Utils (FreeTierStatus (..), LoadingSize (..), LoadingType (..), checkFreeTierStatus, faSprite_, formatUTC, getDurationNSMS, getServiceColors, htmxOverlayIndicator_, levelFillColor, listToIndexHashMap, loadingIndicator_, lookupVecTextByKey, methodFillColor, prettyPrintCount, serviceFillColor, statusFillColorText)
+import Utils (FreeTierStatus (..), LoadingSize (..), LoadingType (..), checkFreeTierStatus, faSprite_, formatUTC, getDurationNSMS, getServiceColors, htmxOverlayIndicator_, listToIndexHashMap, loadingIndicator_, lookupVecTextByKey, methodFillColor, prettyPrintCount, serviceFillColor, statusFillColorText)
 
 import Data.Time.Format.ISO8601 (iso8601ParseM, iso8601Show)
 import Data.UUID qualified as UUID
@@ -323,138 +323,106 @@ rowCountDisplay_ suffix countText suffixText =
     dashSuffix = if T.null suffix then "" else "-" <> suffix
 
 
--- | Render facet data for Log Explorer sidebar in a compact format
--- | The facet counts are already scaled in the Fields.getFacetSummary function based on the selected time range
--- | Facets are normally generated for a 24-hour period, but will be proportionally adjusted for the user's time selection
+-- | Visual grouping for the sidebar. Each group renders one collapsible section.
+data FacetGroup = FGCommon | FGHTTP | FGResource | FGUserSession | FGDatabase | FGErrors
+  deriving stock (Bounded, Enum, Eq, Ord, Show)
+
+
+facetGroupLabel :: FacetGroup -> Text
+facetGroupLabel = \case
+  FGCommon -> "Common Filters"
+  FGHTTP -> "HTTP"
+  FGResource -> "Resource"
+  FGUserSession -> "User & Session"
+  FGDatabase -> "Database"
+  FGErrors -> "Errors & Exceptions"
+
+
+-- | A facet entry the sidebar can render.
+--
+-- @path@ is the canonical KQL field name (dotted OTel form, e.g.
+-- @attributes.http.request.method@). It is the lookup key in 'FacetData' (the
+-- adapter in "Models.Apis.SchemaCatalog" prefixes catalog paths by category to
+-- produce this form) AND the field the user types in KQL — so click-to-filter
+-- emits a query the parser compiles to a flat-column scan via
+-- 'Pkg.Parser.Expr.transformFlattenedAttribute'.
+--
+-- Invariant ('prop_facetsAreFast'): every @path@ must be a member of
+-- 'Pkg.Parser.Expr.flattenedOtelAttributes' so the executed SQL is a direct
+-- column reference, never a jsonb_path fallback.
+data Facet = Facet
+  { path :: Text
+  , label :: Text
+  , group :: FacetGroup
+  , color :: Text -> Text
+  }
+
+
+-- | The full facet list. Order within each group is preserved in the sidebar.
+--
+-- >>> import qualified Pkg.Parser.Expr as PE
+-- >>> import qualified Data.Set as S
+-- >>> all (\f -> S.member f.path PE.flattenedOtelAttributes) facetDefs
+-- True
+facetDefs :: [Facet]
+facetDefs =
+  -- Common
+  [ Facet "resource.service.name" "Service" FGCommon serviceFillColor
+  , Facet "attributes.http.request.method" "HTTP Method" FGCommon methodFillColor
+  , Facet "attributes.http.response.status_code" "HTTP Status" FGCommon statusFillColorText
+  , Facet "attributes.db.operation.name" "DB Operation" FGCommon (const "")
+  , -- HTTP
+    Facet "attributes.http.request.method_original" "Original Method" FGHTTP methodFillColor
+  , Facet "attributes.http.request.resend_count" "Resend Count" FGHTTP (const "")
+  , Facet "attributes.http.request.body.size" "Request Body Size" FGHTTP (const "")
+  , Facet "attributes.url.path" "URL Path" FGHTTP (const "")
+  , Facet "attributes.url.scheme" "URL Scheme" FGHTTP (const "")
+  , Facet "attributes.url.full" "Full URL" FGHTTP (const "")
+  , Facet "attributes.url.fragment" "URL Fragment" FGHTTP (const "")
+  , Facet "attributes.url.query" "URL Query" FGHTTP (const "")
+  , Facet "attributes.user_agent.original" "User Agent" FGHTTP (const "")
+  , -- Resource
+    Facet "resource.service.version" "Service Version" FGResource (const "")
+  , Facet "resource.service.instance.id" "Service Instance ID" FGResource (const "")
+  , Facet "resource.service.namespace" "Service Namespace" FGResource (const "")
+  , Facet "resource.telemetry.sdk.language" "SDK Language" FGResource (const "")
+  , Facet "resource.telemetry.sdk.name" "SDK Name" FGResource (const "")
+  , Facet "resource.telemetry.sdk.version" "SDK Version" FGResource (const "")
+  , -- User & Session
+    Facet "attributes.session.id" "Session ID" FGUserSession (const "")
+  , Facet "attributes.user.id" "User ID" FGUserSession (const "")
+  , Facet "attributes.user.email" "User Email" FGUserSession (const "")
+  , Facet "attributes.user.name" "Username" FGUserSession (const "")
+  , Facet "attributes.user.full_name" "Full Name" FGUserSession (const "")
+  , -- Database
+    Facet "attributes.db.system.name" "Database System" FGDatabase (const "")
+  , Facet "attributes.db.collection.name" "Collection Name" FGDatabase (const "")
+  , Facet "attributes.db.namespace" "Database Namespace" FGDatabase (const "")
+  , Facet "attributes.db.operation.batch.size" "Batch Size" FGDatabase (const "")
+  , -- Errors & Exceptions
+    Facet "attributes.exception.type" "Exception Type" FGErrors (const "bg-fillError-strong")
+  , Facet "attributes.exception.message" "Exception Message" FGErrors (const "")
+  ]
+
+
+-- | Render facet data for Log Explorer sidebar in a compact format.
+-- The facet counts are scaled in the upstream summary based on the selected time range.
 renderFacets :: FacetSummary -> Html ()
 renderFacets facetSummary = do
   let (FacetData facetMap) = facetSummary.facetJson
 
-      -- Color functions for different facet types (using shared Utils)
-      statusColorFn = statusFillColorText
-      methodColorFn = methodFillColor
-      levelColorFn = levelFillColor
-
-      -- Group facet fields by category
-      -- Define mapping of field keys to display names and color functions
-
-      -- Root level facets (displayed at the top)
-      rootFacets :: [(Text, Text, Text -> Text)]
-      rootFacets =
-        [ ("level", "Log Level", levelColorFn)
-        ,
-          ( "status_code"
-          , "Status Code"
-          , \val -> case T.toUpper val of
-              "OK" -> "bg-fillSuccess-strong"
-              "ERROR" -> "bg-fillError-strong"
-              "UNSET" -> "bg-fillWeak"
-              _ -> "bg-fillStrong"
-          )
-        , ("resource___service___name", "Service", serviceFillColor)
-        , ("name", "Operation Name", const "")
-        , ("kind", "Kind", const "")
-        , ("resource___service___version", "Service Version", const "")
-        , ("attributes___http___request___method", "HTTP Method", methodColorFn)
-        , ("attributes___http___response___status_code", "HTTP Status", statusColorFn)
-        , ("attributes___error___type", "Error Type", const "bg-fillError-strong")
-        ]
-
-      -- Grouped facets for better organization
-      facetGroups :: [(Text, [(Text, Text, Text -> Text)])]
-      facetGroups =
-        [
-          ( "HTTP"
-          ,
-            [ ("attributes___http___request___method_original", "Original Method", methodColorFn)
-            , ("attributes___http___request___resend_count", "Resend Count", const "")
-            , ("attributes___http___request___body___size", "Request Body Size", const "")
-            , ("attributes___url___path", "URL Path", const "")
-            , ("attributes___url___scheme", "URL Scheme", const "")
-            , ("attributes___url___full", "Full URL", const "")
-            , ("attributes___url___fragment", "URL Fragment", const "")
-            , ("attributes___url___query", "URL Query", const "")
-            , ("attributes___user_agent___original", "User Agent", const "")
-            ]
-          )
-        ,
-          ( "Severity"
-          ,
-            [ ("severity___severity_text", "Severity Text", levelColorFn)
-            , ("severity___severity_number", "Severity Number", const "")
-            , ("status_message", "Status Message", const "")
-            ]
-          )
-        ,
-          ( "Resource"
-          ,
-            [ ("resource___service___instance___id", "Service Instance ID", const "")
-            , ("resource___service___namespace", "Service Namespace", const "")
-            , ("resource___telemetry___sdk___language", "SDK Language", const "")
-            , ("resource___telemetry___sdk___name", "SDK Name", const "")
-            , ("resource___telemetry___sdk___version", "SDK Version", const "")
-            ]
-          )
-        ,
-          ( "Network"
-          ,
-            [ ("attributes___network___protocol___name", "Protocol Name", const "")
-            , ("attributes___network___protocol___version", "Protocol Version", const "")
-            , ("attributes___network___transport", "Transport", const "")
-            , ("attributes___network___type", "Network Type", const "")
-            , ("attributes___client___address", "Client Address", const "")
-            , ("attributes___server___address", "Server Address", const "")
-            ]
-          )
-        ,
-          ( "User & Session"
-          ,
-            [ ("attributes___user___id", "User ID", const "")
-            , ("attributes___user___email", "User Email", const "")
-            , ("attributes___user___name", "Username", const "")
-            , ("attributes___user___full_name", "Full Name", const "")
-            , ("attributes___session___id", "Session ID", const "")
-            , ("attributes___session___previous___id", "Previous Session", const "")
-            ]
-          )
-        ,
-          ( "Database"
-          ,
-            [ ("attributes___db___system___name", "Database System", const "")
-            , ("attributes___db___collection___name", "Collection Name", const "")
-            , ("attributes___db___namespace", "Database Namespace", const "")
-            , ("attributes___db___operation___name", "DB Operation", const "")
-            , ("attributes___db___response___status_code", "DB Status Code", const "")
-            , ("attributes___db___operation___batch___size", "Batch Size", const "")
-            ]
-          )
-        ,
-          ( "Errors & Exceptions"
-          ,
-            [ ("attributes___error___type", "Error Type", const "bg-fillError-strong")
-            , ("attributes___exception___type", "Exception Type", const "bg-fillError-strong")
-            , ("attributes___exception___message", "Exception Message", const "")
-            ]
-          )
-        ]
-
-  -- Add JS for filtering with checkbox sync
+  -- JS: emit / sync canonical KQL fragments using dotted paths.
   script_
     [text|
     function filterByFacet(field, value) {
       const queryFragment = field + ' == "' + value + '"';
       document.getElementById("filterElement").toggleSubQuery(queryFragment);
     }
-    
-    // Function to update facet checkboxes based on query content
+
     function syncFacetCheckboxes() {
       const filterEl = document.getElementById("filterElement");
       if (!filterEl) return;
-      
-      // Need to get the query directly from the monaco editor
       const query = filterEl.editor ? filterEl.editor.getValue() : "";
-      
-      // Batch DOM updates using requestAnimationFrame
       requestAnimationFrame(() => {
         const checkboxes = document.querySelectorAll('input[type="checkbox"][data-field][data-value]');
         checkboxes.forEach(cb => {
@@ -465,55 +433,47 @@ renderFacets facetSummary = do
         });
       });
     }
-    
-    // Initialize and set up event listeners
+
     document.addEventListener('DOMContentLoaded', () => {
       setTimeout(syncFacetCheckboxes, 100);
-      
-      // Listen for query changes via the custom event
       window.addEventListener('update-query', syncFacetCheckboxes);
     });
   |]
 
-  renderFacetSection "Common Filters" rootFacets facetMap False
-
-  forM_ facetGroups $ \(groupName, facetDisplays) -> renderFacetSection groupName facetDisplays facetMap True
+  forM_ [minBound .. maxBound :: FacetGroup] \g ->
+    renderFacetSection (facetGroupLabel g) (filter (\f -> f.group == g) facetDefs) facetMap (g /= FGCommon)
   where
-    renderFacetSection :: Text -> [(Text, Text, Text -> Text)] -> HM.HashMap Text [FacetValue] -> Bool -> Html ()
-    renderFacetSection sectionName facetDisplays facetMap collapsed = do
-      -- Use div with group for section
+    renderFacetSection :: Text -> [Facet] -> HM.HashMap Text [FacetValue] -> Bool -> Html ()
+    renderFacetSection sectionName fs facetMap collapsed = do
       div_ [class_ "facet-section-group group/section block contain-[layout_style]"] do
         input_ $ [type_ "checkbox", class_ "hidden peer", id_ $ "toggle-" <> T.replace " " "-" sectionName] ++ [checked_ | not collapsed]
-        -- Section header - use label to toggle checkbox
         label_ [class_ "p-2 bg-fillWeak rounded-lg cursor-pointer flex gap-2 items-center peer-checked:[&>svg]:rotate-0", role_ "button", Lucid.for_ $ "toggle-" <> T.replace " " "-" sectionName, Aria.expanded_ (if collapsed then "false" else "true"), [__|on change from previous <input/> if the checked of previous <input/> set @aria-expanded to 'true' else set @aria-expanded to 'false'|]] do
           faSprite_ "chevron-down" "regular" "w-3 h-3 transition-transform -rotate-90"
           span_ [class_ "font-medium text-sm"] (toHtml sectionName)
 
-        -- Facets container
         div_ [class_ "facets-container mt-1 max-h-0 overflow-hidden peer-checked:max-h-[2000px] transition-[max-height] duration-300"] do
-          forM_ (zip [0 ..] facetDisplays) \(idx, (key, displayName, colorFn)) ->
-            whenJust (HM.lookup key facetMap) \values -> do
-              let shouldBeExpanded = sectionName == "Common Filters" && idx < 5
-              label_ [class_ "facet-section border-t border-strokeWeak group/facet block contain-[layout_style]"] do
+          forM_ (zip [0 ..] fs) \(idx :: Int, f) ->
+            whenJust (HM.lookup f.path facetMap) \values -> do
+              let shouldBeExpanded = f.group == FGCommon && idx < 5
+                  key = f.path
+              label_ [class_ "facet-section border-t border-strokeWeak group/facet block contain-[layout_style]", term "data-facet" key] do
                 input_ $ [type_ "checkbox", class_ "hidden", id_ $ "facet-toggle-" <> key] ++ [checked_ | shouldBeExpanded]
-                -- Facet header with actions
                 div_ [class_ "flex items-center justify-between hover:bg-fillWeak rounded"] do
                   div_ [class_ "p-2 flex items-center gap-2 cursor-pointer flex-1"] do
                     faSprite_ "chevron-down" "regular" "w-2.5 h-2.5 transition-transform group-has-[:checked]/facet:rotate-0 -rotate-90"
-                    span_ [class_ "text-sm", term "data-tippy-content" (T.replace "___" "." key)] (toHtml displayName)
+                    span_ [class_ "text-sm", term "data-tippy-content" key] (toHtml f.label)
 
-                  -- Dropdown menu for actions
                   div_ [class_ "dropdown dropdown-end contain-[layout_style]", onclick_ "event.stopPropagation()"] do
                     a_ [tabindex_ "0", class_ "cursor-pointer p-2 hover:bg-fillWeak rounded", Aria.label_ "Facet options", role_ "button"] do
                       faSprite_ "ellipsis-vertical" "regular" "w-3 h-3"
                     ul_ [tabindex_ "0", class_ "dropdown-content z-10 menu p-2 shadow-sm bg-bgRaised rounded-box w-52"] do
                       li_
                         $ a_
-                          [ term "data-field" (T.replace "___" "." key)
+                          [ term "data-field" key
                           , class_ "flex gap-2 items-center"
                           , [__|
-                             init 
-                                set cols to params().cols or '' then 
+                             init
+                                set cols to params().cols or '' then
                                 set colsX to cols.split(',') then
                                 if colsX contains @data-field
                                   set innerHTML of first <span/> in me to 'Remove column'
@@ -534,7 +494,7 @@ renderFacets facetSummary = do
                             span_ [] "Add as table column"
                       li_
                         $ a_
-                          [ term "data-field" (T.replace "___" "." key)
+                          [ term "data-field" key
                           , term "data-key" key
                           , class_ "flex gap-2 items-center"
                           , [__|
@@ -550,16 +510,14 @@ renderFacets facetSummary = do
                           do
                             faSprite_ "group-by" "regular" "w-4 h-4 text-iconNeutral"
                             span_ [] "Group by"
-                      li_ $ a_ [class_ "flex gap-2 items-center", onclick_ $ "viewFieldPatterns('" <> T.replace "___" "." key <> "')"] do
+                      li_ $ a_ [class_ "flex gap-2 items-center", onclick_ $ "viewFieldPatterns('" <> key <> "')"] do
                         faSprite_ "chart-bar" "regular" "w-4 h-4 text-iconNeutral"
                         span_ [] "View patterns"
 
-                -- Render facet values (uses group-has-checked to show/hide)
                 div_ [class_ "facet-values pl-7 pr-2 mb-1 space-y-1 max-h-0 overflow-hidden group-has-[:checked]/facet:max-h-[1000px] transition-[max-height] duration-200"] do
-                  let valuesWithIndices = zip [0 ..] values
+                  let valuesWithIndices = zip [0 :: Int ..] values
                       (visibleValues, hiddenValues) = splitAt 5 valuesWithIndices
                       hiddenCount = length hiddenValues
-                      -- Helper function to render a facet value item
                       renderFacetValue (FacetValue val count) =
                         label_ [class_ "facet-item flex items-center justify-between py-0.5 max-md:py-1.5 px-1 hover:bg-fillWeak rounded cursor-pointer will-change-[background-color]"] do
                           div_ [class_ "flex items-center gap-2 min-w-0 flex-1"] do
@@ -567,21 +525,17 @@ renderFacets facetSummary = do
                               [ type_ "checkbox"
                               , class_ "checkbox checkbox-xs max-md:checkbox-sm"
                               , name_ key
-                              , onclick_ $ "filterByFacet('" <> T.replace "___" "." key <> "', '" <> val <> "')"
-                              , term "data-tippy-content" (T.replace "___" "." key <> " == \"" <> val <> "\"")
-                              , term "data-field" (T.replace "___" "." key)
+                              , onclick_ $ "filterByFacet('" <> key <> "', '" <> val <> "')"
+                              , term "data-tippy-content" (key <> " == \"" <> val <> "\"")
+                              , term "data-field" key
                               , term "data-value" val
                               ]
-
-                            let colorClass = colorFn val
+                            let colorClass = f.color val
                             unless (T.null colorClass) $ span_ [class_ $ colorClass <> " shrink-0 w-0.5 h-3 rounded-sm"] ""
                             span_ [class_ "facet-value truncate text-xs", term "data-tippy-content" val] (toHtml val)
-
                           span_ [class_ "facet-count text-xs text-textWeak shrink-0 tabular-nums"] $ toHtml $ prettyPrintCount count
-                  -- Render visible values
                   forM_ visibleValues \(_, value) -> renderFacetValue value
 
-                  -- Show more/less toggle for hidden values
                   when (hiddenCount > 0) do
                     let moreId = "more-" <> key
                     input_ [type_ "checkbox", class_ "hidden peer/more", id_ moreId]

--- a/src/Pages/LogExplorer/Log.hs
+++ b/src/Pages/LogExplorer/Log.hs
@@ -387,7 +387,7 @@ data Facet = Facet
 -- True
 facetDefs :: [Facet]
 facetDefs =
-  let nc = const "" -- shorthand for "no fill color" — used 13× below
+  let nc = const "" -- no fill color
    in -- Common
       [ Facet "resource.service.name" "Service" FGCommon serviceFillColor
       , Facet "attributes.http.request.method" "HTTP Method" FGCommon methodFillColor
@@ -547,7 +547,14 @@ renderFacets facetSummary = do
                       hiddenCount = length hiddenValues
                       -- val is an observed attribute value; jsEscape it
                       -- before embedding in the JS single-quoted onclick.
-                      jsEscape t = T.replace "'" "\\'" (T.replace "\\" "\\\\" t)
+                      -- Order matters: backslash first, then single quote,
+                      -- then CR (drop) and LF (translate) so a value with
+                      -- "\n</script>..." can't break out.
+                      jsEscape =
+                        T.replace "\n" "\\n"
+                          . T.replace "\r" ""
+                          . T.replace "'" "\\'"
+                          . T.replace "\\" "\\\\"
                       renderFacetValue (FacetValue val count) =
                         label_ [class_ "facet-item flex items-center justify-between py-0.5 max-md:py-1.5 px-1 hover:bg-fillWeak rounded cursor-pointer will-change-[background-color]"] do
                           div_ [class_ "flex items-center gap-2 min-w-0 flex-1"] do

--- a/src/Pages/LogExplorer/Log.hs
+++ b/src/Pages/LogExplorer/Log.hs
@@ -465,7 +465,12 @@ renderFacets facetSummary = do
     });
   |]
 
-  forM_ ([minBound .. maxBound] :: [FacetGroup]) \g ->
+  -- 'universe' from Relude.Extra.Enum would shorten this, but that module
+  -- isn't on this package's import surface; the [minBound..maxBound] form
+  -- compiles to the same list literal.
+  {- HLINT ignore "Use universe" -}
+  let allGroups = [minBound .. maxBound] :: [FacetGroup]
+  forM_ allGroups \g ->
     renderFacetSection (facetGroupLabel g) (Map.findWithDefault [] g byGroup) facetMap (g /= FGCommon)
   where
     renderFacetSection :: Text -> [Facet] -> HM.HashMap Text [FacetValue] -> Bool -> Html ()

--- a/src/Pages/LogExplorer/Log.hs
+++ b/src/Pages/LogExplorer/Log.hs
@@ -427,14 +427,14 @@ facetDefs =
       ]
 
 
--- | Render facet data for Log Explorer sidebar in a compact format.
--- The facet counts are scaled in the upstream summary based on the selected time range.
 -- | 'facetDefs' bucketed by 'FacetGroup', built once at module load time.
 -- 'flip (<>)' preserves source order under Map.fromListWith (which calls f new old).
 facetsByGroup :: Map.Map FacetGroup [Facet]
 facetsByGroup = Map.fromListWith (flip (<>)) [(f.group, [f]) | f <- facetDefs]
 
 
+-- | Render facet data for Log Explorer sidebar in a compact format.
+-- The facet counts are scaled in the upstream summary based on the selected time range.
 renderFacets :: FacetSummary -> Html ()
 renderFacets facetSummary = do
   let (FacetData facetMap) = facetSummary.facetJson
@@ -468,12 +468,7 @@ renderFacets facetSummary = do
     });
   |]
 
-  -- 'universe' from Relude.Extra.Enum would shorten this, but that module
-  -- isn't on this package's import surface; the [minBound..maxBound] form
-  -- compiles to the same list literal.
-  {- HLINT ignore "Use universe" -}
-  let allGroups = [minBound .. maxBound] :: [FacetGroup]
-  forM_ allGroups \g ->
+  forM_ universe \g ->
     renderFacetSection (facetGroupLabel g) (Map.findWithDefault [] g facetsByGroup) facetMap (g /= FGCommon)
   where
     renderFacetSection :: Text -> [Facet] -> HM.HashMap Text [FacetValue] -> Bool -> Html ()

--- a/src/Pages/LogExplorer/Log.hs
+++ b/src/Pages/LogExplorer/Log.hs
@@ -431,10 +431,7 @@ facetDefs =
 renderFacets :: FacetSummary -> Html ()
 renderFacets facetSummary = do
   let (FacetData facetMap) = facetSummary.facetJson
-      -- One pass over facetDefs → Map FacetGroup [Facet], then O(1) lookups
-      -- below. Keeps the render loop linear regardless of list growth.
-      -- @flip (<>)@ preserves source order: fromListWith calls
-      -- @f new old@, so we want @old <> new@ to keep earlier-listed facets first.
+      -- flip (<>) preserves source order under Map.fromListWith (which calls f new old).
       byGroup :: Map.Map FacetGroup [Facet]
       byGroup = Map.fromListWith (flip (<>)) [(f.group, [f]) | f <- facetDefs]
 
@@ -467,7 +464,7 @@ renderFacets facetSummary = do
     });
   |]
 
-  forM_ [minBound .. maxBound :: FacetGroup] \g ->
+  forM_ ([minBound .. maxBound] :: [FacetGroup]) \g ->
     renderFacetSection (facetGroupLabel g) (Map.findWithDefault [] g byGroup) facetMap (g /= FGCommon)
   where
     renderFacetSection :: Text -> [Facet] -> HM.HashMap Text [FacetValue] -> Bool -> Html ()
@@ -479,19 +476,15 @@ renderFacets facetSummary = do
           span_ [class_ "font-medium text-sm"] (toHtml sectionName)
 
         div_ [class_ "facets-container mt-1 max-h-0 overflow-hidden peer-checked:max-h-[2000px] transition-[max-height] duration-300"] do
-          forM_ (zip [0 ..] fs) \(idx :: Int, f) ->
+          forM_ (zip [0 :: Int ..] fs) \(idx, f) ->
             whenJust (HM.lookup f.path facetMap) \values -> do
-              -- @key@ is f.path aliased once because the field is repeated
-              -- 8+ times across nested HTML attrs + hyperscript below;
-              -- inlining doubles vertical noise without buying anything.
-              let key = f.path
-                  shouldBeExpanded = f.group == FGCommon && idx < 5
+              let shouldBeExpanded = f.group == FGCommon && idx < 5
               label_ [class_ "facet-section border-t border-strokeWeak group/facet block contain-[layout_style]"] do
-                input_ $ [type_ "checkbox", class_ "hidden", id_ $ "facet-toggle-" <> key] ++ [checked_ | shouldBeExpanded]
+                input_ $ [type_ "checkbox", class_ "hidden", id_ $ "facet-toggle-" <> f.path] ++ [checked_ | shouldBeExpanded]
                 div_ [class_ "flex items-center justify-between hover:bg-fillWeak rounded"] do
                   div_ [class_ "p-2 flex items-center gap-2 cursor-pointer flex-1"] do
                     faSprite_ "chevron-down" "regular" "w-2.5 h-2.5 transition-transform group-has-[:checked]/facet:rotate-0 -rotate-90"
-                    span_ [class_ "text-sm", term "data-tippy-content" key] (toHtml f.label)
+                    span_ [class_ "text-sm", term "data-tippy-content" f.path] (toHtml f.label)
 
                   div_ [class_ "dropdown dropdown-end contain-[layout_style]", onclick_ "event.stopPropagation()"] do
                     a_ [tabindex_ "0", class_ "cursor-pointer p-2 hover:bg-fillWeak rounded", Aria.label_ "Facet options", role_ "button"] do
@@ -499,7 +492,7 @@ renderFacets facetSummary = do
                     ul_ [tabindex_ "0", class_ "dropdown-content z-10 menu p-2 shadow-sm bg-bgRaised rounded-box w-52"] do
                       li_
                         $ a_
-                          [ term "data-field" key
+                          [ term "data-field" f.path
                           , class_ "flex gap-2 items-center"
                           , [__|
                              init
@@ -524,8 +517,8 @@ renderFacets facetSummary = do
                             span_ [] "Add as table column"
                       li_
                         $ a_
-                          [ term "data-field" key
-                          , term "data-key" key
+                          [ term "data-field" f.path
+                          , term "data-key" f.path
                           , class_ "flex gap-2 items-center"
                           , [__|
                               init call window.updateGroupByButtonText(event, me) end
@@ -540,7 +533,7 @@ renderFacets facetSummary = do
                           do
                             faSprite_ "group-by" "regular" "w-4 h-4 text-iconNeutral"
                             span_ [] "Group by"
-                      li_ $ a_ [class_ "flex gap-2 items-center", onclick_ $ "viewFieldPatterns('" <> key <> "')"] do
+                      li_ $ a_ [class_ "flex gap-2 items-center", onclick_ $ "viewFieldPatterns('" <> f.path <> "')"] do
                         faSprite_ "chart-bar" "regular" "w-4 h-4 text-iconNeutral"
                         span_ [] "View patterns"
 
@@ -554,10 +547,10 @@ renderFacets facetSummary = do
                             input_
                               [ type_ "checkbox"
                               , class_ "checkbox checkbox-xs max-md:checkbox-sm"
-                              , name_ key
-                              , onclick_ $ "filterByFacet('" <> key <> "', '" <> val <> "')"
-                              , term "data-tippy-content" (key <> " == \"" <> val <> "\"")
-                              , term "data-field" key
+                              , name_ f.path
+                              , onclick_ $ "filterByFacet('" <> f.path <> "', '" <> val <> "')"
+                              , term "data-tippy-content" (f.path <> " == \"" <> val <> "\"")
+                              , term "data-field" f.path
                               , term "data-value" val
                               ]
                             let colorClass = f.color val
@@ -567,7 +560,7 @@ renderFacets facetSummary = do
                   forM_ visibleValues \(_, value) -> renderFacetValue value
 
                   when (hiddenCount > 0) do
-                    let moreId = "more-" <> key
+                    let moreId = "more-" <> f.path
                     input_ [type_ "checkbox", class_ "hidden peer/more", id_ moreId]
                     label_ [class_ "text-textBrand text-xs px-1 py-0.5 cursor-pointer hover:underline", Lucid.for_ moreId] do
                       span_ [class_ "peer-checked/more:hidden"] $ toHtml $ "+ More (" <> prettyPrintCount hiddenCount <> ")"

--- a/src/Pages/LogExplorer/Log.hs
+++ b/src/Pages/LogExplorer/Log.hs
@@ -361,12 +361,25 @@ data Facet = Facet
 -- | The full facet list. Order within each group is preserved in the sidebar.
 --
 -- Every entry must be in 'Pkg.Parser.Expr.flattenedOtelAttributes' so KQL
--- compiles the click-to-filter expression to a flat-column scan. Some
--- otherwise-natural facets are deliberately absent because they live in
--- top-level columns rather than @attributes.@ / @resource.@ — `level`,
--- `name` (Operation Name), `kind`, `status_code`, `status_message`, and
--- the `severity.*` group are flat columns the catalog walk doesn't emit
--- yet. Adding a naive entry for them would fail 'prop_facetsAreFast'.
+-- compiles the click-to-filter expression to a flat-column scan rather than
+-- a jsonb_path lookup.
+--
+-- A few facets that existed in the prior tuple-based sidebar are
+-- intentionally absent here:
+--
+--   * @level@, @name@ (Operation Name), @kind@, @status_code@,
+--     @status_message@, @severity.*@ — flat columns at the top level of
+--     @otel_logs_and_spans@. The schema-learning walk doesn't emit these
+--     paths (it walks @attributes@ / @resource@ / @body@ / @events@), so
+--     they'd render empty even if listed.
+--   * @attributes.network.*@, @attributes.client.address@,
+--     @attributes.server.address@, @attributes.error.type@,
+--     @attributes.session.previous.id@, @attributes.db.response.status_code@,
+--     @attributes.http.response.status_code@ subgroups beyond what's listed,
+--     etc. — not yet in 'flattenedOtelAttributes'. Adding them naively here
+--     fails 'prop_facetsAreFast'. The right path is to (a) confirm the flat
+--     column exists, (b) add the dotted path to the whitelist, (c) then list
+--     it here.
 --
 -- >>> import qualified Pkg.Parser.Expr as PE
 -- >>> import qualified Data.Set as S
@@ -418,6 +431,12 @@ facetDefs =
 renderFacets :: FacetSummary -> Html ()
 renderFacets facetSummary = do
   let (FacetData facetMap) = facetSummary.facetJson
+      -- One pass over facetDefs → Map FacetGroup [Facet], then O(1) lookups
+      -- below. Keeps the render loop linear regardless of list growth.
+      -- @flip (<>)@ preserves source order: fromListWith calls
+      -- @f new old@, so we want @old <> new@ to keep earlier-listed facets first.
+      byGroup :: Map.Map FacetGroup [Facet]
+      byGroup = Map.fromListWith (flip (<>)) [(f.group, [f]) | f <- facetDefs]
 
   -- JS: emit / sync canonical KQL fragments using dotted paths.
   script_
@@ -449,7 +468,7 @@ renderFacets facetSummary = do
   |]
 
   forM_ [minBound .. maxBound :: FacetGroup] \g ->
-    renderFacetSection (facetGroupLabel g) (filter ((== g) . (.group)) facetDefs) facetMap (g /= FGCommon)
+    renderFacetSection (facetGroupLabel g) (Map.findWithDefault [] g byGroup) facetMap (g /= FGCommon)
   where
     renderFacetSection :: Text -> [Facet] -> HM.HashMap Text [FacetValue] -> Bool -> Html ()
     renderFacetSection sectionName fs facetMap collapsed = do
@@ -463,7 +482,7 @@ renderFacets facetSummary = do
           forM_ (zip [0 ..] fs) \(idx :: Int, f) ->
             whenJust (HM.lookup f.path facetMap) \values -> do
               let shouldBeExpanded = f.group == FGCommon && idx < 5
-                  key = f.path
+                  key = f.path -- bound once for use across the inner HTML/JS attrs below
               label_ [class_ "facet-section border-t border-strokeWeak group/facet block contain-[layout_style]", term "data-facet" key] do
                 input_ $ [type_ "checkbox", class_ "hidden", id_ $ "facet-toggle-" <> key] ++ [checked_ | shouldBeExpanded]
                 div_ [class_ "flex items-center justify-between hover:bg-fillWeak rounded"] do

--- a/src/Pages/LogExplorer/Log.hs
+++ b/src/Pages/LogExplorer/Log.hs
@@ -360,6 +360,14 @@ data Facet = Facet
 
 -- | The full facet list. Order within each group is preserved in the sidebar.
 --
+-- Every entry must be in 'Pkg.Parser.Expr.flattenedOtelAttributes' so KQL
+-- compiles the click-to-filter expression to a flat-column scan. Some
+-- otherwise-natural facets are deliberately absent because they live in
+-- top-level columns rather than @attributes.@ / @resource.@ — `level`,
+-- `name` (Operation Name), `kind`, `status_code`, `status_message`, and
+-- the `severity.*` group are flat columns the catalog walk doesn't emit
+-- yet. Adding a naive entry for them would fail 'prop_facetsAreFast'.
+--
 -- >>> import qualified Pkg.Parser.Expr as PE
 -- >>> import qualified Data.Set as S
 -- >>> all (\f -> S.member f.path PE.flattenedOtelAttributes) facetDefs
@@ -441,7 +449,7 @@ renderFacets facetSummary = do
   |]
 
   forM_ [minBound .. maxBound :: FacetGroup] \g ->
-    renderFacetSection (facetGroupLabel g) (filter (\f -> f.group == g) facetDefs) facetMap (g /= FGCommon)
+    renderFacetSection (facetGroupLabel g) (filter ((== g) . (.group)) facetDefs) facetMap (g /= FGCommon)
   where
     renderFacetSection :: Text -> [Facet] -> HM.HashMap Text [FacetValue] -> Bool -> Html ()
     renderFacetSection sectionName fs facetMap collapsed = do

--- a/src/Pages/LogExplorer/Log.hs
+++ b/src/Pages/LogExplorer/Log.hs
@@ -545,6 +545,9 @@ renderFacets facetSummary = do
                   let valuesWithIndices = zip [0 :: Int ..] values
                       (visibleValues, hiddenValues) = splitAt 5 valuesWithIndices
                       hiddenCount = length hiddenValues
+                      -- val is an observed attribute value; jsEscape it
+                      -- before embedding in the JS single-quoted onclick.
+                      jsEscape t = T.replace "'" "\\'" (T.replace "\\" "\\\\" t)
                       renderFacetValue (FacetValue val count) =
                         label_ [class_ "facet-item flex items-center justify-between py-0.5 max-md:py-1.5 px-1 hover:bg-fillWeak rounded cursor-pointer will-change-[background-color]"] do
                           div_ [class_ "flex items-center gap-2 min-w-0 flex-1"] do
@@ -552,7 +555,7 @@ renderFacets facetSummary = do
                               [ type_ "checkbox"
                               , class_ "checkbox checkbox-xs max-md:checkbox-sm"
                               , name_ f.path
-                              , onclick_ $ "filterByFacet('" <> f.path <> "', '" <> val <> "')"
+                              , onclick_ $ "filterByFacet('" <> f.path <> "', '" <> jsEscape val <> "')"
                               , term "data-tippy-content" (f.path <> " == \"" <> val <> "\"")
                               , term "data-field" f.path
                               , term "data-value" val

--- a/src/Pages/LogExplorer/Log.hs
+++ b/src/Pages/LogExplorer/Log.hs
@@ -325,7 +325,7 @@ rowCountDisplay_ suffix countText suffixText =
 
 -- | Visual grouping for the sidebar. Each group renders one collapsible section.
 data FacetGroup = FGCommon | FGHTTP | FGResource | FGUserSession | FGDatabase | FGErrors
-  deriving stock (Bounded, Enum, Eq, Ord)
+  deriving stock (Bounded, Enum, Eq, Ord, Show)
 
 
 facetGroupLabel :: FacetGroup -> Text

--- a/src/Pages/LogExplorer/Log.hs
+++ b/src/Pages/LogExplorer/Log.hs
@@ -429,12 +429,15 @@ facetDefs =
 
 -- | Render facet data for Log Explorer sidebar in a compact format.
 -- The facet counts are scaled in the upstream summary based on the selected time range.
+-- | 'facetDefs' bucketed by 'FacetGroup', built once at module load time.
+-- 'flip (<>)' preserves source order under Map.fromListWith (which calls f new old).
+facetsByGroup :: Map.Map FacetGroup [Facet]
+facetsByGroup = Map.fromListWith (flip (<>)) [(f.group, [f]) | f <- facetDefs]
+
+
 renderFacets :: FacetSummary -> Html ()
 renderFacets facetSummary = do
   let (FacetData facetMap) = facetSummary.facetJson
-      -- flip (<>) preserves source order under Map.fromListWith (which calls f new old).
-      byGroup :: Map.Map FacetGroup [Facet]
-      byGroup = Map.fromListWith (flip (<>)) [(f.group, [f]) | f <- facetDefs]
 
   -- JS: emit / sync canonical KQL fragments using dotted paths.
   script_
@@ -471,7 +474,7 @@ renderFacets facetSummary = do
   {- HLINT ignore "Use universe" -}
   let allGroups = [minBound .. maxBound] :: [FacetGroup]
   forM_ allGroups \g ->
-    renderFacetSection (facetGroupLabel g) (Map.findWithDefault [] g byGroup) facetMap (g /= FGCommon)
+    renderFacetSection (facetGroupLabel g) (Map.findWithDefault [] g facetsByGroup) facetMap (g /= FGCommon)
   where
     renderFacetSection :: Text -> [Facet] -> HM.HashMap Text [FacetValue] -> Bool -> Html ()
     renderFacetSection sectionName fs facetMap collapsed = do

--- a/src/Pkg/SchemaLearning/Worker.hs
+++ b/src/Pkg/SchemaLearning/Worker.hs
@@ -183,15 +183,18 @@ regenerateSummaries projects entriesMap = do
   let touched = V.fromList (HS.toList projects)
   fresh <- SC.freshSummaryProjects touched
   let stale = V.filter (not . (`HS.member` fresh)) touched
-      -- Partition entries by project_id in one O(|entriesMap|) pass so the
-      -- per-project fold below is an O(1) lookup. Each combine is a singleton
-      -- list prepended to the accumulator, so list (<>) is O(1) per insert
-      -- and the whole partition is O(|entriesMap|). V.++ here would be
-      -- quadratic across N entries.
+      staleSet = HS.fromList (V.toList stale)
+      -- Partition entries by project_id, restricting up-front to projects
+      -- we'll actually summarise. Without this filter we'd build per-project
+      -- bags for fresh projects and immediately discard them on lookup.
+      -- Each combine prepends a singleton list (O(1)); whole partition is
+      -- O(|entriesMap|). V.++ here would be quadratic.
       byProject :: HM.HashMap Projects.ProjectId (V.Vector CatalogEntry)
       byProject =
         fmap V.fromList
-          $ HM.fromListWith (<>) [(k.projectId, [e]) | (k, e) <- HM.toList entriesMap]
+          $ HM.fromListWith
+            (<>)
+            [(k.projectId, [e]) | (k, e) <- HM.toList entriesMap, HS.member k.projectId staleSet]
       rows =
         V.mapMaybe
           (\pid -> (pid,) . summariseEntries <$> HM.lookup pid byProject)

--- a/src/Pkg/SchemaLearning/Worker.hs
+++ b/src/Pkg/SchemaLearning/Worker.hs
@@ -189,9 +189,14 @@ regenerateSummaries projects entriesMap = do
       byProject :: HM.HashMap Projects.ProjectId (V.Vector CatalogEntry)
       byProject =
         fmap V.fromList
-          $ HM.fromListWith
-            (<>)
-            [(k.projectId, [e]) | (k, e) <- HM.toList entriesMap, HS.member k.projectId staleSet]
+          $ HM.foldlWithKey'
+            ( \acc k e ->
+                if HS.member k.projectId staleSet
+                  then HM.insertWith (<>) k.projectId [e] acc
+                  else acc
+            )
+            HM.empty
+            entriesMap
       rows =
         V.fromList
           $ mapMaybe (\pid -> (pid,) . summariseEntries <$> HM.lookup pid byProject) (HS.toList staleSet)

--- a/src/Pkg/SchemaLearning/Worker.hs
+++ b/src/Pkg/SchemaLearning/Worker.hs
@@ -212,11 +212,7 @@ summariseEntries entries =
   let fieldsAcc =
         V.foldl' mergeFields HM.empty
           $ V.map ((.template.fields)) entries
-      svcs =
-        V.fromList
-          $ HS.toList
-          $ HS.fromList
-          $ catMaybes [e.scope.service | e <- V.toList entries]
+      svcs = V.fromList . ordNub . mapMaybe (.scope.service) $ V.toList entries
       topVals :: HashMap Text TopK
       topVals = V.foldl' mergeCounts HM.empty (V.map (.counts) entries)
    in SummaryDoc{fields = fieldsAcc, services = svcs, topValuesByField = topVals}

--- a/src/Pkg/SchemaLearning/Worker.hs
+++ b/src/Pkg/SchemaLearning/Worker.hs
@@ -88,7 +88,12 @@ flushDirty ref = do
           touchedProjects = HS.fromList [k.projectId | (k, _) <- V.toList dirty]
       SC.upsertTemplates templateRows
       SC.upsertCatalogRows catalogRows
-      summariesN <- regenerateSummaries touchedProjects
+      -- Snapshot the shard's entries after our upserts so the summary fold
+      -- sees the freshly-merged catalog state without reading it back from
+      -- Postgres. Slightly newer than the dirty set (concurrent writers may
+      -- have added more keys), which is fine — the map only grows.
+      entries <- liftIO $ (.entries) <$> readIORef ref
+      summariesN <- regenerateSummaries touchedProjects entries
       let newHashes = HS.fromList $ V.toList $ V.map (.templateHash) templateRows
       liftIO $ Hot.pruneEvicted ref HS.empty newHashes
       pure
@@ -161,19 +166,32 @@ dedupTemplates = V.fromList . HM.elems . V.foldl' step HM.empty
 
 
 -- | Re-derive @apis.schema_summary.doc@ for each project that had at least
--- one dirty key this pass. Reads back the full per-project catalog so the
--- summary reflects all known structure, not just what changed in the batch.
+-- one dirty key this pass.
+--
+-- The fold uses the live in-memory shard slice (caller passes
+-- 'SchemaShardState.entries'), so the bulk refresh costs O(dirty projects ×
+-- avg entries-per-project) of pure work plus exactly two round-trips: one
+-- @SELECT@ to find which touched projects were summarised within the
+-- staleness window, one batched @UPSERT@. No per-project catalog read; no
+-- per-project upsert.
 regenerateSummaries
   :: DB es
   => HS.HashSet Projects.ProjectId
+  -> HM.HashMap SchemaKey CatalogEntry
   -> Eff es Int
-regenerateSummaries projects = do
-  let pids = HS.toList projects
-  forM_ pids \pid -> do
-    entries <- SC.getByProject pid
-    let doc = summariseEntries entries
-    SC.upsertSummary pid doc
-  pure (length pids)
+regenerateSummaries projects entriesMap = do
+  let touched = V.fromList (HS.toList projects)
+  fresh <- SC.freshSummaryProjects touched
+  let stale = V.filter (\p -> not (HS.member p fresh)) touched
+      rows =
+        V.map
+          ( \pid ->
+              let slice = V.fromList [e | (k, e) <- HM.toList entriesMap, k.projectId == pid]
+               in (pid, summariseEntries slice)
+          )
+          stale
+  SC.upsertSummary rows
+  pure (V.length rows)
 
 
 -- | Project-scoped roll-up of catalog entries into a 'SummaryDoc'.

--- a/src/Pkg/SchemaLearning/Worker.hs
+++ b/src/Pkg/SchemaLearning/Worker.hs
@@ -186,6 +186,10 @@ regenerateSummaries projects entriesMap = do
       -- Partition entries by project_id, restricted to projects we'll
       -- actually summarise. List (<>) keeps per-insert O(1); V.++ would be
       -- quadratic.
+      -- TODO(perf): O(|entriesMap|) — scans every entry in the shard even
+      -- when only a few projects are stale. Acceptable while shards hold
+      -- thousands of entries; revisit once the shard grows large enough that
+      -- a per-project index in 'SchemaShardState' is worth carrying.
       byProject :: HM.HashMap Projects.ProjectId (V.Vector CatalogEntry)
       byProject =
         V.fromList

--- a/src/Pkg/SchemaLearning/Worker.hs
+++ b/src/Pkg/SchemaLearning/Worker.hs
@@ -184,8 +184,9 @@ regenerateSummaries projects entriesMap = do
   fresh <- SC.freshSummaryProjects touched
   let stale = V.filter (not . (`HS.member` fresh)) touched
       -- Partition entries by project_id in one O(|entriesMap|) pass so the
-      -- per-project fold below is an O(1) lookup. Accumulate via list (<>)
-      -- which is O(1) amortised, then convert once — V.++ here would be
+      -- per-project fold below is an O(1) lookup. Each combine is a singleton
+      -- list prepended to the accumulator, so list (<>) is O(1) per insert
+      -- and the whole partition is O(|entriesMap|). V.++ here would be
       -- quadratic across N entries.
       byProject :: HM.HashMap Projects.ProjectId (V.Vector CatalogEntry)
       byProject =

--- a/src/Pkg/SchemaLearning/Worker.hs
+++ b/src/Pkg/SchemaLearning/Worker.hs
@@ -183,12 +183,18 @@ regenerateSummaries projects entriesMap = do
   let touched = V.fromList (HS.toList projects)
   fresh <- SC.freshSummaryProjects touched
   let stale = V.filter (\p -> not (HS.member p fresh)) touched
+      -- Partition entries by project_id in one O(|entriesMap|) pass so the
+      -- per-project fold below is an O(1) lookup rather than O(|entriesMap|)
+      -- per stale project.
+      byProject :: HM.HashMap Projects.ProjectId (V.Vector CatalogEntry)
+      byProject =
+        HM.foldlWithKey'
+          (\acc k e -> HM.insertWith (V.++) k.projectId (V.singleton e) acc)
+          HM.empty
+          entriesMap
       rows =
-        V.map
-          ( \pid ->
-              let slice = V.fromList [e | (k, e) <- HM.toList entriesMap, k.projectId == pid]
-               in (pid, summariseEntries slice)
-          )
+        V.mapMaybe
+          (\pid -> (pid,) . summariseEntries <$> HM.lookup pid byProject)
           stale
   SC.upsertSummary rows
   pure (V.length rows)

--- a/src/Pkg/SchemaLearning/Worker.hs
+++ b/src/Pkg/SchemaLearning/Worker.hs
@@ -182,16 +182,15 @@ regenerateSummaries
 regenerateSummaries projects entriesMap = do
   let touched = V.fromList (HS.toList projects)
   fresh <- SC.freshSummaryProjects touched
-  let stale = V.filter (\p -> not (HS.member p fresh)) touched
+  let stale = V.filter (not . (`HS.member` fresh)) touched
       -- Partition entries by project_id in one O(|entriesMap|) pass so the
-      -- per-project fold below is an O(1) lookup rather than O(|entriesMap|)
-      -- per stale project.
+      -- per-project fold below is an O(1) lookup. Accumulate via list (<>)
+      -- which is O(1) amortised, then convert once — V.++ here would be
+      -- quadratic across N entries.
       byProject :: HM.HashMap Projects.ProjectId (V.Vector CatalogEntry)
       byProject =
-        HM.foldlWithKey'
-          (\acc k e -> HM.insertWith (V.++) k.projectId (V.singleton e) acc)
-          HM.empty
-          entriesMap
+        fmap V.fromList
+          $ HM.fromListWith (<>) [(k.projectId, [e]) | (k, e) <- HM.toList entriesMap]
       rows =
         V.mapMaybe
           (\pid -> (pid,) . summariseEntries <$> HM.lookup pid byProject)

--- a/src/Pkg/SchemaLearning/Worker.hs
+++ b/src/Pkg/SchemaLearning/Worker.hs
@@ -188,8 +188,8 @@ regenerateSummaries projects entriesMap = do
       -- quadratic.
       byProject :: HM.HashMap Projects.ProjectId (V.Vector CatalogEntry)
       byProject =
-        fmap V.fromList
-          $ HM.foldlWithKey'
+        V.fromList
+          <$> HM.foldlWithKey'
             ( \acc k e ->
                 if HS.member k.projectId staleSet
                   then HM.insertWith (<>) k.projectId [e] acc

--- a/src/Pkg/SchemaLearning/Worker.hs
+++ b/src/Pkg/SchemaLearning/Worker.hs
@@ -189,14 +189,9 @@ regenerateSummaries projects entriesMap = do
       byProject :: HM.HashMap Projects.ProjectId (V.Vector CatalogEntry)
       byProject =
         V.fromList
-          <$> HM.foldlWithKey'
-            ( \acc k e ->
-                if HS.member k.projectId staleSet
-                  then HM.insertWith (<>) k.projectId [e] acc
-                  else acc
-            )
-            HM.empty
-            entriesMap
+          <$> HM.fromListWith
+            (<>)
+            [(k.projectId, [e]) | (k, e) <- HM.toList entriesMap, HS.member k.projectId staleSet]
       rows =
         V.fromList
           $ mapMaybe (\pid -> (pid,) . summariseEntries <$> HM.lookup pid byProject) (HS.toList staleSet)

--- a/src/Pkg/SchemaLearning/Worker.hs
+++ b/src/Pkg/SchemaLearning/Worker.hs
@@ -183,12 +183,9 @@ regenerateSummaries projects entriesMap = do
   let touched = V.fromList (HS.toList projects)
   fresh <- SC.freshSummaryProjects touched
   let staleSet = HS.difference projects fresh
-      stale = V.fromList (HS.toList staleSet)
-      -- Partition entries by project_id, restricting up-front to projects
-      -- we'll actually summarise. Without this filter we'd build per-project
-      -- bags for fresh projects and immediately discard them on lookup.
-      -- Each combine prepends a singleton list (O(1)); whole partition is
-      -- O(|entriesMap|). V.++ here would be quadratic.
+      -- Partition entries by project_id, restricted to projects we'll
+      -- actually summarise. List (<>) keeps per-insert O(1); V.++ would be
+      -- quadratic.
       byProject :: HM.HashMap Projects.ProjectId (V.Vector CatalogEntry)
       byProject =
         fmap V.fromList
@@ -196,9 +193,8 @@ regenerateSummaries projects entriesMap = do
             (<>)
             [(k.projectId, [e]) | (k, e) <- HM.toList entriesMap, HS.member k.projectId staleSet]
       rows =
-        V.mapMaybe
-          (\pid -> (pid,) . summariseEntries <$> HM.lookup pid byProject)
-          stale
+        V.fromList
+          $ mapMaybe (\pid -> (pid,) . summariseEntries <$> HM.lookup pid byProject) (HS.toList staleSet)
   SC.upsertSummary rows
   pure (V.length rows)
 

--- a/src/Pkg/SchemaLearning/Worker.hs
+++ b/src/Pkg/SchemaLearning/Worker.hs
@@ -182,8 +182,8 @@ regenerateSummaries
 regenerateSummaries projects entriesMap = do
   let touched = V.fromList (HS.toList projects)
   fresh <- SC.freshSummaryProjects touched
-  let stale = V.filter (not . (`HS.member` fresh)) touched
-      staleSet = HS.fromList (V.toList stale)
+  let staleSet = HS.difference projects fresh
+      stale = V.fromList (HS.toList staleSet)
       -- Partition entries by project_id, restricting up-front to projects
       -- we'll actually summarise. Without this filter we'd build per-project
       -- bags for fresh projects and immediately discard them on lookup.

--- a/test/integration/FacetsSpec.hs
+++ b/test/integration/FacetsSpec.hs
@@ -189,6 +189,9 @@ spec = aroundAll withTestResources $
           sumM <- runHasqlEffect tr $ SC.getSummary p
           sumM `shouldSatisfy` isJust
 
+      -- Relies on 'upsertSummary' stamping @now()@ at seed time and the
+      -- whole test completing well inside the 30 s freshness window —
+      -- both safe in practice.
       it "skip-if-fresh: projects refreshed within 30s are excluded from the next pass" $ \tr -> do
         let freshP = mkPid 11
             otherPs = [mkPid 12, mkPid 13]

--- a/test/integration/FacetsSpec.hs
+++ b/test/integration/FacetsSpec.hs
@@ -17,6 +17,7 @@ module FacetsSpec (spec) where
 
 import Data.Aeson qualified as AE
 import Data.HashMap.Strict qualified as HM
+import Data.Text qualified as T
 import Data.UUID qualified as UUID
 import Data.Vector qualified as V
 import Database.PostgreSQL.Entity.DBT (withPool)
@@ -69,7 +70,7 @@ clearAll tr pids = do
 
 
 keyHashFor :: Projects.ProjectId -> Text -> Text -> Text -> Text
-keyHashFor p host method path = toXXHash (p.toText <> host <> method <> path)
+keyHashFor p host method path = toXXHash (T.intercalate "\0" [p.toText, host, method, path])
 
 
 httpScope :: Text -> Text -> Text -> Catalog.Scope

--- a/test/integration/FacetsSpec.hs
+++ b/test/integration/FacetsSpec.hs
@@ -67,6 +67,9 @@ clearAll tr pids = withPool tr.trPool $ do
   -- and isn't load-bearing for these tests.
 
 
+-- | Mirrors the HTTP endpoint hash construction in
+-- 'ProcessMessage.extractObservation' (httpKeyOf branch). If that
+-- production function changes shape, this needs to follow.
 keyHashFor :: Projects.ProjectId -> Text -> Text -> Text -> Text
 keyHashFor p host method path = toXXHash (T.intercalate "\0" [p.toText, host, method, path])
 

--- a/test/integration/FacetsSpec.hs
+++ b/test/integration/FacetsSpec.hs
@@ -61,11 +61,10 @@ clearAll tr pids = withPool tr.trPool $ do
   exec [sql| DELETE FROM apis.schema_catalog WHERE project_id = ANY(?::uuid[]) |] (Only arr)
   exec [sql| DELETE FROM apis.schema_summary WHERE project_id = ANY(?::uuid[]) |] (Only arr)
   exec [sql| DELETE FROM apis.anomalies WHERE project_id = ANY(?::uuid[]) |] (Only arr)
-  exec
-    [sql| DELETE FROM apis.schema_template
-          WHERE NOT EXISTS (SELECT 1 FROM apis.schema_catalog
-                            WHERE template_hash = apis.schema_template.template_hash) |]
-    ()
+  -- Template cleanup is intentionally omitted here: deleting orphan
+  -- templates would race with other specs whose catalog rows still
+  -- reference them. The dead-template GC is a daily job in production
+  -- and isn't load-bearing for these tests.
 
 
 keyHashFor :: Projects.ProjectId -> Text -> Text -> Text -> Text

--- a/test/integration/FacetsSpec.hs
+++ b/test/integration/FacetsSpec.hs
@@ -23,8 +23,7 @@ import Database.PostgreSQL.Entity.DBT (withPool)
 import Database.PostgreSQL.Entity.DBT qualified as DBT
 import Database.PostgreSQL.Simple (Only (..))
 import Database.PostgreSQL.Simple.SqlQQ (sql)
-import Database.PostgreSQL.Simple.ToRow qualified
-import Database.PostgreSQL.Simple.Types qualified
+import Database.PostgreSQL.Simple.Types (PGArray (..))
 import Models.Apis.SchemaCatalog qualified as SC
 import Models.Projects.Projects qualified as Projects
 import Pkg.DeriveUtils (UUIDId (..))
@@ -48,25 +47,25 @@ mkPid n = UUIDId (UUID.fromWords 0 0 0 (fromIntegral n))
 
 clearAll :: TestResources -> [Projects.ProjectId] -> IO ()
 clearAll tr pids = do
-  let exec :: forall ps. Database.PostgreSQL.Simple.ToRow.ToRow ps => Database.PostgreSQL.Simple.Types.Query -> ps -> IO ()
-      exec q ps = void $ withPool tr.trPool $ DBT.execute q ps
+  let arr = PGArray pids
   -- FK targets: every test pid needs a row in projects.projects, otherwise
-  -- anomaly + summary inserts fail with FK violations.
-  forM_ pids \p ->
-    exec
-      [sql| INSERT INTO projects.projects (id, title, payment_plan, active, deleted_at, weekly_notif, daily_notif)
-            VALUES (?, 'facets-test', 'Free', true, NULL, false, false)
-            ON CONFLICT (id) DO NOTHING |]
-      (Only p)
-  forM_ pids \p -> do
-    exec [sql| DELETE FROM apis.schema_catalog WHERE project_id = ? |] (Only p)
-    exec [sql| DELETE FROM apis.schema_summary WHERE project_id = ? |] (Only p)
-    exec [sql| DELETE FROM apis.anomalies WHERE project_id = ? |] (Only p)
-  exec
-    [sql| DELETE FROM apis.schema_template
-          WHERE NOT EXISTS (SELECT 1 FROM apis.schema_catalog
-                            WHERE template_hash = apis.schema_template.template_hash) |]
-    ()
+  -- anomaly + summary inserts fail with FK violations. One round-trip each.
+  void $ withPool tr.trPool $ do
+    _ <-
+      DBT.execute
+        [sql| INSERT INTO projects.projects (id, title, payment_plan, active, deleted_at, weekly_notif, daily_notif)
+              SELECT id, 'facets-test', 'Free', true, NULL, false, false
+              FROM unnest(?::uuid[]) AS id
+              ON CONFLICT (id) DO NOTHING |]
+        (Only arr)
+    _ <- DBT.execute [sql| DELETE FROM apis.schema_catalog WHERE project_id = ANY(?::uuid[]) |] (Only arr)
+    _ <- DBT.execute [sql| DELETE FROM apis.schema_summary WHERE project_id = ANY(?::uuid[]) |] (Only arr)
+    _ <- DBT.execute [sql| DELETE FROM apis.anomalies WHERE project_id = ANY(?::uuid[]) |] (Only arr)
+    DBT.execute
+      [sql| DELETE FROM apis.schema_template
+            WHERE NOT EXISTS (SELECT 1 FROM apis.schema_catalog
+                              WHERE template_hash = apis.schema_template.template_hash) |]
+      ()
 
 
 keyHashFor :: Projects.ProjectId -> Text -> Text -> Text -> Text

--- a/test/integration/FacetsSpec.hs
+++ b/test/integration/FacetsSpec.hs
@@ -47,26 +47,25 @@ mkPid n = UUIDId (UUID.fromWords 0 0 0 (fromIntegral n))
 
 
 clearAll :: TestResources -> [Projects.ProjectId] -> IO ()
-clearAll tr pids = do
+clearAll tr pids = withPool tr.trPool $ do
   let arr = PGArray pids
+      exec q ps = void (DBT.execute q ps)
   -- FK targets: every test pid needs a row in projects.projects, otherwise
   -- anomaly + summary inserts fail with FK violations. One round-trip each.
-  void $ withPool tr.trPool $ do
-    _ <-
-      DBT.execute
-        [sql| INSERT INTO projects.projects (id, title, payment_plan, active, deleted_at, weekly_notif, daily_notif)
-              SELECT id, 'facets-test', 'Free', true, NULL, false, false
-              FROM unnest(?::uuid[]) AS id
-              ON CONFLICT (id) DO NOTHING |]
-        (Only arr)
-    _ <- DBT.execute [sql| DELETE FROM apis.schema_catalog WHERE project_id = ANY(?::uuid[]) |] (Only arr)
-    _ <- DBT.execute [sql| DELETE FROM apis.schema_summary WHERE project_id = ANY(?::uuid[]) |] (Only arr)
-    _ <- DBT.execute [sql| DELETE FROM apis.anomalies WHERE project_id = ANY(?::uuid[]) |] (Only arr)
-    DBT.execute
-      [sql| DELETE FROM apis.schema_template
-            WHERE NOT EXISTS (SELECT 1 FROM apis.schema_catalog
-                              WHERE template_hash = apis.schema_template.template_hash) |]
-      ()
+  exec
+    [sql| INSERT INTO projects.projects (id, title, payment_plan, active, deleted_at, weekly_notif, daily_notif)
+          SELECT id, 'facets-test', 'Free', true, NULL, false, false
+          FROM unnest(?::uuid[]) AS id
+          ON CONFLICT (id) DO NOTHING |]
+    (Only arr)
+  exec [sql| DELETE FROM apis.schema_catalog WHERE project_id = ANY(?::uuid[]) |] (Only arr)
+  exec [sql| DELETE FROM apis.schema_summary WHERE project_id = ANY(?::uuid[]) |] (Only arr)
+  exec [sql| DELETE FROM apis.anomalies WHERE project_id = ANY(?::uuid[]) |] (Only arr)
+  exec
+    [sql| DELETE FROM apis.schema_template
+          WHERE NOT EXISTS (SELECT 1 FROM apis.schema_catalog
+                            WHERE template_hash = apis.schema_template.template_hash) |]
+    ()
 
 
 keyHashFor :: Projects.ProjectId -> Text -> Text -> Text -> Text

--- a/test/integration/FacetsSpec.hs
+++ b/test/integration/FacetsSpec.hs
@@ -1,0 +1,206 @@
+-- | Coverage for the facet pipeline end to end.
+--
+-- Three layers:
+--   * Layer B (handler-shape): seed a 'SummaryDoc' directly, then invoke
+--     'SchemaCatalog.getFacetSummary' through the production effect runner
+--     and assert the dotted keys + ordering the @GET /api/v1/facets@
+--     handler relies on.
+--   * Layer C (round trip): observe spans whose walk hits attribute and
+--     resource paths, run 'Worker.flushDirty', then read the summary back
+--     and assert each expected dotted key is populated.
+--   * Layer C (bulk refresh): K projects, each with one dirty key. Confirm
+--     'regenerateSummaries' folds in-memory + writes one batched upsert
+--     (every project's summary materialises), and that the skip-if-fresh
+--     guard suppresses the write on a project whose summary was already
+--     refreshed within 30 s.
+module FacetsSpec (spec) where
+
+import Data.Aeson qualified as AE
+import Data.HashMap.Strict qualified as HM
+import Data.UUID qualified as UUID
+import Data.Vector qualified as V
+import Database.PostgreSQL.Entity.DBT (withPool)
+import Database.PostgreSQL.Entity.DBT qualified as DBT
+import Database.PostgreSQL.Simple (Only (..))
+import Database.PostgreSQL.Simple.SqlQQ (sql)
+import Database.PostgreSQL.Simple.ToRow qualified
+import Database.PostgreSQL.Simple.Types qualified
+import Models.Apis.SchemaCatalog qualified as SC
+import Models.Projects.Projects qualified as Projects
+import Pkg.DeriveUtils (UUIDId (..))
+import Pkg.SchemaLearning.Catalog qualified as Catalog
+import Pkg.SchemaLearning.Hot qualified as Hot
+import Pkg.SchemaLearning.Worker qualified as Worker
+import Pkg.TestUtils (TestResources (..), frozenTime, runHasqlEffect, withTestResources)
+import Relude
+import Test.Hspec (Spec, aroundAll, describe, it, shouldBe, shouldContain, shouldSatisfy)
+import Utils (toXXHash)
+
+
+pid :: Projects.ProjectId
+pid = UUIDId UUID.nil
+
+
+-- | Project IDs derived from a small int, used for the bulk-refresh test.
+mkPid :: Int -> Projects.ProjectId
+mkPid n = UUIDId (UUID.fromWords 0 0 0 (fromIntegral n))
+
+
+clearAll :: TestResources -> [Projects.ProjectId] -> IO ()
+clearAll tr pids = do
+  let exec :: forall ps. Database.PostgreSQL.Simple.ToRow.ToRow ps => Database.PostgreSQL.Simple.Types.Query -> ps -> IO ()
+      exec q ps = void $ withPool tr.trPool $ DBT.execute q ps
+  -- FK targets: every test pid needs a row in projects.projects, otherwise
+  -- anomaly + summary inserts fail with FK violations.
+  forM_ pids \p ->
+    exec
+      [sql| INSERT INTO projects.projects (id, title, payment_plan, active, deleted_at, weekly_notif, daily_notif)
+            VALUES (?, 'facets-test', 'Free', true, NULL, false, false)
+            ON CONFLICT (id) DO NOTHING |]
+      (Only p)
+  forM_ pids \p -> do
+    exec [sql| DELETE FROM apis.schema_catalog WHERE project_id = ? |] (Only p)
+    exec [sql| DELETE FROM apis.schema_summary WHERE project_id = ? |] (Only p)
+    exec [sql| DELETE FROM apis.anomalies WHERE project_id = ? |] (Only p)
+  exec
+    [sql| DELETE FROM apis.schema_template
+          WHERE NOT EXISTS (SELECT 1 FROM apis.schema_catalog
+                            WHERE template_hash = apis.schema_template.template_hash) |]
+    ()
+
+
+keyHashFor :: Projects.ProjectId -> Text -> Text -> Text -> Text
+keyHashFor p host method path = toXXHash (p.toText <> host <> method <> path)
+
+
+httpScope :: Text -> Text -> Text -> Catalog.Scope
+httpScope host method path =
+  Catalog.Scope
+    { Catalog.service = Just "checkout-svc"
+    , Catalog.spanName = Just (method <> " " <> path)
+    , Catalog.kind = Just "server"
+    , Catalog.host = Just host
+    , Catalog.method = Just method
+    , Catalog.urlPath = Just path
+    , Catalog.statusCodes = V.singleton 200
+    }
+
+
+-- | One ObservationInput with rich attribute + resource leaves so the
+-- catalog walks paths the renderer cares about (http.request.method,
+-- service.name, db.operation.name, ...).
+richObs :: Projects.ProjectId -> Text -> Hot.ObservationInput
+richObs p method =
+  Hot.ObservationInput
+    { keyKind = Catalog.HttpEndpoint
+    , keyHash = keyHashFor p "api.test" method "/orders"
+    , scope = httpScope "api.test" method "/orders"
+    , walk =
+        [ ("http.request.method", V.singleton (AE.String method, Nothing), Catalog.FCAttribute)
+        , ("db.operation.name", V.singleton (AE.String "SELECT", Nothing), Catalog.FCAttribute)
+        , ("service.name", V.singleton (AE.String "checkout-svc", Nothing), Catalog.FCResource)
+        ]
+    , timestamp = frozenTime
+    }
+
+
+-- | Seed an apis.schema_summary row whose doc carries the canonical bare
+-- catalog paths (no section prefix) so we can assert toFacetSummary prefixes
+-- them by category on read.
+seedSummary :: TestResources -> Projects.ProjectId -> IO ()
+seedSummary tr p = do
+  let fld cat = Catalog.FieldStruct mempty mempty cat False
+      doc =
+        Catalog.SummaryDoc
+          { fields =
+              HM.fromList
+                [ ("http.request.method", fld Catalog.FCAttribute)
+                , ("db.operation.name", fld Catalog.FCAttribute)
+                , ("service.name", fld Catalog.FCResource)
+                ]
+          , services = V.singleton "checkout-svc"
+          , topValuesByField =
+              HM.fromList
+                [ ("http.request.method", Catalog.TopK 2 (HM.fromList [("GET", 5), ("POST", 3)]))
+                , ("db.operation.name", Catalog.TopK 1 (HM.fromList [("SELECT", 7)]))
+                , ("service.name", Catalog.TopK 1 (HM.fromList [("checkout-svc", 8)]))
+                ]
+          }
+  runHasqlEffect tr $ SC.upsertSummary (V.singleton (p, doc))
+
+
+spec :: Spec
+spec = aroundAll withTestResources $
+  describe "Facets" $ do
+    describe "Layer B — handler-shape contract" $ do
+      it "getFacetSummary surfaces dotted keys with section prefixes" $ \tr -> do
+        clearAll tr [pid]
+        seedSummary tr pid
+        sumM <- runHasqlEffect tr $ SC.getFacetSummary pid "otel_logs_and_spans" frozenTime frozenTime
+        case sumM of
+          Nothing -> fail "expected a summary, got Nothing"
+          Just s -> do
+            let Catalog.FacetData m = s.facetJson
+                keys = HM.keys m
+            keys `shouldContain` ["attributes.http.request.method"]
+            keys `shouldContain` ["attributes.db.operation.name"]
+            keys `shouldContain` ["resource.service.name"]
+            -- Values come back in descending count order.
+            case HM.lookup "attributes.http.request.method" m of
+              Just vs -> map (.value) vs `shouldBe` ["GET", "POST"]
+              Nothing -> fail "missing attributes.http.request.method"
+
+      it "returns Nothing for an unknown project" $ \tr -> do
+        let unknown = mkPid 9999
+        clearAll tr [unknown]
+        sumM <- runHasqlEffect tr (SC.getFacetSummary unknown "otel_logs_and_spans" frozenTime frozenTime)
+        sumM `shouldSatisfy` isNothing
+
+    describe "Layer C — ingestion → flush → summary" $ do
+      it "rich attribute + resource walk produces all expected dotted facet keys" $ \tr -> do
+        clearAll tr [pid]
+        ref <- newIORef Hot.emptySchemaShardState
+        Hot.observeSpans ref Hot.defaultPolicy pid (V.fromList [richObs pid "GET", richObs pid "POST"])
+        _ <- runHasqlEffect tr (Worker.flushDirty ref)
+        sumM <- runHasqlEffect tr $ SC.getFacetSummary pid "otel_logs_and_spans" frozenTime frozenTime
+        case sumM of
+          Nothing -> fail "expected a summary after flushDirty"
+          Just s -> do
+            let Catalog.FacetData m = s.facetJson
+                keys = HM.keys m
+            keys `shouldContain` ["attributes.http.request.method"]
+            keys `shouldContain` ["attributes.db.operation.name"]
+            keys `shouldContain` ["resource.service.name"]
+            case HM.lookup "attributes.http.request.method" m of
+              Just vs -> map (.value) vs `shouldSatisfy` \xs -> "GET" `elem` xs && "POST" `elem` xs
+              Nothing -> fail "missing attributes.http.request.method after flush"
+
+    describe "Layer C — bulk refresh" $ do
+      it "K projects, K dirty keys: one flushDirty pass refreshes all summaries" $ \tr -> do
+        let projs = [mkPid i | i <- [1 .. 5]]
+        clearAll tr projs
+        ref <- newIORef Hot.emptySchemaShardState
+        forM_ projs \p -> Hot.observeSpans ref Hot.defaultPolicy p (V.singleton (richObs p "GET"))
+        r <- runHasqlEffect tr (Worker.flushDirty ref)
+        r.summariesUpdated `shouldBe` length projs
+        -- Every project has a non-empty doc post-flush.
+        forM_ projs \p -> do
+          sumM <- runHasqlEffect tr $ SC.getSummary p
+          sumM `shouldSatisfy` isJust
+
+      it "skip-if-fresh: projects refreshed within 30s are excluded from the next pass" $ \tr -> do
+        let freshP = mkPid 11
+            otherPs = [mkPid 12, mkPid 13]
+            projs = freshP : otherPs
+        clearAll tr projs
+        -- Seed freshP with a recognisable doc + recent generated_at (upsertSummary stamps now()).
+        seedSummary tr freshP
+        ref <- newIORef Hot.emptySchemaShardState
+        -- All three get a dirty key; freshP must be skipped on this flush.
+        forM_ projs \p -> Hot.observeSpans ref Hot.defaultPolicy p (V.singleton (richObs p "GET"))
+        r <- runHasqlEffect tr (Worker.flushDirty ref)
+        r.summariesUpdated `shouldBe` length otherPs -- freshP skipped
+        -- The two non-fresh projects were summarised this pass.
+        forM_ otherPs \p -> do
+          s <- runHasqlEffect tr $ SC.getSummary p
+          s `shouldSatisfy` isJust


### PR DESCRIPTION
## Summary

- Log Explorer sidebar only ever rendered the `Operation Name` facet because the renderer hard-coded triple-underscore keys (`attributes___http___request___method`) while the schema-learning catalog emits bare dotted paths (`http.request.method`). Collapse both sides to **one canonical key form**: the dotted OTel path that's already a member of `Pkg.Parser.Expr.flattenedOtelAttributes` and that the KQL parser compiles to a direct flat-column scan. ~100 lines of nested tuple lists in `Pages.LogExplorer.Log` become a single `[Facet]` list; `Models.Apis.SchemaCatalog.toFacetSummary` prefixes catalog paths by field category. A doctest (`prop_facetsAreFast`) gates every entry against the whitelist at compile time, so the failure class is now structurally impossible.
- `regenerateSummaries` no longer reads catalog rows back from Postgres per touched project. It folds each project's slice straight from the live in-memory `SchemaShardState.entries` and writes **one batched UNNEST upsert**. A skip-if-fresh guard (30 s window) collapses many flush passes into one summary write on noisy projects. `getByProject` is removed (single caller went away).

## Test plan

- [x] `cabal test doctests --test-option="--match=Pages.LogExplorer.Log"` — passes (613 examples). `prop_facetsAreFast` confirms every `Facet.path` is in `flattenedOtelAttributes`.
- [x] `USE_EXTERNAL_DB=true cabal test integration-tests --test-option="--match=/Facets/"` — `FacetsSpec` covers all three layers:
  - Layer B (handler-shape): `getFacetSummary` returns dotted keys + descending-count ordering; unknown project → `Nothing`.
  - Layer C (round-trip): observe rich attribute+resource walks → `flushDirty` → assert `attributes.http.request.method`, `attributes.db.operation.name`, `resource.service.name` all populated.
  - Layer C (bulk refresh): K projects with K dirty keys produce K summaries in one pass; the 30 s skip-if-fresh window excludes already-fresh projects from the next upsert.
- [ ] Manual smoke: visit `/p/<pid>/log_explorer`, confirm sidebar populates under HTTP / Database / Resource groups (not just Operation Name), and that clicking a value inserts `attributes.http.request.method == "GET"` into the KQL box and produces a flat-column scan.