### PR TITLE
facets: restore top-level + severity facets, empty-state row, more tests

### DIFF
--- a/src/Models/Apis/SchemaCatalog.hs
+++ b/src/Models/Apis/SchemaCatalog.hs
@@ -351,6 +351,7 @@ toFacetSummary pid tableName doc =
       Catalog.FCPathParam -> "attributes.url.path_param." <> path
       Catalog.FCRequestBody -> "body.request." <> path
       Catalog.FCResponseBody -> "body.response." <> path
+      Catalog.FCTopLevel -> path -- bare flat column (e.g. "level", "name", "severity.severity_text")
 
 
 -- ---------------------------------------------------------------------------

--- a/src/Pages/LogExplorer/Log.hs
+++ b/src/Pages/LogExplorer/Log.hs
@@ -12,6 +12,11 @@ module Pages.LogExplorer.Log (
   TraceTreeEntry (..),
   buildTraceTree,
   fmtPct1,
+  -- Sidebar facet definitions — exported for high-level tests.
+  Facet (..),
+  FacetGroup (..),
+  facetDefs,
+  renderFacets,
 )
 where
 
@@ -54,7 +59,7 @@ import Servant qualified
 import System.Config (AuthContext (..), EnvConfig (..))
 import System.Types
 import Text.Megaparsec (parseMaybe)
-import Utils (FreeTierStatus (..), LoadingSize (..), LoadingType (..), checkFreeTierStatus, faSprite_, formatUTC, getDurationNSMS, getServiceColors, htmxOverlayIndicator_, listToIndexHashMap, loadingIndicator_, lookupVecTextByKey, methodFillColor, prettyPrintCount, serviceFillColor, statusFillColorText)
+import Utils (FreeTierStatus (..), LoadingSize (..), LoadingType (..), checkFreeTierStatus, faSprite_, formatUTC, getDurationNSMS, getServiceColors, htmxOverlayIndicator_, levelFillColor, listToIndexHashMap, loadingIndicator_, lookupVecTextByKey, methodFillColor, prettyPrintCount, serviceFillColor, statusFillColorText)
 
 import Data.Time.Format.ISO8601 (iso8601ParseM, iso8601Show)
 import Data.UUID qualified as UUID
@@ -324,7 +329,7 @@ rowCountDisplay_ suffix countText suffixText =
 
 
 -- | Visual grouping for the sidebar. Each group renders one collapsible section.
-data FacetGroup = FGCommon | FGHTTP | FGResource | FGUserSession | FGDatabase | FGErrors
+data FacetGroup = FGCommon | FGHTTP | FGSeverity | FGResource | FGUserSession | FGDatabase | FGErrors
   deriving stock (Bounded, Enum, Eq, Ord, Show)
 
 
@@ -332,6 +337,7 @@ facetGroupLabel :: FacetGroup -> Text
 facetGroupLabel = \case
   FGCommon -> "Common Filters"
   FGHTTP -> "HTTP"
+  FGSeverity -> "Severity"
   FGResource -> "Resource"
   FGUserSession -> "User & Session"
   FGDatabase -> "Database"
@@ -340,16 +346,11 @@ facetGroupLabel = \case
 
 -- | A facet entry the sidebar can render.
 --
--- @path@ is the canonical KQL field name (dotted OTel form, e.g.
--- @attributes.http.request.method@). It is the lookup key in 'FacetData' (the
--- adapter in "Models.Apis.SchemaCatalog" prefixes catalog paths by category to
--- produce this form) AND the field the user types in KQL — so click-to-filter
--- emits a query the parser compiles to a flat-column scan via
--- 'Pkg.Parser.Expr.transformFlattenedAttribute'.
---
--- Invariant ('prop_facetsAreFast'): every @path@ must be a member of
--- 'Pkg.Parser.Expr.flattenedOtelAttributes' so the executed SQL is a direct
--- column reference, never a jsonb_path fallback.
+-- @path@ is the canonical KQL field name — the lookup key in 'FacetData' AND
+-- the field a user types in KQL. Invariant ('prop_facetsAreFast'): @path@ must
+-- be a flat-column reference (in 'Pkg.Parser.Expr.flattenedOtelAttributes' or
+-- 'Pkg.Parser.Expr.topLevelOtelColumns') so click-to-filter compiles to a
+-- direct column scan, not a jsonb_path fallback.
 data Facet = Facet
   { path :: Text
   , label :: Text
@@ -358,38 +359,21 @@ data Facet = Facet
   }
 
 
--- | The full facet list. Order within each group is preserved in the sidebar.
---
--- Every entry must be in 'Pkg.Parser.Expr.flattenedOtelAttributes' so KQL
--- compiles the click-to-filter expression to a flat-column scan rather than
--- a jsonb_path lookup.
---
--- A few facets that existed in the prior tuple-based sidebar are
--- intentionally absent here:
---
---   * @level@, @name@ (Operation Name), @kind@, @status_code@,
---     @status_message@, @severity.*@ — flat columns at the top level of
---     @otel_logs_and_spans@. The schema-learning walk doesn't emit these
---     paths (it walks @attributes@ / @resource@ / @body@ / @events@), so
---     they'd render empty even if listed.
---   * @attributes.network.*@, @attributes.client.address@,
---     @attributes.server.address@, @attributes.error.type@,
---     @attributes.session.previous.id@, @attributes.db.response.status_code@,
---     subgroups beyond what's listed, etc. — not yet in
---     'flattenedOtelAttributes'. Adding them naively here fails the
---     in-whitelist doctest. The right path is to (a) confirm the flat
---     column exists, (b) add the dotted path to the whitelist, (c) then
---     list it here.
+-- | The full facet list. Source order is preserved within each group.
 --
 -- >>> import qualified Pkg.Parser.Expr as PE
 -- >>> import qualified Data.Set as S
--- >>> all (\f -> S.member f.path PE.flattenedOtelAttributes) facetDefs
+-- >>> all (\f -> S.member f.path PE.flattenedOtelAttributes || S.member f.path PE.topLevelOtelColumns) facetDefs
 -- True
 facetDefs :: [Facet]
 facetDefs =
   let nc = const "" -- no fill color
    in -- Common
       [ Facet "resource.service.name" "Service" FGCommon serviceFillColor
+      , Facet "name" "Operation Name" FGCommon nc
+      , Facet "level" "Log Level" FGCommon levelFillColor
+      , Facet "status_code" "Status Code" FGCommon statusFillColorText
+      , Facet "kind" "Kind" FGCommon nc
       , Facet "attributes.http.request.method" "HTTP Method" FGCommon methodFillColor
       , Facet "attributes.http.response.status_code" "HTTP Status" FGCommon statusFillColorText
       , Facet "attributes.db.operation.name" "DB Operation" FGCommon nc
@@ -403,6 +387,10 @@ facetDefs =
       , Facet "attributes.url.fragment" "URL Fragment" FGHTTP nc
       , Facet "attributes.url.query" "URL Query" FGHTTP nc
       , Facet "attributes.user_agent.original" "User Agent" FGHTTP nc
+      , -- Severity
+        Facet "severity.severity_text" "Severity Text" FGSeverity levelFillColor
+      , Facet "severity.severity_number" "Severity Number" FGSeverity nc
+      , Facet "status_message" "Status Message" FGSeverity nc
       , -- Resource
         Facet "resource.service.version" "Service Version" FGResource nc
       , Facet "resource.service.instance.id" "Service Instance ID" FGResource nc
@@ -468,9 +456,8 @@ renderFacets facetSummary = do
     });
   |]
 
-  forM_ universe \g -> do
-    let fs = filter (\f -> HM.member f.path facetMap) (Map.findWithDefault [] g facetsByGroup)
-    unless (null fs) $ renderFacetSection (facetGroupLabel g) fs facetMap (g /= FGCommon)
+  forM_ universe \g ->
+    renderFacetSection (facetGroupLabel g) (Map.findWithDefault [] g facetsByGroup) facetMap (g /= FGCommon)
   where
     renderFacetSection :: Text -> [Facet] -> HM.HashMap Text [FacetValue] -> Bool -> Html ()
     renderFacetSection sectionName fs facetMap collapsed = do
@@ -481,10 +468,10 @@ renderFacets facetSummary = do
           span_ [class_ "font-medium text-sm"] (toHtml sectionName)
 
         div_ [class_ "facets-container mt-1 max-h-0 overflow-hidden peer-checked:max-h-[2000px] transition-[max-height] duration-300"] do
-          forM_ (zip [0 :: Int ..] fs) \(idx, f) ->
-            whenJust (HM.lookup f.path facetMap) \values -> do
-              let shouldBeExpanded = f.group == FGCommon && idx < 5
-              label_ [class_ "facet-section border-t border-strokeWeak group/facet block contain-[layout_style]"] do
+          forM_ (zip [0 :: Int ..] fs) \(idx, f) -> do
+            let values = HM.lookupDefault [] f.path facetMap
+                shouldBeExpanded = f.group == FGCommon && idx < 5 && not (null values)
+            label_ [class_ "facet-section border-t border-strokeWeak group/facet block contain-[layout_style]"] do
                 input_ $ [type_ "checkbox", class_ "hidden", id_ $ "facet-toggle-" <> f.path] ++ [checked_ | shouldBeExpanded]
                 div_ [class_ "flex items-center justify-between hover:bg-fillWeak rounded"] do
                   div_ [class_ "p-2 flex items-center gap-2 cursor-pointer flex-1"] do
@@ -546,11 +533,10 @@ renderFacets facetSummary = do
                   let valuesWithIndices = zip [0 :: Int ..] values
                       (visibleValues, hiddenValues) = splitAt 5 valuesWithIndices
                       hiddenCount = length hiddenValues
-                      -- val is an observed attribute value; jsEscape it
-                      -- before embedding in the JS single-quoted onclick.
-                      -- Order matters: backslash first, then single quote,
-                      -- then CR (drop) and LF (translate) so a value with
-                      -- "\n</script>..." can't break out.
+                      -- jsEscape an observed value before embedding in the JS
+                      -- single-quoted onclick. Order: backslash, single quote,
+                      -- CR (drop), LF (translate) — so a value containing
+                      -- "\n</script>..." can't break out of the surrounding tag.
                       jsEscape =
                         T.replace "\n" "\\n"
                           . T.replace "\r" ""
@@ -572,7 +558,9 @@ renderFacets facetSummary = do
                             unless (T.null colorClass) $ span_ [class_ $ colorClass <> " shrink-0 w-0.5 h-3 rounded-sm"] ""
                             span_ [class_ "facet-value truncate text-xs", term "data-tippy-content" val] (toHtml val)
                           span_ [class_ "facet-count text-xs text-textWeak shrink-0 tabular-nums"] $ toHtml $ prettyPrintCount count
-                  forM_ visibleValues \(_, value) -> renderFacetValue value
+                  if null values
+                    then div_ [class_ "facet-empty px-1 py-1 text-xs italic text-textWeak"] "no values in window"
+                    else forM_ visibleValues \(_, value) -> renderFacetValue value
 
                   when (hiddenCount > 0) do
                     let moreId = "more-" <> f.path

--- a/src/Pages/LogExplorer/Log.hs
+++ b/src/Pages/LogExplorer/Log.hs
@@ -472,21 +472,21 @@ renderFacets facetSummary = do
             let values = HM.lookupDefault [] f.path facetMap
                 shouldBeExpanded = f.group == FGCommon && idx < 5 && not (null values)
             label_ [class_ "facet-section border-t border-strokeWeak group/facet block contain-[layout_style]"] do
-                input_ $ [type_ "checkbox", class_ "hidden", id_ $ "facet-toggle-" <> f.path] ++ [checked_ | shouldBeExpanded]
-                div_ [class_ "flex items-center justify-between hover:bg-fillWeak rounded"] do
-                  div_ [class_ "p-2 flex items-center gap-2 cursor-pointer flex-1"] do
-                    faSprite_ "chevron-down" "regular" "w-2.5 h-2.5 transition-transform group-has-[:checked]/facet:rotate-0 -rotate-90"
-                    span_ [class_ "text-sm", term "data-tippy-content" f.path] (toHtml f.label)
+              input_ $ [type_ "checkbox", class_ "hidden", id_ $ "facet-toggle-" <> f.path] ++ [checked_ | shouldBeExpanded]
+              div_ [class_ "flex items-center justify-between hover:bg-fillWeak rounded"] do
+                div_ [class_ "p-2 flex items-center gap-2 cursor-pointer flex-1"] do
+                  faSprite_ "chevron-down" "regular" "w-2.5 h-2.5 transition-transform group-has-[:checked]/facet:rotate-0 -rotate-90"
+                  span_ [class_ "text-sm", term "data-tippy-content" f.path] (toHtml f.label)
 
-                  div_ [class_ "dropdown dropdown-end contain-[layout_style]", onclick_ "event.stopPropagation()"] do
-                    a_ [tabindex_ "0", class_ "cursor-pointer p-2 hover:bg-fillWeak rounded", Aria.label_ "Facet options", role_ "button"] do
-                      faSprite_ "ellipsis-vertical" "regular" "w-3 h-3"
-                    ul_ [tabindex_ "0", class_ "dropdown-content z-10 menu p-2 shadow-sm bg-bgRaised rounded-box w-52"] do
-                      li_
-                        $ a_
-                          [ term "data-field" f.path
-                          , class_ "flex gap-2 items-center"
-                          , [__|
+                div_ [class_ "dropdown dropdown-end contain-[layout_style]", onclick_ "event.stopPropagation()"] do
+                  a_ [tabindex_ "0", class_ "cursor-pointer p-2 hover:bg-fillWeak rounded", Aria.label_ "Facet options", role_ "button"] do
+                    faSprite_ "ellipsis-vertical" "regular" "w-3 h-3"
+                  ul_ [tabindex_ "0", class_ "dropdown-content z-10 menu p-2 shadow-sm bg-bgRaised rounded-box w-52"] do
+                    li_
+                      $ a_
+                        [ term "data-field" f.path
+                        , class_ "flex gap-2 items-center"
+                        , [__|
                              init
                                 set cols to params().cols or '' then
                                 set colsX to cols.split(',') then
@@ -503,16 +503,16 @@ renderFacets facetSummary = do
                                   set innerHTML of first <span/> in me to 'Add as table column'
                                 end
                               |]
-                          ]
-                          do
-                            faSprite_ "table-column" "regular" "w-4 h-4 text-iconNeutral"
-                            span_ [] "Add as table column"
-                      li_
-                        $ a_
-                          [ term "data-field" f.path
-                          , term "data-key" f.path
-                          , class_ "flex gap-2 items-center"
-                          , [__|
+                        ]
+                        do
+                          faSprite_ "table-column" "regular" "w-4 h-4 text-iconNeutral"
+                          span_ [] "Add as table column"
+                    li_
+                      $ a_
+                        [ term "data-field" f.path
+                        , term "data-key" f.path
+                        , class_ "flex gap-2 items-center"
+                        , [__|
                               init call window.updateGroupByButtonText(event, me) end
                               on refreshItem call window.updateGroupByButtonText(event, me) end
 
@@ -521,55 +521,55 @@ renderFacets facetSummary = do
                                 trigger refreshItem on me
                               end
                           |]
-                          ]
-                          do
-                            faSprite_ "group-by" "regular" "w-4 h-4 text-iconNeutral"
-                            span_ [] "Group by"
-                      li_ $ a_ [class_ "flex gap-2 items-center", onclick_ $ "viewFieldPatterns('" <> f.path <> "')"] do
-                        faSprite_ "chart-bar" "regular" "w-4 h-4 text-iconNeutral"
-                        span_ [] "View patterns"
+                        ]
+                        do
+                          faSprite_ "group-by" "regular" "w-4 h-4 text-iconNeutral"
+                          span_ [] "Group by"
+                    li_ $ a_ [class_ "flex gap-2 items-center", onclick_ $ "viewFieldPatterns('" <> f.path <> "')"] do
+                      faSprite_ "chart-bar" "regular" "w-4 h-4 text-iconNeutral"
+                      span_ [] "View patterns"
 
-                div_ [class_ "facet-values pl-7 pr-2 mb-1 space-y-1 max-h-0 overflow-hidden group-has-[:checked]/facet:max-h-[1000px] transition-[max-height] duration-200"] do
-                  let valuesWithIndices = zip [0 :: Int ..] values
-                      (visibleValues, hiddenValues) = splitAt 5 valuesWithIndices
-                      hiddenCount = length hiddenValues
-                      -- jsEscape an observed value before embedding in the JS
-                      -- single-quoted onclick. Order: backslash, single quote,
-                      -- CR (drop), LF (translate) — so a value containing
-                      -- "\n</script>..." can't break out of the surrounding tag.
-                      jsEscape =
-                        T.replace "\n" "\\n"
-                          . T.replace "\r" ""
-                          . T.replace "'" "\\'"
-                          . T.replace "\\" "\\\\"
-                      renderFacetValue (FacetValue val count) =
-                        label_ [class_ "facet-item flex items-center justify-between py-0.5 max-md:py-1.5 px-1 hover:bg-fillWeak rounded cursor-pointer will-change-[background-color]"] do
-                          div_ [class_ "flex items-center gap-2 min-w-0 flex-1"] do
-                            input_
-                              [ type_ "checkbox"
-                              , class_ "checkbox checkbox-xs max-md:checkbox-sm"
-                              , name_ f.path
-                              , onclick_ $ "filterByFacet('" <> f.path <> "', '" <> jsEscape val <> "')"
-                              , term "data-tippy-content" (f.path <> " == \"" <> val <> "\"")
-                              , term "data-field" f.path
-                              , term "data-value" val
-                              ]
-                            let colorClass = f.color val
-                            unless (T.null colorClass) $ span_ [class_ $ colorClass <> " shrink-0 w-0.5 h-3 rounded-sm"] ""
-                            span_ [class_ "facet-value truncate text-xs", term "data-tippy-content" val] (toHtml val)
-                          span_ [class_ "facet-count text-xs text-textWeak shrink-0 tabular-nums"] $ toHtml $ prettyPrintCount count
-                  if null values
-                    then div_ [class_ "facet-empty px-1 py-1 text-xs italic text-textWeak"] "no values in window"
-                    else forM_ visibleValues \(_, value) -> renderFacetValue value
+              div_ [class_ "facet-values pl-7 pr-2 mb-1 space-y-1 max-h-0 overflow-hidden group-has-[:checked]/facet:max-h-[1000px] transition-[max-height] duration-200"] do
+                let valuesWithIndices = zip [0 :: Int ..] values
+                    (visibleValues, hiddenValues) = splitAt 5 valuesWithIndices
+                    hiddenCount = length hiddenValues
+                    -- jsEscape an observed value before embedding in the JS
+                    -- single-quoted onclick. Order: backslash, single quote,
+                    -- CR (drop), LF (translate) — so a value containing
+                    -- "\n</script>..." can't break out of the surrounding tag.
+                    jsEscape =
+                      T.replace "\n" "\\n"
+                        . T.replace "\r" ""
+                        . T.replace "'" "\\'"
+                        . T.replace "\\" "\\\\"
+                    renderFacetValue (FacetValue val count) =
+                      label_ [class_ "facet-item flex items-center justify-between py-0.5 max-md:py-1.5 px-1 hover:bg-fillWeak rounded cursor-pointer will-change-[background-color]"] do
+                        div_ [class_ "flex items-center gap-2 min-w-0 flex-1"] do
+                          input_
+                            [ type_ "checkbox"
+                            , class_ "checkbox checkbox-xs max-md:checkbox-sm"
+                            , name_ f.path
+                            , onclick_ $ "filterByFacet('" <> f.path <> "', '" <> jsEscape val <> "')"
+                            , term "data-tippy-content" (f.path <> " == \"" <> val <> "\"")
+                            , term "data-field" f.path
+                            , term "data-value" val
+                            ]
+                          let colorClass = f.color val
+                          unless (T.null colorClass) $ span_ [class_ $ colorClass <> " shrink-0 w-0.5 h-3 rounded-sm"] ""
+                          span_ [class_ "facet-value truncate text-xs", term "data-tippy-content" val] (toHtml val)
+                        span_ [class_ "facet-count text-xs text-textWeak shrink-0 tabular-nums"] $ toHtml $ prettyPrintCount count
+                if null values
+                  then div_ [class_ "facet-empty px-1 py-1 text-xs italic text-textWeak"] "no values in window"
+                  else forM_ visibleValues \(_, value) -> renderFacetValue value
 
-                  when (hiddenCount > 0) do
-                    let moreId = "more-" <> f.path
-                    input_ [type_ "checkbox", class_ "hidden peer/more", id_ moreId]
-                    label_ [class_ "text-textBrand text-xs px-1 py-0.5 cursor-pointer hover:underline", Lucid.for_ moreId] do
-                      span_ [class_ "peer-checked/more:hidden"] $ toHtml $ "+ More (" <> prettyPrintCount hiddenCount <> ")"
-                      span_ [class_ "hidden peer-checked/more:inline"] $ toHtml $ "- Less (" <> prettyPrintCount hiddenCount <> ")"
+                when (hiddenCount > 0) do
+                  let moreId = "more-" <> f.path
+                  input_ [type_ "checkbox", class_ "hidden peer/more", id_ moreId]
+                  label_ [class_ "text-textBrand text-xs px-1 py-0.5 cursor-pointer hover:underline", Lucid.for_ moreId] do
+                    span_ [class_ "peer-checked/more:hidden"] $ toHtml $ "+ More (" <> prettyPrintCount hiddenCount <> ")"
+                    span_ [class_ "hidden peer-checked/more:inline"] $ toHtml $ "- Less (" <> prettyPrintCount hiddenCount <> ")"
 
-                    div_ [class_ "hidden peer-checked/more:block space-y-1"] $ forM_ hiddenValues \(_, value) -> renderFacetValue value
+                  div_ [class_ "hidden peer-checked/more:block space-y-1"] $ forM_ hiddenValues \(_, value) -> renderFacetValue value
 
 
 keepNonEmpty :: Maybe Text -> Maybe Text

--- a/src/Pkg/Parser/Expr.hs
+++ b/src/Pkg/Parser/Expr.hs
@@ -1,4 +1,4 @@
-module Pkg.Parser.Expr (pSubject, pExpr, Subject (..), Values (..), Expr (..), kqlTimespanToTimeBucket, FieldKey (..), pSquareBracketKey, pTerm, jsonPathQuery, display, pDuration, pNowFunction, pAgoFunction, pValues, Parser, symbol, sc, ToQueryText (..), flattenedOtelAttributes, transformFlattenedAttribute, outputFieldAliases) where
+module Pkg.Parser.Expr (pSubject, pExpr, Subject (..), Values (..), Expr (..), kqlTimespanToTimeBucket, FieldKey (..), pSquareBracketKey, pTerm, jsonPathQuery, display, pDuration, pNowFunction, pAgoFunction, pValues, Parser, symbol, sc, ToQueryText (..), flattenedOtelAttributes, topLevelOtelColumns, transformFlattenedAttribute, outputFieldAliases) where
 
 import Control.Monad.Combinators.Expr (
   Operator (InfixL),
@@ -640,7 +640,16 @@ flattenedOtelAttributes =
     , "attributes.exception.message"
     , "attributes.exception.stacktrace"
     , "attributes.exception.escaped"
+    , "severity.severity_text"
+    , "severity.severity_number"
     ]
+
+
+-- | Bare top-level columns on @otel_logs_and_spans@. KQL accepts these
+-- without translation (no @___@); listed here so the facet doctest
+-- ('prop_facetsAreFast') can gate them as fast-filter columns too.
+topLevelOtelColumns :: Set T.Text
+topLevelOtelColumns = fromList ["level", "name", "kind", "status_code", "status_message"]
 
 
 -- | Map user-facing output field names (SELECT aliases) to their real DB column names.

--- a/src/Pkg/SchemaLearning/Catalog.hs
+++ b/src/Pkg/SchemaLearning/Catalog.hs
@@ -510,6 +510,10 @@ data FieldCategoryEnum
   | FCAttribute
   | FCResource
   | FCEvent
+  | -- | Top-level columns on @otel_logs_and_spans@ (level, name, kind,
+    -- status_code, severity_*). Emitted bare in the facet output — no
+    -- @attributes.@/@resource.@ prefix.
+    FCTopLevel
   deriving stock (Eq, Generic, Ord, Read, Show)
   deriving anyclass (Default, NFData)
   deriving (AE.FromJSON, AE.ToJSON, Display, FromField, ToField) via WrappedEnumSC "FC" FieldCategoryEnum

--- a/src/ProcessMessage.hs
+++ b/src/ProcessMessage.hs
@@ -381,6 +381,24 @@ extractObservation canonicalTemplates otelSpan =
       !bodyValue = fromMaybe AE.Null (unAesonTextMaybe otelSpan.body)
       !eventsValue = fromMaybe AE.Null (unAesonTextMaybe otelSpan.events)
 
+      -- Top-level flat columns: level/kind/name/status_code/status_message
+      -- and the severity sub-record. Emitted bare so the facet adapter
+      -- doesn't prefix them with @attributes.@ / @resource.@.
+      !topLevelValue =
+        AE.Object
+          $ AEKM.fromList
+            [ (AEK.fromText k, v)
+            | (k, v) <-
+                catMaybes
+                  [ ("name",) . AE.String <$> otelSpan.name
+                  , ("kind",) . AE.String <$> otelSpan.kind
+                  , ("level",) . AE.String <$> otelSpan.level
+                  , ("status_code",) . AE.String <$> otelSpan.status_code
+                  , ("status_message",) . AE.String <$> otelSpan.status_message
+                  , ("severity",) . AE.toJSON <$> otelSpan.severity
+                  ]
+            ]
+
       !walk
         | isHttpSpan =
             let !pathParams = fromMaybe AE.emptyObject $ attrValue ^? key "http" . key "request" . key "path_params"
@@ -396,6 +414,7 @@ extractObservation canonicalTemplates otelSpan =
                   , tagWalk Fields.FCResponseHeader (valueToFields $ redacted respHeaders)
                   , tagWalk Fields.FCRequestBody (valueToFields reqBody)
                   , tagWalk Fields.FCResponseBody (valueToFields respBody)
+                  , tagWalk Fields.FCTopLevel (valueToFields topLevelValue)
                   ]
         | otherwise =
             mconcat
@@ -403,6 +422,7 @@ extractObservation canonicalTemplates otelSpan =
               , tagWalk Fields.FCResource (valueToFields $ redacted (AE.Object $ AEKM.fromMapText resMap))
               , tagWalk Fields.FCRequestBody (valueToFields $ redacted bodyValue)
               , tagWalk Fields.FCEvent (valueToFields $ redacted eventsValue)
+              , tagWalk Fields.FCTopLevel (valueToFields topLevelValue)
               ]
    in SchemaHot.ObservationInput
         { keyKind = keyKind

--- a/test/integration/FacetsSpec.hs
+++ b/test/integration/FacetsSpec.hs
@@ -16,7 +16,10 @@
 module FacetsSpec (spec) where
 
 import Data.Aeson qualified as AE
+import Data.Aeson.Key qualified as AEK
+import Data.Aeson.KeyMap qualified as AEKM
 import Data.HashMap.Strict qualified as HM
+import Data.Set qualified as S
 import Data.Text qualified as T
 import Data.UUID qualified as UUID
 import Data.Vector qualified as V
@@ -25,16 +28,20 @@ import Database.PostgreSQL.Entity.DBT qualified as DBT
 import Database.PostgreSQL.Simple (Only (..))
 import Database.PostgreSQL.Simple.SqlQQ (sql)
 import Database.PostgreSQL.Simple.Types (PGArray (..))
+import Lucid (renderText)
 import Models.Apis.SchemaCatalog qualified as SC
 import Models.Projects.Projects qualified as Projects
+import Pages.LogExplorer.Log qualified as LogPage
 import Pkg.DeriveUtils (UUIDId (..))
+import Pkg.Parser.Expr qualified as PE
 import Pkg.SchemaLearning.Catalog qualified as Catalog
 import Pkg.SchemaLearning.Hot qualified as Hot
 import Pkg.SchemaLearning.Worker qualified as Worker
-import Pkg.TestUtils (TestResources (..), frozenTime, runHasqlEffect, withTestResources)
+import Pkg.TestUtils (TestResources (..), frozenTime, runAsBase, runHasqlEffect, withTestResources)
 import Relude
-import Test.Hspec (Spec, aroundAll, describe, it, shouldBe, shouldContain, shouldSatisfy)
+import Test.Hspec (Spec, aroundAll, describe, it, shouldBe, shouldContain, shouldNotContain, shouldSatisfy)
 import Utils (toXXHash)
+import Web.ApiHandlers qualified as ApiH
 
 
 pid :: Projects.ProjectId
@@ -102,6 +109,22 @@ richObs p method =
         , ("service.name", V.singleton (AE.String "checkout-svc", Nothing), Catalog.FCResource)
         ]
     , timestamp = frozenTime
+    }
+
+
+-- | Variant that adds FCTopLevel leaves so we can assert the walker carries
+-- top-level columns (name/kind/level/status_code/severity.*) through the
+-- summary pipeline.
+richObsWithTopLevel :: Projects.ProjectId -> Text -> Hot.ObservationInput
+richObsWithTopLevel p method =
+  (richObs p method)
+    { Hot.walk =
+        (richObs p method).walk
+          <> [ ("name", V.singleton (AE.String ("POST /orders" :: Text), Nothing), Catalog.FCTopLevel)
+             , ("level", V.singleton (AE.String ("INFO" :: Text), Nothing), Catalog.FCTopLevel)
+             , ("kind", V.singleton (AE.String ("server" :: Text), Nothing), Catalog.FCTopLevel)
+             , ("severity.severity_text", V.singleton (AE.String ("INFO" :: Text), Nothing), Catalog.FCTopLevel)
+             ]
     }
 
 
@@ -176,6 +199,22 @@ spec = aroundAll withTestResources $
               Just vs -> map (.value) vs `shouldSatisfy` \xs -> "GET" `elem` xs && "POST" `elem` xs
               Nothing -> fail "missing attributes.http.request.method after flush"
 
+      it "top-level columns (name, level, kind, severity.*) flow through the walker" $ \tr -> do
+        clearAll tr [pid]
+        ref <- newIORef Hot.emptySchemaShardState
+        let obs = richObsWithTopLevel pid "POST"
+        Hot.observeSpans ref Hot.defaultPolicy pid (V.singleton obs)
+        _ <- runHasqlEffect tr (Worker.flushDirty ref)
+        sumM <- runHasqlEffect tr $ SC.getFacetSummary pid "otel_logs_and_spans" frozenTime frozenTime
+        case sumM of
+          Nothing -> fail "expected a summary"
+          Just s -> do
+            let Catalog.FacetData m = s.facetJson
+                keys = HM.keys m
+            keys `shouldContain` ["name"]
+            keys `shouldContain` ["level"]
+            keys `shouldContain` ["severity.severity_text"]
+
     describe "Layer C — bulk refresh" $ do
       it "K projects, K dirty keys: one flushDirty pass refreshes all summaries" $ \tr -> do
         let projs = [mkPid i | i <- [1 .. 5]]
@@ -208,3 +247,50 @@ spec = aroundAll withTestResources $
         forM_ otherPs \p -> do
           s <- runHasqlEffect tr $ SC.getSummary p
           s `shouldSatisfy` isJust
+
+    describe "Layer A — handler wire shape" $ do
+      it "GET /api/v1/facets returns dotted keys only (no triple-underscore)" $ \tr -> do
+        clearAll tr [pid]
+        seedSummary tr pid
+        body <- runAsBase tr $ ApiH.apiFacets pid Nothing Nothing Nothing Nothing
+        case body of
+          AE.Object o -> do
+            let keys = AEK.toText <$> AEKM.keys o
+            keys `shouldContain` ["attributes.http.request.method"]
+            keys `shouldNotContain` ["attributes___http___request___method"]
+            not (any (T.isInfixOf "___") keys) `shouldBe` True
+          _ -> fail "apiFacets did not return a JSON object"
+
+    describe "Layer A — sidebar HTML render" $ do
+      it "renderFacets emits one row per Facet.path, keyed by the canonical dotted form" $ \_ -> do
+        let m =
+              HM.fromList
+                [ ("attributes.http.request.method", [Catalog.FacetValue "GET" 3])
+                , ("resource.service.name", [Catalog.FacetValue "checkout-svc" 5])
+                , ("level", [Catalog.FacetValue "INFO" 7])
+                ]
+            summary =
+              Catalog.FacetSummary
+                { id = UUID.nil
+                , projectId = pid.toText
+                , tableName = "otel_logs_and_spans"
+                , facetJson = Catalog.FacetData m
+                }
+            html = toText $ renderText (LogPage.renderFacets summary)
+        T.isInfixOf "data-field=\"attributes.http.request.method\"" html `shouldBe` True
+        T.isInfixOf "data-field=\"resource.service.name\"" html `shouldBe` True
+        T.isInfixOf "data-field=\"level\"" html `shouldBe` True
+        -- jsEscape contract: the onclick wires the facet path + value through
+        -- filterByFacet. Lucid HTML-escapes attribute values, so the single
+        -- quotes round-trip as &#39;.
+        T.isInfixOf "filterByFacet(&#39;attributes.http.request.method&#39;, &#39;GET&#39;)" html `shouldBe` True
+        -- Section headers for groups that have populated facets show up.
+        T.isInfixOf "Common Filters" html `shouldBe` True
+        -- Facets without values still render with the empty-state row.
+        T.isInfixOf "no values in window" html `shouldBe` True
+
+      it "every Facet.path is fast (in flattenedOtelAttributes or topLevelOtelColumns)" $ \_ ->
+        all
+          (\f -> S.member f.path PE.flattenedOtelAttributes || S.member f.path PE.topLevelOtelColumns)
+          LogPage.facetDefs
+          `shouldBe` True


### PR DESCRIPTION
## Summary

Follow-up to #399. Restores facets that got dropped in the consolidation, adds an empty-state row for facets with no observed values, and lays down three high-level tests that pin the renderer↔producer contract.

- **Top-level columns flow through the catalog.** Added `FCTopLevel` field category; `ProcessMessage.extractObservation` now walks the span's flat columns (`name`, `kind`, `level`, `status_code`, `status_message`, `severity.*`) into the catalog. `toFacetSummary` emits these bare. `level`, `name`, `kind`, `status_code` are back in the Common Filters group; a new Severity group hosts `severity.severity_text`, `severity.severity_number`, `status_message`.
- **KQL fast-filter parity.** `severity.severity_text` and `severity.severity_number` join `flattenedOtelAttributes`. A new `topLevelOtelColumns` set in `Pkg.Parser.Expr` carries the bare columns. `prop_facetsAreFast` accepts membership in either set.
- **Empty-state UX.** Facets with no values in the current window render a muted "no values in window" row instead of being silently dropped. The round-13 section-level filter is reverted (groups always have at least one row now).
- **High-level tests.**
  - Layer A: `apiFacets` handler — `GET /api/v1/facets` returns dotted keys only; no `___` keys leak.
  - Layer A: renderer — feed a synthetic `FacetSummary` into `renderFacets`, assert the HTML carries `data-field="<dotted>"` markers, group headers render, and the empty-state row appears for unpopulated facets.
  - Round-trip: extended the ingestion test to assert `name`, `level`, `severity.severity_text` show up post-flush via the new FCTopLevel path.
  - Pure: every `facetDefs` entry sits in `flattenedOtelAttributes` ∪ `topLevelOtelColumns`.

## Test plan

- [x] `cabal test doctests --test-option="--match=Pages.LogExplorer.Log"` — passes (whitelist invariant intact)
- [x] `USE_EXTERNAL_DB=true cabal test integration-tests --test-option="--match=/Facets/"` — **9 / 9 examples pass**
- [x] `hlint` clean on the touched files
- [ ] Manual smoke: visit `/p/<pid>/log_explorer`, confirm Severity + Common Filter sections render, and empty facets show the muted "no values in window" row instead of disappearing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)