### PR TITLE
Ingestion/derive bulk insert cap

### DIFF
--- a/monoscope.cabal
+++ b/monoscope.cabal
@@ -429,6 +429,7 @@ library
     , valor >=1.0.0.0
     , vector
     , vector-algorithms
+    , vector-split
     , wai
     , wai-cors
     , wai-extra

--- a/package.yaml
+++ b/package.yaml
@@ -151,6 +151,7 @@ library:
     - proto-lens
     - proto-lens-runtime
     - vector-algorithms
+    - vector-split
     - effectful
     - effectful-core
     - effectful-th

--- a/src/Models/Telemetry/Telemetry.hs
+++ b/src/Models/Telemetry/Telemetry.hs
@@ -106,8 +106,6 @@ import Hasql.DynamicStatements.Snippet (Snippet, encoderAndParam, param, toPrepa
 import Hasql.Encoders qualified as E
 import Hasql.Interpolate qualified as HI
 import Hasql.Session qualified as HSession
-import Hasql.Transaction qualified as Tx
-import Hasql.Transaction.Sessions qualified as TxS
 import Models.Apis.ErrorPatterns qualified as ErrorPatterns
 import Models.Projects.Projects qualified as Projects
 import Pkg.DeriveUtils (AesonText (..), DB, UUIDId (..), WrappedEnum (..), WrappedEnumSC (..), encodeEnumSC, idFromText, textArrayEnc, unAesonTextMaybe)
@@ -1000,59 +998,40 @@ handOffBatches worker caches records = do
           unless ok $ atomicModifyIORef' worker.droppedBatches \n -> (n + 1, ())
 
 
--- | Hasql bulk insert for OtelLogsAndSpans, chunked to fit the 65535-param PG
--- bind limit (700 * 88 = 61600). On a non-transient failure bisects to isolate
--- poison rows (cap: 10 levels → isolates single rows for batches ≤ 1024).
--- Transient errors propagate so the caller can retry. Row snippets are built
--- once above 'go' so otelRowSnippet effects fire exactly once regardless of
--- bisection depth.
---
--- The 1024 cap is set by 'messagesPerPubsubPullBatch' (default 200) and the
--- Kafka batchSize: raise the cap if either grows past 1024 or a poison row
--- will only get BISECT_DEPTH_EXHAUSTED instead of POISON_ROW_DROPPED.
-bulkInsertOtelLogsAndSpans :: (Hasql :> es, IOE :> es, Log :> es) => V.Vector OtelLogsAndSpans -> Eff es Int64
-bulkInsertOtelLogsAndSpans records
-  | V.null records = pure 0
-  | otherwise = do
-      when (V.length records > 1024)
-        $ Log.logInfo "BISECT_CAP_MAY_NOT_ISOLATE"
-        $ AE.object ["record_count" AE..= V.length records, "cap" AE..= (1024 :: Int)]
-      pairs <- V.mapM (\r -> (r,) <$> otelRowSnippet r) records
-      go (10 :: Int) pairs
-  where
-    rawInsert pairs
-      | [single] <- chunks = Hasql.session (HSession.statement () (chunkStmt single))
-      | otherwise = Hasql.transaction TxS.ReadCommitted TxS.Write $ Relude.sum <$> traverse (Tx.statement () . chunkStmt) chunks
-      where
-        chunkSize = 700
-        chunks = unfoldr (\v -> if V.null v then Nothing else Just (V.splitAt chunkSize v)) (V.map snd pairs)
-        chunkStmt c = toPreparableStatement (otelInsertHeader <> mconcat (intersperse ", " (V.toList c))) D.rowsAffected
+maxParamsPerStmt, maxBisectDepth, bisectCap :: Int
+maxParamsPerStmt = 65535
+maxBisectDepth = 9
+bisectCap = 2 ^ maxBisectDepth
 
-    -- Outer guards V.null; the single-row branch handles 1; recursive calls
-    -- always split a ≥2 vector — so 'go' never sees an empty vector and
-    -- never recurses past V.length == 1. No V.null guard needed here.
-    go d pairs =
-      tryAny (rawInsert pairs) >>= \case
-        Right n -> pure n
-        Left e
-          | Hasql.isTransientException e -> throwIO e
-          | V.length pairs == 1 ->
-              Log.logAttention
-                "POISON_ROW_DROPPED"
-                (AE.object ["id" AE..= (fst (V.head pairs)).id, "error" AE..= show @Text e])
-                $> 0
-          | d <= 0 -> do
-              Log.logAttention "BISECT_DEPTH_EXHAUSTED"
-                $ AE.object ["record_count" AE..= V.length pairs, "error" AE..= show @Text e]
-              throwIO e
-          | otherwise ->
-              -- <*> is sequential in Eff es: a throw from the left half
-              -- short-circuits and skips the right half. Correct for
-              -- transients (whole batch must retry); also means a
-              -- depth-exhausted left half doesn't attempt the right.
-              -- Don't introduce parallelism here without revisiting that.
-              let (l, r) = V.splitAt (V.length pairs `div` 2) pairs
-               in (+) <$> go (d - 1) l <*> go (d - 1) r
+
+-- | Bulk-insert with row-level poison isolation. Slices oversized inputs so
+-- every Bind fits libpq's 65 535-param ceiling; the bisector then has enough
+-- depth (log2 bisectCap) to drill any failing slice to the offending row.
+--
+-- >>> bisectCap * length otelColumns <= maxParamsPerStmt
+-- True
+bulkInsertOtelLogsAndSpans :: (Hasql :> es, IOE :> es, Log :> es) => V.Vector OtelLogsAndSpans -> Eff es Int64
+bulkInsertOtelLogsAndSpans = fmap Relude.sum . traverse insertSlice . unfoldr step
+  where
+    step v = if V.null v then Nothing else Just (V.splitAt bisectCap v)
+    insertSlice rs = V.mapM (\r -> (r,) <$> otelRowSnippet r) rs >>= go maxBisectDepth
+
+    go d pairs = tryAny (Hasql.session $ HSession.statement () (stmt pairs)) >>= \case
+      Right n -> pure n
+      Left e
+        | Hasql.isTransientException e -> throwIO e
+        | V.length pairs == 1 ->
+            Log.logAttention "POISON_ROW_DROPPED"
+              (AE.object ["id" AE..= (fst (V.head pairs)).id, "error" AE..= show @Text e]) $> 0
+        | d <= 0 ->
+            Log.logAttention "BISECT_DEPTH_EXHAUSTED"
+              (AE.object ["record_count" AE..= V.length pairs, "error" AE..= show @Text e]) >> throwIO e
+        | otherwise ->
+            let (l, r) = V.splitAt (V.length pairs `div` 2) pairs
+             in (+) <$> go (d - 1) l <*> go (d - 1) r
+
+    stmt pairs = toPreparableStatement
+      (otelInsertHeader <> mconcat (intersperse ", " (V.toList (V.map snd pairs)))) D.rowsAffected
 
 
 -- | Thrown when an OtelLogsAndSpans row reaches the bulk insert path with an

--- a/src/Models/Telemetry/Telemetry.hs
+++ b/src/Models/Telemetry/Telemetry.hs
@@ -1010,8 +1010,9 @@ bisectCap = 2 ^ maxBisectDepth
 -- every Bind fits libpq's 65 535-param ceiling; the bisector then has enough
 -- depth (log2 bisectCap) to drill any failing slice to the offending row.
 --
--- Slices commit independently. A transient mid-traverse leaves earlier slices
--- durable; caller-level retry duplicates them (no ON CONFLICT).
+-- Slices commit independently — no enclosing transaction, since TF doesn't
+-- support real transactions and PG matches. Retry duplicates are absorbed by
+-- TF dedup on (id, timestamp) at flush time; PG doesn't retry.
 --
 -- >>> bisectCap * length otelColumns <= maxParamsPerStmt
 -- True

--- a/src/Models/Telemetry/Telemetry.hs
+++ b/src/Models/Telemetry/Telemetry.hs
@@ -60,7 +60,6 @@ module Models.Telemetry.Telemetry (
   insertSystemLog,
   generateSummary,
   otelSpanColsSql,
-  bisectCap,
 )
 where
 
@@ -1011,12 +1010,17 @@ bisectCap = 2 ^ maxBisectDepth
 -- every Bind fits libpq's 65 535-param ceiling; the bisector then has enough
 -- depth (log2 bisectCap) to drill any failing slice to the offending row.
 --
+-- Slices commit independently. A transient mid-traverse leaves earlier slices
+-- durable; caller-level retry duplicates them (no ON CONFLICT).
+--
 -- >>> bisectCap * length otelColumns <= maxParamsPerStmt
 -- True
 bulkInsertOtelLogsAndSpans :: (Hasql :> es, IOE :> es, Log :> es) => V.Vector OtelLogsAndSpans -> Eff es Int64
 bulkInsertOtelLogsAndSpans = fmap Relude.sum . traverse insertSlice . unfoldr step
   where
-    step v = if V.null v then Nothing else Just (V.splitAt bisectCap v)
+    step v
+      | V.null v = Nothing
+      | otherwise = Just (V.splitAt bisectCap v)
     insertSlice rs = V.mapM (\r -> (r,) <$> otelRowSnippet r) rs >>= go maxBisectDepth
 
     go d pairs =
@@ -1041,7 +1045,7 @@ bulkInsertOtelLogsAndSpans = fmap Relude.sum . traverse insertSlice . unfoldr st
 
     stmt pairs =
       toPreparableStatement
-        (otelInsertHeader <> mconcat (intersperse ", " (V.toList (V.map snd pairs))))
+        (otelInsertHeader <> mconcat (intersperse ", " (V.toList (snd <$> pairs))))
         D.rowsAffected
 
 

--- a/src/Models/Telemetry/Telemetry.hs
+++ b/src/Models/Telemetry/Telemetry.hs
@@ -1020,10 +1020,10 @@ bisectCap = 2 ^ maxBisectDepth
 -- >>> bisectCap * length otelColumns <= maxParamsPerStmt
 -- True
 bulkInsertOtelLogsAndSpans :: (Hasql :> es, IOE :> es, Log :> es) => V.Vector OtelLogsAndSpans -> Eff es Int64
-bulkInsertOtelLogsAndSpans records =
-  fmap Relude.sum . traverse insertSlice $ chunksOf bisectCap (V.toList records)
+bulkInsertOtelLogsAndSpans =
+  fmap Relude.sum . traverse insertSlice . unfoldr (\v -> if V.null v then Nothing else Just (V.splitAt bisectCap v))
   where
-    insertSlice chunk = V.mapM (\r -> (r,) <$> otelRowSnippet r) (V.fromList chunk) >>= go maxBisectDepth
+    insertSlice rs = V.mapM (\r -> (r,) <$> otelRowSnippet r) rs >>= go maxBisectDepth
 
     go d pairs =
       tryAny (Hasql.session $ HSession.statement () (stmt pairs)) >>= \case
@@ -1047,7 +1047,7 @@ bulkInsertOtelLogsAndSpans records =
 
     stmt pairs =
       toPreparableStatement
-        (otelInsertHeader <> mconcat (intersperse ", " (V.toList (snd <$> pairs))))
+        (otelInsertHeader <> mconcat (intersperse ", " (map snd (V.toList pairs))))
         D.rowsAffected
 
 

--- a/src/Models/Telemetry/Telemetry.hs
+++ b/src/Models/Telemetry/Telemetry.hs
@@ -1020,12 +1020,10 @@ bisectCap = 2 ^ maxBisectDepth
 -- >>> bisectCap * length otelColumns <= maxParamsPerStmt
 -- True
 bulkInsertOtelLogsAndSpans :: (Hasql :> es, IOE :> es, Log :> es) => V.Vector OtelLogsAndSpans -> Eff es Int64
-bulkInsertOtelLogsAndSpans = fmap Relude.sum . traverse insertSlice . unfoldr step
+bulkInsertOtelLogsAndSpans records =
+  fmap Relude.sum . traverse insertSlice $ chunksOf bisectCap (V.toList records)
   where
-    step v
-      | V.null v = Nothing
-      | otherwise = Just (V.splitAt bisectCap v)
-    insertSlice rs = V.mapM (\r -> (r,) <$> otelRowSnippet r) rs >>= go maxBisectDepth
+    insertSlice chunk = V.mapM (\r -> (r,) <$> otelRowSnippet r) (V.fromList chunk) >>= go maxBisectDepth
 
     go d pairs =
       tryAny (Hasql.session $ HSession.statement () (stmt pairs)) >>= \case
@@ -1049,7 +1047,7 @@ bulkInsertOtelLogsAndSpans = fmap Relude.sum . traverse insertSlice . unfoldr st
 
     stmt pairs =
       toPreparableStatement
-        (otelInsertHeader <> mconcat (intersperse ", " (map snd (V.toList pairs))))
+        (otelInsertHeader <> mconcat (intersperse ", " (V.toList (snd <$> pairs))))
         D.rowsAffected
 
 

--- a/src/Models/Telemetry/Telemetry.hs
+++ b/src/Models/Telemetry/Telemetry.hs
@@ -1015,7 +1015,7 @@ bisectCap = 2 ^ maxBisectDepth
 -- path (enableTf=False) accepts the same per-slice contract — partial commit
 -- on failure, no rollback across slices.
 --
--- >>> bisectCap * length otelColumns <= maxParamsPerStmt
+-- >>> bisectCap * length otelColumns <= 65535  -- libpq Bind param ceiling
 -- True
 bulkInsertOtelLogsAndSpans :: (Hasql :> es, IOE :> es, Log :> es) => V.Vector OtelLogsAndSpans -> Eff es Int64
 bulkInsertOtelLogsAndSpans = fmap Relude.sum . traverse insertSlice . VS.chunksOf bisectCap

--- a/src/Models/Telemetry/Telemetry.hs
+++ b/src/Models/Telemetry/Telemetry.hs
@@ -1012,7 +1012,9 @@ bisectCap = 2 ^ maxBisectDepth
 --
 -- Slices commit independently — no enclosing transaction, since TF doesn't
 -- support real transactions and PG matches. Retry duplicates are absorbed by
--- TF dedup on (id, timestamp) at flush time; PG doesn't retry.
+-- TF dedup on (id, timestamp) at flush time; PG doesn't retry. The PG-only
+-- path (enableTf=False) accepts the same per-slice contract — partial commit
+-- on failure, no rollback across slices.
 --
 -- >>> bisectCap * length otelColumns <= maxParamsPerStmt
 -- True
@@ -1046,7 +1048,7 @@ bulkInsertOtelLogsAndSpans = fmap Relude.sum . traverse insertSlice . unfoldr st
 
     stmt pairs =
       toPreparableStatement
-        (otelInsertHeader <> mconcat (intersperse ", " (V.toList (snd <$> pairs))))
+        (otelInsertHeader <> mconcat (intersperse ", " (map snd (V.toList pairs))))
         D.rowsAffected
 
 

--- a/src/Models/Telemetry/Telemetry.hs
+++ b/src/Models/Telemetry/Telemetry.hs
@@ -85,6 +85,7 @@ import Data.Time (UTCTime)
 import Data.Time.Clock (addUTCTime)
 import Data.UUID qualified as UUID
 import Data.Vector qualified as V
+import Data.Vector.Split qualified as VS
 import Database.PostgreSQL.Simple (ResultError (ConversionFailed))
 
 import Data.Effectful.Hasql (Hasql)
@@ -999,10 +1000,7 @@ handOffBatches worker caches records = do
           unless ok $ atomicModifyIORef' worker.droppedBatches \n -> (n + 1, ())
 
 
--- 'maxParamsPerStmt' anchors the doctest invariant below; if you raise depth,
--- the doctest catches the overflow.
-maxParamsPerStmt, maxBisectDepth, bisectCap :: Int
-maxParamsPerStmt = 65535
+maxBisectDepth, bisectCap :: Int
 maxBisectDepth = 9
 bisectCap = 2 ^ maxBisectDepth
 
@@ -1020,8 +1018,7 @@ bisectCap = 2 ^ maxBisectDepth
 -- >>> bisectCap * length otelColumns <= maxParamsPerStmt
 -- True
 bulkInsertOtelLogsAndSpans :: (Hasql :> es, IOE :> es, Log :> es) => V.Vector OtelLogsAndSpans -> Eff es Int64
-bulkInsertOtelLogsAndSpans =
-  fmap Relude.sum . traverse insertSlice . unfoldr (\v -> if V.null v then Nothing else Just (V.splitAt bisectCap v))
+bulkInsertOtelLogsAndSpans = fmap Relude.sum . traverse insertSlice . VS.chunksOf bisectCap
   where
     insertSlice rs = V.mapM (\r -> (r,) <$> otelRowSnippet r) rs >>= go maxBisectDepth
 

--- a/src/Models/Telemetry/Telemetry.hs
+++ b/src/Models/Telemetry/Telemetry.hs
@@ -60,6 +60,7 @@ module Models.Telemetry.Telemetry (
   insertSystemLog,
   generateSummary,
   otelSpanColsSql,
+  bisectCap,
 )
 where
 
@@ -998,6 +999,8 @@ handOffBatches worker caches records = do
           unless ok $ atomicModifyIORef' worker.droppedBatches \n -> (n + 1, ())
 
 
+-- 'maxParamsPerStmt' anchors the doctest invariant below; if you raise depth,
+-- the doctest catches the overflow.
 maxParamsPerStmt, maxBisectDepth, bisectCap :: Int
 maxParamsPerStmt = 65535
 maxBisectDepth = 9
@@ -1032,6 +1035,7 @@ bulkInsertOtelLogsAndSpans = fmap Relude.sum . traverse insertSlice . unfoldr st
                 (AE.object ["record_count" AE..= V.length pairs, "error" AE..= show @Text e])
                 >> throwIO e
           | otherwise ->
+              -- <*> is sequential in Eff: a throw from the left short-circuits the right. Do not parallelize.
               let (l, r) = V.splitAt (V.length pairs `div` 2) pairs
                in (+) <$> go (d - 1) l <*> go (d - 1) r
 

--- a/src/Models/Telemetry/Telemetry.hs
+++ b/src/Models/Telemetry/Telemetry.hs
@@ -60,6 +60,7 @@ module Models.Telemetry.Telemetry (
   insertSystemLog,
   generateSummary,
   otelSpanColsSql,
+  bisectCap,
 )
 where
 
@@ -1244,7 +1245,7 @@ data Context = Context
 -- 'otelSpanColsSql' + 'otelColumns' are touched in the same change:
 --
 -- >>> length otelColumns
--- 25
+-- 89
 data OtelLogsAndSpans = OtelLogsAndSpans
   { project_id :: Text
   , id :: Text -- UUID

--- a/src/Models/Telemetry/Telemetry.hs
+++ b/src/Models/Telemetry/Telemetry.hs
@@ -1016,22 +1016,29 @@ bulkInsertOtelLogsAndSpans = fmap Relude.sum . traverse insertSlice . unfoldr st
     step v = if V.null v then Nothing else Just (V.splitAt bisectCap v)
     insertSlice rs = V.mapM (\r -> (r,) <$> otelRowSnippet r) rs >>= go maxBisectDepth
 
-    go d pairs = tryAny (Hasql.session $ HSession.statement () (stmt pairs)) >>= \case
-      Right n -> pure n
-      Left e
-        | Hasql.isTransientException e -> throwIO e
-        | V.length pairs == 1 ->
-            Log.logAttention "POISON_ROW_DROPPED"
-              (AE.object ["id" AE..= (fst (V.head pairs)).id, "error" AE..= show @Text e]) $> 0
-        | d <= 0 ->
-            Log.logAttention "BISECT_DEPTH_EXHAUSTED"
-              (AE.object ["record_count" AE..= V.length pairs, "error" AE..= show @Text e]) >> throwIO e
-        | otherwise ->
-            let (l, r) = V.splitAt (V.length pairs `div` 2) pairs
-             in (+) <$> go (d - 1) l <*> go (d - 1) r
+    go d pairs =
+      tryAny (Hasql.session $ HSession.statement () (stmt pairs)) >>= \case
+        Right n -> pure n
+        Left e
+          | Hasql.isTransientException e -> throwIO e
+          | V.length pairs == 1 ->
+              Log.logAttention
+                "POISON_ROW_DROPPED"
+                (AE.object ["id" AE..= (fst (V.head pairs)).id, "error" AE..= show @Text e])
+                $> 0
+          | d <= 0 ->
+              Log.logAttention
+                "BISECT_DEPTH_EXHAUSTED"
+                (AE.object ["record_count" AE..= V.length pairs, "error" AE..= show @Text e])
+                >> throwIO e
+          | otherwise ->
+              let (l, r) = V.splitAt (V.length pairs `div` 2) pairs
+               in (+) <$> go (d - 1) l <*> go (d - 1) r
 
-    stmt pairs = toPreparableStatement
-      (otelInsertHeader <> mconcat (intersperse ", " (V.toList (V.map snd pairs)))) D.rowsAffected
+    stmt pairs =
+      toPreparableStatement
+        (otelInsertHeader <> mconcat (intersperse ", " (V.toList (V.map snd pairs))))
+        D.rowsAffected
 
 
 -- | Thrown when an OtelLogsAndSpans row reaches the bulk insert path with an

--- a/src/Pkg/TestUtils.hs
+++ b/src/Pkg/TestUtils.hs
@@ -1245,9 +1245,9 @@ createTestAPIKey tr projectId keyName = do
 -- | Ingest via resource attribute (key embedded in payload) or via header (key in Authorization header)
 ingestLog, ingestLogWithHeader :: TestResources -> Text -> Text -> UTCTime -> IO ()
 ingestLog tr apiKey bodyText timestamp =
-  void $ OtlpServer.logsServiceExport tr.trLogger tr.trATCtx tr.trTracerProvider (Proto $ createOtelLogAtTime apiKey bodyText timestamp)
+  void $ OtlpServer.logsServiceExport tr.trLogger tr.trATCtx tr.trTracerProvider (Proto $ createOtelLogAtTime apiKey [bodyText] timestamp)
 ingestLogWithHeader tr apiKey bodyText timestamp =
-  void $ runTestBg frozenTime tr $ OtlpServer.processLogsRequest (Just apiKey) (createOtelLogAtTime "" bodyText timestamp)
+  void $ runTestBg frozenTime tr $ OtlpServer.processLogsRequest (Just apiKey) (createOtelLogAtTime "" [bodyText] timestamp)
 
 
 -- | Like 'ingestLog' but timestamps the record with the current test-clock value.
@@ -1498,10 +1498,10 @@ mkResource :: Text -> [PC.KeyValue] -> PR.Resource
 mkResource apiKey extras = defMessage & PRF.attributes .~ ([mkAttr "service.name" "test-service", mkAttr "at-project-key" apiKey] <> extras)
 
 
-createOtelLogAtTime :: Text -> Text -> UTCTime -> LS.ExportLogsServiceRequest
-createOtelLogAtTime apiKey bodyText timestamp =
-  let logRecord = defMessage & PLF.timeUnixNano .~ toNanos timestamp & PLF.body .~ (defMessage & PCF.stringValue .~ bodyText) & PLF.severityText .~ "INFO"
-      scopeLog = defMessage & PLF.logRecords .~ [logRecord]
+createOtelLogAtTime :: Text -> [Text] -> UTCTime -> LS.ExportLogsServiceRequest
+createOtelLogAtTime apiKey bodyTexts timestamp =
+  let mkRec b = defMessage & PLF.timeUnixNano .~ toNanos timestamp & PLF.body .~ (defMessage & PCF.stringValue .~ b) & PLF.severityText .~ "INFO"
+      scopeLog = defMessage & PLF.logRecords .~ map mkRec bodyTexts
    in defMessage & LSF.resourceLogs .~ [defMessage & PLF.resource .~ mkResource apiKey [] & PLF.scopeLogs .~ [scopeLog]]
 
 

--- a/test/integration/Opentelemetry/GrpcIngestionSpec.hs
+++ b/test/integration/Opentelemetry/GrpcIngestionSpec.hs
@@ -151,8 +151,10 @@ spec = aroundAll withTestResources do
       metricResult <- runQueryEffect tr $ Charts.queryMetrics Nothing (Just Charts.DTMetric) (Just pid) (Just "summarize count(*) by bin_auto(timestamp)") Nothing Nothing (Just timeFrom) (Just timeTo) (Just "metrics") []
       V.length metricResult.dataset `shouldSatisfy` (> 0)
 
-    -- n = 2 * bisectCap + 1 exposes slicing off-by-one and the singleton-tail slice.
-    let n = 2 * Telemetry.bisectCap + 1
+    -- 2 * bisectCap + 1 → 3 slices including a singleton tail; poisonIdx
+    -- lands mid second slice. Tracks bisectCap in Telemetry.hs.
+    let n = 1025
+        poisonIdx = 519
 
     it "Test 8.1: slices and persists a >bisectCap OTLP request" $ \tr -> do
       key <- createTestAPIKey tr pid "Bulk Test Key"
@@ -167,7 +169,6 @@ spec = aroundAll withTestResources do
     it "Test 8.2: isolates one poison row in a >bisectCap batch (count == n-1)" $ \tr -> do
       -- NUL in flat text attr bypasses JSONB cleaning → server reject → bisection drops.
       let tag = "bulk-8.2"
-          poisonIdx = Telemetry.bisectCap + 7 -- mid-batch, second slice
           mkRow i = Telemetry.mkSystemLog pid "bulk-poison-test" Telemetry.SLInfo (show i)
             (Map.fromList (("test.tag", AE.String tag) : [("code.function.name", AE.String "G\NULET") | i == poisonIdx]))
             Nothing frozenTime

--- a/test/integration/Opentelemetry/GrpcIngestionSpec.hs
+++ b/test/integration/Opentelemetry/GrpcIngestionSpec.hs
@@ -153,29 +153,29 @@ spec = aroundAll withTestResources do
 
     -- 2 * bisectCap + 1 → 3 slices including a singleton tail; poisonIdx
     -- lands mid second slice. Tracks bisectCap in Telemetry.hs.
-    let n = 1025
+    let bulkN = 1025
         poisonIdx = 519
 
     it "Test 8.1: slices and persists a >bisectCap OTLP request" $ \tr -> do
       key <- createTestAPIKey tr pid "Bulk Test Key"
       let tag = "bulk-8.1"
-          bodies = [tag <> "/" <> show i | i <- [1 .. n] :: [Int]]
+          bodies = [tag <> "/" <> show i | i <- [1 .. bulkN] :: [Int]]
       void $ OtlpServer.logsServiceExport tr.trLogger tr.trATCtx tr.trTracerProvider (Proto $ createOtelLogAtTime key bodies frozenTime)
       void $ runAllBackgroundJobs frozenTime tr.trATCtx
       counts :: [Int64] <- runQueryEffect tr
         $ Hasql.interp [HI.sql|SELECT count(*)::bigint FROM otel_logs_and_spans WHERE body::text LIKE '%' || #{tag} || '%'|]
-      counts `shouldBe` [fromIntegral n]
+      counts `shouldBe` [fromIntegral bulkN]
 
-    it "Test 8.2: isolates one poison row in a >bisectCap batch (count == n-1)" $ \tr -> do
+    it "Test 8.2: isolates one poison row in a >bisectCap batch (count == bulkN-1)" $ \tr -> do
       -- NUL in flat text attr bypasses JSONB cleaning → server reject → bisection drops.
       let tag = "bulk-8.2"
           mkRow i = Telemetry.mkSystemLog pid "bulk-poison-test" Telemetry.SLInfo (show i)
             (Map.fromList (("test.tag", AE.String tag) : [("code.function.name", AE.String "G\NULET") | i == poisonIdx]))
             Nothing frozenTime
-      runTestBg frozenTime tr $ Telemetry.bulkInsertOtelLogsAndSpansTF False =<< Telemetry.mintOtelLogIds (V.generate n mkRow)
+      runTestBg frozenTime tr $ Telemetry.bulkInsertOtelLogsAndSpansTF False =<< Telemetry.mintOtelLogIds (V.generate bulkN mkRow)
       counts :: [Int64] <- runQueryEffect tr
         $ Hasql.interp [HI.sql|SELECT count(*)::bigint FROM otel_logs_and_spans WHERE attributes ->> 'test.tag' = #{tag}|]
-      counts `shouldBe` [fromIntegral (n - 1)]
+      counts `shouldBe` [fromIntegral (bulkN - 1)]
 
     -- Tests for gRPC Authorization header authentication (NEW!)
     describe "gRPC Authorization Header Authentication" do

--- a/test/integration/Opentelemetry/GrpcIngestionSpec.hs
+++ b/test/integration/Opentelemetry/GrpcIngestionSpec.hs
@@ -4,6 +4,7 @@ module Opentelemetry.GrpcIngestionSpec (spec) where
 
 import Control.Lens ((.~))
 import Data.Effectful.Hasql qualified as Hasql
+import Data.Generics.Product (field)
 import Data.Map.Strict qualified as Map
 import Data.Time (addUTCTime)
 import Data.Time.Format.ISO8601 (iso8601Show)
@@ -177,7 +178,7 @@ spec = aroundAll withTestResources do
             (Map.singleton "test.tag" (AE.String tag)) Nothing frozenTime
       rows <- Telemetry.mintOtelLogIds (V.generate bulkN mkRow) & runTestBg frozenTime tr
       let firstId = (rows V.! 0).id
-          rows' = rows V.// [(poisonIdx, (rows V.! poisonIdx) & #id .~ firstId)]
+          rows' = rows V.// [(poisonIdx, (rows V.! poisonIdx) & field @"id" .~ firstId)]
       runTestBg frozenTime tr $ Telemetry.bulkInsertOtelLogsAndSpansTF False rows'
       counts :: [Int64] <- runQueryEffect tr
         $ Hasql.interp [HI.sql|SELECT count(*)::bigint FROM otel_logs_and_spans WHERE attributes ->> 'test.tag' = #{tag}|]

--- a/test/integration/Opentelemetry/GrpcIngestionSpec.hs
+++ b/test/integration/Opentelemetry/GrpcIngestionSpec.hs
@@ -2,6 +2,7 @@
 
 module Opentelemetry.GrpcIngestionSpec (spec) where
 
+import Control.Lens ((.~))
 import Data.Effectful.Hasql qualified as Hasql
 import Data.Map.Strict qualified as Map
 import Data.Time (addUTCTime)
@@ -167,12 +168,17 @@ spec = aroundAll withTestResources do
       counts `shouldBe` [fromIntegral bulkN]
 
     it "Test 8.2: isolates one poison row in a >bisectCap batch (count == bulkN-1)" $ \tr -> do
-      -- NUL in flat text attr bypasses JSONB cleaning → server reject → bisection drops.
+      -- Force a PK collision (project_id, timestamp, id): the poison row reuses
+      -- row 0's id. Within the same multi-row INSERT this fails server-side;
+      -- bisection drills to single rows, row 0 commits, the singleton poison
+      -- then re-collides with the just-committed row and is dropped.
       let tag = "bulk-8.2"
           mkRow i = Telemetry.mkSystemLog pid "bulk-poison-test" Telemetry.SLInfo (show i)
-            (Map.fromList (("test.tag", AE.String tag) : [("code.function.name", AE.String "G\NULET") | i == poisonIdx]))
-            Nothing frozenTime
-      runTestBg frozenTime tr $ Telemetry.bulkInsertOtelLogsAndSpansTF False =<< Telemetry.mintOtelLogIds (V.generate bulkN mkRow)
+            (Map.singleton "test.tag" (AE.String tag)) Nothing frozenTime
+      rows <- Telemetry.mintOtelLogIds (V.generate bulkN mkRow) & runTestBg frozenTime tr
+      let firstId = (rows V.! 0).id
+          rows' = rows V.// [(poisonIdx, (rows V.! poisonIdx) & #id .~ firstId)]
+      runTestBg frozenTime tr $ Telemetry.bulkInsertOtelLogsAndSpansTF False rows'
       counts :: [Int64] <- runQueryEffect tr
         $ Hasql.interp [HI.sql|SELECT count(*)::bigint FROM otel_logs_and_spans WHERE attributes ->> 'test.tag' = #{tag}|]
       counts `shouldBe` [fromIntegral (bulkN - 1)]

--- a/test/integration/Opentelemetry/GrpcIngestionSpec.hs
+++ b/test/integration/Opentelemetry/GrpcIngestionSpec.hs
@@ -4,7 +4,7 @@ module Opentelemetry.GrpcIngestionSpec (spec) where
 
 import Control.Lens ((.~))
 import Data.Effectful.Hasql qualified as Hasql
-import Data.Generics.Product (field)
+import Data.Generics.Product qualified as GL
 import Data.Map.Strict qualified as Map
 import Data.Time (addUTCTime)
 import Data.Time.Format.ISO8601 (iso8601Show)
@@ -178,7 +178,7 @@ spec = aroundAll withTestResources do
             (Map.singleton "test.tag" (AE.String tag)) Nothing frozenTime
       rows <- Telemetry.mintOtelLogIds (V.generate bulkN mkRow) & runTestBg frozenTime tr
       let firstId = (rows V.! 0).id
-          rows' = rows V.// [(poisonIdx, (rows V.! poisonIdx) & field @"id" .~ firstId)]
+          rows' = rows V.// [(poisonIdx, (rows V.! poisonIdx) & GL.field @"id" .~ firstId)]
       runTestBg frozenTime tr $ Telemetry.bulkInsertOtelLogsAndSpansTF False rows'
       counts :: [Int64] <- runQueryEffect tr
         $ Hasql.interp [HI.sql|SELECT count(*)::bigint FROM otel_logs_and_spans WHERE attributes ->> 'test.tag' = #{tag}|]

--- a/test/integration/Opentelemetry/GrpcIngestionSpec.hs
+++ b/test/integration/Opentelemetry/GrpcIngestionSpec.hs
@@ -2,10 +2,7 @@
 
 module Opentelemetry.GrpcIngestionSpec (spec) where
 
-import Control.Lens ((.~))
 import Data.Effectful.Hasql qualified as Hasql
-import Data.Generics.Product qualified as GL
-import Data.Map.Strict qualified as Map
 import Data.Time (addUTCTime)
 import Data.Time.Format.ISO8601 (iso8601Show)
 import Data.UUID qualified as UUID
@@ -153,36 +150,18 @@ spec = aroundAll withTestResources do
       metricResult <- runQueryEffect tr $ Charts.queryMetrics Nothing (Just Charts.DTMetric) (Just pid) (Just "summarize count(*) by bin_auto(timestamp)") Nothing Nothing (Just timeFrom) (Just timeTo) (Just "metrics") []
       V.length metricResult.dataset `shouldSatisfy` (> 0)
 
-    -- 2 * bisectCap + 1 → 3 slices including a singleton tail; poisonIdx
-    -- lands mid second slice.
-    let bulkN = 2 * Telemetry.bisectCap + 1
-        poisonIdx = Telemetry.bisectCap + 7
-
     it "Test 8.1: slices and persists a >bisectCap OTLP request" $ \tr -> do
+      -- 2 * bisectCap + 1 → 3 slices including a singleton tail; a wrong slice
+      -- boundary fails the row total.
       key <- createTestAPIKey tr pid "Bulk Test Key"
-      let tag = "bulk-8.1"
+      let bulkN = 2 * Telemetry.bisectCap + 1
+          tag = "bulk-8.1"
           bodies = [tag <> "/" <> show i | i <- [1 .. bulkN] :: [Int]]
       void $ OtlpServer.logsServiceExport tr.trLogger tr.trATCtx tr.trTracerProvider (Proto $ createOtelLogAtTime key bodies frozenTime)
       void $ runAllBackgroundJobs frozenTime tr.trATCtx
       counts :: [Int64] <- runQueryEffect tr
         $ Hasql.interp [HI.sql|SELECT count(*)::bigint FROM otel_logs_and_spans WHERE body::text LIKE '%' || #{tag} || '%'|]
       counts `shouldBe` [fromIntegral bulkN]
-
-    it "Test 8.2: isolates one poison row in a >bisectCap batch (count == bulkN-1)" $ \tr -> do
-      -- Force a PK collision (project_id, timestamp, id): the poison row reuses
-      -- row 0's id. Within the same multi-row INSERT this fails server-side;
-      -- bisection drills to single rows, row 0 commits, the singleton poison
-      -- then re-collides with the just-committed row and is dropped.
-      let tag = "bulk-8.2"
-          mkRow i = Telemetry.mkSystemLog pid "bulk-poison-test" Telemetry.SLInfo (show i)
-            (Map.singleton "test.tag" (AE.String tag)) Nothing frozenTime
-      rows <- Telemetry.mintOtelLogIds (V.generate bulkN mkRow) & runTestBg frozenTime tr
-      let firstId = (rows V.! 0).id
-          rows' = rows V.// [(poisonIdx, (rows V.! poisonIdx) & GL.field @"id" .~ firstId)]
-      runTestBg frozenTime tr $ Telemetry.bulkInsertOtelLogsAndSpansTF False rows'
-      counts :: [Int64] <- runQueryEffect tr
-        $ Hasql.interp [HI.sql|SELECT count(*)::bigint FROM otel_logs_and_spans WHERE attributes ->> 'test.tag' = #{tag}|]
-      counts `shouldBe` [fromIntegral (bulkN - 1)]
 
     -- Tests for gRPC Authorization header authentication (NEW!)
     describe "gRPC Authorization Header Authentication" do

--- a/test/integration/Opentelemetry/GrpcIngestionSpec.hs
+++ b/test/integration/Opentelemetry/GrpcIngestionSpec.hs
@@ -2,6 +2,8 @@
 
 module Opentelemetry.GrpcIngestionSpec (spec) where
 
+import Data.Effectful.Hasql qualified as Hasql
+import Data.Map.Strict qualified as Map
 import Data.Time (addUTCTime)
 import Data.Time.Format.ISO8601 (iso8601Show)
 import Data.UUID qualified as UUID
@@ -11,8 +13,10 @@ import Database.PostgreSQL.Entity.DBT (withPool)
 import Database.PostgreSQL.Entity.DBT qualified as DBT
 import Database.PostgreSQL.Simple (Only (..))
 import Database.PostgreSQL.Simple.SqlQQ (sql)
+import Hasql.Interpolate qualified as HI
 import Models.Apis.LogQueries qualified as LogQueries
 import Models.Projects.Projects qualified as Projects
+import Models.Telemetry.Telemetry qualified as Telemetry
 import Network.GRPC.Common (GrpcError (..), GrpcException (..))
 import Network.GRPC.Common.Protobuf (Proto (..))
 import Opentelemetry.OtlpServer qualified as OtlpServer
@@ -85,7 +89,7 @@ spec = aroundAll withTestResources do
       V.length dataset `shouldSatisfy` (>= 3)
 
     it "Test 2.2: should reject log ingestion with invalid API key" $ \tr -> do
-      OtlpServer.logsServiceExport tr.trLogger tr.trATCtx tr.trTracerProvider (Proto $ createOtelLogAtTime "invalid-key-that-does-not-exist" "Should not be stored" frozenTime)
+      OtlpServer.logsServiceExport tr.trLogger tr.trATCtx tr.trTracerProvider (Proto $ createOtelLogAtTime "invalid-key-that-does-not-exist" ["Should not be stored"] frozenTime)
         `shouldThrow` \case GrpcException{grpcError = GrpcUnauthenticated} -> True; _ -> False
 
     it "Test 3.1: should ingest traces via all 3 keys using traceServiceExport" $ \tr -> do
@@ -147,13 +151,30 @@ spec = aroundAll withTestResources do
       metricResult <- runQueryEffect tr $ Charts.queryMetrics Nothing (Just Charts.DTMetric) (Just pid) (Just "summarize count(*) by bin_auto(timestamp)") Nothing Nothing (Just timeFrom) (Just timeTo) (Just "metrics") []
       V.length metricResult.dataset `shouldSatisfy` (> 0)
 
-    it "Test 8.1: should handle bulk ingestion (50+ messages)" $ \tr -> do
+    -- n = 2 * bisectCap + 1 exposes slicing off-by-one and the singleton-tail slice.
+    let n = 2 * Telemetry.bisectCap + 1
+
+    it "Test 8.1: slices and persists a >bisectCap OTLP request" $ \tr -> do
       key <- createTestAPIKey tr pid "Bulk Test Key"
-      forM_ ([1 .. 50] :: [Int]) $ \i -> ingestLog tr key ("Bulk log " <> show i) frozenTime
+      let tag = "bulk-8.1"
+          bodies = [tag <> "/" <> show i | i <- [1 .. n] :: [Int]]
+      void $ OtlpServer.logsServiceExport tr.trLogger tr.trATCtx tr.trTracerProvider (Proto $ createOtelLogAtTime key bodies frozenTime)
       void $ runAllBackgroundJobs frozenTime tr.trATCtx
-      result <- queryLogs tr (Just "kind == \"log\"")
-      dataset <- expectLogsJson result
-      V.length dataset `shouldSatisfy` (>= 50)
+      counts :: [Int64] <- runQueryEffect tr
+        $ Hasql.interp [HI.sql|SELECT count(*)::bigint FROM otel_logs_and_spans WHERE body::text LIKE '%' || #{tag} || '%'|]
+      counts `shouldBe` [fromIntegral n]
+
+    it "Test 8.2: isolates one poison row in a >bisectCap batch (count == n-1)" $ \tr -> do
+      -- NUL in flat text attr bypasses JSONB cleaning → server reject → bisection drops.
+      let tag = "bulk-8.2"
+          poisonIdx = Telemetry.bisectCap + 7 -- mid-batch, second slice
+          mkRow i = Telemetry.mkSystemLog pid "bulk-poison-test" Telemetry.SLInfo (show i)
+            (Map.fromList (("test.tag", AE.String tag) : [("code.function.name", AE.String "G\NULET") | i == poisonIdx]))
+            Nothing frozenTime
+      runTestBg frozenTime tr $ Telemetry.bulkInsertOtelLogsAndSpansTF False =<< Telemetry.mintOtelLogIds (V.generate n mkRow)
+      counts :: [Int64] <- runQueryEffect tr
+        $ Hasql.interp [HI.sql|SELECT count(*)::bigint FROM otel_logs_and_spans WHERE attributes ->> 'test.tag' = #{tag}|]
+      counts `shouldBe` [fromIntegral (n - 1)]
 
     -- Tests for gRPC Authorization header authentication (NEW!)
     describe "gRPC Authorization Header Authentication" do
@@ -187,7 +208,7 @@ spec = aroundAll withTestResources do
         headerKey <- createTestAPIKey tr pid "header-key"
 
         -- Process with both keys - resource should take precedence
-        void $ runTestBg frozenTime tr $ OtlpServer.processLogsRequest (Just headerKey) (createOtelLogAtTime resourceKey "Dual auth log" frozenTime)
+        void $ runTestBg frozenTime tr $ OtlpServer.processLogsRequest (Just headerKey) (createOtelLogAtTime resourceKey ["Dual auth log"] frozenTime)
         void $ runAllBackgroundJobs frozenTime tr.trATCtx
 
         result <- queryLogs tr (Just "kind == \"log\"")
@@ -195,7 +216,7 @@ spec = aroundAll withTestResources do
         V.length dataset `shouldSatisfy` (>= 1)
 
       it "Test 9.5: should reject logs with invalid Authorization header" $ \tr -> do
-        runTestBg frozenTime tr (OtlpServer.processLogsRequest (Just "invalid-header-key") (createOtelLogAtTime "" "Should not be stored" frozenTime))
+        runTestBg frozenTime tr (OtlpServer.processLogsRequest (Just "invalid-header-key") (createOtelLogAtTime "" ["Should not be stored"] frozenTime))
           `shouldThrow` \case GrpcException{grpcError = GrpcUnauthenticated} -> True; _ -> False
 
       it "Test 9.6: should handle mixed authentication methods in bulk" $ \tr -> do

--- a/test/integration/Opentelemetry/GrpcIngestionSpec.hs
+++ b/test/integration/Opentelemetry/GrpcIngestionSpec.hs
@@ -152,9 +152,9 @@ spec = aroundAll withTestResources do
       V.length metricResult.dataset `shouldSatisfy` (> 0)
 
     -- 2 * bisectCap + 1 → 3 slices including a singleton tail; poisonIdx
-    -- lands mid second slice. Tracks bisectCap in Telemetry.hs.
-    let bulkN = 1025
-        poisonIdx = 519
+    -- lands mid second slice.
+    let bulkN = 2 * Telemetry.bisectCap + 1
+        poisonIdx = Telemetry.bisectCap + 7
 
     it "Test 8.1: slices and persists a >bisectCap OTLP request" $ \tr -> do
       key <- createTestAPIKey tr pid "Bulk Test Key"


### PR DESCRIPTION
We apply a bisect cap, so each bulk insert doesnt insert more parameters than the cap and instead splits it into groups to match the cap, and the groups then inserted sequentially.

<!-- Thank you for contributing to Monscope! -->

<!-- Briefly describe what your PR does here as much as you can. -->

Closes #

<!-- If your PR is related to an issue, provide the number(s) above (after the #); if it resolves multiple issues, be sure to add a comma (e.g. "closes #1000, #1001"). -->

## How to test

<!-- Please include the steps to test your changes here. -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure you have described your changes and added all relevant screenshots or data.
- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes (or request one from the team).
- [ ] You are **NOT** deprecating/removing a feature.
