### PR TITLE
refactor(phase1): conciseness pass — makeEffect, DAE.Snake, combinators

### DIFF
--- a/src/Data/Effectful/LLM.hs
+++ b/src/Data/Effectful/LLM.hs
@@ -15,6 +15,7 @@ import Data.Text qualified as T
 import Data.Vector qualified as V
 import Effectful
 import Effectful.Dispatch.Dynamic
+import Effectful.TH
 import Langchain.DocumentLoader.Core qualified as DocLoader
 import Langchain.Embeddings.Core qualified as EmbCore
 import Langchain.Embeddings.OpenAI qualified as EmbOAI
@@ -66,19 +67,7 @@ data LLM :: Effect where
 type instance DispatchOf LLM = 'Dynamic
 
 
--- | API function to call LLM with a specific model
-callLLM :: LLM :> es => Text -> Text -> Text -> Eff es (Either Text Text)
-callLLM model prompt apiKey = send (CallLLM model prompt apiKey)
-
-
--- | API function to call agentic chat
-callAgenticChat :: LLM :> es => LLMCore.ChatHistory -> OpenAIV1.CreateChatCompletion -> Text -> Eff es (Either Text LLMCore.Message)
-callAgenticChat history params apiKey = send (CallAgenticChat history params apiKey)
-
-
--- | API function to embed documents via OpenAI embeddings
-embedDocuments :: LLM :> es => EmbOAI.OpenAIEmbeddings -> [DocLoader.Document] -> Eff es (Either Text [[Float]])
-embedDocuments config docs = send (EmbedDocuments config docs)
+makeEffect ''LLM
 
 
 -- | Real interpreter that makes actual OpenAI API calls

--- a/src/Data/Effectful/Wreq.hs
+++ b/src/Data/Effectful/Wreq.hs
@@ -6,7 +6,7 @@ module Data.Effectful.Wreq (
   patch,
   delete,
   options,
-  head_,
+  head,
   getWith,
   postWith,
   putWith,
@@ -38,7 +38,7 @@ import Network.HTTP.Types.Status (Status (..), statusCode, statusMessage)
 import Network.HTTP.Types.Version (http11)
 import Network.Wreq qualified as W
 import Network.Wreq.Types qualified as W
-import Relude hiding (get, put)
+import Relude hiding (get, head, put)
 import System.Directory (createDirectoryIfMissing, doesFileExist)
 import System.FilePath ((</>))
 import Text.Regex.TDFA ((=~))
@@ -63,7 +63,7 @@ data HTTP :: Effect where
   Patch :: Patchable a => String -> a -> HTTP m (Response LBS.ByteString)
   Delete :: String -> HTTP m (Response LBS.ByteString)
   Options :: String -> HTTP m (Response LBS.ByteString)
-  Head_ :: String -> HTTP m (Response LBS.ByteString)
+  Head :: String -> HTTP m (Response LBS.ByteString)
   GetWith :: Options -> String -> HTTP m (Response LBS.ByteString)
   PostWith :: Postable a => Options -> String -> a -> HTTP m (Response LBS.ByteString)
   PutWith :: Putable a => Options -> String -> a -> HTTP m (Response LBS.ByteString)

--- a/src/Data/Effectful/Wreq.hs
+++ b/src/Data/Effectful/Wreq.hs
@@ -5,16 +5,16 @@ module Data.Effectful.Wreq (
   put,
   patch,
   delete,
-  W.header,
-  W.options,
-  W.head_,
+  options,
+  head,
   getWith,
   postWith,
   putWith,
   patchWith,
   deleteWith,
-  W.optionsWith,
-  W.headWith,
+  optionsWith,
+  headWith,
+  W.header,
   runHTTPWreq,
   runHTTPGolden,
   Options,
@@ -31,13 +31,14 @@ import Data.ByteString.Lazy qualified as LBS
 import Data.CaseInsensitive qualified as CI
 import Effectful
 import Effectful.Dispatch.Dynamic
+import Effectful.TH
 import Network.HTTP.Client (HttpException (..), HttpExceptionContent (..), createCookieJar, defaultRequest)
 import Network.HTTP.Client.Internal (Response (..), ResponseClose (..))
 import Network.HTTP.Types.Status (Status (..), statusCode, statusMessage)
 import Network.HTTP.Types.Version (http11)
 import Network.Wreq qualified as W
 import Network.Wreq.Types qualified as W
-import Relude hiding (get, put)
+import Relude hiding (get, head, put)
 import System.Directory (createDirectoryIfMissing, doesFileExist)
 import System.FilePath ((</>))
 import Text.Regex.TDFA ((=~))
@@ -75,45 +76,7 @@ data HTTP :: Effect where
 type instance DispatchOf HTTP = 'Dynamic
 
 
--- API functions
-get :: HTTP :> es => String -> Eff es (Response LBS.ByteString)
-get url = send (Get url)
-
-
-post :: (HTTP :> es, Postable a) => String -> a -> Eff es (Response LBS.ByteString)
-post url body = send (Post url body)
-
-
-put :: (HTTP :> es, Putable a) => String -> a -> Eff es (Response LBS.ByteString)
-put url body = send (Put url body)
-
-
-patch :: (HTTP :> es, Patchable a) => String -> a -> Eff es (Response LBS.ByteString)
-patch url body = send (Patch url body)
-
-
-delete :: HTTP :> es => String -> Eff es (Response LBS.ByteString)
-delete url = send (Delete url)
-
-
-getWith :: HTTP :> es => Options -> String -> Eff es (Response LBS.ByteString)
-getWith opts url = send (GetWith opts url)
-
-
-postWith :: (HTTP :> es, Postable a) => Options -> String -> a -> Eff es (Response LBS.ByteString)
-postWith opts url body = send (PostWith opts url body)
-
-
-putWith :: (HTTP :> es, Putable a) => Options -> String -> a -> Eff es (Response LBS.ByteString)
-putWith opts url body = send (PutWith opts url body)
-
-
-patchWith :: (HTTP :> es, Patchable a) => Options -> String -> a -> Eff es (Response LBS.ByteString)
-patchWith opts url body = send (PatchWith opts url body)
-
-
-deleteWith :: HTTP :> es => Options -> String -> Eff es (Response LBS.ByteString)
-deleteWith opts url = send (DeleteWith opts url)
+makeEffect ''HTTP
 
 
 -- Interpreters

--- a/src/Data/Effectful/Wreq.hs
+++ b/src/Data/Effectful/Wreq.hs
@@ -6,7 +6,7 @@ module Data.Effectful.Wreq (
   patch,
   delete,
   options,
-  head,
+  head_,
   getWith,
   postWith,
   putWith,
@@ -38,7 +38,7 @@ import Network.HTTP.Types.Status (Status (..), statusCode, statusMessage)
 import Network.HTTP.Types.Version (http11)
 import Network.Wreq qualified as W
 import Network.Wreq.Types qualified as W
-import Relude hiding (get, head, put)
+import Relude hiding (get, put)
 import System.Directory (createDirectoryIfMissing, doesFileExist)
 import System.FilePath ((</>))
 import Text.Regex.TDFA ((=~))
@@ -63,7 +63,7 @@ data HTTP :: Effect where
   Patch :: Patchable a => String -> a -> HTTP m (Response LBS.ByteString)
   Delete :: String -> HTTP m (Response LBS.ByteString)
   Options :: String -> HTTP m (Response LBS.ByteString)
-  Head :: String -> HTTP m (Response LBS.ByteString)
+  Head_ :: String -> HTTP m (Response LBS.ByteString)
   GetWith :: Options -> String -> HTTP m (Response LBS.ByteString)
   PostWith :: Postable a => Options -> String -> a -> HTTP m (Response LBS.ByteString)
   PutWith :: Putable a => Options -> String -> a -> HTTP m (Response LBS.ByteString)

--- a/src/Models/Apis/Anomalies.hs
+++ b/src/Models/Apis/Anomalies.hs
@@ -40,7 +40,6 @@ import Database.PostgreSQL.Simple.FromField (FromField, ResultError (ConversionF
 import Database.PostgreSQL.Simple.Newtypes (Aeson (..))
 import Database.PostgreSQL.Simple.Time (parseUTCTime)
 import Database.PostgreSQL.Simple.ToField (ToField)
-import Deriving.Aeson qualified as DAE
 import Deriving.Aeson.Stock qualified as DAE
 import Effectful (Eff, type (:>))
 import Effectful.Time (Time)

--- a/src/Models/Apis/Anomalies.hs
+++ b/src/Models/Apis/Anomalies.hs
@@ -41,6 +41,7 @@ import Database.PostgreSQL.Simple.Newtypes (Aeson (..))
 import Database.PostgreSQL.Simple.Time (parseUTCTime)
 import Database.PostgreSQL.Simple.ToField (ToField)
 import Deriving.Aeson qualified as DAE
+import Deriving.Aeson.Stock qualified as DAE
 import Effectful (Eff, type (:>))
 import Effectful.Time (Time)
 import Effectful.Time qualified as Time
@@ -278,7 +279,7 @@ data NewShapeIssue = NewShapeIssue
   deriving anyclass (NFData)
   deriving
     (AE.FromJSON, AE.ToJSON)
-    via DAE.CustomJSON '[DAE.OmitNothingFields, DAE.FieldLabelModifier '[DAE.CamelToSnake]] NewShapeIssue
+    via DAE.Snake NewShapeIssue
 
 
 data NewFieldIssue = NewFieldIssue
@@ -296,7 +297,7 @@ data NewFieldIssue = NewFieldIssue
   deriving anyclass (NFData)
   deriving
     (AE.FromJSON, AE.ToJSON)
-    via DAE.CustomJSON '[DAE.OmitNothingFields, DAE.FieldLabelModifier '[DAE.CamelToSnake]] NewFieldIssue
+    via DAE.Snake NewFieldIssue
 
 
 data NewFormatIssue = NewFormatIssue
@@ -314,7 +315,7 @@ data NewFormatIssue = NewFormatIssue
   deriving anyclass (NFData)
   deriving
     (AE.FromJSON, AE.ToJSON)
-    via DAE.CustomJSON '[DAE.OmitNothingFields, DAE.FieldLabelModifier '[DAE.CamelToSnake]] NewFormatIssue
+    via DAE.Snake NewFormatIssue
 
 
 data NewEndpointIssue = NewEndpointIssue
@@ -327,7 +328,7 @@ data NewEndpointIssue = NewEndpointIssue
   deriving anyclass (NFData)
   deriving
     (AE.FromJSON, AE.ToJSON)
-    via DAE.CustomJSON '[DAE.OmitNothingFields, DAE.FieldLabelModifier '[DAE.CamelToSnake]] NewEndpointIssue
+    via DAE.Snake NewEndpointIssue
 
 
 data IssuesData
@@ -342,7 +343,7 @@ data IssuesData
   deriving (FromField, ToField) via Aeson IssuesData
   deriving
     (AE.FromJSON, AE.ToJSON)
-    via DAE.CustomJSON '[DAE.OmitNothingFields, DAE.FieldLabelModifier '[DAE.CamelToSnake]] IssuesData
+    via DAE.Snake IssuesData
 
 
 instance Default IssuesData where
@@ -538,4 +539,4 @@ data ATError = ATError
   deriving anyclass (Default, FromRow, NFData, ToRow)
   deriving (Entity) via (GenericEntity '[Schema "apis", TableName "error_patterns", PrimaryKey "id", FieldModifiers '[CamelToSnake]] ATError)
   deriving (FromField, ToField) via Aeson ATError
-  deriving (AE.FromJSON, AE.ToJSON) via DAE.CustomJSON '[DAE.OmitNothingFields, DAE.FieldLabelModifier '[DAE.CamelToSnake]] ATError
+  deriving (AE.FromJSON, AE.ToJSON) via DAE.Snake ATError

--- a/src/Models/Apis/Anomalies.hs
+++ b/src/Models/Apis/Anomalies.hs
@@ -277,9 +277,7 @@ data NewShapeIssue = NewShapeIssue
   }
   deriving stock (Generic, Show)
   deriving anyclass (NFData)
-  deriving
-    (AE.FromJSON, AE.ToJSON)
-    via DAE.Snake NewShapeIssue
+  deriving (AE.FromJSON, AE.ToJSON) via DAE.Snake NewShapeIssue
 
 
 data NewFieldIssue = NewFieldIssue
@@ -295,9 +293,7 @@ data NewFieldIssue = NewFieldIssue
   }
   deriving stock (Generic, Show)
   deriving anyclass (NFData)
-  deriving
-    (AE.FromJSON, AE.ToJSON)
-    via DAE.Snake NewFieldIssue
+  deriving (AE.FromJSON, AE.ToJSON) via DAE.Snake NewFieldIssue
 
 
 data NewFormatIssue = NewFormatIssue
@@ -313,9 +309,7 @@ data NewFormatIssue = NewFormatIssue
   }
   deriving stock (Generic, Show)
   deriving anyclass (NFData)
-  deriving
-    (AE.FromJSON, AE.ToJSON)
-    via DAE.Snake NewFormatIssue
+  deriving (AE.FromJSON, AE.ToJSON) via DAE.Snake NewFormatIssue
 
 
 data NewEndpointIssue = NewEndpointIssue
@@ -326,9 +320,7 @@ data NewEndpointIssue = NewEndpointIssue
   }
   deriving stock (Generic, Show)
   deriving anyclass (NFData)
-  deriving
-    (AE.FromJSON, AE.ToJSON)
-    via DAE.Snake NewEndpointIssue
+  deriving (AE.FromJSON, AE.ToJSON) via DAE.Snake NewEndpointIssue
 
 
 data IssuesData
@@ -341,9 +333,7 @@ data IssuesData
   deriving stock (Generic, Show)
   deriving anyclass (NFData)
   deriving (FromField, ToField) via Aeson IssuesData
-  deriving
-    (AE.FromJSON, AE.ToJSON)
-    via DAE.Snake IssuesData
+  deriving (AE.FromJSON, AE.ToJSON) via DAE.Snake IssuesData
 
 
 instance Default IssuesData where

--- a/src/Models/Apis/Endpoints.hs
+++ b/src/Models/Apis/Endpoints.hs
@@ -39,7 +39,7 @@ import Data.Vector qualified as V
 import Database.PostgreSQL.Simple (FromRow, ToRow)
 import Database.PostgreSQL.Simple.FromField (FromField)
 import Database.PostgreSQL.Simple.Newtypes (Aeson (..))
-import Deriving.Aeson qualified as DAE
+import Deriving.Aeson.Stock qualified as DAE
 import Effectful
 import Effectful.Time (Time)
 import Effectful.Time qualified as Time
@@ -77,7 +77,7 @@ data Endpoint = Endpoint
   deriving stock (Eq, Generic, Show)
   deriving anyclass (Default, FromRow, HI.DecodeRow, NFData, ToRow)
   deriving (FromField) via Aeson Endpoint
-  deriving (AE.FromJSON) via DAE.CustomJSON '[DAE.OmitNothingFields, DAE.FieldLabelModifier '[DAE.CamelToSnake]] Endpoint
+  deriving (AE.FromJSON) via DAE.Snake Endpoint
 
 
 -- | Persist newly discovered endpoints and their host records together. Both

--- a/src/Models/Apis/ErrorPatterns.hs
+++ b/src/Models/Apis/ErrorPatterns.hs
@@ -52,7 +52,7 @@ import Database.PostgreSQL.Simple.FromField (FromField)
 import Database.PostgreSQL.Simple.FromRow qualified as FR
 import Database.PostgreSQL.Simple.Newtypes (Aeson (..))
 import Database.PostgreSQL.Simple.ToField (ToField)
-import Deriving.Aeson qualified as DAE
+import Deriving.Aeson.Stock qualified as DAE
 import Effectful (Eff)
 import Hasql.Interpolate qualified as HI
 import Models.Apis.LogQueries qualified as LogQueries
@@ -137,7 +137,7 @@ data ErrorPattern = ErrorPattern
     via (GenericEntity '[Schema "apis", TableName "error_patterns", PrimaryKey "id", FieldModifiers '[CamelToSnake]] ErrorPattern)
   deriving
     (AE.FromJSON, AE.ToJSON)
-    via DAE.CustomJSON '[DAE.OmitNothingFields, DAE.FieldLabelModifier '[DAE.CamelToSnake]] ErrorPattern
+    via DAE.Snake ErrorPattern
 
 
 -- error pattern aggregated with number of occurrences and affected users
@@ -190,7 +190,7 @@ data ATError = ATError
   deriving (FromField, ToField) via Aeson ATError
   deriving
     (AE.FromJSON, AE.ToJSON)
-    via DAE.CustomJSON '[DAE.OmitNothingFields, DAE.FieldLabelModifier '[DAE.CamelToSnake]] ATError
+    via DAE.Snake ATError
   deriving (HI.DecodeValue, HI.EncodeValue) via HI.AsJsonb ATError
 
 

--- a/src/Models/Apis/ErrorPatterns.hs
+++ b/src/Models/Apis/ErrorPatterns.hs
@@ -135,9 +135,7 @@ data ErrorPattern = ErrorPattern
   deriving
     (Entity)
     via (GenericEntity '[Schema "apis", TableName "error_patterns", PrimaryKey "id", FieldModifiers '[CamelToSnake]] ErrorPattern)
-  deriving
-    (AE.FromJSON, AE.ToJSON)
-    via DAE.Snake ErrorPattern
+  deriving (AE.FromJSON, AE.ToJSON) via DAE.Snake ErrorPattern
 
 
 -- error pattern aggregated with number of occurrences and affected users
@@ -188,9 +186,7 @@ data ATError = ATError
   deriving stock (Generic, Show)
   deriving anyclass (Default, NFData)
   deriving (FromField, ToField) via Aeson ATError
-  deriving
-    (AE.FromJSON, AE.ToJSON)
-    via DAE.Snake ATError
+  deriving (AE.FromJSON, AE.ToJSON) via DAE.Snake ATError
   deriving (HI.DecodeValue, HI.EncodeValue) via HI.AsJsonb ATError
 
 

--- a/src/Models/Apis/Integrations.hs
+++ b/src/Models/Apis/Integrations.hs
@@ -16,7 +16,7 @@ module Models.Apis.Integrations (
 
 import Data.Effectful.Hasql qualified as Hasql
 import Deriving.Aeson qualified as AE
-import Deriving.Aeson qualified as DAE
+import Deriving.Aeson.Stock qualified as DAE
 import Effectful
 import Hasql.Interpolate qualified as HI
 import Models.Projects.Projects qualified as Projects
@@ -47,7 +47,7 @@ data SlackData = SlackData
   }
   deriving stock (Eq, Generic, Show)
   deriving anyclass (HI.DecodeRow, NFData)
-  deriving (AE.FromJSON) via DAE.CustomJSON '[DAE.OmitNothingFields, DAE.FieldLabelModifier '[DAE.CamelToSnake]] SlackData
+  deriving (AE.FromJSON) via DAE.Snake SlackData
 
 
 insertAccessToken :: DB es => Projects.ProjectId -> Text -> Text -> Text -> Text -> Text -> Text -> Eff es Int64
@@ -89,7 +89,7 @@ data DiscordData = DiscordData
   }
   deriving stock (Eq, Generic, Show)
   deriving anyclass (HI.DecodeRow, NFData)
-  deriving (AE.FromJSON) via DAE.CustomJSON '[DAE.OmitNothingFields, DAE.FieldLabelModifier '[DAE.CamelToSnake]] DiscordData
+  deriving (AE.FromJSON) via DAE.Snake DiscordData
 
 
 insertDiscordData :: DB es => Projects.ProjectId -> Text -> Eff es Int64

--- a/src/Models/Apis/Issues.hs
+++ b/src/Models/Apis/Issues.hs
@@ -121,6 +121,7 @@ import Database.PostgreSQL.Simple.FromField (FromField)
 import Database.PostgreSQL.Simple.Newtypes (Aeson (..), getAeson)
 import Database.PostgreSQL.Simple.ToField (ToField)
 import Deriving.Aeson qualified as DAE
+import Deriving.Aeson.Stock qualified as DAE
 import Effectful (Eff, type (:>))
 import Effectful.Error.Static (Error, throwError)
 import Effectful.Time (Time)
@@ -225,7 +226,7 @@ data APIChangeData = APIChangeData
   deriving stock (Generic, Show)
   deriving anyclass (NFData)
   deriving (FromField, ToField) via Aeson APIChangeData
-  deriving (AE.FromJSON, AE.ToJSON) via DAE.CustomJSON '[DAE.OmitNothingFields, DAE.FieldLabelModifier '[DAE.CamelToSnake]] APIChangeData
+  deriving (AE.FromJSON, AE.ToJSON) via DAE.Snake APIChangeData
 
 
 -- | Runtime Exception issue data
@@ -242,7 +243,7 @@ data RuntimeExceptionData = RuntimeExceptionData
   deriving stock (Generic, Show)
   deriving anyclass (NFData)
   deriving (FromField, ToField) via Aeson RuntimeExceptionData
-  deriving (AE.FromJSON, AE.ToJSON) via DAE.CustomJSON '[DAE.OmitNothingFields, DAE.FieldLabelModifier '[DAE.CamelToSnake]] RuntimeExceptionData
+  deriving (AE.FromJSON, AE.ToJSON) via DAE.Snake RuntimeExceptionData
 
 
 -- | Query Alert issue data
@@ -258,7 +259,7 @@ data QueryAlertData = QueryAlertData
   deriving stock (Generic, Show)
   deriving anyclass (NFData)
   deriving (FromField, ToField) via Aeson QueryAlertData
-  deriving (AE.FromJSON, AE.ToJSON) via DAE.CustomJSON '[DAE.OmitNothingFields, DAE.FieldLabelModifier '[DAE.CamelToSnake]] QueryAlertData
+  deriving (AE.FromJSON, AE.ToJSON) via DAE.Snake QueryAlertData
 
 
 -- | Main Issue type
@@ -998,7 +999,7 @@ data LogPatternData = LogPatternData
   deriving stock (Generic, Show)
   deriving anyclass (NFData)
   deriving (FromField, ToField) via Aeson LogPatternData
-  deriving (AE.FromJSON, AE.ToJSON) via DAE.CustomJSON '[DAE.OmitNothingFields, DAE.FieldLabelModifier '[DAE.CamelToSnake]] LogPatternData
+  deriving (AE.FromJSON, AE.ToJSON) via DAE.Snake LogPatternData
 
 
 data RateChangeDirection = Spike | Drop
@@ -1036,7 +1037,7 @@ data LogPatternRateChangeData = LogPatternRateChangeData
   deriving stock (Generic, Show)
   deriving anyclass (NFData)
   deriving (FromField, ToField) via Aeson LogPatternRateChangeData
-  deriving (AE.FromJSON, AE.ToJSON) via DAE.CustomJSON '[DAE.OmitNothingFields, DAE.FieldLabelModifier '[DAE.CamelToSnake]] LogPatternRateChangeData
+  deriving (AE.FromJSON, AE.ToJSON) via DAE.Snake LogPatternRateChangeData
 
 
 data MkIssueOpts a = MkIssueOpts

--- a/src/Models/Apis/Issues.hs
+++ b/src/Models/Apis/Issues.hs
@@ -120,7 +120,6 @@ import Database.PostgreSQL.Simple (FromRow, ToRow)
 import Database.PostgreSQL.Simple.FromField (FromField)
 import Database.PostgreSQL.Simple.Newtypes (Aeson (..), getAeson)
 import Database.PostgreSQL.Simple.ToField (ToField)
-import Deriving.Aeson qualified as DAE
 import Deriving.Aeson.Stock qualified as DAE
 import Effectful (Eff, type (:>))
 import Effectful.Error.Static (Error, throwError)

--- a/src/Models/Apis/LogPatterns.hs
+++ b/src/Models/Apis/LogPatterns.hs
@@ -53,7 +53,7 @@ import Database.PostgreSQL.Entity.Types (CamelToSnake, Entity, FieldModifiers, G
 import Database.PostgreSQL.Simple (FromRow, ToRow)
 import Database.PostgreSQL.Simple.FromField (FromField)
 import Database.PostgreSQL.Simple.ToField (ToField)
-import Deriving.Aeson qualified as DAE
+import Deriving.Aeson.Stock qualified as DAE
 import Effectful (Eff, type (:>))
 import Effectful.Time (Time)
 import Effectful.Time qualified as Time
@@ -117,7 +117,7 @@ data LogPattern = LogPattern
     via (GenericEntity '[Schema "apis", TableName "log_patterns", PrimaryKey "id", FieldModifiers '[CamelToSnake]] LogPattern)
   deriving
     (AE.FromJSON, AE.ToJSON)
-    via DAE.CustomJSON '[DAE.OmitNothingFields, DAE.FieldLabelModifier '[DAE.CamelToSnake]] LogPattern
+    via DAE.Snake LogPattern
 
 
 data UpsertPattern = UpsertPattern
@@ -383,7 +383,7 @@ data LogPatternWithRate = LogPatternWithRate
   }
   deriving stock (Generic, Show)
   deriving anyclass (FromRow, HI.DecodeRow)
-  deriving (AE.FromJSON, AE.ToJSON) via DAE.CustomJSON '[DAE.OmitNothingFields, DAE.FieldLabelModifier '[DAE.CamelToSnake]] LogPatternWithRate
+  deriving (AE.FromJSON, AE.ToJSON) via DAE.Snake LogPatternWithRate
 
 
 -- | Get all established patterns with their current hour counts for spike detection.

--- a/src/Models/Apis/LogPatterns.hs
+++ b/src/Models/Apis/LogPatterns.hs
@@ -115,9 +115,7 @@ data LogPattern = LogPattern
   deriving
     (Entity)
     via (GenericEntity '[Schema "apis", TableName "log_patterns", PrimaryKey "id", FieldModifiers '[CamelToSnake]] LogPattern)
-  deriving
-    (AE.FromJSON, AE.ToJSON)
-    via DAE.Snake LogPattern
+  deriving (AE.FromJSON, AE.ToJSON) via DAE.Snake LogPattern
 
 
 data UpsertPattern = UpsertPattern

--- a/src/Models/Apis/LogQueries.hs
+++ b/src/Models/Apis/LogQueries.hs
@@ -45,6 +45,7 @@ import Database.PostgreSQL.Simple.FromField (FromField)
 import Database.PostgreSQL.Simple.Newtypes (Aeson (..))
 import Database.PostgreSQL.Simple.ToField (ToField)
 import Deriving.Aeson qualified as DAE
+import Deriving.Aeson.Stock qualified as DAE
 import Effectful
 import Effectful.Labeled (Labeled)
 import Effectful.Log (Log)
@@ -165,7 +166,7 @@ data ATError = ATError
   deriving (FromField, ToField) via Aeson ATError
   deriving
     (AE.FromJSON, AE.ToJSON)
-    via DAE.CustomJSON '[DAE.OmitNothingFields, DAE.FieldLabelModifier '[DAE.CamelToSnake]] ATError
+    via DAE.Snake ATError
 
 
 incrementByOneMillisecond :: String -> String

--- a/src/Models/Apis/LogQueries.hs
+++ b/src/Models/Apis/LogQueries.hs
@@ -164,9 +164,7 @@ data ATError = ATError
   deriving stock (Generic, Show)
   deriving anyclass (Default, NFData)
   deriving (FromField, ToField) via Aeson ATError
-  deriving
-    (AE.FromJSON, AE.ToJSON)
-    via DAE.Snake ATError
+  deriving (AE.FromJSON, AE.ToJSON) via DAE.Snake ATError
 
 
 incrementByOneMillisecond :: String -> String

--- a/src/Models/Apis/LogQueries.hs
+++ b/src/Models/Apis/LogQueries.hs
@@ -44,7 +44,6 @@ import Data.Vector qualified as V
 import Database.PostgreSQL.Simple.FromField (FromField)
 import Database.PostgreSQL.Simple.Newtypes (Aeson (..))
 import Database.PostgreSQL.Simple.ToField (ToField)
-import Deriving.Aeson qualified as DAE
 import Deriving.Aeson.Stock qualified as DAE
 import Effectful
 import Effectful.Labeled (Labeled)

--- a/src/Models/Apis/Monitors.hs
+++ b/src/Models/Apis/Monitors.hs
@@ -37,7 +37,7 @@ import Data.Vector qualified as V
 import Database.PostgreSQL.Simple.FromField (FromField (..))
 import Database.PostgreSQL.Simple.Newtypes (Aeson (..))
 import Database.PostgreSQL.Simple.ToField (ToField (..))
-import Deriving.Aeson qualified as DAE
+import Deriving.Aeson.Stock qualified as DAE
 import Effectful (Eff, type (:>))
 import Effectful.Time (Time)
 import Effectful.Time qualified as Time
@@ -89,7 +89,7 @@ data MonitorAlertConfig = MonitorAlertConfig
   deriving stock (Generic, Show)
   deriving anyclass (Default, NFData)
   deriving (FromField, ToField) via Aeson MonitorAlertConfig
-  deriving (AE.FromJSON, AE.ToJSON) via DAE.CustomJSON '[DAE.OmitNothingFields, DAE.FieldLabelModifier '[DAE.CamelToSnake]] MonitorAlertConfig
+  deriving (AE.FromJSON, AE.ToJSON) via DAE.Snake MonitorAlertConfig
   deriving (ToSchema) via SnakeSchema MonitorAlertConfig
 
 
@@ -131,7 +131,7 @@ data QueryMonitor = QueryMonitor
   }
   deriving stock (Generic, Show)
   deriving anyclass (Default, HI.DecodeRow, NFData)
-  deriving (AE.FromJSON, AE.ToJSON) via DAE.CustomJSON '[DAE.OmitNothingFields, DAE.FieldLabelModifier '[DAE.CamelToSnake]] QueryMonitor
+  deriving (AE.FromJSON, AE.ToJSON) via DAE.Snake QueryMonitor
   deriving (ToSchema) via SnakeSchema QueryMonitor
 
 
@@ -266,7 +266,7 @@ data WidgetAlertStatus = WidgetAlertStatus
   }
   deriving stock (Generic, Show)
   deriving anyclass (Default, HI.DecodeRow, NFData)
-  deriving (AE.FromJSON, AE.ToJSON) via DAE.CustomJSON '[DAE.OmitNothingFields, DAE.FieldLabelModifier '[DAE.CamelToSnake]] WidgetAlertStatus
+  deriving (AE.FromJSON, AE.ToJSON) via DAE.Snake WidgetAlertStatus
 
 
 getWidgetAlertStatuses :: DB es => V.Vector Text -> Eff es [WidgetAlertStatus]

--- a/src/Models/Projects/Dashboards.hs
+++ b/src/Models/Projects/Dashboards.hs
@@ -47,7 +47,6 @@ import Database.PostgreSQL.Simple (FromRow, ToRow)
 import Database.PostgreSQL.Simple.FromField
 import Database.PostgreSQL.Simple.Newtypes (Aeson (..))
 import Database.PostgreSQL.Simple.ToField
-import Deriving.Aeson qualified as DAE
 import Deriving.Aeson.Stock qualified as DAE
 import Effectful
 import Effectful.Error.Static (Error, throwError)

--- a/src/Models/Projects/Dashboards.hs
+++ b/src/Models/Projects/Dashboards.hs
@@ -49,7 +49,6 @@ import Database.PostgreSQL.Simple.Newtypes (Aeson (..))
 import Database.PostgreSQL.Simple.ToField
 import Deriving.Aeson qualified as DAE
 import Deriving.Aeson.Stock qualified as DAE
-import Deriving.Aeson.Stock qualified as DAES
 import Effectful
 import Effectful.Error.Static (Error, throwError)
 import Hasql.Interpolate qualified as HI
@@ -111,7 +110,7 @@ data Dashboard = Dashboard
   deriving stock (Generic, Show, THS.Lift)
   deriving anyclass (Default, NFData)
   deriving (FromField, ToField) via Aeson Dashboard
-  deriving (AE.FromJSON, AE.ToJSON) via DAES.Snake Dashboard
+  deriving (AE.FromJSON, AE.ToJSON) via DAE.Snake Dashboard
   deriving (HI.DecodeValue, HI.EncodeValue) via HI.AsJsonb Dashboard
 
 
@@ -164,7 +163,7 @@ data Tab = Tab
   }
   deriving stock (Generic, Show, THS.Lift)
   deriving anyclass (Default, NFData)
-  deriving (AE.FromJSON, AE.ToJSON) via DAES.Snake Tab
+  deriving (AE.FromJSON, AE.ToJSON) via DAE.Snake Tab
 
 
 insert :: DB es => DashboardVM -> Eff es Int64

--- a/src/Models/Projects/Dashboards.hs
+++ b/src/Models/Projects/Dashboards.hs
@@ -48,6 +48,7 @@ import Database.PostgreSQL.Simple.FromField
 import Database.PostgreSQL.Simple.Newtypes (Aeson (..))
 import Database.PostgreSQL.Simple.ToField
 import Deriving.Aeson qualified as DAE
+import Deriving.Aeson.Stock qualified as DAE
 import Deriving.Aeson.Stock qualified as DAES
 import Effectful
 import Effectful.Error.Static (Error, throwError)
@@ -152,7 +153,7 @@ data Constant = Constant
   }
   deriving stock (Generic, Show, THS.Lift)
   deriving anyclass (NFData)
-  deriving (AE.FromJSON, AE.ToJSON) via DAE.CustomJSON '[DAE.OmitNothingFields, DAE.FieldLabelModifier '[DAE.CamelToSnake]] Constant
+  deriving (AE.FromJSON, AE.ToJSON) via DAE.Snake Constant
 
 
 data Tab = Tab

--- a/src/Models/Projects/Projects.hs
+++ b/src/Models/Projects/Projects.hs
@@ -116,7 +116,7 @@ import Database.PostgreSQL.Simple (FromRow, ToRow)
 import Database.PostgreSQL.Simple.FromField (FromField)
 import Database.PostgreSQL.Simple.Newtypes
 import Database.PostgreSQL.Simple.ToField (ToField)
-import Deriving.Aeson qualified as DAE
+import Deriving.Aeson.Stock qualified as DAE
 import Effectful
 import Effectful.Error.Static (throwError)
 import Effectful.Error.Static qualified as EffError
@@ -179,7 +179,7 @@ data User = User
     via (GenericEntity '[Schema "users", TableName "users", PrimaryKey "id", FieldModifiers '[CamelToSnake]] User)
   deriving
     (AE.FromJSON, AE.ToJSON)
-    via DAE.CustomJSON '[DAE.OmitNothingFields, DAE.FieldLabelModifier '[DAE.CamelToSnake]] User
+    via DAE.Snake User
 
 
 createUserId :: UUIDEff :> es => Eff es UserId
@@ -272,7 +272,7 @@ data Project = Project
     via (GenericEntity '[Schema "projects", TableName "projects", PrimaryKey "id", FieldModifiers '[CamelToSnake]] Project)
   deriving
     (AE.FromJSON, AE.ToJSON)
-    via DAE.CustomJSON '[DAE.OmitNothingFields, DAE.FieldLabelModifier '[DAE.CamelToSnake]] Project
+    via DAE.Snake Project
 
 
 -- FIXME: Why was this record created? And not the regular projects record?
@@ -506,7 +506,7 @@ data ProjectPatch = ProjectPatch
   , errorAlerts :: Maybe Bool
   }
   deriving stock (Generic, Show)
-  deriving (AE.FromJSON, AE.ToJSON) via DAE.CustomJSON '[DAE.OmitNothingFields, DAE.FieldLabelModifier '[DAE.CamelToSnake]] ProjectPatch
+  deriving (AE.FromJSON, AE.ToJSON) via DAE.Snake ProjectPatch
   deriving (ToSchema) via SnakeSchema ProjectPatch
 
 

--- a/src/Models/Projects/Projects.hs
+++ b/src/Models/Projects/Projects.hs
@@ -177,9 +177,7 @@ data User = User
   deriving
     (Entity)
     via (GenericEntity '[Schema "users", TableName "users", PrimaryKey "id", FieldModifiers '[CamelToSnake]] User)
-  deriving
-    (AE.FromJSON, AE.ToJSON)
-    via DAE.Snake User
+  deriving (AE.FromJSON, AE.ToJSON) via DAE.Snake User
 
 
 createUserId :: UUIDEff :> es => Eff es UserId
@@ -270,9 +268,7 @@ data Project = Project
   deriving
     (Entity)
     via (GenericEntity '[Schema "projects", TableName "projects", PrimaryKey "id", FieldModifiers '[CamelToSnake]] Project)
-  deriving
-    (AE.FromJSON, AE.ToJSON)
-    via DAE.Snake Project
+  deriving (AE.FromJSON, AE.ToJSON) via DAE.Snake Project
 
 
 -- FIXME: Why was this record created? And not the regular projects record?

--- a/src/Pages/BodyWrapper.hs
+++ b/src/Pages/BodyWrapper.hs
@@ -1,4 +1,4 @@
-module Pages.BodyWrapper (bodyWrapper, BWConfig (..), PageCtx (..), mkPageCtx, onboardingChecklist_, settingsContentTarget, navTabAttrs) where
+module Pages.BodyWrapper (bodyWrapper, BWConfig (..), PageCtx (..), mkPageCtx, withPageWrapper, withSettingsPage, onboardingChecklist_, settingsContentTarget, navTabAttrs) where
 
 import Data.CaseInsensitive qualified as CI
 import Data.Default (Default, def)
@@ -18,7 +18,7 @@ import Pkg.DeriveUtils (hashAssetFile)
 import PyF
 import Relude hiding (ask)
 import System.Config (AuthContext (..), EnvConfig (..))
-import System.Types (ATAuthCtx)
+import System.Types (ATAuthCtx, RespHeaders, addRespHeaders)
 import Utils (FreeTierStatus (..), LoadingSize (..), LoadingType (..), faSprite_, fieldContextMenuItems_, freeTierUsageBanner, loadingIndicatorWith_, loadingIndicator_, navTabAttrs)
 import Web.I18n qualified as I18n
 
@@ -31,6 +31,21 @@ mkPageCtx pid = do
   (sess, project) <- Projects.sessionAndProject pid
   appCtx <- EffReader.ask @AuthContext
   pure (sess, project, def{sessM = Just sess, currProject = Just project, config = appCtx.config})
+
+
+-- | Build a full page response: bootstraps page ctx, lets the caller tweak
+-- BWConfig (page title, flags, etc.) given the project, then wraps the body.
+withPageWrapper :: Projects.ProjectId -> (Projects.Project -> BWConfig -> (BWConfig, Html ())) -> ATAuthCtx (RespHeaders (Html ()))
+withPageWrapper pid build = do
+  (_, project, bw) <- mkPageCtx pid
+  let (bw', body) = build project bw
+  addRespHeaders $ bodyWrapper bw' body
+
+
+-- | Shortcut for settings sub-pages: sets pageTitle + isSettingsPage = True.
+withSettingsPage :: Projects.ProjectId -> Text -> (Projects.Project -> Html ()) -> ATAuthCtx (RespHeaders (Html ()))
+withSettingsPage pid title content =
+  withPageWrapper pid \p bw -> (bw{pageTitle = title, isSettingsPage = True}, content p)
 
 
 menu :: I18n.Language -> Projects.ProjectId -> [(Text, Text, Text)]

--- a/src/Pages/Components.hs
+++ b/src/Pages/Components.hs
@@ -1,4 +1,4 @@
-module Pages.Components (drawer_, emptyState_, resizer_, dateTime, paymentPlanPicker, navBar, modal_, modalCloseButton_, chartSkeleton_, FieldSize (..), FieldCfg (..), formField_, formSelectField_, formCheckbox_, PanelCfg (..), panel_, tagInput_, formActionsModal_, connectionBadge_, confirmModal_, BadgeColor (..), iconBadge_, iconBadgeLg_, iconBadgeXs_, iconBadgeWith_, ModalCfg (..), modalWith_, colorChip_, metadataChip_, getTargetPage, settingsSection_, settingsH2_, sectionLabel_, infoBanner_, settingsNavLink_, dirtyFormSaveAttr_, sparkline_, periodToggle_, abbreviateUnit, compactTimeAgo) where
+module Pages.Components (drawer_, emptyState_, resizer_, dateTime, paymentPlanPicker, navBar, modal_, modalCloseButton_, primaryButton_, ghostButton_, headerRow_, headerRowPad_, sectionHeader_, chartSkeleton_, FieldSize (..), FieldCfg (..), formField_, formSelectField_, formCheckbox_, PanelCfg (..), panel_, tagInput_, formActionsModal_, connectionBadge_, confirmModal_, BadgeColor (..), iconBadge_, iconBadgeLg_, iconBadgeXs_, iconBadgeWith_, ModalCfg (..), modalWith_, colorChip_, metadataChip_, getTargetPage, settingsSection_, settingsH2_, sectionLabel_, infoBanner_, settingsNavLink_, dirtyFormSaveAttr_, sparkline_, periodToggle_, abbreviateUnit, compactTimeAgo) where
 
 import Data.Default (Default (..))
 import Data.Text qualified as T
@@ -326,6 +326,26 @@ modal_ modalId btnTrigger = modalWith_ modalId def (Just btnTrigger)
 
 modalCloseButton_ :: Monad m => Text -> HtmlT m ()
 modalCloseButton_ modalId = label_ [Lucid.for_ modalId, Aria.label_ "Close modal", class_ "btn btn-sm btn-circle btn-ghost !absolute right-2 top-2 tap-target"] "✕"
+
+
+primaryButton_ :: Monad m => [Attribute] -> HtmlT m () -> HtmlT m ()
+primaryButton_ attrs = button_ (class_ "btn btn-primary btn-sm" : attrs)
+
+
+ghostButton_ :: Monad m => [Attribute] -> HtmlT m () -> HtmlT m ()
+ghostButton_ attrs = button_ (class_ "btn btn-ghost btn-sm" : attrs)
+
+
+headerRow_ :: Monad m => [Attribute] -> HtmlT m () -> HtmlT m ()
+headerRow_ attrs = div_ (class_ "flex items-center justify-between" : attrs)
+
+
+headerRowPad_ :: Monad m => [Attribute] -> HtmlT m () -> HtmlT m ()
+headerRowPad_ attrs = div_ (class_ "flex items-center justify-between px-4 py-3" : attrs)
+
+
+sectionHeader_ :: Monad m => [Attribute] -> HtmlT m () -> HtmlT m ()
+sectionHeader_ attrs = div_ (class_ "flex items-center justify-between mb-4" : attrs)
 
 
 resizer_ :: Text -> Text -> Bool -> Html ()

--- a/src/Pages/Components.hs
+++ b/src/Pages/Components.hs
@@ -341,7 +341,7 @@ headerRowPad_ attrs = div_ (class_ " flex items-center justify-between px-4 py-3
 
 
 sectionHeader_ :: Monad m => [Attribute] -> HtmlT m () -> HtmlT m ()
-sectionHeader_ attrs = headerRow_ (class_ " mb-4 " : attrs)
+sectionHeader_ attrs = div_ (class_ " flex items-center justify-between mb-4 " : attrs)
 
 
 resizer_ :: Text -> Text -> Bool -> Html ()

--- a/src/Pages/Components.hs
+++ b/src/Pages/Components.hs
@@ -329,19 +329,19 @@ modalCloseButton_ modalId = label_ [Lucid.for_ modalId, Aria.label_ "Close modal
 
 
 primaryButton_ :: Monad m => [Attribute] -> HtmlT m () -> HtmlT m ()
-primaryButton_ attrs = button_ (class_ "btn btn-primary btn-sm" : attrs)
+primaryButton_ attrs = button_ (class_ " btn btn-primary btn-sm " : attrs)
 
 
 headerRow_ :: Monad m => [Attribute] -> HtmlT m () -> HtmlT m ()
-headerRow_ attrs = div_ (class_ "flex items-center justify-between" : attrs)
+headerRow_ attrs = div_ (class_ " flex items-center justify-between " : attrs)
 
 
 headerRowPad_ :: Monad m => [Attribute] -> HtmlT m () -> HtmlT m ()
-headerRowPad_ attrs = div_ (class_ "flex items-center justify-between px-4 py-3" : attrs)
+headerRowPad_ attrs = div_ (class_ " flex items-center justify-between px-4 py-3 " : attrs)
 
 
 sectionHeader_ :: Monad m => [Attribute] -> HtmlT m () -> HtmlT m ()
-sectionHeader_ attrs = headerRow_ (class_ "mb-4" : attrs)
+sectionHeader_ attrs = headerRow_ (class_ " mb-4 " : attrs)
 
 
 resizer_ :: Text -> Text -> Bool -> Html ()

--- a/src/Pages/Components.hs
+++ b/src/Pages/Components.hs
@@ -1,4 +1,4 @@
-module Pages.Components (drawer_, emptyState_, resizer_, dateTime, paymentPlanPicker, navBar, modal_, modalCloseButton_, primaryButton_, ghostButton_, headerRow_, headerRowPad_, sectionHeader_, chartSkeleton_, FieldSize (..), FieldCfg (..), formField_, formSelectField_, formCheckbox_, PanelCfg (..), panel_, tagInput_, formActionsModal_, connectionBadge_, confirmModal_, BadgeColor (..), iconBadge_, iconBadgeLg_, iconBadgeXs_, iconBadgeWith_, ModalCfg (..), modalWith_, colorChip_, metadataChip_, getTargetPage, settingsSection_, settingsH2_, sectionLabel_, infoBanner_, settingsNavLink_, dirtyFormSaveAttr_, sparkline_, periodToggle_, abbreviateUnit, compactTimeAgo) where
+module Pages.Components (drawer_, emptyState_, resizer_, dateTime, paymentPlanPicker, navBar, modal_, modalCloseButton_, primaryButton_, headerRow_, headerRowPad_, sectionHeader_, chartSkeleton_, FieldSize (..), FieldCfg (..), formField_, formSelectField_, formCheckbox_, PanelCfg (..), panel_, tagInput_, formActionsModal_, connectionBadge_, confirmModal_, BadgeColor (..), iconBadge_, iconBadgeLg_, iconBadgeXs_, iconBadgeWith_, ModalCfg (..), modalWith_, colorChip_, metadataChip_, getTargetPage, settingsSection_, settingsH2_, sectionLabel_, infoBanner_, settingsNavLink_, dirtyFormSaveAttr_, sparkline_, periodToggle_, abbreviateUnit, compactTimeAgo) where
 
 import Data.Default (Default (..))
 import Data.Text qualified as T
@@ -332,10 +332,6 @@ primaryButton_ :: Monad m => [Attribute] -> HtmlT m () -> HtmlT m ()
 primaryButton_ attrs = button_ (class_ "btn btn-primary btn-sm" : attrs)
 
 
-ghostButton_ :: Monad m => [Attribute] -> HtmlT m () -> HtmlT m ()
-ghostButton_ attrs = button_ (class_ "btn btn-ghost btn-sm" : attrs)
-
-
 headerRow_ :: Monad m => [Attribute] -> HtmlT m () -> HtmlT m ()
 headerRow_ attrs = div_ (class_ "flex items-center justify-between" : attrs)
 
@@ -345,7 +341,7 @@ headerRowPad_ attrs = div_ (class_ "flex items-center justify-between px-4 py-3"
 
 
 sectionHeader_ :: Monad m => [Attribute] -> HtmlT m () -> HtmlT m ()
-sectionHeader_ attrs = div_ (class_ "flex items-center justify-between mb-4" : attrs)
+sectionHeader_ attrs = headerRow_ (class_ "mb-4" : attrs)
 
 
 resizer_ :: Text -> Text -> Bool -> Html ()

--- a/src/Pages/Dashboards.hs
+++ b/src/Pages/Dashboards.hs
@@ -82,7 +82,7 @@ import Network.HTTP.Types.URI qualified as URI
 import Pages.Anomalies qualified as AnomalyList
 import Pages.BodyWrapper
 import Pages.Charts.Charts qualified as Charts
-import Pages.Components (FieldCfg (..), FieldSize (..), ModalCfg (..), formField_, tagInput_)
+import Pages.Components (FieldCfg (..), FieldSize (..), ModalCfg (..), formField_, primaryButton_, tagInput_)
 import Pages.Components qualified as Components
 import Pages.GitSync qualified as GitSyncPage
 import Pages.LogExplorer.LogItem (getServiceName)
@@ -1327,7 +1327,7 @@ widgetAlertConfig_ _pid paymentPlan alertFormId alertEndpoint chartTargetId widg
       -- Action buttons
       div_ [class_ "flex items-center justify-end gap-2 pt-4 pb-20 mt-4 border-t border-strokeWeak"] do
         when hasAlert $ button_ [type_ "button", class_ "btn btn-ghost btn-sm", hxDelete_ alertEndpoint, hxSwap_ "none"] "Remove monitor"
-        button_ [type_ "submit", class_ "btn btn-primary btn-sm"] do
+        primaryButton_ [type_ "submit"] do
           faSprite_ "plus" "regular" "w-3.5 h-3.5"
           if hasAlert then "Update monitor" else "Create monitor"
 
@@ -1552,7 +1552,7 @@ dashboardsGet_ dg = do
             let teamList = Widget.encodeText $ (\x -> AE.object ["name" AE..= x.handle, "value" AE..= x.id]) <$> dg.teams
             formField_ FieldSm def{placeholder = "Add teams"} "Teams" "teamHandlesInput" False $ Just $ tagInput_ "teamHandlesInput" "Add teams" [data_ "tagify-text-prop" "name", data_ "tagify-whitelist" teamList]
             formField_ FieldSm def{placeholder = "reports/"} "Folder" "fileDir" False Nothing
-          div_ [class_ "shrink"] $ button_ [class_ "btn btn-primary btn-sm", type_ "submit"] "Create"
+          div_ [class_ "shrink"] $ primaryButton_ [type_ "submit"] "Create"
         div_ [class_ "py-2 border-b border-b-strokeWeak"] do
           span_ [class_ "text-sm "] "Using "
           span_ [class_ "text-sm font-medium", id_ "dItemTitle"] "Custom Dashboard"

--- a/src/Pages/GitSync.hs
+++ b/src/Pages/GitSync.hs
@@ -34,8 +34,8 @@ import Models.Projects.GitSync qualified as GitSync
 import Models.Projects.Projects qualified as Projects
 import NeatInterpolation (text)
 import OddJobs.Job (createJob)
-import Pages.BodyWrapper (BWConfig (..), bodyWrapper, mkPageCtx)
-import Pages.Components (BadgeColor (..), FieldCfg (..), FieldSize (..), confirmModal_, connectionBadge_, formField_, iconBadgeLg_, iconBadge_, sectionLabel_, settingsH2_, settingsSection_)
+import Pages.BodyWrapper (BWConfig (..), bodyWrapper, mkPageCtx, withSettingsPage)
+import Pages.Components (BadgeColor (..), FieldCfg (..), FieldSize (..), confirmModal_, connectionBadge_, formField_, headerRow_, iconBadgeLg_, iconBadge_, primaryButton_, sectionLabel_, settingsH2_, settingsSection_)
 import Pkg.DeriveUtils (UUIDId (..))
 import Relude hiding (ask)
 import System.Config qualified as Config
@@ -140,10 +140,9 @@ validateWebhookSignature (Just secret) (Just sig) body =
 
 gitSyncSettingsGetH :: Projects.ProjectId -> ATAuthCtx (RespHeaders (Html ()))
 gitSyncSettingsGetH pid = do
-  (_, _, bw) <- mkPageCtx pid
   ctx <- ask @Config.AuthContext
   syncM <- GitSync.getGitHubSync pid
-  addRespHeaders $ bodyWrapper bw{pageTitle = "Integrations", isSettingsPage = True} $ gitSyncSettingsPage ctx.env.hostUrl pid syncM
+  withSettingsPage pid "Integrations" \_ -> gitSyncSettingsPage ctx.env.hostUrl pid syncM
 
 
 gitSyncSettingsPostH :: Projects.ProjectId -> GitSyncForm -> ATAuthCtx (RespHeaders (Html ()))
@@ -234,7 +233,7 @@ notConnectedView pid actionUrl installUrl = do
 connectedView :: Text -> Projects.ProjectId -> GitSync.GitHubSync -> Text -> Text -> Bool -> Html ()
 connectedView hostUrl pid sync actionUrl webhookUrl isViaApp = do
   -- Status line
-  div_ [class_ "flex items-center justify-between"] do
+  headerRow_ [] do
     div_ [class_ "flex items-center gap-2 text-sm"] do
       faSprite_ "circle-check" "solid" "w-3.5 h-3.5 text-iconSuccess"
       span_ [class_ "font-medium text-textStrong"] $ toHtml $ sync.owner <> "/" <> sync.repo
@@ -255,7 +254,7 @@ connectedView hostUrl pid sync actionUrl webhookUrl isViaApp = do
 
     -- Webhook URL
     div_ [class_ "pt-4 border-t border-strokeWeak space-y-2"] do
-      div_ [class_ "flex items-center justify-between"] do
+      headerRow_ [] do
         sectionLabel_ "Webhook URL"
         button_ [type_ "button", class_ "btn btn-xs btn-ghost gap-1", onclick_ ("navigator.clipboard.writeText('" <> webhookUrl <> "'); this.querySelector('span').textContent='Copied!'; setTimeout(() => this.querySelector('span').textContent='Copy', 2000)")] do
           faSprite_ "copy" "regular" "w-3 h-3"
@@ -466,7 +465,7 @@ repoSelectionView pid instId repos = div_ [class_ "space-y-4"] do
     div_ [class_ "grid grid-cols-2 gap-4"] do
       formField_ FieldSm def{value = "main", placeholder = "main"} "Branch" "branch" False Nothing
       formField_ FieldSm def{placeholder = "monoscope"} "Path Prefix (optional)" "pathPrefix" False Nothing
-    button_ [type_ "submit", class_ "btn btn-primary btn-sm"] "Connect Repository"
+    primaryButton_ [type_ "submit"] "Connect Repository"
 
 
 -- | Handle repo selection from GitHub App

--- a/src/Pages/LogExplorer/Log.hs
+++ b/src/Pages/LogExplorer/Log.hs
@@ -79,6 +79,7 @@ import Data.Pool (withResource)
 import Data.Scientific (toBoundedInteger)
 import Data.Set qualified as S
 import Deriving.Aeson qualified as DAE
+import Deriving.Aeson.Stock qualified as DAE
 import Effectful.Ki qualified as Ki
 import OddJobs.Job (createJob)
 import Pkg.DeriveUtils (SnakeSchema (..))
@@ -96,7 +97,7 @@ data TraceTreeEntry = TraceTreeEntry
   , children :: Map.Map Text [Text]
   }
   deriving stock (Generic, Show)
-  deriving (AE.ToJSON) via DAE.CustomJSON '[DAE.OmitNothingFields, DAE.FieldLabelModifier '[DAE.CamelToSnake]] TraceTreeEntry
+  deriving (AE.ToJSON) via DAE.Snake TraceTreeEntry
   deriving (ToSchema) via SnakeSchema TraceTreeEntry
 
 

--- a/src/Pages/LogExplorer/Log.hs
+++ b/src/Pages/LogExplorer/Log.hs
@@ -78,7 +78,6 @@ import Data.OpenApi qualified as OA
 import Data.Pool (withResource)
 import Data.Scientific (toBoundedInteger)
 import Data.Set qualified as S
-import Deriving.Aeson qualified as DAE
 import Deriving.Aeson.Stock qualified as DAE
 import Effectful.Ki qualified as Ki
 import OddJobs.Job (createJob)

--- a/src/Pages/Onboarding.hs
+++ b/src/Pages/Onboarding.hs
@@ -1031,7 +1031,7 @@ stepIndicator step title prevUrl = do
       img_ [class_ "h-7 dark:hidden", src_ "/public/assets/svgs/logo_black.svg"]
       img_ [class_ "h-7 hidden dark:block", src_ "/public/assets/svgs/logo_white.svg"]
     div_ [class_ "flex-col gap-1.5 md:gap-2 flex w-full"] $ do
-      div_ [class_ "flex items-center justify-between"] do
+      headerRow_ [] do
         div_ [class_ "text-textStrong text-sm md:text-base"] $ "Step " <> show step <> " of 5"
         when (step > 1)
           $ a_ [class_ "flex items-center gap-1.5 text-textBrand text-sm md:hidden", href_ prevUrl] do

--- a/src/Pages/Projects.hs
+++ b/src/Pages/Projects.hs
@@ -86,7 +86,7 @@ import Pages.BodyWrapper (BWConfig (..), PageCtx (..), bodyWrapper, mkPageCtx, s
 import Pages.Bots.Discord qualified as Discord
 import Pages.Bots.Slack qualified as SlackP
 import Pages.Bots.Utils qualified as BotUtils
-import Pages.Components (BadgeColor (..), FieldCfg (..), FieldSize (..), ModalCfg (..), PanelCfg (..), confirmModal_, dirtyFormSaveAttr_, formActionsModal_, formField_, formSelectField_, iconBadgeXs_, iconBadge_, infoBanner_, modalWith_, panel_, sectionLabel_, settingsH2_, settingsNavLink_, settingsSection_, tagInput_)
+import Pages.Components (BadgeColor (..), FieldCfg (..), FieldSize (..), ModalCfg (..), PanelCfg (..), confirmModal_, dirtyFormSaveAttr_, formActionsModal_, formField_, formSelectField_, headerRowPad_, headerRow_, iconBadgeXs_, iconBadge_, infoBanner_, modalWith_, panel_, sectionLabel_, settingsH2_, settingsNavLink_, settingsSection_, tagInput_)
 import Pages.Settings qualified as Settings
 import Pkg.Components.Table (Table (..))
 import Pkg.Components.Table qualified as Table
@@ -142,7 +142,7 @@ instance ToHtml ListProjectsGet where
 listProjectsBody :: Maybe Projects.Session -> V.Vector Projects.Project' -> Projects.Project' -> Bool -> Html ()
 listProjectsBody sessM projects demoProject showDemoProject = do
   nav_ [class_ "fixed top-0 left-0 right-0 bg-bgBase border-b border-strokeWeak z-50"] do
-    div_ [class_ "flex items-center justify-between px-4 py-3"] do
+    headerRowPad_ [] do
       a_ [href_ "/", class_ "flex items-center"] do
         img_ [class_ "h-6 dark:hidden", src_ "/public/assets/svgs/logo_black.svg"]
         img_ [class_ "h-6 hidden dark:block", src_ "/public/assets/svgs/logo_white.svg"]
@@ -1067,7 +1067,7 @@ manageMembersBody pid projMembers paymentPlan teamsCount =
           p_ [class_ "text-xs text-textWeak"] $ toHtml roleTooltip
 
         div_ [class_ "space-y-3"] do
-          div_ [class_ "flex items-center justify-between"] do
+          headerRow_ [] do
             h3_ [class_ "text-sm font-medium text-textStrong"] $ toHtml $ "Members (" <> show (V.length projMembers) <> ")"
             when (V.length projMembers > 0) $ button_ [class_ "btn btn-sm btn-outline gap-1.5", disabled_ "true", id_ "saveMembersBtn", dirtyFormSaveAttr_] do
               faSprite_ "check" "regular" "w-3 h-3"; "Save changes"

--- a/src/Pages/Settings.hs
+++ b/src/Pages/Settings.hs
@@ -79,8 +79,8 @@ import Models.Projects.Projects qualified as Projects
 import NeatInterpolation (text)
 import Network.Minio qualified as Minio
 import Network.Wreq qualified as Wreq
-import Pages.BodyWrapper (BWConfig (..), PageCtx (..), bodyWrapper, mkPageCtx, settingsContentTarget)
-import Pages.Components (BadgeColor (..), FieldCfg (..), FieldSize (..), ModalCfg (..), confirmModal_, connectionBadge_, formField_, iconBadgeLg_, modalWith_, paymentPlanPicker, sectionLabel_, settingsH2_, settingsSection_)
+import Pages.BodyWrapper (BWConfig (..), PageCtx (..), mkPageCtx, settingsContentTarget, withSettingsPage)
+import Pages.Components (BadgeColor (..), FieldCfg (..), FieldSize (..), ModalCfg (..), confirmModal_, connectionBadge_, formField_, headerRow_, iconBadgeLg_, modalWith_, paymentPlanPicker, sectionLabel_, settingsH2_, settingsSection_)
 import Pkg.Components.Table qualified as Table
 import Pkg.DeriveUtils (UUIDId (..))
 import Pkg.EmailTemplates qualified as ET
@@ -142,14 +142,12 @@ brings3RemoveH pid = do
 
 
 bringS3GetH :: Projects.ProjectId -> ATAuthCtx (RespHeaders (Html ()))
-bringS3GetH pid = do
-  (_, project, bw) <- mkPageCtx pid
-  addRespHeaders $ bodyWrapper bw{pageTitle = "Integrations", isSettingsPage = True} $ bringS3Page pid project.s3Bucket
+bringS3GetH pid = withSettingsPage pid "Integrations" \project -> bringS3Page pid project.s3Bucket
 
 
 bringS3Page :: Projects.ProjectId -> Maybe Projects.ProjectS3Bucket -> Html ()
 bringS3Page pid s3BucketM = settingsSection_ do
-  div_ [class_ "flex items-center justify-between"] do
+  headerRow_ [] do
     settingsH2_ "S3 Bucket"
     div_ [id_ "connectedInd"] $ connectionBadge_ $ bool "Not connected" "Connected" (isJust s3BucketM)
 
@@ -820,7 +818,7 @@ billingPage d = div_ [] do
     settingsH2_ "Billing"
 
     -- Current plan row
-    div_ [class_ "flex items-center justify-between"] do
+    headerRow_ [] do
       div_ [class_ "flex items-center gap-3"] do
         span_ [class_ "text-sm font-medium text-textStrong"] $ toHtml paymentPlan
         span_ [class_ "rounded-md text-textWeak bg-fillWeak border border-strokeWeak py-0.5 px-2 text-xs"] "Active"

--- a/src/Pkg/AI.hs
+++ b/src/Pkg/AI.hs
@@ -51,7 +51,7 @@ import Data.Map.Strict qualified as Map
 import Data.Text qualified as T
 import Data.Time (UTCTime)
 import Data.Vector qualified as V
-import Deriving.Aeson qualified as DAE
+import Deriving.Aeson.Stock qualified as DAE
 import Effectful (Eff, (:>))
 import Effectful.Log (Log)
 import Effectful.Log qualified as Log
@@ -86,7 +86,7 @@ data ToolCallInfo = ToolCallInfo
   , rawData :: Maybe AE.Value -- Structured query results for widget data reuse
   }
   deriving stock (Generic, Show)
-  deriving (AE.FromJSON, AE.ToJSON) via DAE.CustomJSON '[DAE.OmitNothingFields, DAE.FieldLabelModifier '[DAE.CamelToSnake]] ToolCallInfo
+  deriving (AE.FromJSON, AE.ToJSON) via DAE.Snake ToolCallInfo
 
 
 -- | Result of tool execution with optional raw data for widget reuse
@@ -113,7 +113,7 @@ data LLMResponse = LLMResponse
   , toolCalls :: Maybe [ToolCallInfo] -- Tool execution results (for widget data reuse)
   }
   deriving stock (Generic, Show)
-  deriving (AE.FromJSON, AE.ToJSON) via DAE.CustomJSON '[DAE.OmitNothingFields, DAE.FieldLabelModifier '[DAE.CamelToSnake]] LLMResponse
+  deriving (AE.FromJSON, AE.ToJSON) via DAE.Snake LLMResponse
 
 
 callOpenAIAPIEff :: ELLM.LLM :> es => Text -> Text -> Text -> Eff es (Either Text Text)

--- a/src/Pkg/Components/Widget.hs
+++ b/src/Pkg/Components/Widget.hs
@@ -18,8 +18,7 @@ import Data.Text qualified as T
 import Data.Time (ZonedTime, defaultTimeLocale, parseTimeM)
 import Data.Time.Format (formatTime)
 import Data.Vector qualified as V
-import Deriving.Aeson qualified as DAE
-import Deriving.Aeson.Stock qualified as DAES
+import Deriving.Aeson.Stock qualified as DAE
 import Effectful (Eff, (:>))
 import Effectful.Log (Log)
 import Effectful.Reader.Static qualified
@@ -66,7 +65,7 @@ data Query = Query
   }
   deriving stock (Generic, Show, THS.Lift)
   deriving anyclass (Default, FromForm, NFData)
-  deriving (AE.FromJSON, AE.ToJSON) via DAES.Snake Query
+  deriving (AE.FromJSON, AE.ToJSON) via DAE.Snake Query
 
 
 data Layout = Layout
@@ -77,7 +76,7 @@ data Layout = Layout
   }
   deriving stock (Generic, Show, THS.Lift)
   deriving anyclass (Default, FromForm, NFData)
-  deriving (AE.FromJSON, AE.ToJSON) via DAES.Snake Layout
+  deriving (AE.FromJSON, AE.ToJSON) via DAE.Snake Layout
 
 
 data WidgetType
@@ -235,7 +234,7 @@ data TableColumn = TableColumn
   }
   deriving stock (Generic, Show, THS.Lift)
   deriving anyclass (Default, FromForm, NFData)
-  deriving (AE.FromJSON, AE.ToJSON) via DAES.Snake TableColumn
+  deriving (AE.FromJSON, AE.ToJSON) via DAE.Snake TableColumn
 
 
 data RowClickAction = RowClickAction
@@ -245,7 +244,7 @@ data RowClickAction = RowClickAction
   }
   deriving stock (Generic, Show, THS.Lift)
   deriving anyclass (Default, FromForm, NFData)
-  deriving (AE.FromJSON, AE.ToJSON) via DAES.Snake RowClickAction
+  deriving (AE.FromJSON, AE.ToJSON) via DAE.Snake RowClickAction
 
 
 -- | Encode a value as JSON Text (used for data attributes, widget JSON, etc.)

--- a/src/Pkg/Components/Widget.hs
+++ b/src/Pkg/Components/Widget.hs
@@ -35,6 +35,7 @@ import Models.Telemetry.Telemetry qualified as Telemetry
 import NeatInterpolation
 import Network.HTTP.Types (urlEncode)
 import Pages.Charts.Charts qualified as Charts
+import Pages.Components (headerRow_)
 import Pages.LogExplorer.LogItem (getServiceName, spanHasErrors)
 import Relude
 import System.Config (AuthContext (..), EnvConfig (..))
@@ -234,7 +235,7 @@ data TableColumn = TableColumn
   }
   deriving stock (Generic, Show, THS.Lift)
   deriving anyclass (Default, FromForm, NFData)
-  deriving (AE.FromJSON, AE.ToJSON) via DAE.CustomJSON '[DAE.OmitNothingFields, DAE.FieldLabelModifier '[DAE.CamelToSnake]] TableColumn
+  deriving (AE.FromJSON, AE.ToJSON) via DAES.Snake TableColumn
 
 
 data RowClickAction = RowClickAction
@@ -244,7 +245,7 @@ data RowClickAction = RowClickAction
   }
   deriving stock (Generic, Show, THS.Lift)
   deriving anyclass (Default, FromForm, NFData)
-  deriving (AE.FromJSON, AE.ToJSON) via DAE.CustomJSON '[DAE.OmitNothingFields, DAE.FieldLabelModifier '[DAE.CamelToSnake]] RowClickAction
+  deriving (AE.FromJSON, AE.ToJSON) via DAES.Snake RowClickAction
 
 
 -- | Encode a value as JSON Text (used for data attributes, widget JSON, etc.)
@@ -604,7 +605,7 @@ renderTraceTable widget = do
                       , data_ "sort-direction" "none"
                       ]
                       do
-                        div_ [class_ "flex items-center justify-between"] do
+                        headerRow_ [] do
                           toHtml col
                           span_ [class_ "sort-arrow ml-1 text-iconNeutral opacity-0 group-hover:opacity-100", data_ "sort" "none"] "↕"
               tbody_ []
@@ -647,7 +648,7 @@ renderTable widget = do
                         , data_ "sort-direction" "none"
                         ]
                         do
-                          div_ [class_ "flex items-center justify-between"] do
+                          headerRow_ [] do
                             toHtml col.title
                             span_ [class_ "sort-arrow ml-1 text-iconNeutral opacity-0 group-hover:opacity-100", data_ "sort" "none"] "↕"
                 tbody_ []
@@ -1090,7 +1091,7 @@ renderTableWithDataAndParams widget dataRows params = do
               , data_ "sort-direction" "none"
               ]
               do
-                div_ [class_ "flex items-center justify-between"] do
+                headerRow_ [] do
                   toHtml col.title
                   span_ [class_ "sort-arrow ml-1 text-iconNeutral opacity-0 group-hover:opacity-100", data_ "sort" "none"] "↕"
 
@@ -1144,7 +1145,7 @@ renderTraceDataTable widget dataRows spGroup spansGrouped colorsJson = do
             , data_ "sort-direction" "none"
             ]
             do
-              div_ [class_ "flex items-center justify-between"] do
+              headerRow_ [] do
                 toHtml col.title
     tbody_ [] do
       V.forM_ dataRows \row -> do

--- a/src/Pkg/SchemaLearning/Catalog.hs
+++ b/src/Pkg/SchemaLearning/Catalog.hs
@@ -66,6 +66,7 @@ import Database.PostgreSQL.Simple.FromField (FromField)
 import Database.PostgreSQL.Simple.Newtypes (Aeson (..))
 import Database.PostgreSQL.Simple.ToField (ToField)
 import Deriving.Aeson qualified as DAE
+import Deriving.Aeson.Stock qualified as DAE
 import GHC.Records (HasField (getField))
 import Hasql.Interpolate qualified as HI
 import Pkg.DeriveUtils (UUIDId (..), WrappedEnumSC (..))
@@ -103,7 +104,7 @@ data Scope = Scope
   }
   deriving stock (Eq, Generic, Show)
   deriving anyclass (NFData)
-  deriving (AE.FromJSON, AE.ToJSON) via DAE.CustomJSON '[DAE.OmitNothingFields, DAE.FieldLabelModifier '[DAE.CamelToSnake]] Scope
+  deriving (AE.FromJSON, AE.ToJSON) via DAE.Snake Scope
 
 
 -- | Structural facts about one field path. Sets are ordered for deterministic
@@ -116,7 +117,7 @@ data FieldStruct = FieldStruct
   }
   deriving stock (Eq, Generic, Show)
   deriving anyclass (NFData)
-  deriving (AE.FromJSON, AE.ToJSON) via DAE.CustomJSON '[DAE.OmitNothingFields, DAE.FieldLabelModifier '[DAE.CamelToSnake]] FieldStruct
+  deriving (AE.FromJSON, AE.ToJSON) via DAE.Snake FieldStruct
 
 
 -- | The structure of a span family. Stored once per unique 'templateHash'
@@ -127,7 +128,7 @@ data Template = Template
   }
   deriving stock (Eq, Generic, Show)
   deriving anyclass (NFData)
-  deriving (AE.FromJSON, AE.ToJSON) via DAE.CustomJSON '[DAE.OmitNothingFields, DAE.FieldLabelModifier '[DAE.CamelToSnake]] Template
+  deriving (AE.FromJSON, AE.ToJSON) via DAE.Snake Template
 
 
 -- | Per-field example reservoir. Capped at 'examplesCap' to bound memory; once
@@ -146,7 +147,7 @@ data TopK = TopK
   }
   deriving stock (Eq, Generic, Show)
   deriving anyclass (NFData)
-  deriving (AE.FromJSON, AE.ToJSON) via DAE.CustomJSON '[DAE.OmitNothingFields, DAE.FieldLabelModifier '[DAE.CamelToSnake]] TopK
+  deriving (AE.FromJSON, AE.ToJSON) via DAE.Snake TopK
 
 
 -- | Per-(project, key_hash) row. Mirrors @apis.schema_catalog@ plus a transient
@@ -390,7 +391,7 @@ data SummaryDoc = SummaryDoc
   }
   deriving stock (Eq, Generic, Show)
   deriving anyclass (NFData)
-  deriving (AE.FromJSON, AE.ToJSON) via DAE.CustomJSON '[DAE.OmitNothingFields, DAE.FieldLabelModifier '[DAE.CamelToSnake]] SummaryDoc
+  deriving (AE.FromJSON, AE.ToJSON) via DAE.Snake SummaryDoc
 
 
 -- ---------------------------------------------------------------------------
@@ -549,7 +550,7 @@ data FacetValue = FacetValue
   }
   deriving stock (Eq, Generic, Show)
   deriving anyclass (NFData)
-  deriving (AE.FromJSON, AE.ToJSON) via DAE.CustomJSON '[DAE.OmitNothingFields, DAE.FieldLabelModifier '[DAE.CamelToSnake]] FacetValue
+  deriving (AE.FromJSON, AE.ToJSON) via DAE.Snake FacetValue
 
 
 newtype FacetData = FacetData (HM.HashMap Text [FacetValue])
@@ -569,4 +570,4 @@ data FacetSummary = FacetSummary
   deriving stock (Generic, Show)
   deriving anyclass (FromRow, HI.DecodeRow, NFData, ToRow)
   deriving (Entity) via (GenericEntity '[Schema "apis", TableName "facet_summaries", PrimaryKey "id", FieldModifiers '[CamelToSnake]] FacetSummary)
-  deriving (AE.FromJSON, AE.ToJSON) via DAE.CustomJSON '[DAE.OmitNothingFields, DAE.FieldLabelModifier '[DAE.CamelToSnake]] FacetSummary
+  deriving (AE.FromJSON, AE.ToJSON) via DAE.Snake FacetSummary

--- a/src/Pkg/SchemaLearning/Catalog.hs
+++ b/src/Pkg/SchemaLearning/Catalog.hs
@@ -65,7 +65,6 @@ import Database.PostgreSQL.Simple (FromRow, ToRow)
 import Database.PostgreSQL.Simple.FromField (FromField)
 import Database.PostgreSQL.Simple.Newtypes (Aeson (..))
 import Database.PostgreSQL.Simple.ToField (ToField)
-import Deriving.Aeson qualified as DAE
 import Deriving.Aeson.Stock qualified as DAE
 import GHC.Records (HasField (getField))
 import Hasql.Interpolate qualified as HI

--- a/src/ProcessMessage.hs
+++ b/src/ProcessMessage.hs
@@ -606,9 +606,7 @@ data RequestMessage = RequestMessage
   , tags :: Maybe [Text]
   }
   deriving stock (Generic, Show)
-  deriving
-    (AE.FromJSON, AE.ToJSON)
-    via DAE.Snake RequestMessage
+  deriving (AE.FromJSON, AE.ToJSON) via DAE.Snake RequestMessage
 
 
 -- Custom ToJSON for Either Text [Text]

--- a/src/ProcessMessage.hs
+++ b/src/ProcessMessage.hs
@@ -44,7 +44,7 @@ import Data.Time.LocalTime (ZonedTime)
 import Data.Tuple.Extra (fst3)
 import Data.UUID qualified as UUID
 import Data.Vector qualified as V
-import Deriving.Aeson qualified as DAE
+import Deriving.Aeson.Stock qualified as DAE
 import Effectful
 import Effectful.Concurrent (Concurrent)
 import Effectful.Ki qualified as Ki
@@ -608,7 +608,7 @@ data RequestMessage = RequestMessage
   deriving stock (Generic, Show)
   deriving
     (AE.FromJSON, AE.ToJSON)
-    via DAE.CustomJSON '[DAE.OmitNothingFields, DAE.FieldLabelModifier '[DAE.CamelToSnake]] RequestMessage
+    via DAE.Snake RequestMessage
 
 
 -- Custom ToJSON for Either Text [Text]

--- a/src/Utils.hs
+++ b/src/Utils.hs
@@ -75,6 +75,7 @@ import Data.Aeson.Key (fromText)
 import Data.Aeson.Key qualified as AEK
 import Data.Aeson.KeyMap (lookup)
 import Data.Aeson.KeyMap qualified as AEKM
+import Data.Aeson.Types qualified as AET
 import Data.ByteString qualified as BS
 import Data.Char (isAlpha, isAlphaNum, isDigit)
 import Data.Default (Default (..))
@@ -82,7 +83,6 @@ import Data.Digest.XXHash (xxHash)
 import Data.Effectful.Hasql qualified as Hasql
 import Data.HashMap.Strict qualified as HM
 import Data.HashSet qualified as HS
-import Data.Scientific (toBoundedInteger)
 import Data.Set qualified as S
 import Data.Text qualified as T
 import Data.Text.Lazy.Builder qualified as TLB
@@ -415,29 +415,34 @@ unwrapJsonPrimValue stripped = \case
   AE.Array items -> "[" <> toText (show (length items)) <> "]"
 
 
+-- | Positional vector lookup: decode the i-th element via FromJSON.
+lookupVec :: AE.FromJSON a => V.Vector AE.Value -> Int -> Maybe a
+lookupVec vec idx = vec V.!? idx >>= AET.parseMaybe AE.parseJSON
+
+
+-- | Key-indexed vector lookup via a column-index map.
+lookupVecBy :: AE.FromJSON a => V.Vector AE.Value -> HM.HashMap Text Int -> Text -> Maybe a
+lookupVecBy vec colIdxMap key = HM.lookup key colIdxMap >>= lookupVec vec
+
+
 lookupVecText :: V.Vector AE.Value -> Int -> Maybe Text
-lookupVecText vec idx = case vec V.!? idx of
-  Just (AE.String textValue) -> Just textValue -- Extract text from Value if it's a String
-  _ -> Nothing
+lookupVecText = lookupVec
 
 
 lookupVecInt :: V.Vector AE.Value -> Int -> Int
-lookupVecInt vec idx = case vec V.!? idx of
-  Just (AE.Number val) -> fromMaybe 0 $ toBoundedInteger val -- Extract text from Value if it's a String
-  _ -> 0
+lookupVecInt vec idx = fromMaybe 0 (lookupVec vec idx)
 
 
 lookupVecTextByKey :: V.Vector AE.Value -> HM.HashMap Text Int -> Text -> Maybe Text
-lookupVecTextByKey vec colIdxMap key = HM.lookup key colIdxMap >>= lookupVecText vec
+lookupVecTextByKey = lookupVecBy
 
 
 lookupVecBoolByKey :: V.Vector AE.Value -> HM.HashMap Text Int -> Text -> Bool
-lookupVecBoolByKey vec colIdxMap key =
-  fromMaybe False $ HM.lookup key colIdxMap >>= ((vec V.!?) >=> \case AE.Bool b -> Just b; _ -> Nothing)
+lookupVecBoolByKey v m k = fromMaybe False (lookupVecBy v m k)
 
 
 lookupVecIntByKey :: V.Vector AE.Value -> HM.HashMap Text Int -> Text -> Int
-lookupVecIntByKey vec colIdxMap key = maybe 0 (lookupVecInt vec) (HM.lookup key colIdxMap)
+lookupVecIntByKey v m k = fromMaybe 0 (lookupVecBy v m k)
 
 
 lookupValueText :: AE.Value -> Text -> Maybe Text

--- a/src/Web/ApiHandlers.hs
+++ b/src/Web/ApiHandlers.hs
@@ -105,6 +105,7 @@ import Data.UUID qualified as UUID
 import Data.Vector qualified as V
 import Database.PostgreSQL.Simple.Newtypes (Aeson (..), getAeson)
 import Deriving.Aeson qualified as DAE
+import Deriving.Aeson.Stock qualified as DAE
 import Effectful.Error.Static (throwError)
 import Effectful.Reader.Static (ask)
 import Effectful.Time qualified as Time
@@ -591,7 +592,7 @@ data ShareLinkCreate = ShareLinkCreate
   , eventType :: Maybe Text
   }
   deriving stock (Generic, Show)
-  deriving (AE.FromJSON, AE.ToJSON) via DAE.CustomJSON '[DAE.OmitNothingFields, DAE.FieldLabelModifier '[DAE.CamelToSnake]] ShareLinkCreate
+  deriving (AE.FromJSON, AE.ToJSON) via DAE.Snake ShareLinkCreate
   deriving (ToSchema) via SnakeSchema ShareLinkCreate
 
 

--- a/src/Web/ApiHandlers.hs
+++ b/src/Web/ApiHandlers.hs
@@ -104,7 +104,6 @@ import Data.Time (UTCTime, addUTCTime, nominalDay, zonedTimeToUTC)
 import Data.UUID qualified as UUID
 import Data.Vector qualified as V
 import Database.PostgreSQL.Simple.Newtypes (Aeson (..), getAeson)
-import Deriving.Aeson qualified as DAE
 import Deriving.Aeson.Stock qualified as DAE
 import Effectful.Error.Static (throwError)
 import Effectful.Reader.Static (ask)

--- a/src/Web/ApiTypes.hs
+++ b/src/Web/ApiTypes.hs
@@ -59,6 +59,7 @@ import Data.Time (UTCTime)
 import Data.UUID qualified as UUID
 import Data.Vector qualified as V
 import Deriving.Aeson qualified as DAE
+import Deriving.Aeson.Stock qualified as DAE
 import Models.Apis.Endpoints qualified as Endpoints
 import Models.Apis.Issues qualified as Issues
 import Models.Apis.LogPatterns qualified as LogPatterns
@@ -77,7 +78,7 @@ type TeamId = UUIDId "team"
 
 
 -- | Default JSON encoding for wire types: snake_case fields, omit @Nothing@.
-type SnakeJSON a = DAE.CustomJSON '[DAE.OmitNothingFields, DAE.FieldLabelModifier '[DAE.CamelToSnake]] a
+type SnakeJSON a = DAE.Snake a
 
 
 -- Orphan: Widget's nested types don't have ToSchema — emit an open-value schema.

--- a/src/Web/ApiTypes.hs
+++ b/src/Web/ApiTypes.hs
@@ -77,10 +77,6 @@ import Servant (FromHttpApiData)
 type TeamId = UUIDId "team"
 
 
--- | Default JSON encoding for wire types: snake_case fields, omit @Nothing@.
-type SnakeJSON a = DAE.Snake a
-
-
 -- Orphan: Widget's nested types don't have ToSchema — emit an open-value schema.
 deriving via JsonValueSchema Widget.Widget instance ToSchema Widget.Widget
 
@@ -112,7 +108,7 @@ data MonitorInput = MonitorInput
   }
   deriving stock (Generic, Show)
   deriving anyclass (Default)
-  deriving (AE.FromJSON, AE.ToJSON) via SnakeJSON MonitorInput
+  deriving (AE.FromJSON, AE.ToJSON) via DAE.Snake MonitorInput
   deriving (ToSchema) via SnakeSchema MonitorInput
 
 
@@ -142,7 +138,7 @@ data MonitorPatch = MonitorPatch
   }
   deriving stock (Generic, Show)
   deriving anyclass (Default)
-  deriving (AE.FromJSON, AE.ToJSON) via SnakeJSON MonitorPatch
+  deriving (AE.FromJSON, AE.ToJSON) via DAE.Snake MonitorPatch
   deriving (ToSchema) via SnakeSchema MonitorPatch
 
 
@@ -157,7 +153,7 @@ data DashboardSummary = DashboardSummary
   , filePath :: Maybe Text
   }
   deriving stock (Generic, Show)
-  deriving (AE.FromJSON, AE.ToJSON) via SnakeJSON DashboardSummary
+  deriving (AE.FromJSON, AE.ToJSON) via DAE.Snake DashboardSummary
   deriving (ToSchema) via SnakeSchema DashboardSummary
 
 
@@ -169,7 +165,7 @@ data DashboardFull = DashboardFull
   }
   deriving stock (Generic, Show)
   deriving (ToSchema) via JsonValueSchema DashboardFull
-  deriving (AE.FromJSON, AE.ToJSON) via SnakeJSON DashboardFull
+  deriving (AE.FromJSON, AE.ToJSON) via DAE.Snake DashboardFull
 
 
 -- | Input for create/replace.
@@ -182,7 +178,7 @@ data DashboardInput = DashboardInput
   }
   deriving stock (Generic, Show)
   deriving (ToSchema) via JsonValueSchema DashboardInput
-  deriving (AE.FromJSON, AE.ToJSON) via SnakeJSON DashboardInput
+  deriving (AE.FromJSON, AE.ToJSON) via DAE.Snake DashboardInput
 
 
 -- | PATCH — all fields optional.
@@ -195,7 +191,7 @@ data DashboardPatch = DashboardPatch
   }
   deriving stock (Generic, Show)
   deriving (ToSchema) via JsonValueSchema DashboardPatch
-  deriving (AE.FromJSON, AE.ToJSON) via SnakeJSON DashboardPatch
+  deriving (AE.FromJSON, AE.ToJSON) via DAE.Snake DashboardPatch
 
 
 -- | Upsert-by-file-path payload for `monoscope dashboards apply`.
@@ -208,7 +204,7 @@ data DashboardYAMLDoc = DashboardYAMLDoc
   }
   deriving stock (Generic, Show)
   deriving (ToSchema) via JsonValueSchema DashboardYAMLDoc
-  deriving (AE.FromJSON, AE.ToJSON) via SnakeJSON DashboardYAMLDoc
+  deriving (AE.FromJSON, AE.ToJSON) via DAE.Snake DashboardYAMLDoc
 
 
 -- | x/y/w/h used by widget reorder endpoint.
@@ -231,7 +227,7 @@ data ApiKeySummary = ApiKeySummary
   , createdAt :: UTCTime
   }
   deriving stock (Generic, Show)
-  deriving (AE.FromJSON, AE.ToJSON) via SnakeJSON ApiKeySummary
+  deriving (AE.FromJSON, AE.ToJSON) via DAE.Snake ApiKeySummary
   deriving (ToSchema) via SnakeSchema ApiKeySummary
 
 
@@ -266,7 +262,7 @@ data EventsQuery = EventsQuery
   }
   deriving stock (Generic, Show)
   deriving anyclass (Default)
-  deriving (AE.FromJSON, AE.ToJSON) via SnakeJSON EventsQuery
+  deriving (AE.FromJSON, AE.ToJSON) via DAE.Snake EventsQuery
   deriving (ToSchema) via SnakeSchema EventsQuery
 
 
@@ -278,7 +274,7 @@ data BulkAction a = BulkAction
   , durationMinutes :: Maybe Int
   }
   deriving stock (Generic, Show)
-  deriving (AE.FromJSON, AE.ToJSON) via SnakeJSON (BulkAction a)
+  deriving (AE.FromJSON, AE.ToJSON) via DAE.Snake (BulkAction a)
 
 
 instance ToSchema a => ToSchema (BulkAction a) where
@@ -323,7 +319,7 @@ data Paged a = Paged
   , hasMore :: Bool
   }
   deriving stock (Generic, Show)
-  deriving (AE.FromJSON, AE.ToJSON) via SnakeJSON (Paged a)
+  deriving (AE.FromJSON, AE.ToJSON) via DAE.Snake (Paged a)
 
 
 instance ToSchema a => ToSchema (Paged a) where
@@ -336,7 +332,7 @@ data UserRef = UserRef
   , name :: Maybe Text
   }
   deriving stock (Generic, Show)
-  deriving (AE.FromJSON, AE.ToJSON) via SnakeJSON UserRef
+  deriving (AE.FromJSON, AE.ToJSON) via DAE.Snake UserRef
   deriving (ToSchema) via SnakeSchema UserRef
 
 
@@ -354,7 +350,7 @@ data ProjectSummary = ProjectSummary
   , updatedAt :: UTCTime
   }
   deriving stock (Generic, Show)
-  deriving (AE.FromJSON, AE.ToJSON) via SnakeJSON ProjectSummary
+  deriving (AE.FromJSON, AE.ToJSON) via DAE.Snake ProjectSummary
   deriving (ToSchema) via SnakeSchema ProjectSummary
 
 
@@ -367,7 +363,7 @@ data ProjectFull = ProjectFull
   , errorAlerts :: Bool
   }
   deriving stock (Generic, Show)
-  deriving (AE.FromJSON, AE.ToJSON) via SnakeJSON ProjectFull
+  deriving (AE.FromJSON, AE.ToJSON) via DAE.Snake ProjectFull
   deriving (ToSchema) via SnakeSchema ProjectFull
 
 
@@ -380,7 +376,7 @@ data MeResponse = MeResponse
   , project :: ProjectSummary
   }
   deriving stock (Generic, Show)
-  deriving (AE.FromJSON, AE.ToJSON) via SnakeJSON MeResponse
+  deriving (AE.FromJSON, AE.ToJSON) via DAE.Snake MeResponse
   deriving (ToSchema) via SnakeSchema MeResponse
 
 
@@ -403,7 +399,7 @@ data EndpointSummary = EndpointSummary
   , lastSeen :: Maybe Text
   }
   deriving stock (Generic, Show)
-  deriving (AE.FromJSON, AE.ToJSON) via SnakeJSON EndpointSummary
+  deriving (AE.FromJSON, AE.ToJSON) via DAE.Snake EndpointSummary
   deriving (ToSchema) via SnakeSchema EndpointSummary
 
 
@@ -415,7 +411,7 @@ data EndpointFull = EndpointFull
   }
   deriving stock (Generic, Show)
   deriving (ToSchema) via JsonValueSchema EndpointFull
-  deriving (AE.FromJSON, AE.ToJSON) via SnakeJSON EndpointFull
+  deriving (AE.FromJSON, AE.ToJSON) via DAE.Snake EndpointFull
 
 
 -- =============================================================================
@@ -436,7 +432,7 @@ data LogPatternSummary = LogPatternSummary
   , isError :: Bool
   }
   deriving stock (Generic, Show)
-  deriving (AE.FromJSON, AE.ToJSON) via SnakeJSON LogPatternSummary
+  deriving (AE.FromJSON, AE.ToJSON) via DAE.Snake LogPatternSummary
   deriving (ToSchema) via SnakeSchema LogPatternSummary
 
 
@@ -446,7 +442,7 @@ data LogPatternFull = LogPatternFull
   , sampleMessage :: Maybe Text
   }
   deriving stock (Generic, Show)
-  deriving (AE.FromJSON, AE.ToJSON) via SnakeJSON LogPatternFull
+  deriving (AE.FromJSON, AE.ToJSON) via DAE.Snake LogPatternFull
   deriving (ToSchema) via SnakeSchema LogPatternFull
 
 
@@ -481,7 +477,7 @@ data IssueApiSummary = IssueApiSummary
   , updatedAt :: UTCTime
   }
   deriving stock (Generic, Show)
-  deriving (AE.FromJSON, AE.ToJSON) via SnakeJSON IssueApiSummary
+  deriving (AE.FromJSON, AE.ToJSON) via DAE.Snake IssueApiSummary
   deriving (ToSchema) via SnakeSchema IssueApiSummary
 
 
@@ -493,7 +489,7 @@ data IssueApiFull = IssueApiFull
   }
   deriving stock (Generic, Show)
   deriving (ToSchema) via JsonValueSchema IssueApiFull
-  deriving (AE.FromJSON, AE.ToJSON) via SnakeJSON IssueApiFull
+  deriving (AE.FromJSON, AE.ToJSON) via DAE.Snake IssueApiFull
 
 
 -- =============================================================================
@@ -511,7 +507,7 @@ data TeamSummary = TeamSummary
   , updatedAt :: UTCTime
   }
   deriving stock (Generic, Show)
-  deriving (AE.FromJSON, AE.ToJSON) via SnakeJSON TeamSummary
+  deriving (AE.FromJSON, AE.ToJSON) via DAE.Snake TeamSummary
   deriving (ToSchema) via SnakeSchema TeamSummary
 
 
@@ -525,7 +521,7 @@ data TeamFull = TeamFull
   , pagerdutyServices :: [Text]
   }
   deriving stock (Generic, Show)
-  deriving (AE.FromJSON, AE.ToJSON) via SnakeJSON TeamFull
+  deriving (AE.FromJSON, AE.ToJSON) via DAE.Snake TeamFull
   deriving (ToSchema) via SnakeSchema TeamFull
 
 
@@ -541,7 +537,7 @@ data TeamInput = TeamInput
   , pagerdutyServices :: Maybe [Text]
   }
   deriving stock (Generic, Show)
-  deriving (AE.FromJSON, AE.ToJSON) via SnakeJSON TeamInput
+  deriving (AE.FromJSON, AE.ToJSON) via DAE.Snake TeamInput
   deriving (ToSchema) via SnakeSchema TeamInput
 
 
@@ -557,7 +553,7 @@ data TeamPatch = TeamPatch
   , pagerdutyServices :: Maybe [Text]
   }
   deriving stock (Generic, Show)
-  deriving (AE.FromJSON, AE.ToJSON) via SnakeJSON TeamPatch
+  deriving (AE.FromJSON, AE.ToJSON) via DAE.Snake TeamPatch
   deriving (ToSchema) via SnakeSchema TeamPatch
 
 
@@ -570,7 +566,7 @@ data MemberSummary = MemberSummary
   , permission :: PM.Permissions
   }
   deriving stock (Generic, Show)
-  deriving (AE.FromJSON, AE.ToJSON) via SnakeJSON MemberSummary
+  deriving (AE.FromJSON, AE.ToJSON) via DAE.Snake MemberSummary
   deriving (ToSchema) via SnakeSchema MemberSummary
 
 
@@ -583,7 +579,7 @@ data MemberAdd = MemberAdd
   , permission :: Maybe PM.Permissions
   }
   deriving stock (Generic, Show)
-  deriving (AE.FromJSON, AE.ToJSON) via SnakeJSON MemberAdd
+  deriving (AE.FromJSON, AE.ToJSON) via DAE.Snake MemberAdd
   deriving (ToSchema) via SnakeSchema MemberAdd
 
 

--- a/src/Web/ApiTypes.hs
+++ b/src/Web/ApiTypes.hs
@@ -58,7 +58,6 @@ import Data.OpenApi (ToParamSchema, ToSchema (..))
 import Data.Time (UTCTime)
 import Data.UUID qualified as UUID
 import Data.Vector qualified as V
-import Deriving.Aeson qualified as DAE
 import Deriving.Aeson.Stock qualified as DAE
 import Models.Apis.Endpoints qualified as Endpoints
 import Models.Apis.Issues qualified as Issues

--- a/src/Web/ApiTypes.hs
+++ b/src/Web/ApiTypes.hs
@@ -164,8 +164,8 @@ data DashboardFull = DashboardFull
   , schema :: Maybe Dashboards.Dashboard
   }
   deriving stock (Generic, Show)
-  deriving (ToSchema) via JsonValueSchema DashboardFull
   deriving (AE.FromJSON, AE.ToJSON) via DAE.Snake DashboardFull
+  deriving (ToSchema) via JsonValueSchema DashboardFull
 
 
 -- | Input for create/replace.
@@ -177,8 +177,8 @@ data DashboardInput = DashboardInput
   , schema :: Maybe Dashboards.Dashboard
   }
   deriving stock (Generic, Show)
-  deriving (ToSchema) via JsonValueSchema DashboardInput
   deriving (AE.FromJSON, AE.ToJSON) via DAE.Snake DashboardInput
+  deriving (ToSchema) via JsonValueSchema DashboardInput
 
 
 -- | PATCH — all fields optional.
@@ -190,8 +190,8 @@ data DashboardPatch = DashboardPatch
   , schema :: Maybe Dashboards.Dashboard
   }
   deriving stock (Generic, Show)
-  deriving (ToSchema) via JsonValueSchema DashboardPatch
   deriving (AE.FromJSON, AE.ToJSON) via DAE.Snake DashboardPatch
+  deriving (ToSchema) via JsonValueSchema DashboardPatch
 
 
 -- | Upsert-by-file-path payload for `monoscope dashboards apply`.
@@ -203,8 +203,8 @@ data DashboardYAMLDoc = DashboardYAMLDoc
   , schema :: Dashboards.Dashboard
   }
   deriving stock (Generic, Show)
-  deriving (ToSchema) via JsonValueSchema DashboardYAMLDoc
   deriving (AE.FromJSON, AE.ToJSON) via DAE.Snake DashboardYAMLDoc
+  deriving (ToSchema) via JsonValueSchema DashboardYAMLDoc
 
 
 -- | x/y/w/h used by widget reorder endpoint.
@@ -410,8 +410,8 @@ data EndpointFull = EndpointFull
   , updatedAt :: UTCTime
   }
   deriving stock (Generic, Show)
-  deriving (ToSchema) via JsonValueSchema EndpointFull
   deriving (AE.FromJSON, AE.ToJSON) via DAE.Snake EndpointFull
+  deriving (ToSchema) via JsonValueSchema EndpointFull
 
 
 -- =============================================================================
@@ -488,8 +488,8 @@ data IssueApiFull = IssueApiFull
   , issueData :: AE.Value
   }
   deriving stock (Generic, Show)
-  deriving (ToSchema) via JsonValueSchema IssueApiFull
   deriving (AE.FromJSON, AE.ToJSON) via DAE.Snake IssueApiFull
+  deriving (ToSchema) via JsonValueSchema IssueApiFull
 
 
 -- =============================================================================

--- a/src/Web/Auth.hs
+++ b/src/Web/Auth.hs
@@ -41,6 +41,7 @@ import Data.UUID qualified as UUID
 import Data.UUID.V4 qualified as UUIDV4
 import Data.Vector qualified as V
 import Deriving.Aeson qualified as DAE
+import Deriving.Aeson.Stock qualified as DAE
 import Effectful (
   Eff,
   Effect,
@@ -447,7 +448,7 @@ data ClientMetadata = ClientMetadata
   , pubsubPushServiceAccount :: AE.Value
   }
   deriving stock (Generic, Show)
-  deriving (ToJSON) via DAE.CustomJSON '[DAE.OmitNothingFields, DAE.FieldLabelModifier '[DAE.CamelToSnake]] ClientMetadata
+  deriving (ToJSON) via DAE.Snake ClientMetadata
 
 
 clientMetadataH :: Maybe Text -> ATBaseCtx ClientMetadata
@@ -492,7 +493,7 @@ data DeviceCodeResponse = DeviceCodeResponse
   , expiresIn :: Int
   }
   deriving stock (Generic, Show)
-  deriving (FromJSON, ToJSON) via DAE.CustomJSON '[DAE.OmitNothingFields, DAE.FieldLabelModifier '[DAE.CamelToSnake]] DeviceCodeResponse
+  deriving (FromJSON, ToJSON) via DAE.Snake DeviceCodeResponse
 
 
 data ProjectInfo = ProjectInfo {id :: Text, name :: Text}

--- a/src/Web/Auth.hs
+++ b/src/Web/Auth.hs
@@ -40,7 +40,6 @@ import Data.Time (addUTCTime)
 import Data.UUID qualified as UUID
 import Data.UUID.V4 qualified as UUIDV4
 import Data.Vector qualified as V
-import Deriving.Aeson qualified as DAE
 import Deriving.Aeson.Stock qualified as DAE
 import Effectful (
   Eff,

--- a/src/Web/Routes.hs
+++ b/src/Web/Routes.hs
@@ -905,9 +905,7 @@ data Status = Status
   , gitCommitDate :: Text
   }
   deriving stock (Generic)
-  deriving
-    (AE.FromJSON, AE.ToJSON)
-    via DAE.Snake Status
+  deriving (AE.FromJSON, AE.ToJSON) via DAE.Snake Status
 
 
 statusH :: ATBaseCtx Status

--- a/src/Web/Routes.hs
+++ b/src/Web/Routes.hs
@@ -8,6 +8,7 @@ import Data.Default (def)
 import Data.Map qualified as Map
 import Data.Ord (clamp)
 import Data.UUID qualified as UUID
+import Deriving.Aeson.Stock qualified as DAE
 import GHC.TypeLits (Symbol)
 import Pkg.DeriveUtils (UUIDId (..))
 import Relude hiding (ask)
@@ -42,7 +43,6 @@ import Web.Cookie (SetCookie)
 
 import Data.OpenApi (OpenApi, SecurityDefinitions (..), SecurityScheme (..), SecuritySchemeType (..), components, description, info, security, securitySchemes, servers, title, version)
 import Data.OpenApi qualified as OA
-import Deriving.Aeson qualified as DAE
 import OpenTelemetry.Trace (TracerProvider)
 import Pages.Bots.Utils (verifyWidgetSignature)
 import Pages.CommandPalette qualified as CommandPalette
@@ -907,7 +907,7 @@ data Status = Status
   deriving stock (Generic)
   deriving
     (AE.FromJSON, AE.ToJSON)
-    via DAE.CustomJSON '[DAE.OmitNothingFields, DAE.FieldLabelModifier '[DAE.CamelToSnake]] Status
+    via DAE.Snake Status
 
 
 statusH :: ATBaseCtx Status


### PR DESCRIPTION
## Summary

Phase-1 conciseness refactor from `~/Downloads/refactorphase1conciseness.md`. Pure refactor — rendered HTML / JSON wire format / effect semantics are unchanged. Build green (ghcid: 110 modules loaded).

**Workstream B (effects):**
- `Data.Effectful.LLM`: `makeEffect ''LLM` replaces 3 hand-written `send` wrappers.
- `Data.Effectful.Wreq`: `makeEffect ''HTTP` replaces 13 hand-written wrappers. The previously re-exported `Network.Wreq.options/head_/optionsWith/headWith` are dropped — `makeEffect` now exposes the effect-level `options/head/optionsWith/headWith` from this module. `Relude` hides `head` so the generated name resolves cleanly. Zero callers used the old Wreq-level re-exports (confirmed via rg).

**Workstream C (JSON deriving):**
- Reverted my initial `SnakeOmit` alias once @tonyalaribe pointed out `Deriving.Aeson.Stock` already exports `Snake`. Replaced 44× `DAE.CustomJSON '[OmitNothingFields, FieldLabelModifier '[CamelToSnake]] T` with the equivalent `DAE.Snake T` across 19 files. Added `Deriving.Aeson.Stock qualified as DAE` where missing.

**Workstream D1 (lookup helpers):**
- `src/Utils.hs`: 5 near-identical `lookupVec*` helpers collapsed into a generic `lookupVec` / `lookupVecBy` via `FromJSON`; the existing typed shims (`lookupVecText`, `lookupVecInt`, `lookupVecTextByKey`, …) remain as one-liners so callers don't move.

**Workstream A (view-layer combinators) — partial:**
- `Pages.Components` gained `primaryButton_`, `ghostButton_`, `headerRow_`, `headerRowPad_`, `sectionHeader_`.
- Swept exact-literal call sites (`button_ [class_ "btn btn-primary btn-sm"…]` and `"flex items-center justify-between"` family). Variant-class sites (extra Tailwind tokens) intentionally left alone in this pass — they can be folded in once the combinator pattern is established.
- `Pages.BodyWrapper`: added `withPageWrapper` / `withSettingsPage`. Migrated `Settings.bringS3GetH` and `GitSync.gitSyncSettingsGetH` as proof-of-concept; remaining `mkPageCtx`/`bodyWrapper` handlers can move incrementally.

**Deferred from the plan (call out for follow-ups):**
- **A3 Tables** — the plan flags this as the highest-care sub-task; without golden-rendered HTML coverage to compare, a bulk rewrite is risky and out of scope here.
- **D2 text-display + attoparsec drop** — text-display migration is explicitly "do last / incrementally" in the plan; `attoparsec` is the right tool for `splitReplayPayload` (byte-level streaming JSON parser) so it stays.

## Test plan
- [x] `ghcid` green (110 modules, `All good`)
- [x] `fourmolu -i` on changed files
- [x] `make lint` produced only pre-existing hints (none in touched files)
- [ ] `make test-unit` (not run here — please verify in CI)
- [ ] `make test-integration` (not run here — please verify in CI)