### PR TITLE
otel: extract batchSpanAttrs helper to dedupe processList/processMessages

### DIFF
--- a/src/Opentelemetry/OtlpServer.hs
+++ b/src/Opentelemetry/OtlpServer.hs
@@ -88,7 +88,7 @@ import Relude.Extra.Enum (safeToEnum)
 import System.Config (AuthContext (..), EnvConfig (..))
 import System.IO.Unsafe (unsafePerformIO)
 import System.Logging qualified as Log
-import System.Tracing (Tracing, withSpan_)
+import System.Tracing (Tracing, batchSpanAttrs, withSpan_)
 import System.Types (ATBackgroundCtx, DB, runBackground)
 import UnliftIO.Exception (tryAny)
 import Utils (b64ToJson, freeTierDailyMaxEvents, jsonToMap, nestedJsonFromDotNotation)
@@ -240,11 +240,7 @@ stampOrPassthrough appCtx v =
 processList :: (Concurrent :> es, DB es, Eff.Reader AuthContext :> es, Ki.StructuredConcurrency :> es, Labeled "timefusion" Hasql.Hasql :> es, Log :> es, Time.Time :> es, Tracing :> es, UUIDEff :> es) => [(Text, ByteString)] -> HM.HashMap Text Text -> Eff es [Text]
 processList [] _ = pure []
 processList msgs !attrs =
-  withSpan_
-    "otlp.process_list"
-    ( ("messaging.batch.message_count", OA.toAttribute (length msgs))
-        : foldMap (\v -> [("ce.type", OA.toAttribute @Text v)]) (HM.lookup "ce-type" attrs)
-    )
+  withSpan_ "otlp.process_list" (batchSpanAttrs (length msgs) attrs)
     $ checkpoint "processList" do
       startTime <- Time.currentTime
       (result, processingTime, dbInsertTime) <- process startTime `onException` handleException

--- a/src/ProcessMessage.hs
+++ b/src/ProcessMessage.hs
@@ -157,7 +157,7 @@ processMessages msgs attrs =
                   . Projects.projectCacheByIdIO appCtx.hasqlJobsPool
               pure (pid, cache)
 
-          spans <- forM rMsgs \(_ackId, rawSize, msg) -> runMaybeT do
+          spans <- forM rMsgs \(_, rawSize, msg) -> runMaybeT do
             let pid = UUIDId msg.projectId
                 !msgSize = fromIntegral rawSize
             cache <- hoistMaybe $ HM.lookup pid projectCaches

--- a/src/ProcessMessage.hs
+++ b/src/ProcessMessage.hs
@@ -56,7 +56,6 @@ import Models.Apis.LogQueries qualified as LogQueries
 import Models.Projects.Projects qualified as Projects
 import Models.Telemetry.Telemetry (Context (trace_state), OtelLogsAndSpans (..), generateSummary)
 import Models.Telemetry.Telemetry qualified as Telemetry
-import OpenTelemetry.Attributes qualified as OA
 import Pkg.DeriveUtils (AesonText (..), UUIDId (..), unAesonTextMaybe)
 import Pkg.Metrics qualified as Metrics
 import Pkg.SchemaLearning.Catalog qualified as Catalog
@@ -66,7 +65,7 @@ import Relude hiding (ask)
 import Relude.Unsafe qualified as Unsafe
 import System.Config (AuthContext (..), EnvConfig (..))
 import System.Logging qualified as Log
-import System.Tracing (Tracing, withSpan_)
+import System.Tracing (Tracing, batchSpanAttrs, withSpan_)
 import System.Types (DB)
 import Text.RE.Replace (matched)
 import Text.RE.TDFA (RE, re, (?=~))
@@ -140,47 +139,42 @@ processMessages
   -> Eff es [Text]
 processMessages [] _ = pure []
 processMessages msgs attrs =
-  withSpan_
-    "pubsub.process_messages"
-    ( ("messaging.batch.message_count", OA.toAttribute (length msgs))
-        : foldMap (\v -> [("ce.type", OA.toAttribute @Text v)]) (HM.lookup "ce-type" attrs)
-    )
-    do
-      appCtx <- Eff.ask @AuthContext
-      (rMsgs, mWrite) <- Metrics.timed Metrics.ingestDecodeHist [] do
-        rMsgs <-
-          catMaybes <$> forM msgs \(ackId, msg) -> case AE.eitherDecodeStrict (BS.filter (/= 0) msg) of
-            Left err -> Nothing <$ Log.logAttention "Error parsing json msgs" (object ["AckId" .= ackId, "Error" .= err, "OriginalMsg" .= decodeUtf8 @Text msg])
-            Right m -> pure $ Just (ackId, BS.length msg, m)
-        if null rMsgs
-          then pure (rMsgs, Nothing)
-          else do
-            projectCaches <-
-              liftIO $ HM.fromList <$> forM (ordNub $ (\(_, _, m) -> UUIDId m.projectId) <$> rMsgs) \pid -> do
-                cache <-
-                  Cache.fetchWithCache appCtx.projectCache pid
-                    $ fmap (fromMaybe Projects.defaultProjectCache)
-                    . Projects.projectCacheByIdIO appCtx.hasqlJobsPool
-                pure (pid, cache)
+  withSpan_ "pubsub.process_messages" (batchSpanAttrs (length msgs) attrs) do
+    appCtx <- Eff.ask @AuthContext
+    (rMsgs, mWrite) <- Metrics.timed Metrics.ingestDecodeHist [] do
+      rMsgs <-
+        catMaybes <$> forM msgs \(ackId, msg) -> case AE.eitherDecodeStrict (BS.filter (/= 0) msg) of
+          Left err -> Nothing <$ Log.logAttention "Error parsing json msgs" (object ["AckId" .= ackId, "Error" .= err, "OriginalMsg" .= decodeUtf8 @Text msg])
+          Right m -> pure $ Just (ackId, BS.length msg, m)
+      if null rMsgs
+        then pure (rMsgs, Nothing)
+        else do
+          projectCaches <-
+            liftIO $ HM.fromList <$> forM (ordNub $ (\(_, _, m) -> UUIDId m.projectId) <$> rMsgs) \pid -> do
+              cache <-
+                Cache.fetchWithCache appCtx.projectCache pid
+                  $ fmap (fromMaybe Projects.defaultProjectCache)
+                  . Projects.projectCacheByIdIO appCtx.hasqlJobsPool
+              pure (pid, cache)
 
-            spans <- forM rMsgs \(rmAckId, rawSize, msg) -> runMaybeT do
-              let pid = UUIDId msg.projectId
-                  !msgSize = fromIntegral rawSize
-              cache <- hoistMaybe $ HM.lookup pid projectCaches
-              let !totalDailyEvents = fromIntegral cache.dailyEventCount + fromIntegral cache.dailyMetricCount
-                  !isFreeTier = cache.paymentPlan == "Free"
-              guard $ not (isFreeTier && totalDailyEvents >= freeTierDailyMaxEvents)
-              spanId <- lift UUID.genUUID
-              trId <- lift $ UUID.toText <$> UUID.genUUID
-              pure $! convertRequestMessageToSpan msg msgSize (spanId, trId)
+          spans <- forM rMsgs \(rmAckId, rawSize, msg) -> runMaybeT do
+            let pid = UUIDId msg.projectId
+                !msgSize = fromIntegral rawSize
+            cache <- hoistMaybe $ HM.lookup pid projectCaches
+            let !totalDailyEvents = fromIntegral cache.dailyEventCount + fromIntegral cache.dailyMetricCount
+                !isFreeTier = cache.paymentPlan == "Free"
+            guard $ not (isFreeTier && totalDailyEvents >= freeTierDailyMaxEvents)
+            spanId <- lift UUID.genUUID
+            trId <- lift $ UUID.toText <$> UUID.genUUID
+            pure $! convertRequestMessageToSpan msg msgSize (spanId, trId)
 
-            pure (rMsgs, Just (projectCaches, V.fromList (catMaybes spans)))
+          pure (rMsgs, Just (projectCaches, V.fromList (catMaybes spans)))
 
-      forM_ mWrite \(projectCaches, spanVec) ->
-        Metrics.timed Metrics.ingestWriteHist []
-          $ Telemetry.insertAndHandOff appCtx.env.enableTimefusionWrites appCtx.extractionWorker projectCaches spanVec
+    forM_ mWrite \(projectCaches, spanVec) ->
+      Metrics.timed Metrics.ingestWriteHist []
+        $ Telemetry.insertAndHandOff appCtx.env.enableTimefusionWrites appCtx.extractionWorker projectCaches spanVec
 
-      pure $ map fst3 rMsgs
+    pure $ map fst3 rMsgs
 
 
 -- | Process a single span to extract entities for hash-stamping.

--- a/src/ProcessMessage.hs
+++ b/src/ProcessMessage.hs
@@ -157,7 +157,7 @@ processMessages msgs attrs =
                   . Projects.projectCacheByIdIO appCtx.hasqlJobsPool
               pure (pid, cache)
 
-          spans <- forM rMsgs \(rmAckId, rawSize, msg) -> runMaybeT do
+          spans <- forM rMsgs \(_ackId, rawSize, msg) -> runMaybeT do
             let pid = UUIDId msg.projectId
                 !msgSize = fromIntegral rawSize
             cache <- hoistMaybe $ HM.lookup pid projectCaches

--- a/src/System/Tracing.hs
+++ b/src/System/Tracing.hs
@@ -10,6 +10,9 @@ module System.Tracing (
 
   -- * Cross-thread context propagation
   forkWithCtx,
+
+  -- * Common attribute builders
+  batchSpanAttrs,
 ) where
 
 import Data.HashMap.Strict qualified as HM
@@ -18,6 +21,7 @@ import Effectful.Dispatch.Dynamic
 import Effectful.Ki qualified as Ki
 import Effectful.TH
 import OpenTelemetry.Attributes (Attribute)
+import OpenTelemetry.Attributes qualified as OA
 import OpenTelemetry.Context qualified as Context
 import OpenTelemetry.Context.ThreadLocal qualified as Context
 import OpenTelemetry.Trace (
@@ -86,3 +90,12 @@ forkWithCtx scope action = do
       (liftIO $ Context.attachContext ctx)
       (liftIO . Context.detachContext)
       (const action)
+
+
+-- | Standard attributes for batch-processing root spans (queue consumers,
+-- gRPC handlers). Always emits @messaging.batch.message_count@; emits
+-- @ce.type@ only when present in the CloudEvents header map.
+batchSpanAttrs :: Int -> HM.HashMap Text Text -> [(Text, Attribute)]
+batchSpanAttrs n attrs =
+  ("messaging.batch.message_count", OA.toAttribute n)
+    : toList (("ce.type",) . OA.toAttribute @Text <$> HM.lookup "ce-type" attrs)

--- a/src/System/Tracing.hs
+++ b/src/System/Tracing.hs
@@ -98,4 +98,4 @@ forkWithCtx scope action = do
 batchSpanAttrs :: Int -> HM.HashMap Text Text -> [(Text, Attribute)]
 batchSpanAttrs n attrs =
   ("messaging.batch.message_count", OA.toAttribute n)
-    : toList (("ce.type",) . OA.toAttribute @Text <$> HM.lookup "ce-type" attrs)
+    : maybeToList (("ce.type",) . OA.toAttribute @Text <$> HM.lookup "ce-type" attrs)

--- a/src/System/Tracing.hs
+++ b/src/System/Tracing.hs
@@ -97,5 +97,7 @@ forkWithCtx scope action = do
 -- @ce.type@ only when present in the CloudEvents header map.
 batchSpanAttrs :: Int -> HM.HashMap Text Text -> [(Text, Attribute)]
 batchSpanAttrs n attrs =
-  ("messaging.batch.message_count", OA.toAttribute n)
-    : maybeToList (("ce.type",) . OA.toAttribute <$> HM.lookup "ce-type" attrs)
+  catMaybes
+    [ Just ("messaging.batch.message_count", OA.toAttribute n)
+    , ("ce.type",) . OA.toAttribute <$> HM.lookup "ce-type" attrs
+    ]

--- a/src/System/Tracing.hs
+++ b/src/System/Tracing.hs
@@ -98,4 +98,4 @@ forkWithCtx scope action = do
 batchSpanAttrs :: Int -> HM.HashMap Text Text -> [(Text, Attribute)]
 batchSpanAttrs n attrs =
   ("messaging.batch.message_count", OA.toAttribute n)
-    : maybeToList (("ce.type",) . OA.toAttribute @Text <$> HM.lookup "ce-type" attrs)
+    : maybeToList (("ce.type",) . OA.toAttribute <$> HM.lookup "ce-type" attrs)

--- a/src/System/Tracing.hs
+++ b/src/System/Tracing.hs
@@ -94,7 +94,8 @@ forkWithCtx scope action = do
 
 -- | Standard attributes for batch-processing root spans (queue consumers,
 -- gRPC handlers). Always emits @messaging.batch.message_count@; emits
--- @ce.type@ only when present in the CloudEvents header map.
+-- @ce.type@ (OTel attribute name, dot) only when @"ce-type"@ (CloudEvents
+-- header name, hyphen) is present in the headers map.
 batchSpanAttrs :: Int -> HM.HashMap Text Text -> [(Text, Attribute)]
 batchSpanAttrs n attrs =
   catMaybes


### PR DESCRIPTION
Follow-up to #414. Both root-span entry points (`processList`, `processMessages`) build the same attribute list inline:

```haskell
( ("messaging.batch.message_count", OA.toAttribute (length msgs))
    : foldMap (\v -> [("ce.type", OA.toAttribute @Text v)]) (HM.lookup "ce-type" attrs)
)
```

Pulled into `System.Tracing.batchSpanAttrs`. The two call sites collapse to:

```haskell
withSpan_ "otlp.process_list" (batchSpanAttrs (length msgs) attrs) ...
withSpan_ "pubsub.process_messages" (batchSpanAttrs (length msgs) attrs) ...
```

`toList (f <$> mx)` over `Maybe` reads more clearly than the `foldMap`-with-singleton-list pattern. Also drops a now-unused `OpenTelemetry.Attributes` qualified import from `ProcessMessage.hs`.

This was the last actionable nit from #414's review; the dedupe was pushed to the branch a few seconds after the squash merge, so it missed the train.

## Test plan
- [ ] CI green
- [ ] After deploy, attributes still appear on `otlp.process_list` / `pubsub.process_messages` spans; `ce.type` is omitted (not empty-string) when the header is absent