### PR TITLE
kafka: DLQ replay consumer + linear backoff for failed usage submissions

### DIFF
--- a/src/Models/Projects/Projects.hs
+++ b/src/Models/Projects/Projects.hs
@@ -820,13 +820,19 @@ splitUsageIntoChunks total
        in replicate fulls (ChunkQuantity cap) <> [ChunkQuantity rem_ | rem_ > 0]
 
 
+-- Failed chunks back off linearly: skip until LEAST(attempt_count, 14) days
+-- have passed since last_attempt_at. Pending rows (attempt_count = 0) are
+-- always due, so the first attempt happens on the next tick as before.
 pendingUsageSubmissions :: DB es => ProjectId -> Eff es [UsageSubmission]
 pendingUsageSubmissions pid =
   EHasql.interp
     [HI.sql|
       SELECT id, project_id, window_start, window_end, quantity::int8, status, submitted_at, last_error, created_at
       FROM projects.usage_report_submissions
-      WHERE project_id = #{pid} AND status <> 'submitted'
+      WHERE project_id = #{pid}
+        AND status <> 'submitted'
+        AND (last_attempt_at IS NULL
+             OR last_attempt_at < now() - (LEAST(attempt_count, 14) * interval '1 day'))
       ORDER BY created_at ASC
     |]
 
@@ -887,7 +893,10 @@ markUsageSubmissionFailed sid err =
   EHasql.interpExecute
     [HI.sql|
       UPDATE projects.usage_report_submissions
-      SET status = 'failed', last_error = #{err}
+      SET status = 'failed',
+          last_error = #{err},
+          attempt_count = attempt_count + 1,
+          last_attempt_at = now()
       WHERE id = #{sid}
     |]
 

--- a/src/Pkg/Queue.hs
+++ b/src/Pkg/Queue.hs
@@ -208,14 +208,15 @@ publishJSONToKafka appCtx topicName jsonData attributes = checkpoint "publishJSO
     Right res -> pure res
 
 
-kafkaService :: Log.Logger -> AuthContext -> TracerProvider -> [Text] -> Int -> ([(Text, ByteString)] -> HM.HashMap Text Text -> ATBackgroundCtx [Text]) -> IO ()
-kafkaService appLogger appCtx tp kafkaTopics batchSize fn = checkpoint "kafkaService" do
+kafkaService :: Log.Logger -> AuthContext -> TracerProvider -> Text -> [Text] -> Int -> ([(Text, ByteString)] -> HM.HashMap Text Text -> ATBackgroundCtx [Text]) -> IO ()
+kafkaService appLogger appCtx tp groupId kafkaTopics batchSize fn = checkpoint "kafkaService" do
   instanceUuid <- UUID.toText <$> UUID.nextRandom
   let clientId = "monoscope-" <> T.take 8 instanceUuid
-      -- DLQ is intentionally NOT subscribed: re-consuming our own dead letters
-      -- in the live loop just amplifies pain during a sustained downstream
-      -- outage. Drain it via a separate one-off script when needed.
+      -- DLQ replay runs under a separate group (see Server.hs) so its
+      -- partitions don't get rebalanced onto primary consumers. Failures on
+      -- DLQ messages drop+log (below) instead of re-DLQ'ing — see processGroup.
       consumerSub = K.topics (map K.TopicName kafkaTopics) <> K.offsetReset K.Earliest
+      isDlqConsumer = kafkaTopics == [appCtx.config.kafkaDeadLetterTopic]
 
   -- Single LogT context for the whole service; client_id (and other static
   -- consumer metadata) is attached via localData so every log entry below
@@ -223,7 +224,7 @@ kafkaService appLogger appCtx tp kafkaTopics batchSize fn = checkpoint "kafkaSer
   runLogT "kafka-service" appLogger LogInfo
     $ LogBase.localData
       [ "client_id" AE..= clientId
-      , "group_id" AE..= appCtx.config.kafkaGroupId
+      , "group_id" AE..= groupId
       ]
       do
         LogBase.logInfo "Starting Kafka consumer service" (AE.object ["topics" AE..= kafkaTopics, "brokers" AE..= appCtx.config.kafkaBrokers])
@@ -284,11 +285,20 @@ kafkaService appLogger appCtx tp kafkaTopics batchSize fn = checkpoint "kafkaSer
                           -- and commit only if the DLQ publish succeeded.
                           if Hasql.isTransientException e
                             then pure []
-                            else do
-                              dlqRes <- liftIO $ publishToDeadLetterQueue appLogger appCtx allRecords attributes errText
-                              pure $ case dlqRes of
-                                Right _ -> successTps
-                                Left _ -> []
+                            else
+                              if isDlqConsumer
+                                then do
+                                  -- DLQ replay: a poison message that failed on the
+                                  -- primary topic AND again here is permanent. Drop +
+                                  -- commit (otherwise it loops forever). Original
+                                  -- error-reason / failed-at headers preserve forensics.
+                                  LogBase.logAttention "kafkaService: permanent failure on DLQ replay — dropping" (AE.object ["error" AE..= errText, "attributes" AE..= attributes, "record_count" AE..= length allRecords])
+                                  pure successTps
+                                else do
+                                  dlqRes <- liftIO $ publishToDeadLetterQueue appLogger appCtx allRecords attributes errText
+                                  pure $ case dlqRes of
+                                    Right _ -> successTps
+                                    Left _ -> []
               -- Bound must stay well under the hasql pool (shared with web) —
               -- AcquisitionTimeout (→ Hasql.isTransientException → no commit →
               -- redelivery storm) is the failure mode to avoid. Single committer
@@ -330,7 +340,7 @@ kafkaService appLogger appCtx tp kafkaTopics batchSize fn = checkpoint "kafkaSer
     consumerProps :: EnvConfig -> Text -> K.ConsumerProperties
     consumerProps cfg clientId =
       K.brokersList (map K.BrokerAddress cfg.kafkaBrokers)
-        <> K.groupId (K.ConsumerGroupId cfg.kafkaGroupId)
+        <> K.groupId (K.ConsumerGroupId groupId)
         <> K.clientId (K.ClientId clientId)
         <> K.extraProp "security.protocol" "sasl_plaintext"
         <> K.extraProp "sasl.mechanism" "SCRAM-SHA-256"

--- a/src/System/Config.hs
+++ b/src/System/Config.hs
@@ -122,6 +122,18 @@ data EnvConfig = EnvConfig
   , enableTimefusionReads :: Bool
   , enableTimefusionWrites :: Bool
   , kafkaDeadLetterTopic :: Text
+  , kafkaDeadLetterGroupId :: Text
+  -- ^ Consumer group for DLQ replay. Must NOT equal 'kafkaGroupId' — a shared
+  -- group would rebalance DLQ partitions onto primary consumers and double-DLQ
+  -- on failure. Empty string falls back at runtime to "<kafkaGroupId>_dlq".
+  , enableKafkaDeadLetterService :: Bool
+  -- ^ Wire a consumer that drains 'kafkaDeadLetterTopic' back through
+  -- 'processList' (routing via the preserved 'ce-type' / 'original-topic'
+  -- headers). Failures on DLQ messages drop+log instead of re-DLQ'ing —
+  -- poison can't loop. Requires 'enableKafkaService'.
+  , kafkaDeadLetterBatchSize :: Int
+  -- ^ Poll batch size for the DLQ consumer. Kept small (DLQ traffic is
+  -- replay, not steady-state) so a poison batch can't stall a large window.
   , enableFreetier :: Bool
   , enableBrowserMonitoring :: Bool
   , enableSessionReplay :: Bool
@@ -215,6 +227,8 @@ instance DefConfig EnvConfig where
       , openaiModel = "gpt-5.4-mini"
       , openaiSmallModel = "gpt-5.4-nano"
       , kafkaGroupConcurrency = 4
+      , enableKafkaDeadLetterService = True
+      , kafkaDeadLetterBatchSize = 50
       , extractionWorkerShards = 4
       , extractionQueueCapacity = 64
       , drainFlushBatchSize = 1000

--- a/src/System/Server.hs
+++ b/src/System/Server.hs
@@ -115,6 +115,9 @@ runServer appLogger env tp = do
         if env.config.replayBatchSize == 0
           then max 1 (env.config.messagesPerPubsubPullBatch `div` 2)
           else env.config.replayBatchSize
+      -- Separate consumer group for DLQ replay — must differ from kafkaGroupId
+      -- so the DLQ partitions don't rebalance onto primary consumers.
+      dlqGroupId cfg = if T.null cfg.kafkaDeadLetterGroupId then cfg.kafkaGroupId <> "_dlq" else cfg.kafkaDeadLetterGroupId
   let logExc = logException env.config.environment appLogger env.config.logLevel
   -- Extraction worker shard fibers. Each shard runs `processEagerBatch` per
   -- batch inside its own `runBackground` effect stack. The error-decay fiber
@@ -142,9 +145,11 @@ runServer appLogger env tp = do
         , guard env.config.enablePubsubService $> async (supervise logExc "pubsub" $ Queue.pubsubService appLogger env tp env.config.requestPubsubTopics processMessages)
         , Just $ async $ supervise logExc "background-jobs" bgJobWorker
         , Just $ async $ supervise logExc "otlp-grpc" $ OtlpServer.runServer appLogger env tp
-        , guard (env.config.enableKafkaService && not (any T.null env.config.kafkaTopics)) $> async (supervise logExc "kafka" $ Queue.kafkaService appLogger env tp env.config.kafkaTopics env.config.messagesPerPubsubPullBatch OtlpServer.processList)
-        , guard (env.config.enableKafkaService && not (any T.null env.config.kafkaTopics)) $> async (supervise logExc "kafka" $ Queue.kafkaService appLogger env tp env.config.kafkaTopics env.config.messagesPerPubsubPullBatch OtlpServer.processList)
-        , guard env.config.enableReplayService $> async (supervise logExc "kafka-replay" $ Queue.kafkaService appLogger env tp env.config.rrwebTopics effectiveReplayBatch processReplayEvents)
+        , guard (env.config.enableKafkaService && not (any T.null env.config.kafkaTopics)) $> async (supervise logExc "kafka" $ Queue.kafkaService appLogger env tp env.config.kafkaGroupId env.config.kafkaTopics env.config.messagesPerPubsubPullBatch OtlpServer.processList)
+        , guard (env.config.enableKafkaService && not (any T.null env.config.kafkaTopics)) $> async (supervise logExc "kafka" $ Queue.kafkaService appLogger env tp env.config.kafkaGroupId env.config.kafkaTopics env.config.messagesPerPubsubPullBatch OtlpServer.processList)
+        , guard (env.config.enableKafkaService && env.config.enableKafkaDeadLetterService && not (T.null env.config.kafkaDeadLetterTopic))
+            $> async (supervise logExc "kafka-dlq" $ Queue.kafkaService appLogger env tp (dlqGroupId env.config) [env.config.kafkaDeadLetterTopic] env.config.kafkaDeadLetterBatchSize OtlpServer.processList)
+        , guard env.config.enableReplayService $> async (supervise logExc "kafka-replay" $ Queue.kafkaService appLogger env tp env.config.kafkaGroupId env.config.rrwebTopics effectiveReplayBatch processReplayEvents)
         ]
       <> fmap Just workerFibers
   void $ liftIO $ waitAnyCancel asyncs

--- a/static/migrations/0099_usage_submissions_backoff.sql
+++ b/static/migrations/0099_usage_submissions_backoff.sql
@@ -1,0 +1,9 @@
+-- Back off retries for failed usage chunks so a permanently-broken project
+-- (canceled sub, deleted customer, bad sub_item_id) stops re-logging every
+-- daily ReportUsage tick. attempt_count is bumped on every failure; the
+-- daily drain query in pendingUsageSubmissions skips failed rows whose
+-- last_attempt_at is within LEAST(attempt_count, 14) days. Once the upstream
+-- issue is fixed the next due tick picks the chunk up — no manual reset.
+ALTER TABLE projects.usage_report_submissions
+  ADD COLUMN IF NOT EXISTS attempt_count    int         NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS last_attempt_at  timestamptz;


### PR DESCRIPTION
## Summary

Two unrelated reliability fixes bundled together:

- **Kafka DLQ replay consumer.** Wires a second `kafkaService` against `kafkaDeadLetterTopic` under its own group id (defaults to `<kafkaGroupId>_dlq`) so DLQ partitions don't rebalance onto primary consumers. If a DLQ message itself fails, drop+log instead of re-DLQ'ing so poison can't loop. New env knobs: `enableKafkaDeadLetterService`, `kafkaDeadLetterBatchSize`, `kafkaDeadLetterGroupId`.
- **Usage submission backoff.** Adds `attempt_count` + `last_attempt_at` on `projects.usage_report_submissions`. `pendingUsageSubmissions` now skips failed rows until `LEAST(attempt_count, 14)` days have passed since `last_attempt_at`, so a permanently-broken project (canceled sub, deleted customer, bad `sub_item_id`) stops re-logging every daily `ReportUsage` tick. Pending rows still run on the next tick.

## Test plan
- [ ] Verify DLQ consumer starts under `<kafkaGroupId>_dlq` and is independent of the primary consumer group
- [ ] Force a poison message on the DLQ topic and confirm it is dropped+logged, not re-DLQ'd
- [ ] Apply migration 0099, mark a submission failed, confirm it is skipped on the next tick and picked up after the backoff window elapses