### PR TITLE
perf: drop UPDATE-2 CASE-WHEN ladder for native unnest-join now that …

### DIFF
--- a/src/BackgroundJobs.hs
+++ b/src/BackgroundJobs.hs
@@ -1997,6 +1997,11 @@ flushDrainTask shard task
       Relude.unless (null hss) $ void $ LogPatterns.upsertHourlyStatBatch hss
 
       -- UPDATE-2: additive per-row tag append. Dual-forked to Postgres + TimeFusion.
+      -- TimeFusion now supports `UPDATE ... FROM (unnest)` natively (see the
+      -- TF DmlQueryPlanner + MergeBuilder dispatch and the vendored
+      -- datafusion-sql guard removal). Both backends consume the same shape;
+      -- the `NOT @>` predicate makes re-extraction of the same pattern a
+      -- no-op (zero rows touched) on both engines.
       let taggedSpans =
             [ (bs.spanCtxId, bs.traceId, tag, bs.timestamp)
             | bs <- task.spans
@@ -2011,35 +2016,21 @@ flushDrainTask shard task
             (minTs, maxTs) = foldl' (\(!lo, !hi) t -> (min lo t, max hi t)) (head tsList, head tsList) tsList
             effectiveMinTs = max minTs hashCutoff
             maxTsPad = addUTCTime 1 maxTs
-            tuples = zip3 spanIds' traceIds' tagArr
-            -- CASE rewrite of the original `UPDATE ... FROM (unnest)` form so
-            -- TimeFusion's PGWire (which doesn't support UPDATE...FROM with a
-            -- joinable subquery) accepts the statement. One CASE branch per
-            -- tuple; idempotency check inline. Empty inputs short-circuit.
-            -- No table alias: TimeFusion's UPDATE planner doesn't resolve
-            -- alias-qualified column refs inside CASE/SET expressions.
-            -- Unqualified is unambiguous (single-table UPDATE) on both PG and TF.
-            whenBranch (s, t, tag) =
-              [HI.sql| WHEN context___span_id = #{s}
-                        AND context___trace_id = #{t}
-                        AND NOT (COALESCE(hashes, '{}'::text[]) @> ARRAY[#{tag}])
-                       THEN ARRAY[#{tag}] |]
-            -- TimeFusion doesn't accept row-constructor IN syntax
-            -- `(col1, col2) IN ((a,b), ...)`. Expand to explicit OR chain.
-            orMatch (s, t, _) =
-              [HI.sql| (context___span_id = #{s} AND context___trace_id = #{t}) |]
             update2Sql =
-              [HI.sql| UPDATE otel_logs_and_spans
-                          SET hashes = COALESCE(hashes, '{}'::text[]) || (CASE |]
-                <> mconcat (whenBranch <$> tuples)
-                <> [HI.sql| ELSE ARRAY[]::text[] END)
-                        WHERE project_id = #{pid.toText}
-                          AND timestamp >= #{effectiveMinTs}
-                          AND timestamp <  #{maxTsPad}
-                          AND ( |]
-                <> mconcat (intersperse [HI.sql| OR |] (orMatch <$> tuples))
-                <> [HI.sql| ) |]
-        Relude.when (ctx.config.enableHashUpdates && maxTs >= hashCutoff && not (null tuples))
+              [HI.sql| UPDATE otel_logs_and_spans o
+                          SET hashes = COALESCE(o.hashes, '{}'::text[]) || ARRAY[u.tag]
+                          FROM (
+                            SELECT unnest(#{spanIds'}::text[]) AS span_id,
+                                   unnest(#{traceIds'}::text[]) AS trace_id,
+                                   unnest(#{tagArr}::text[])    AS tag
+                          ) u
+                          WHERE o.project_id = #{pid.toText}
+                            AND o.timestamp >= #{effectiveMinTs}
+                            AND o.timestamp <  #{maxTsPad}
+                            AND o.context___span_id = u.span_id
+                            AND o.context___trace_id = u.trace_id
+                            AND NOT (COALESCE(o.hashes, '{}'::text[]) @> ARRAY[u.tag]) |]
+        Relude.when (ctx.config.enableHashUpdates && maxTs >= hashCutoff)
           $ void
           $ dualExecPgTf ctx update2Sql
       -- TODO(otel-metrics): emit counters for drain_flushes_completed, spans_flushed, patterns_persisted.


### PR DESCRIPTION
…TF supports UPDATE ... FROM

TimeFusion's DmlQueryPlanner now lowers `UPDATE ... FROM` to MergeBuilder on the Delta side (with a vendored datafusion-sql guard removal), so the CASE-WHEN rewrite we used to satisfy TF's PGWire is no longer needed. The unnest-join shape mirrors UPDATE-1 and is HOT-friendly on Postgres.

The `NOT @>` predicate keeps re-extraction of the same pattern a no-op (zero rows touched) on both engines, replacing the per-branch idempotency check that lived inside each CASE WHEN.

Net deletion: ~30 LOC. The whenBranch + orMatch builders and the 4000-parameter CASE ladder are gone; the new statement is one short SQL template regardless of batch size.

<!-- Thank you for contributing to Monscope! -->

<!-- Briefly describe what your PR does here as much as you can. -->

Closes #

<!-- If your PR is related to an issue, provide the number(s) above (after the #); if it resolves multiple issues, be sure to add a comma (e.g. "closes #1000, #1001"). -->

## How to test

<!-- Please include the steps to test your changes here. -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure you have described your changes and added all relevant screenshots or data.
- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes (or request one from the team).
- [ ] You are **NOT** deprecating/removing a feature.
