### PR TITLE
refactor(LogQueries): wrap row-extraction with jsonb_build_array

### DIFF
--- a/src/Models/Apis/LogQueries.hs
+++ b/src/Models/Apis/LogQueries.hs
@@ -217,7 +217,7 @@ executeArbitraryQuery colCount querySql = do
       $ rawSql ("SELECT jsonb_build_array(" <> aliases <> ") FROM (")
       <> querySql
       <> rawSql (") sub(" <> aliases <> ")")
-  pure $ V.fromList $ mapMaybe jsonArrayToVector results
+  pure $ V.mapMaybe jsonArrayToVector (V.fromList results)
 
 
 -- | Execute a user-provided SQL query with mandatory project_id filtering.
@@ -331,7 +331,7 @@ selectLogTable pid queryAST queryText cursorM dateRange projectedColsByUser sour
       -- in `toColNames` (display columns only). Include it in the alias list or
       -- PG rejects with "column alias list must be the same length as the number
       -- of output columns".
-      $ executeArbitraryQuery (length queryComponents.toColNames + if queryComponents.hasCountOver then 1 else 0) (rawSql q)
+      $ executeArbitraryQuery (length queryComponents.toColNames + fromEnum queryComponents.hasCountOver) (rawSql q)
   case result of
     Left e -> pure $ Left $ show e
     Right logItemsV -> do

--- a/src/Models/Apis/LogQueries.hs
+++ b/src/Models/Apis/LogQueries.hs
@@ -198,10 +198,18 @@ logExplorerUrlPath pid q cols cursor since fromV toV layout source recent = "/p/
 
 -- | Execute arbitrary SQL query and return results as vector of vectors.
 -- Wraps the inner SELECT with `jsonb_build_array` so each row is returned as a
--- single jsonb array of its column values. Works on both Postgres and
--- TimeFusion (both ship `jsonb_build_array(VARIADIC any)`). Caller passes the
--- expected column count — see `Pkg.Parser.wrapForRowExtraction`.
+-- single jsonb array of its column values, in declared column order. Replaces
+-- the legacy `(SELECT json_agg(x.value ORDER BY x.ordinality)::jsonb FROM
+-- json_each(row_to_json(sub.*)) WITH ORDINALITY AS x)` wrapper: same wire
+-- output, but works on TimeFusion (no json_each / row_to_json / WITH ORDINALITY
+-- / row-correlated UDTF needed) and dodges PostgreSQL's JSON-parser hazard on
+-- TEXT columns containing NULL bytes or lone surrogates.
+--
+-- Caller passes the expected column count of the inner SELECT. `colCount <= 0`
+-- returns an empty vector without touching the database — `sub()` with zero
+-- column aliases is not valid SQL.
 executeArbitraryQuery :: DB es => Int -> HI.Sql -> Eff es (V.Vector (V.Vector AE.Value))
+executeArbitraryQuery colCount _ | colCount <= 0 = pure V.empty
 executeArbitraryQuery colCount querySql = do
   let aliases = T.intercalate "," ["c" <> show i | i <- [1 .. colCount]]
   results :: [AE.Value] <-
@@ -215,6 +223,7 @@ executeArbitraryQuery colCount querySql = do
 -- | Execute a user-provided SQL query with mandatory project_id filtering.
 -- SECURITY: Validates query for dangerous patterns and verifies project_id filter is present in query.
 -- Note: The query must already contain project_id='<pid>' filtering (via {{project_id}} placeholder substitution done before calling this function)
+-- TODO: Still uses the legacy json_each/row_to_json wrapper since callers (Dashboards, AI raw-SQL) pass arbitrary user/LLM SQL without a known column count. Migrate to jsonb_build_array once column counts can be derived (e.g. via a parsing pass or a probe).
 executeSecuredQuery :: DB es => Projects.ProjectId -> Text -> Int -> Eff es (Either Text (V.Vector (V.Vector AE.Value)))
 executeSecuredQuery pid userQuery limit
   | not (validateSqlQuery userQuery) = pure $ Left "Query contains disallowed operations"

--- a/src/Models/Apis/LogQueries.hs
+++ b/src/Models/Apis/LogQueries.hs
@@ -197,14 +197,18 @@ logExplorerUrlPath pid q cols cursor since fromV toV layout source recent = "/p/
 
 
 -- | Execute arbitrary SQL query and return results as vector of vectors.
--- Wraps in row_to_json + json_each to preserve column order via hasql.
-executeArbitraryQuery :: DB es => HI.Sql -> Eff es (V.Vector (V.Vector AE.Value))
-executeArbitraryQuery querySql = do
+-- Wraps the inner SELECT with `jsonb_build_array` so each row is returned as a
+-- single jsonb array of its column values. Works on both Postgres and
+-- TimeFusion (both ship `jsonb_build_array(VARIADIC any)`). Caller passes the
+-- expected column count — see `Pkg.Parser.wrapForRowExtraction`.
+executeArbitraryQuery :: DB es => Int -> HI.Sql -> Eff es (V.Vector (V.Vector AE.Value))
+executeArbitraryQuery colCount querySql = do
+  let aliases = T.intercalate "," ["c" <> show i | i <- [1 .. colCount]]
   results :: [AE.Value] <-
     Hasql.interp
-      $ rawSql "SELECT (SELECT json_agg(x.value ORDER BY x.ordinality)::jsonb FROM json_each(row_to_json(sub.*)) WITH ORDINALITY AS x) FROM ("
+      $ rawSql ("SELECT jsonb_build_array(" <> aliases <> ") FROM (")
       <> querySql
-      <> rawSql ") AS sub"
+      <> rawSql (") sub(" <> aliases <> ")")
   pure $ V.fromList $ mapMaybe jsonArrayToVector results
 
 
@@ -314,7 +318,7 @@ selectLogTable pid queryAST queryText cursorM dateRange projectedColsByUser sour
       ]
       $ try @SomeException
       $ checkpoint (toAnnotation ("selectLogTable", q))
-      $ executeArbitraryQuery (rawSql q)
+      $ executeArbitraryQuery (length queryComponents.toColNames) (rawSql q)
   case result of
     Left e -> pure $ Left $ show e
     Right logItemsV -> do
@@ -444,10 +448,9 @@ data SessionRow = SessionRow
 
 
 -- | Mirrors the column order of the SELECT in 'fetchSessions'. Decoded
--- directly via hasql to bypass the row_to_json/json_each wrapper used by
--- 'executeArbitraryQuery' — that wrapper trips PostgreSQL's JSON parser
--- whenever a TEXT value (e.g. a user_agent or url_path captured from raw
--- OTLP) contains characters JSON forbids (NULL bytes, lone surrogates).
+-- directly via hasql as a perf-oriented typed path; 'executeArbitraryQuery'
+-- now uses 'jsonb_build_array' which is safe for NULL bytes and lone
+-- surrogates, so this no longer doubles as a parser-bug workaround.
 data RawSessionRow = RawSessionRow
   { sessionId :: Text
   , userId :: Maybe Text
@@ -854,7 +857,7 @@ fetchEventExamples enableTfReads pid queryAST dateRange expandKind skip limitN =
             <> expandFilter
             <> [HI.sql| ORDER BY timestamp ASC OFFSET #{skip}::BIGINT LIMIT #{limitN}::BIGINT|]
   Log.logTrace "fetchEventExamples: query" $ AE.object ["project_id" AE..= pid]
-  rows <- Hasql.withHasqlTimefusion enableTfReads $ checkpoint (toAnnotation ("fetchEventExamples" :: Text, pid)) $ executeArbitraryQuery q
+  rows <- Hasql.withHasqlTimefusion enableTfReads $ checkpoint (toAnnotation ("fetchEventExamples" :: Text, pid)) $ executeArbitraryQuery (length (colsNoAsClause cols)) q
   pure (rows, listToColNames cols)
 
 

--- a/src/Models/Apis/LogQueries.hs
+++ b/src/Models/Apis/LogQueries.hs
@@ -216,7 +216,7 @@ executeArbitraryQuery colCount querySql = do
 -- | Execute a user-provided SQL query with mandatory project_id filtering.
 -- SECURITY: Validates query for dangerous patterns and verifies project_id filter is present in query.
 -- Note: The query must already contain project_id='<pid>' filtering (via {{project_id}} placeholder substitution done before calling this function)
--- TODO: Still uses the legacy json_each/row_to_json wrapper since callers (Dashboards, AI raw-SQL) pass arbitrary user/LLM SQL without a known column count. Migrate to jsonb_build_array once column counts can be derived (e.g. via a parsing pass or a probe).
+-- TODO: migrate to jsonb_build_array once column count is derivable for arbitrary user/LLM SQL.
 executeSecuredQuery :: DB es => Projects.ProjectId -> Text -> Int -> Eff es (Either Text (V.Vector (V.Vector AE.Value)))
 executeSecuredQuery pid userQuery limit
   | not (validateSqlQuery userQuery) = pure $ Left "Query contains disallowed operations"

--- a/src/Models/Apis/LogQueries.hs
+++ b/src/Models/Apis/LogQueries.hs
@@ -210,7 +210,7 @@ executeArbitraryQuery colCount querySql = do
       $ rawSql ("SELECT jsonb_build_array(" <> aliases <> ") FROM (")
       <> querySql
       <> rawSql (") sub(" <> aliases <> ")")
-  pure $ V.mapMaybe jsonArrayToVector (V.fromList results)
+  pure $ V.fromList $ mapMaybe jsonArrayToVector results
 
 
 -- | Execute a user-provided SQL query with mandatory project_id filtering.

--- a/src/Models/Apis/LogQueries.hs
+++ b/src/Models/Apis/LogQueries.hs
@@ -327,7 +327,11 @@ selectLogTable pid queryAST queryText cursorM dateRange projectedColsByUser sour
       ]
       $ try @SomeException
       $ checkpoint (toAnnotation ("selectLogTable", q))
-      $ executeArbitraryQuery (length queryComponents.toColNames) (rawSql q)
+      -- hasCountOver appends a count(*) OVER() column to the SELECT but it isn't
+      -- in `toColNames` (display columns only). Include it in the alias list or
+      -- PG rejects with "column alias list must be the same length as the number
+      -- of output columns".
+      $ executeArbitraryQuery (length queryComponents.toColNames + if queryComponents.hasCountOver then 1 else 0) (rawSql q)
   case result of
     Left e -> pure $ Left $ show e
     Right logItemsV -> do
@@ -849,8 +853,9 @@ fetchEventExamples enableTfReads pid queryAST dateRange expandKind skip limitN =
         ExpandSession sid -> [HI.sql| AND attributes___session___id = #{sid}|]
         ExpandPattern tpl -> [HI.sql| AND array_to_string(summary, chr(30)) ILIKE #{templateToLike tpl}|]
       cols = defaultSelectSqlQuery (Just SSpans)
+      rawCols = colsNoAsClause cols
       -- Mirror selectLogTable's summary column handling: wrap TEXT[] as JSON for row output.
-      processedCols = map (\c -> if c == "summary" || "summary" `T.isSuffixOf` c then "to_json(summary)" else c) $ colsNoAsClause cols
+      processedCols = map (\c -> if c == "summary" || "summary" `T.isSuffixOf` c then "to_json(summary)" else c) rawCols
       selectClause = T.intercalate ", " processedCols
       -- Sessions: fetch one root event per trace via DISTINCT ON so [+N] expansion
       -- covers all traces.  Patterns/other: fetch raw events as before.
@@ -866,7 +871,7 @@ fetchEventExamples enableTfReads pid queryAST dateRange expandKind skip limitN =
             <> expandFilter
             <> [HI.sql| ORDER BY timestamp ASC OFFSET #{skip}::BIGINT LIMIT #{limitN}::BIGINT|]
   Log.logTrace "fetchEventExamples: query" $ AE.object ["project_id" AE..= pid]
-  rows <- Hasql.withHasqlTimefusion enableTfReads $ checkpoint (toAnnotation ("fetchEventExamples" :: Text, pid)) $ executeArbitraryQuery (length (colsNoAsClause cols)) q
+  rows <- Hasql.withHasqlTimefusion enableTfReads $ checkpoint (toAnnotation ("fetchEventExamples" :: Text, pid)) $ executeArbitraryQuery (length rawCols) q
   pure (rows, listToColNames cols)
 
 

--- a/src/Models/Apis/LogQueries.hs
+++ b/src/Models/Apis/LogQueries.hs
@@ -196,18 +196,11 @@ logExplorerUrlPath pid q cols cursor since fromV toV layout source recent = "/p/
         ]
 
 
--- | Execute arbitrary SQL query and return results as vector of vectors.
--- Wraps the inner SELECT with `jsonb_build_array` so each row is returned as a
--- single jsonb array of its column values, in declared column order. Replaces
--- the legacy `(SELECT json_agg(x.value ORDER BY x.ordinality)::jsonb FROM
--- json_each(row_to_json(sub.*)) WITH ORDINALITY AS x)` wrapper: same wire
--- output, but works on TimeFusion (no json_each / row_to_json / WITH ORDINALITY
--- / row-correlated UDTF needed) and dodges PostgreSQL's JSON-parser hazard on
--- TEXT columns containing NULL bytes or lone surrogates.
---
--- Caller passes the expected column count of the inner SELECT. `colCount <= 0`
--- returns an empty vector without touching the database — `sub()` with zero
--- column aliases is not valid SQL.
+-- | Wrap the inner SELECT so each row arrives as a jsonb array of column values.
+-- Uses jsonb_build_array(c1,…,cN) instead of json_each / row_to_json / WITH
+-- ORDINALITY — the latter is unsupported on TimeFusion and trips PG's JSON
+-- parser on NULL bytes. `colCount <= 0` short-circuits to V.empty since sub()
+-- with zero aliases is invalid SQL.
 executeArbitraryQuery :: DB es => Int -> HI.Sql -> Eff es (V.Vector (V.Vector AE.Value))
 executeArbitraryQuery colCount _ | colCount <= 0 = pure V.empty
 executeArbitraryQuery colCount querySql = do
@@ -327,10 +320,7 @@ selectLogTable pid queryAST queryText cursorM dateRange projectedColsByUser sour
       ]
       $ try @SomeException
       $ checkpoint (toAnnotation ("selectLogTable", q))
-      -- hasCountOver appends a count(*) OVER() column to the SELECT but it isn't
-      -- in `toColNames` (display columns only). Include it in the alias list or
-      -- PG rejects with "column alias list must be the same length as the number
-      -- of output columns".
+      -- +1 for count(*) OVER() appended to SELECT but absent from toColNames.
       $ executeArbitraryQuery (length queryComponents.toColNames + fromEnum queryComponents.hasCountOver) (rawSql q)
   case result of
     Left e -> pure $ Left $ show e

--- a/src/Pkg/Parser.hs
+++ b/src/Pkg/Parser.hs
@@ -1,5 +1,5 @@
 -- Parser implemented with help and code from: https://markkarpov.com/tutorial/megaparsec.html
-module Pkg.Parser (queryASTToComponents, parseQueryToComponents, getProcessedColumns, fixedUTCTime, parseQuery, sectionsToComponents, defSqlQueryCfg, defPid, SqlQueryCfg (..), QueryComponents (..), NormalizedQuery (..), normalizeQuery, buildDateRange, buildGroupBy, buildOrderBy, buildLimit, buildWhereCondition, listToColNames, colsNoAsClause, defaultSelectSqlQuery, pSource, parseQueryToAST, ToQueryText (..), calculateAutoBinWidth, replacePlaceholders, variablePresets, variablePresetsKQL, constantToSQLList, constantToKQLList, defaultQueryLimit) where
+module Pkg.Parser (queryASTToComponents, parseQueryToComponents, getProcessedColumns, fixedUTCTime, parseQuery, sectionsToComponents, defSqlQueryCfg, defPid, SqlQueryCfg (..), QueryComponents (..), NormalizedQuery (..), normalizeQuery, buildDateRange, buildGroupBy, buildOrderBy, buildLimit, buildWhereCondition, listToColNames, colsNoAsClause, defaultSelectSqlQuery, pSource, parseQueryToAST, ToQueryText (..), calculateAutoBinWidth, replacePlaceholders, variablePresets, variablePresetsKQL, constantToSQLList, constantToKQLList, defaultQueryLimit, wrapForRowExtraction) where
 
 import Control.Error (hush)
 import Data.Default (Default (def))
@@ -536,6 +536,18 @@ colsNoAsClause = mapMaybe (\x -> Safe.headMay $ T.strip <$> T.splitOn "as" x)
 
 instance HasField "toColNames" QueryComponents [Text] where
   getField qc = qc.finalColumns
+
+
+-- | Wrap an inner SELECT producing N columns in a single jsonb-array projection.
+-- Replaces the legacy `json_agg(json_each(row_to_json(sub.*)) WITH ORDINALITY)`
+-- idiom: both Postgres and TimeFusion ship `jsonb_build_array(VARIADIC any)`,
+-- and derived-column aliases (`sub(c1..cN)`) decouple us from the inner SELECT
+-- expression shapes. Same wire output as the legacy wrapper but avoids the
+-- JSON-parser hazard on TEXT columns containing NULL bytes or lone surrogates.
+wrapForRowExtraction :: Int -> Text -> Text
+wrapForRowExtraction n inner =
+  let aliases = T.intercalate "," [ "c" <> show i | i <- [1 .. n] ]
+   in "SELECT jsonb_build_array(" <> aliases <> ") FROM (" <> inner <> ") sub(" <> aliases <> ")"
 
 
 -- | Replace all occurrences of {{key}} in the input text using the provided mapping.

--- a/src/Pkg/Parser.hs
+++ b/src/Pkg/Parser.hs
@@ -546,7 +546,7 @@ instance HasField "toColNames" QueryComponents [Text] where
 -- JSON-parser hazard on TEXT columns containing NULL bytes or lone surrogates.
 wrapForRowExtraction :: Int -> Text -> Text
 wrapForRowExtraction n inner =
-  let aliases = T.intercalate "," [ "c" <> show i | i <- [1 .. n] ]
+  let aliases = T.intercalate "," ["c" <> show i | i <- [1 .. n]]
    in "SELECT jsonb_build_array(" <> aliases <> ") FROM (" <> inner <> ") sub(" <> aliases <> ")"
 
 

--- a/src/Pkg/Parser.hs
+++ b/src/Pkg/Parser.hs
@@ -1,5 +1,5 @@
 -- Parser implemented with help and code from: https://markkarpov.com/tutorial/megaparsec.html
-module Pkg.Parser (queryASTToComponents, parseQueryToComponents, getProcessedColumns, fixedUTCTime, parseQuery, sectionsToComponents, defSqlQueryCfg, defPid, SqlQueryCfg (..), QueryComponents (..), NormalizedQuery (..), normalizeQuery, buildDateRange, buildGroupBy, buildOrderBy, buildLimit, buildWhereCondition, listToColNames, colsNoAsClause, defaultSelectSqlQuery, pSource, parseQueryToAST, ToQueryText (..), calculateAutoBinWidth, replacePlaceholders, variablePresets, variablePresetsKQL, constantToSQLList, constantToKQLList, defaultQueryLimit, wrapForRowExtraction) where
+module Pkg.Parser (queryASTToComponents, parseQueryToComponents, getProcessedColumns, fixedUTCTime, parseQuery, sectionsToComponents, defSqlQueryCfg, defPid, SqlQueryCfg (..), QueryComponents (..), NormalizedQuery (..), normalizeQuery, buildDateRange, buildGroupBy, buildOrderBy, buildLimit, buildWhereCondition, listToColNames, colsNoAsClause, defaultSelectSqlQuery, pSource, parseQueryToAST, ToQueryText (..), calculateAutoBinWidth, replacePlaceholders, variablePresets, variablePresetsKQL, constantToSQLList, constantToKQLList, defaultQueryLimit) where
 
 import Control.Error (hush)
 import Data.Default (Default (def))
@@ -536,18 +536,6 @@ colsNoAsClause = mapMaybe (\x -> Safe.headMay $ T.strip <$> T.splitOn "as" x)
 
 instance HasField "toColNames" QueryComponents [Text] where
   getField qc = qc.finalColumns
-
-
--- | Wrap an inner SELECT producing N columns in a single jsonb-array projection.
--- Replaces the legacy `json_agg(json_each(row_to_json(sub.*)) WITH ORDINALITY)`
--- idiom: both Postgres and TimeFusion ship `jsonb_build_array(VARIADIC any)`,
--- and derived-column aliases (`sub(c1..cN)`) decouple us from the inner SELECT
--- expression shapes. Same wire output as the legacy wrapper but avoids the
--- JSON-parser hazard on TEXT columns containing NULL bytes or lone surrogates.
-wrapForRowExtraction :: Int -> Text -> Text
-wrapForRowExtraction n inner =
-  let aliases = T.intercalate "," ["c" <> show i | i <- [1 .. n]]
-   in "SELECT jsonb_build_array(" <> aliases <> ") FROM (" <> inner <> ") sub(" <> aliases <> ")"
 
 
 -- | Replace all occurrences of {{key}} in the input text using the provided mapping.


### PR DESCRIPTION
## Summary

Replaces the legacy `json_each(row_to_json(*)) WITH ORDINALITY` row-extraction wrapper in `executeArbitraryQuery` with the equivalent `SELECT jsonb_build_array(c1,…,cN) FROM (<inner>) sub(c1,…,cN)`.

Why:

- The legacy wrapper depends on `json_each`, `row_to_json`, `WITH ORDINALITY`, and row-correlated lateral subqueries — none of which TimeFusion (DataFusion-backed) supports today. So log-explorer queries against the TF backend fail at parse time with `table function 'json_each' not found`.
- The wrapper also trips PG's own JSON parser when a TEXT column contains NULL bytes or lone surrogates (documented near `RawSessionRow`); `jsonb_build_array` builds JSON from typed values and avoids that.

Companion PR in TimeFusion exposes a `jsonb_build_array` alias on the existing `json_build_array` UDF so the same wrapper works on both backends.

## Changes

- `executeArbitraryQuery :: HI.Sql -> …` → `Int -> HI.Sql -> …`. New `Int` is the column count of the inner SELECT. Wrapper builds `c1,…,cN` aliases inline. `colCount <= 0` short-circuits to `V.empty` since `sub()` with zero aliases is invalid SQL.
- Two callers updated:
  - `selectLogTable` passes `length toColNames + fromEnum hasCountOver` since the `count(*) OVER()` extra column isn't in `toColNames` but is emitted in the SELECT.
  - `fetchEventExamples` passes `length rawCols` (binds `colsNoAsClause cols` once and reuses).
- `executeSecuredQuery` left on the legacy wrapper for now — its callers (Dashboards, AI raw-SQL) take raw user/LLM SQL without column info and never worked against TimeFusion anyway. TODO inline.

## Test plan

- [x] `cabal build lib:monoscope` — clean compile.
- [ ] Manual: run the original failing log-explorer query against the dev TimeFusion cluster (depends on companion TF PR being deployed).
- [ ] Existing PG regression suite still passes (`jsonb_build_array` is native in PG).