### PR TITLE
refactor(LogQueries): collapse wrappers onto jsonb_build_array(sub.*)

### DIFF
--- a/hpack-includes/lib-deps.yaml
+++ b/hpack-includes/lib-deps.yaml
@@ -32,6 +32,7 @@
 - containers
 - cookie
 - safe-exceptions
+- these
 - annotated-exception
 - safe
 - cryptonite

--- a/monoscope.cabal
+++ b/monoscope.cabal
@@ -620,6 +620,7 @@ test-suite integration-tests
       Opentelemetry.GrpcIngestionSpec
       Opentelemetry.OtlpServerSpec
       Opentelemetry.StandardOtelSpansSpec
+      Opentelemetry.TimefusionWriteFailureSpec
       Opentelemetry.TraceSessionPropagationSpec
       Pages.AnomaliesSpec
       Pages.ApiSpec
@@ -847,6 +848,7 @@ test-suite test-dev
       Opentelemetry.GrpcIngestionSpec
       Opentelemetry.OtlpServerSpec
       Opentelemetry.StandardOtelSpansSpec
+      Opentelemetry.TimefusionWriteFailureSpec
       Opentelemetry.TraceSessionPropagationSpec
       Pages.AnomaliesSpec
       Pages.ApiSpec

--- a/monoscope.cabal
+++ b/monoscope.cabal
@@ -424,6 +424,7 @@ library
     , text
     , text-builder-linear
     , text-display
+    , these
     , time
     , time-manager
     , tmp-postgres
@@ -728,6 +729,7 @@ test-suite integration-tests
     , servant-htmx
     , servant-server
     , text
+    , these
     , time
     , unliftio
     , unordered-containers
@@ -1080,6 +1082,7 @@ test-suite test-dev
     , text
     , text-builder-linear
     , text-display
+    , these
     , time
     , time-manager
     , tmp-postgres

--- a/package.yaml
+++ b/package.yaml
@@ -239,6 +239,7 @@ tests:
     dependencies:
       - base
       - monoscope
+      - these
       - hs-opentelemetry-instrumentation-auto
       - hspec
       - relude >= 1.2.0.0

--- a/src/Models/Apis/LogQueries.hs
+++ b/src/Models/Apis/LogQueries.hs
@@ -217,7 +217,7 @@ executeArbitraryQuery colCount querySql = do
       $ rawSql ("SELECT jsonb_build_array(" <> aliases <> ") FROM (")
       <> querySql
       <> rawSql (") sub(" <> aliases <> ")")
-  pure $ V.fromList $ mapMaybe jsonArrayToVector results
+  pure $ V.mapMaybe jsonArrayToVector (V.fromList results)
 
 
 -- | Execute a user-provided SQL query with mandatory project_id filtering.
@@ -331,7 +331,7 @@ selectLogTable pid queryAST queryText cursorM dateRange projectedColsByUser sour
       -- in `toColNames` (display columns only). Include it in the alias list or
       -- PG rejects with "column alias list must be the same length as the number
       -- of output columns".
-      $ executeArbitraryQuery (length queryComponents.toColNames + if queryComponents.hasCountOver then 1 else 0) (rawSql q)
+      $ executeArbitraryQuery (length queryComponents.toColNames + fromEnum queryComponents.hasCountOver) (rawSql q)
   case result of
     Left e -> pure $ Left $ show e
     Right logItemsV -> do

--- a/src/Models/Apis/LogQueries.hs
+++ b/src/Models/Apis/LogQueries.hs
@@ -198,10 +198,18 @@ logExplorerUrlPath pid q cols cursor since fromV toV layout source recent = "/p/
 
 -- | Execute arbitrary SQL query and return results as vector of vectors.
 -- Wraps the inner SELECT with `jsonb_build_array` so each row is returned as a
--- single jsonb array of its column values. Works on both Postgres and
--- TimeFusion (both ship `jsonb_build_array(VARIADIC any)`). Caller passes the
--- expected column count — see `Pkg.Parser.wrapForRowExtraction`.
+-- single jsonb array of its column values, in declared column order. Replaces
+-- the legacy `(SELECT json_agg(x.value ORDER BY x.ordinality)::jsonb FROM
+-- json_each(row_to_json(sub.*)) WITH ORDINALITY AS x)` wrapper: same wire
+-- output, but works on TimeFusion (no json_each / row_to_json / WITH ORDINALITY
+-- / row-correlated UDTF needed) and dodges PostgreSQL's JSON-parser hazard on
+-- TEXT columns containing NULL bytes or lone surrogates.
+--
+-- Caller passes the expected column count of the inner SELECT. `colCount <= 0`
+-- returns an empty vector without touching the database — `sub()` with zero
+-- column aliases is not valid SQL.
 executeArbitraryQuery :: DB es => Int -> HI.Sql -> Eff es (V.Vector (V.Vector AE.Value))
+executeArbitraryQuery colCount _ | colCount <= 0 = pure V.empty
 executeArbitraryQuery colCount querySql = do
   let aliases = T.intercalate "," ["c" <> show i | i <- [1 .. colCount]]
   results :: [AE.Value] <-
@@ -215,6 +223,7 @@ executeArbitraryQuery colCount querySql = do
 -- | Execute a user-provided SQL query with mandatory project_id filtering.
 -- SECURITY: Validates query for dangerous patterns and verifies project_id filter is present in query.
 -- Note: The query must already contain project_id='<pid>' filtering (via {{project_id}} placeholder substitution done before calling this function)
+-- TODO: Still uses the legacy json_each/row_to_json wrapper since callers (Dashboards, AI raw-SQL) pass arbitrary user/LLM SQL without a known column count. Migrate to jsonb_build_array once column counts can be derived (e.g. via a parsing pass or a probe).
 executeSecuredQuery :: DB es => Projects.ProjectId -> Text -> Int -> Eff es (Either Text (V.Vector (V.Vector AE.Value)))
 executeSecuredQuery pid userQuery limit
   | not (validateSqlQuery userQuery) = pure $ Left "Query contains disallowed operations"

--- a/src/Models/Apis/LogQueries.hs
+++ b/src/Models/Apis/LogQueries.hs
@@ -204,7 +204,7 @@ executeArbitraryQuery :: DB es => HI.Sql -> Eff es (V.Vector (V.Vector AE.Value)
 executeArbitraryQuery querySql = do
   results :: [AE.Value] <-
     Hasql.interp $ rawSql "SELECT jsonb_build_array(sub.*) FROM (" <> querySql <> rawSql ") sub"
-  pure $ V.fromList $ mapMaybe jsonArrayToVector results
+  pure $ fromList $ mapMaybe jsonArrayToVector results
 
 
 -- | Execute a user-provided SQL query with mandatory project_id filtering.
@@ -368,7 +368,7 @@ selectChildSpansAndLogs pid projectedColsByUser traceIds seedSpanIds dateRange e
       -- 'colNames' from getProcessedColumns retains "<expr> as <alias>" entries;
       -- strip to bare aliases so the index map matches what callers / 'lookupVecTextByKey'
       -- look up (e.g. "latency_breakdown", "parent_id").
-      pure $ keepDescendantsOf (listToIndexHashMap (listToColNames colNames)) seedSpanIds (V.toList results)
+      pure $ keepDescendantsOf (listToIndexHashMap (listToColNames colNames)) seedSpanIds results
 
 
 -- | Keep only rows that are transitive descendants of any @seedSpanIds@
@@ -380,14 +380,14 @@ selectChildSpansAndLogs pid projectedColsByUser traceIds seedSpanIds dateRange e
 --
 -- Seed rows themselves are NOT included in the output; callers already hold
 -- them (in 'requestVecs') and we only return strict descendants.
-keepDescendantsOf :: HM.HashMap Text Int -> V.Vector Text -> [V.Vector AE.Value] -> [V.Vector AE.Value]
+keepDescendantsOf :: HM.HashMap Text Int -> V.Vector Text -> V.Vector (V.Vector AE.Value) -> [V.Vector AE.Value]
 keepDescendantsOf colIdxMap seedSpanIds rows
-  | V.null seedSpanIds || null rows = []
+  | V.null seedSpanIds || V.null rows = []
   | otherwise =
       let sid r = lookupVecTextByKey r colIdxMap "latency_breakdown"
           pid' r = lookupVecTextByKey r colIdxMap "parent_id"
           childrenByParent :: HM.HashMap Text [V.Vector AE.Value]
-          childrenByParent = HM.fromListWith (<>) [(p, [r]) | r <- rows, Just p <- [pid' r]]
+          childrenByParent = HM.fromListWith (<>) [(p, [r]) | r <- V.toList rows, Just p <- [pid' r]]
           seeds = V.toList seedSpanIds
           go _ [] acc = reverse acc
           go visited (s : rest) acc =

--- a/src/Models/Apis/LogQueries.hs
+++ b/src/Models/Apis/LogQueries.hs
@@ -197,14 +197,18 @@ logExplorerUrlPath pid q cols cursor since fromV toV layout source recent = "/p/
 
 
 -- | Execute arbitrary SQL query and return results as vector of vectors.
--- Wraps in row_to_json + json_each to preserve column order via hasql.
-executeArbitraryQuery :: DB es => HI.Sql -> Eff es (V.Vector (V.Vector AE.Value))
-executeArbitraryQuery querySql = do
+-- Wraps the inner SELECT with `jsonb_build_array` so each row is returned as a
+-- single jsonb array of its column values. Works on both Postgres and
+-- TimeFusion (both ship `jsonb_build_array(VARIADIC any)`). Caller passes the
+-- expected column count — see `Pkg.Parser.wrapForRowExtraction`.
+executeArbitraryQuery :: DB es => Int -> HI.Sql -> Eff es (V.Vector (V.Vector AE.Value))
+executeArbitraryQuery colCount querySql = do
+  let aliases = T.intercalate "," ["c" <> show i | i <- [1 .. colCount]]
   results :: [AE.Value] <-
     Hasql.interp
-      $ rawSql "SELECT (SELECT json_agg(x.value ORDER BY x.ordinality)::jsonb FROM json_each(row_to_json(sub.*)) WITH ORDINALITY AS x) FROM ("
+      $ rawSql ("SELECT jsonb_build_array(" <> aliases <> ") FROM (")
       <> querySql
-      <> rawSql ") AS sub"
+      <> rawSql (") sub(" <> aliases <> ")")
   pure $ V.fromList $ mapMaybe jsonArrayToVector results
 
 
@@ -314,7 +318,7 @@ selectLogTable pid queryAST queryText cursorM dateRange projectedColsByUser sour
       ]
       $ try @SomeException
       $ checkpoint (toAnnotation ("selectLogTable", q))
-      $ executeArbitraryQuery (rawSql q)
+      $ executeArbitraryQuery (length queryComponents.toColNames) (rawSql q)
   case result of
     Left e -> pure $ Left $ show e
     Right logItemsV -> do
@@ -444,10 +448,9 @@ data SessionRow = SessionRow
 
 
 -- | Mirrors the column order of the SELECT in 'fetchSessions'. Decoded
--- directly via hasql to bypass the row_to_json/json_each wrapper used by
--- 'executeArbitraryQuery' — that wrapper trips PostgreSQL's JSON parser
--- whenever a TEXT value (e.g. a user_agent or url_path captured from raw
--- OTLP) contains characters JSON forbids (NULL bytes, lone surrogates).
+-- directly via hasql as a perf-oriented typed path; 'executeArbitraryQuery'
+-- now uses 'jsonb_build_array' which is safe for NULL bytes and lone
+-- surrogates, so this no longer doubles as a parser-bug workaround.
 data RawSessionRow = RawSessionRow
   { sessionId :: Text
   , userId :: Maybe Text
@@ -854,7 +857,7 @@ fetchEventExamples enableTfReads pid queryAST dateRange expandKind skip limitN =
             <> expandFilter
             <> [HI.sql| ORDER BY timestamp ASC OFFSET #{skip}::BIGINT LIMIT #{limitN}::BIGINT|]
   Log.logTrace "fetchEventExamples: query" $ AE.object ["project_id" AE..= pid]
-  rows <- Hasql.withHasqlTimefusion enableTfReads $ checkpoint (toAnnotation ("fetchEventExamples" :: Text, pid)) $ executeArbitraryQuery q
+  rows <- Hasql.withHasqlTimefusion enableTfReads $ checkpoint (toAnnotation ("fetchEventExamples" :: Text, pid)) $ executeArbitraryQuery (length (colsNoAsClause cols)) q
   pure (rows, listToColNames cols)
 
 

--- a/src/Models/Apis/LogQueries.hs
+++ b/src/Models/Apis/LogQueries.hs
@@ -197,35 +197,27 @@ logExplorerUrlPath pid q cols cursor since fromV toV layout source recent = "/p/
 
 
 -- | Wrap the inner SELECT so each row arrives as a jsonb array of column values.
--- Uses jsonb_build_array(c1,…,cN) instead of json_each / row_to_json / WITH
--- ORDINALITY — the latter is unsupported on TimeFusion and trips PG's JSON
--- parser on NULL bytes. `colCount <= 0` short-circuits to V.empty since sub()
--- with zero aliases is invalid SQL.
-executeArbitraryQuery :: DB es => Int -> HI.Sql -> Eff es (V.Vector (V.Vector AE.Value))
-executeArbitraryQuery colCount _ | colCount <= 0 = pure V.empty
-executeArbitraryQuery colCount querySql = do
-  let aliases = T.intercalate "," ["c" <> show i | i <- [1 .. colCount]]
+-- Relies on Postgres-parity `qualifier.*` expansion inside `jsonb_build_array`,
+-- which works natively on PG and on TimeFusion via the WildcardFnArgExpander
+-- analyzer rule. No client-side column count needed.
+executeArbitraryQuery :: DB es => HI.Sql -> Eff es (V.Vector (V.Vector AE.Value))
+executeArbitraryQuery querySql = do
   results :: [AE.Value] <-
-    Hasql.interp
-      $ rawSql ("SELECT jsonb_build_array(" <> aliases <> ") FROM (")
-      <> querySql
-      <> rawSql (") sub(" <> aliases <> ")")
+    Hasql.interp $ rawSql "SELECT jsonb_build_array(sub.*) FROM (" <> querySql <> rawSql ") sub"
   pure $ V.fromList $ mapMaybe jsonArrayToVector results
 
 
 -- | Execute a user-provided SQL query with mandatory project_id filtering.
--- SECURITY: Validates query for dangerous patterns and verifies project_id filter is present in query.
--- Note: The query must already contain project_id='<pid>' filtering (via {{project_id}} placeholder substitution done before calling this function)
--- TODO: migrate to jsonb_build_array once column count is derivable for arbitrary user/LLM SQL.
+-- SECURITY: Validates query for dangerous patterns and verifies project_id filter is present.
+-- The query must already contain `project_id='<pid>'` filtering (via {{project_id}}
+-- placeholder substitution done before calling this function).
 executeSecuredQuery :: DB es => Projects.ProjectId -> Text -> Int -> Eff es (Either Text (V.Vector (V.Vector AE.Value)))
 executeSecuredQuery pid userQuery limit
   | not (validateSqlQuery userQuery) = pure $ Left "Query contains disallowed operations"
   | not (hasProjectIdFilter userQuery pid) = pure $ Left "Query must filter by project_id"
   | otherwise = do
-      let selectQuery = "SELECT (SELECT json_agg(x.value ORDER BY x.ordinality)::jsonb FROM json_each(row_to_json(sub.*)) WITH ORDINALITY AS x) FROM (SELECT * FROM (" <> userQuery <> ") AS subq LIMIT " <> show limit <> ") AS sub"
-      resultE <- try @Hasql.HasqlException do
-        results :: [AE.Value] <- Hasql.interp $ rawSql selectQuery
-        pure $ V.fromList $ mapMaybe jsonArrayToVector results
+      let limited = "SELECT * FROM (" <> userQuery <> ") AS subq LIMIT " <> show limit
+      resultE <- try @Hasql.HasqlException $ executeArbitraryQuery (rawSql limited)
       pure $ first (\e -> "Query execution failed: " <> toText (displayException e)) resultE
 
 
@@ -320,8 +312,7 @@ selectLogTable pid queryAST queryText cursorM dateRange projectedColsByUser sour
       ]
       $ try @SomeException
       $ checkpoint (toAnnotation ("selectLogTable", q))
-      -- +1 for count(*) OVER() appended to SELECT but absent from toColNames.
-      $ executeArbitraryQuery (length queryComponents.toColNames + fromEnum queryComponents.hasCountOver) (rawSql q)
+      $ executeArbitraryQuery (rawSql q)
   case result of
     Left e -> pure $ Left $ show e
     Right logItemsV -> do
@@ -861,7 +852,7 @@ fetchEventExamples enableTfReads pid queryAST dateRange expandKind skip limitN =
             <> expandFilter
             <> [HI.sql| ORDER BY timestamp ASC OFFSET #{skip}::BIGINT LIMIT #{limitN}::BIGINT|]
   Log.logTrace "fetchEventExamples: query" $ AE.object ["project_id" AE..= pid]
-  rows <- Hasql.withHasqlTimefusion enableTfReads $ checkpoint (toAnnotation ("fetchEventExamples" :: Text, pid)) $ executeArbitraryQuery (length rawCols) q
+  rows <- Hasql.withHasqlTimefusion enableTfReads $ checkpoint (toAnnotation ("fetchEventExamples" :: Text, pid)) $ executeArbitraryQuery q
   pure (rows, listToColNames cols)
 
 

--- a/src/Models/Apis/LogQueries.hs
+++ b/src/Models/Apis/LogQueries.hs
@@ -216,7 +216,7 @@ executeArbitraryQuery colCount querySql = do
 -- | Execute a user-provided SQL query with mandatory project_id filtering.
 -- SECURITY: Validates query for dangerous patterns and verifies project_id filter is present in query.
 -- Note: The query must already contain project_id='<pid>' filtering (via {{project_id}} placeholder substitution done before calling this function)
--- TODO: Still uses the legacy json_each/row_to_json wrapper since callers (Dashboards, AI raw-SQL) pass arbitrary user/LLM SQL without a known column count. Migrate to jsonb_build_array once column counts can be derived (e.g. via a parsing pass or a probe).
+-- TODO: migrate to jsonb_build_array once column count is derivable for arbitrary user/LLM SQL.
 executeSecuredQuery :: DB es => Projects.ProjectId -> Text -> Int -> Eff es (Either Text (V.Vector (V.Vector AE.Value)))
 executeSecuredQuery pid userQuery limit
   | not (validateSqlQuery userQuery) = pure $ Left "Query contains disallowed operations"

--- a/src/Models/Apis/LogQueries.hs
+++ b/src/Models/Apis/LogQueries.hs
@@ -210,7 +210,7 @@ executeArbitraryQuery colCount querySql = do
       $ rawSql ("SELECT jsonb_build_array(" <> aliases <> ") FROM (")
       <> querySql
       <> rawSql (") sub(" <> aliases <> ")")
-  pure $ V.mapMaybe jsonArrayToVector (V.fromList results)
+  pure $ V.fromList $ mapMaybe jsonArrayToVector results
 
 
 -- | Execute a user-provided SQL query with mandatory project_id filtering.

--- a/src/Models/Apis/LogQueries.hs
+++ b/src/Models/Apis/LogQueries.hs
@@ -204,7 +204,7 @@ executeArbitraryQuery :: DB es => HI.Sql -> Eff es (V.Vector (V.Vector AE.Value)
 executeArbitraryQuery querySql = do
   results :: [AE.Value] <-
     Hasql.interp $ rawSql "SELECT jsonb_build_array(sub.*) FROM (" <> querySql <> rawSql ") sub"
-  pure $ fromList $ mapMaybe jsonArrayToVector results
+  pure $ V.fromList $ mapMaybe jsonArrayToVector results
 
 
 -- | Execute a user-provided SQL query with mandatory project_id filtering.
@@ -441,9 +441,11 @@ data SessionRow = SessionRow
 
 
 -- | Mirrors the column order of the SELECT in 'fetchSessions'. Decoded
--- directly via hasql as a perf-oriented typed path; 'executeArbitraryQuery'
--- now uses 'jsonb_build_array' which is safe for NULL bytes and lone
--- surrogates, so this no longer doubles as a parser-bug workaround.
+-- directly via hasql to bypass the jsonb wrapper entirely — Postgres'
+-- jsonb type still rejects NULL bytes / lone surrogates in TEXT values
+-- regardless of which function builds it, so the only safe path for raw
+-- OTLP text (user_agent, url_path, ...) is to never round-trip through
+-- jsonb at all.
 data RawSessionRow = RawSessionRow
   { sessionId :: Text
   , userId :: Maybe Text

--- a/src/Models/Apis/LogQueries.hs
+++ b/src/Models/Apis/LogQueries.hs
@@ -327,7 +327,11 @@ selectLogTable pid queryAST queryText cursorM dateRange projectedColsByUser sour
       ]
       $ try @SomeException
       $ checkpoint (toAnnotation ("selectLogTable", q))
-      $ executeArbitraryQuery (length queryComponents.toColNames) (rawSql q)
+      -- hasCountOver appends a count(*) OVER() column to the SELECT but it isn't
+      -- in `toColNames` (display columns only). Include it in the alias list or
+      -- PG rejects with "column alias list must be the same length as the number
+      -- of output columns".
+      $ executeArbitraryQuery (length queryComponents.toColNames + if queryComponents.hasCountOver then 1 else 0) (rawSql q)
   case result of
     Left e -> pure $ Left $ show e
     Right logItemsV -> do
@@ -849,8 +853,9 @@ fetchEventExamples enableTfReads pid queryAST dateRange expandKind skip limitN =
         ExpandSession sid -> [HI.sql| AND attributes___session___id = #{sid}|]
         ExpandPattern tpl -> [HI.sql| AND array_to_string(summary, chr(30)) ILIKE #{templateToLike tpl}|]
       cols = defaultSelectSqlQuery (Just SSpans)
+      rawCols = colsNoAsClause cols
       -- Mirror selectLogTable's summary column handling: wrap TEXT[] as JSON for row output.
-      processedCols = map (\c -> if c == "summary" || "summary" `T.isSuffixOf` c then "to_json(summary)" else c) $ colsNoAsClause cols
+      processedCols = map (\c -> if c == "summary" || "summary" `T.isSuffixOf` c then "to_json(summary)" else c) rawCols
       selectClause = T.intercalate ", " processedCols
       -- Sessions: fetch one root event per trace via DISTINCT ON so [+N] expansion
       -- covers all traces.  Patterns/other: fetch raw events as before.
@@ -866,7 +871,7 @@ fetchEventExamples enableTfReads pid queryAST dateRange expandKind skip limitN =
             <> expandFilter
             <> [HI.sql| ORDER BY timestamp ASC OFFSET #{skip}::BIGINT LIMIT #{limitN}::BIGINT|]
   Log.logTrace "fetchEventExamples: query" $ AE.object ["project_id" AE..= pid]
-  rows <- Hasql.withHasqlTimefusion enableTfReads $ checkpoint (toAnnotation ("fetchEventExamples" :: Text, pid)) $ executeArbitraryQuery (length (colsNoAsClause cols)) q
+  rows <- Hasql.withHasqlTimefusion enableTfReads $ checkpoint (toAnnotation ("fetchEventExamples" :: Text, pid)) $ executeArbitraryQuery (length rawCols) q
   pure (rows, listToColNames cols)
 
 

--- a/src/Models/Apis/LogQueries.hs
+++ b/src/Models/Apis/LogQueries.hs
@@ -196,18 +196,11 @@ logExplorerUrlPath pid q cols cursor since fromV toV layout source recent = "/p/
         ]
 
 
--- | Execute arbitrary SQL query and return results as vector of vectors.
--- Wraps the inner SELECT with `jsonb_build_array` so each row is returned as a
--- single jsonb array of its column values, in declared column order. Replaces
--- the legacy `(SELECT json_agg(x.value ORDER BY x.ordinality)::jsonb FROM
--- json_each(row_to_json(sub.*)) WITH ORDINALITY AS x)` wrapper: same wire
--- output, but works on TimeFusion (no json_each / row_to_json / WITH ORDINALITY
--- / row-correlated UDTF needed) and dodges PostgreSQL's JSON-parser hazard on
--- TEXT columns containing NULL bytes or lone surrogates.
---
--- Caller passes the expected column count of the inner SELECT. `colCount <= 0`
--- returns an empty vector without touching the database — `sub()` with zero
--- column aliases is not valid SQL.
+-- | Wrap the inner SELECT so each row arrives as a jsonb array of column values.
+-- Uses jsonb_build_array(c1,…,cN) instead of json_each / row_to_json / WITH
+-- ORDINALITY — the latter is unsupported on TimeFusion and trips PG's JSON
+-- parser on NULL bytes. `colCount <= 0` short-circuits to V.empty since sub()
+-- with zero aliases is invalid SQL.
 executeArbitraryQuery :: DB es => Int -> HI.Sql -> Eff es (V.Vector (V.Vector AE.Value))
 executeArbitraryQuery colCount _ | colCount <= 0 = pure V.empty
 executeArbitraryQuery colCount querySql = do
@@ -327,10 +320,7 @@ selectLogTable pid queryAST queryText cursorM dateRange projectedColsByUser sour
       ]
       $ try @SomeException
       $ checkpoint (toAnnotation ("selectLogTable", q))
-      -- hasCountOver appends a count(*) OVER() column to the SELECT but it isn't
-      -- in `toColNames` (display columns only). Include it in the alias list or
-      -- PG rejects with "column alias list must be the same length as the number
-      -- of output columns".
+      -- +1 for count(*) OVER() appended to SELECT but absent from toColNames.
       $ executeArbitraryQuery (length queryComponents.toColNames + fromEnum queryComponents.hasCountOver) (rawSql q)
   case result of
     Left e -> pure $ Left $ show e

--- a/src/Models/Apis/LogQueries.hs
+++ b/src/Models/Apis/LogQueries.hs
@@ -359,11 +359,16 @@ selectChildSpansAndLogs pid projectedColsByUser traceIds seedSpanIds dateRange e
   if V.null seedSpanIds
     then pure []
     else do
-      results <- Hasql.interp $ rawSql ("SELECT json_build_array(" <> r <> ")::jsonb FROM otel_logs_and_spans WHERE project_id=") <> [HI.sql|#{pid.toText}::text|] <> dateRangeSql <> [HI.sql| AND context___trace_id=ANY(#{traceIdsList}) AND parent_id IS NOT NULL AND id::text != ALL(#{excludedList}) ORDER BY timestamp DESC LIMIT 2000|]
+      let inner =
+            rawSql ("SELECT " <> r <> " FROM otel_logs_and_spans WHERE project_id=")
+              <> [HI.sql|#{pid.toText}::text|]
+              <> dateRangeSql
+              <> [HI.sql| AND context___trace_id=ANY(#{traceIdsList}) AND parent_id IS NOT NULL AND id::text != ALL(#{excludedList}) ORDER BY timestamp DESC LIMIT 2000|]
+      results <- executeArbitraryQuery inner
       -- 'colNames' from getProcessedColumns retains "<expr> as <alias>" entries;
       -- strip to bare aliases so the index map matches what callers / 'lookupVecTextByKey'
       -- look up (e.g. "latency_breakdown", "parent_id").
-      pure $ keepDescendantsOf (listToIndexHashMap (listToColNames colNames)) seedSpanIds (mapMaybe valueToVector results)
+      pure $ keepDescendantsOf (listToIndexHashMap (listToColNames colNames)) seedSpanIds (V.toList results)
 
 
 -- | Keep only rows that are transitive descendants of any @seedSpanIds@

--- a/src/Models/Apis/LogQueries.hs
+++ b/src/Models/Apis/LogQueries.hs
@@ -834,7 +834,7 @@ fetchEventExamples enableTfReads pid queryAST dateRange expandKind skip limitN =
         ExpandPattern tpl -> [HI.sql| AND array_to_string(summary, chr(30)) ILIKE #{templateToLike tpl}|]
       cols = defaultSelectSqlQuery (Just SSpans)
       -- Mirror selectLogTable's summary column handling: wrap TEXT[] as JSON for row output.
-      processedCols = map (\c -> if c == "summary" || "summary" `T.isSuffixOf` c then "to_json(summary)" else c) (colsNoAsClause cols)
+      processedCols = map (\c -> if c == "summary" || "summary" `T.isSuffixOf` c then "to_json(summary)" else c) $ colsNoAsClause cols
       selectClause = T.intercalate ", " processedCols
       -- Sessions: fetch one root event per trace via DISTINCT ON so [+N] expansion
       -- covers all traces.  Patterns/other: fetch raw events as before.

--- a/src/Models/Apis/LogQueries.hs
+++ b/src/Models/Apis/LogQueries.hs
@@ -399,12 +399,6 @@ keepDescendantsOf colIdxMap seedSpanIds rows
        in go (S.fromList seeds) seeds []
 
 
-valueToVector :: AE.Value -> Maybe (V.Vector AE.Value)
-valueToVector val = case val of
-  AE.Array arr -> Just arr
-  _ -> Nothing
-
-
 data PatternRow = PatternRow {logPattern :: Text, count :: Int64, level :: Maybe Text, service :: Maybe Text, volume :: [Int], mergedCount :: Int, isError :: Bool}
 
 
@@ -839,9 +833,8 @@ fetchEventExamples enableTfReads pid queryAST dateRange expandKind skip limitN =
         ExpandSession sid -> [HI.sql| AND attributes___session___id = #{sid}|]
         ExpandPattern tpl -> [HI.sql| AND array_to_string(summary, chr(30)) ILIKE #{templateToLike tpl}|]
       cols = defaultSelectSqlQuery (Just SSpans)
-      rawCols = colsNoAsClause cols
       -- Mirror selectLogTable's summary column handling: wrap TEXT[] as JSON for row output.
-      processedCols = map (\c -> if c == "summary" || "summary" `T.isSuffixOf` c then "to_json(summary)" else c) rawCols
+      processedCols = map (\c -> if c == "summary" || "summary" `T.isSuffixOf` c then "to_json(summary)" else c) (colsNoAsClause cols)
       selectClause = T.intercalate ", " processedCols
       -- Sessions: fetch one root event per trace via DISTINCT ON so [+N] expansion
       -- covers all traces.  Patterns/other: fetch raw events as before.

--- a/src/Models/Apis/LogQueries.hs
+++ b/src/Models/Apis/LogQueries.hs
@@ -216,8 +216,8 @@ executeSecuredQuery pid userQuery limit
   | not (validateSqlQuery userQuery) = pure $ Left "Query contains disallowed operations"
   | not (hasProjectIdFilter userQuery pid) = pure $ Left "Query must filter by project_id"
   | otherwise = do
-      let limited = "SELECT * FROM (" <> userQuery <> ") AS subq LIMIT " <> show limit
-      resultE <- try @Hasql.HasqlException $ executeArbitraryQuery (rawSql limited)
+      let limited = rawSql ("SELECT * FROM (" <> userQuery <> ") AS subq") <> [HI.sql| LIMIT #{limit}|]
+      resultE <- try @Hasql.HasqlException $ executeArbitraryQuery limited
       pure $ first (\e -> "Query execution failed: " <> toText (displayException e)) resultE
 
 

--- a/src/Models/Apis/SchemaCatalog.hs
+++ b/src/Models/Apis/SchemaCatalog.hs
@@ -252,7 +252,7 @@ upsertSummary rows0 = unless (V.null rows0) $ do
   let rows = V.map (second (HI.AsJsonb . scrubNulValue . AE.toJSON)) rows0
   tryAny (batch rows) >>= \case
     Right () -> pass
-    Left _ -> V.forM_ rows \r -> void $ tryAny (batch (V.singleton r))
+    Left _ -> V.forM_ rows (void . tryAny . batch . V.singleton)
   where
     batch xs =
       let (pids, docs) = V.unzip xs

--- a/src/Models/Projects/ProjectApiKeys.hs
+++ b/src/Models/Projects/ProjectApiKeys.hs
@@ -17,11 +17,11 @@ module Models.Projects.ProjectApiKeys (
 )
 where
 
+import Control.Exception (throwIO)
 import Data.Aeson qualified as AE
 import Data.Base64.Types qualified as B64T
 import Data.Cache qualified as Cache
 import Data.Default (Default)
-import Control.Exception (throwIO)
 import Data.Effectful.Hasql qualified as Hasql
 import Data.OpenApi (ToParamSchema (..), ToSchema (..), declareNamedSchema)
 import Data.Time (UTCTime)

--- a/src/Models/Projects/ProjectApiKeys.hs
+++ b/src/Models/Projects/ProjectApiKeys.hs
@@ -21,6 +21,7 @@ import Data.Aeson qualified as AE
 import Data.Base64.Types qualified as B64T
 import Data.Cache qualified as Cache
 import Data.Default (Default)
+import Control.Exception (throwIO)
 import Data.Effectful.Hasql qualified as Hasql
 import Data.OpenApi (ToParamSchema (..), ToSchema (..), declareNamedSchema)
 import Data.Time (UTCTime)
@@ -137,12 +138,14 @@ projectIdsByProjectApiKeys projectKeys = do
 
 
 -- | IO-level helper for cache callbacks that need to query hasql directly.
+-- DB-level failures (connection refused, pool exhausted, …) throw
+-- 'Hasql.HasqlException' so the caller (and ultimately 'Pkg.Queue') can route
+-- the batch to the DLQ. A clean @Right Nothing@ is preserved as the
+-- legitimate "key not in DB" signal — only infrastructure failures throw.
 queryProjectIdByKey :: OHasql.TracedPool -> Text -> IO (Maybe Projects.ProjectId)
 queryProjectIdByKey hpool key =
-  whenRightM
-    Nothing
-    (OHasql.use hpool (Session.statement () (HI.interp True [HI.sql| SELECT project_id FROM projects.project_api_keys WHERE key_prefix = #{key} |])))
-    pure
+  OHasql.use hpool (Session.statement () (HI.interp True [HI.sql| SELECT project_id FROM projects.project_api_keys WHERE key_prefix = #{key} |]))
+    >>= either (throwIO . Hasql.HasqlException) pure
 
 
 -- AES256 encryption

--- a/src/Models/Telemetry/Schema.hs
+++ b/src/Models/Telemetry/Schema.hs
@@ -13,7 +13,7 @@ module Models.Telemetry.Schema (
 import Data.Aeson qualified as AE
 import Data.Map qualified as Map
 import Data.OpenApi (ToSchema)
-import Data.Set qualified as Set
+import Data.Set qualified as S
 import Data.Text qualified as T
 import Deriving.Aeson qualified as DAE
 import Deriving.Aeson.Stock qualified as DAE
@@ -303,7 +303,7 @@ deriveSchema liveAttrs =
       -- duration, body, etc.). Drop only the dotted-form entries that the
       -- live set doesn't confirm.
       isTopLevel k = not ("." `T.isInfixOf` k)
-      keepHand k _ = isTopLevel k || k `Set.member` liveAttrs
+      keepHand k _ = isTopLevel k || k `S.member` liveAttrs
       kept = Map.filterWithKey keepHand handCoded
       -- For any live column not already in 'kept', add a bare entry.
       missing = [k | k <- toList liveAttrs, not (Map.member k kept)]

--- a/src/Models/Telemetry/Telemetry.hs
+++ b/src/Models/Telemetry/Telemetry.hs
@@ -48,7 +48,6 @@ module Models.Telemetry.Telemetry (
   PoisonMsg,
   BulkInsertResult (..),
   RowPoisonInfo (..),
-  rowPoisonInfo,
   handOffBatches,
   mintOtelLogIds,
   getMetricChartListData,
@@ -86,7 +85,7 @@ import Data.List qualified as L (groupBy)
 import Data.List.Extra (chunksOf)
 import Data.List.NonEmpty qualified as NE
 import Data.Map qualified as Map
-import Data.Maybe (fromJust)
+import Data.HashSet qualified as HS
 import Data.Set qualified as S
 import Data.Text qualified as T
 import Data.Text.Display (Display)
@@ -880,11 +879,6 @@ data RowPoisonInfo = RowPoisonInfo
   deriving stock (Generic)
 
 
--- | Construct from per-side errors. At least one must be 'Just'.
-rowPoisonInfo :: Maybe SomeException -> Maybe SomeException -> RowPoisonInfo
-rowPoisonInfo = RowPoisonInfo
-
-
 -- | Result of a single-side ('bulkInsertOtelLogsAndSpans') bulk write. Rows
 -- that bisect-isolated to a non-transient failure are surfaced here instead of
 -- silently dropped — caller routes them to the DLQ.
@@ -911,7 +905,7 @@ writeFailureSummary = These.these (const "pg-failed") (const "tf-failed") (\_ _ 
 -- avoid duplicating rows on the successful side.
 writeFailureDlqHeaders :: WriteFailure -> HM.HashMap Text Text
 writeFailureDlqHeaders wf =
-  let (pgOk, tfOk) = These.these (\_ -> ("false", "true")) (\_ -> ("true", "false")) (\_ _ -> ("false", "false")) wf
+  let (pgOk, tfOk) = These.these (const ("false", "true")) (const ("true", "false")) (\_ _ -> ("false", "false")) wf
    in HM.fromList
         [ ("monoscope-write-failure", writeFailureSummary wf)
         , ("monoscope-pg-succeeded", pgOk)
@@ -1022,15 +1016,13 @@ bulkInsertOtelLogsAndSpansTF enableTf records = do
     -- rejected it. Rows accepted by both stores are silently absent (full success).
     combinePoison :: BulkInsertResult -> BulkInsertResult -> V.Vector (OtelLogsAndSpans, RowPoisonInfo)
     combinePoison pg tf =
-      let pgMap = HM.fromList [(r.id, (r, e)) | (r, e) <- V.toList pg.poisonRows]
-          tfMap = HM.fromList [(r.id, (r, e)) | (r, e) <- V.toList tf.poisonRows]
-       in V.fromList
-            [ (row, RowPoisonInfo (fmap snd pgEntry) (fmap snd tfEntry))
-            | rid <- HM.keys (HM.union (() <$ pgMap) (() <$ tfMap))
-            , let pgEntry = HM.lookup rid pgMap
-                  tfEntry = HM.lookup rid tfMap
-                  row = maybe (fst (fromJust tfEntry)) fst pgEntry
-            ]
+      let mkMap bir = HM.fromList [(r.id, (r, e)) | (r, e) <- V.toList bir.poisonRows]
+          pgMap = mkMap pg
+          tfMap = mkMap tf
+          both = HM.intersectionWith (\(r, pe) (_, te) -> (r, RowPoisonInfo (Just pe) (Just te))) pgMap tfMap
+          pgOnly = HM.map (\(r, e) -> (r, RowPoisonInfo (Just e) Nothing)) (pgMap `HM.difference` tfMap)
+          tfOnly = HM.map (\(r, e) -> (r, RowPoisonInfo Nothing (Just e))) (tfMap `HM.difference` pgMap)
+       in V.fromList $ HM.elems (both <> pgOnly <> tfOnly)
 
 
 -- | Persist `records` to Postgres (+TimeFusion when enabled) and hand each
@@ -1714,10 +1706,13 @@ insertSystemLog
   -> Eff es ()
 insertSystemLog enableTf otelLog = do
   minted <- mintOtelLogIds (V.singleton otelLog)
-  -- System logs are best-effort: failure here would just shadow whatever
-  -- caused the original log. Discard the WriteFailure rather than throw or
-  -- propagate — it's already been logAttention'd by bulkInsertOtelLogsAndSpansTF.
-  void $ bulkInsertOtelLogsAndSpansTF enableTf minted
+  -- System logs are best-effort. The inner write logs its own failure via
+  -- logAttention; surface a higher-level "system log dropped" so an incident
+  -- triager investigating the original event can see that its trail was lost.
+  bulkInsertOtelLogsAndSpansTF enableTf minted >>= \case
+    Right _ -> pass
+    Left wf ->
+      Log.logAttention "SYSTEM_LOG_DROPPED" (AE.object ["reason" AE..= writeFailureSummary wf])
 
 
 -- | Generate summary array for an OtelLogsAndSpans record

--- a/src/Models/Telemetry/Telemetry.hs
+++ b/src/Models/Telemetry/Telemetry.hs
@@ -42,6 +42,13 @@ module Models.Telemetry.Telemetry (
   bulkInsertMetrics,
   bulkInsertOtelLogsAndSpansTF,
   insertAndHandOff,
+  WriteFailure,
+  writeFailureSummary,
+  writeFailureDlqHeaders,
+  PoisonMsg,
+  BulkInsertResult (..),
+  RowPoisonInfo (..),
+  rowPoisonInfo,
   handOffBatches,
   mintOtelLogIds,
   getMetricChartListData,
@@ -78,9 +85,13 @@ import Data.List qualified as L (groupBy)
 import Data.List.Extra (chunksOf)
 import Data.List.NonEmpty qualified as NE
 import Data.Map qualified as Map
+import Data.HashSet qualified as HS
+import Data.Maybe (fromJust)
 import Data.Set qualified as S
 import Data.Text qualified as T
 import Data.Text.Display (Display)
+import Data.These (These (..))
+import Data.These qualified as These
 import Data.Time (UTCTime)
 import Data.Time.Clock (addUTCTime)
 import Data.UUID qualified as UUID
@@ -846,6 +857,118 @@ mintOtelLogIds :: UUIDEff :> es => V.Vector OtelLogsAndSpans -> Eff es (V.Vector
 mintOtelLogIds = V.mapM \r -> genUUID <&> \uid -> r & #id .~ UUID.toText uid
 
 
+-- | This = PG failed; That = TF failed; These = both. Both stores are mandatory
+-- because dashboards still read from PG; any failure must reach the DLQ via
+-- 'Pkg.Queue' — never silent-ack.
+type WriteFailure = These SomeException SomeException
+
+
+-- | A message that couldn't be parsed/converted. Callers MUST publish these to
+-- the DLQ before committing source-topic offsets so the bytes are preserved
+-- for manual investigation (never silent-drop).
+type PoisonMsg = (Text, ByteString, Text)
+  -- ^ @(ackId, rawBytes, errorReason)@
+
+
+-- | Per-row outcome from a dual-write. At least one of @pgError@ / @tfError@ is
+-- 'Just'; if a row is fully successful it never appears here.
+data RowPoisonInfo = RowPoisonInfo
+  { pgError :: Maybe SomeException
+  , tfError :: Maybe SomeException
+  }
+  deriving stock (Generic)
+
+
+-- | Construct from per-side errors. At least one must be 'Just'.
+rowPoisonInfo :: Maybe SomeException -> Maybe SomeException -> RowPoisonInfo
+rowPoisonInfo = RowPoisonInfo
+
+
+-- | Result of a single-side ('bulkInsertOtelLogsAndSpans') bulk write. Rows
+-- that bisect-isolated to a non-transient failure are surfaced here instead of
+-- silently dropped — caller routes them to the DLQ.
+data BulkInsertResult = BulkInsertResult
+  { rowsInserted :: !Int64
+  , poisonRows :: !(V.Vector (OtelLogsAndSpans, SomeException))
+  }
+  deriving stock (Generic)
+
+
+instance Semigroup BulkInsertResult where
+  BulkInsertResult n1 p1 <> BulkInsertResult n2 p2 = BulkInsertResult (n1 + n2) (p1 <> p2)
+
+
+instance Monoid BulkInsertResult where
+  mempty = BulkInsertResult 0 V.empty
+
+
+writeFailureSummary :: WriteFailure -> Text
+writeFailureSummary = These.these (const "pg-failed") (const "tf-failed") (\_ _ -> "both-failed")
+
+
+-- | DLQ headers a replay tool reads to rewrite only the missing side(s) and
+-- avoid duplicating rows on the successful side.
+writeFailureDlqHeaders :: WriteFailure -> HM.HashMap Text Text
+writeFailureDlqHeaders wf =
+  let (pgOk, tfOk) = These.these (\_ -> ("false", "true")) (\_ -> ("true", "false")) (\_ _ -> ("false", "false")) wf
+   in HM.fromList
+        [ ("monoscope-write-failure", writeFailureSummary wf)
+        , ("monoscope-pg-succeeded", pgOk)
+        , ("monoscope-tf-succeeded", tfOk)
+        ]
+
+
+-- | Retry a Hasql write up to @n@ times on transient errors with exponential
+-- backoff (100ms → 5s cap; ~25s total at n=10). Non-transient errors return
+-- 'Left' immediately. TimeFusion's PGWire "TuplesOk" wire-mismatch is treated
+-- as success (rows landed; only the wire tag is wrong) — retrying would
+-- duplicate rows. PG never produces "TuplesOk" so the swallow is a no-op there.
+--
+-- Generic over PG vs TF: both call sites are symmetric. Programmer-bug
+-- exceptions (non-Hasql) propagate as Left without retry.
+retryHasqlWrite
+  :: (Concurrent :> es, IOE :> es, Log :> es, Monoid a)
+  => Int
+  -- ^ max attempts (must be >= 1)
+  -> Text
+  -- ^ store label for log lines ("pg" / "tf")
+  -> Eff es a
+  -- ^ write action; throws on transient failure (will retry)
+  -> Eff es (Either SomeException a)
+retryHasqlWrite maxAttempts store act = go 1
+  where
+    go attempt =
+      tryAny act >>= \case
+        Right a -> pure (Right a)
+        Left e
+          | "TuplesOk" `T.isInfixOf` show e -> do
+              -- Rows DID land; we just lack the row count (mempty is a safe
+              -- approximation since the caller cares about poison, not the count).
+              Log.logTrace "retryHasqlWrite: TuplesOk wire-mismatch ignored" $ AE.object ["store" AE..= store]
+              pure (Right mempty)
+          | attempt < maxAttempts, Hasql.isTransientException e -> do
+              let delayMicros = min 5000000 (100000 * (2 ^ (attempt - 1) :: Int)) -- 100ms,200ms,…cap 5s
+              Log.logAttention "retryHasqlWrite: transient error, retrying"
+                $ AE.object
+                  [ "store" AE..= store
+                  , "attempt" AE..= attempt
+                  , "max_attempts" AE..= maxAttempts
+                  , "backoff_us" AE..= delayMicros
+                  , "error" AE..= show @Text e
+                  ]
+              threadDelay delayMicros
+              go (attempt + 1)
+          | otherwise -> pure (Left e)
+
+
+-- | Dual-write to PG + TimeFusion concurrently. Both stores are mandatory.
+--
+--   * 'Left WriteFailure' — bounded transient-retry budget exhausted on at
+--     least one side; the whole batch needs to be DLQ'd as a unit.
+--   * 'Right' poisonRows — per-side bulk-insert returned poison rows
+--     (constraint violations, schema mismatch, etc.). Each row carries
+--     'RowPoisonInfo' saying which side(s) rejected it so the DLQ replay tool
+--     can rewrite only the missing side. Empty vector = full success.
 bulkInsertOtelLogsAndSpansTF
   :: ( Concurrent :> es
      , Hasql :> es
@@ -855,79 +978,57 @@ bulkInsertOtelLogsAndSpansTF
      , Log :> es
      )
   => Bool
-  -- ^ enableTimefusionWrites (passed by caller to avoid a `Reader AuthContext`
-  -- constraint here — keeps this module a leaf of `System.Config` so the
-  -- extraction worker in `AuthContext` can be typed against `OtelLogsAndSpans`).
   -> V.Vector OtelLogsAndSpans
-  -> Eff es ()
+  -> Eff es (Either WriteFailure (V.Vector (OtelLogsAndSpans, RowPoisonInfo)))
 bulkInsertOtelLogsAndSpansTF enableTf records = do
-  Log.logTrace "bulkInsertOtelLogsAndSpansTF called" $ AE.object [("record_count", AE.toJSON $ V.length records), ("enableTimefusionWrites", AE.toJSON enableTf)]
+  Log.logTrace "bulkInsertOtelLogsAndSpansTF called"
+    $ AE.object [("record_count", AE.toJSON $ V.length records), ("enableTimefusionWrites", AE.toJSON enableTf)]
   if enableTf
     then Ki.scoped \scope -> do
-      pgThread <- forkWithCtx scope $ tryAny $ void $ bulkInsertOtelLogsAndSpans records
-      tfThread <- forkWithCtx scope do
-        Log.logTrace "TimeFusion write enabled, attempting write" $ AE.object [("record_count", AE.toJSON $ V.length records)]
-        res <- tryAny (retryTimefusion 10 records)
-        whenLeft_ res \e -> do
-          let isHasql = isJust (fromException @Hasql.HasqlException e)
-              errId = if isHasql then "TIMEFUSION_WRITE_FAILED" else "TIMEFUSION_WRITE_BUG" :: Text
-              kind = if isHasql then "infra" else "programmer_error" :: Text
-          Log.logAttention errId
-            $ AE.object
-              [ "error_id" AE..= errId
-              , "kind" AE..= kind
-              , "record_count" AE..= V.length records
-              , "error" AE..= show @Text e
-              ]
-        pure res
-      -- TF-strict commit semantics: TF is the long-term store; PG is being
-      -- phased out (dual-write is temporary). A TF gap is forever; a PG gap
-      -- evaporates with the migration. So:
-      --   - TF success required for the caller to commit the Kafka offset.
-      --   - PG failures are logged but never block the commit.
-      -- Delta Lake INSERTs are atomic per batch, so a successful TF write
-      -- never leaves partial rows; retries happen only when TF itself failed,
-      -- in which case there are no rows to dedupe.
+      pgThread <- forkWithCtx scope $ retryHasqlWrite 10 "pg" (bulkInsertOtelLogsAndSpans records)
+      tfThread <- forkWithCtx scope $ retryHasqlWrite 10 "tf" (labeled @"timefusion" @Hasql $ bulkInsertOtelLogsAndSpans records)
       (pgRes, tfRes) <- Ki.atomically $ (,) <$> Ki.await pgThread <*> Ki.await tfThread
-      case (pgRes, tfRes) of
-        (Right _, Right _) -> pass
-        (Left ePg, Right _) ->
-          Log.logAttention "PG_WRITE_FAILED_TF_OK"
-            $ AE.object ["record_count" AE..= V.length records, "error" AE..= show @Text ePg]
-        (Right _, Left eTf) -> throwIO eTf
-        (Left ePg, Left eTf) -> do
-          Log.logAttention "BOTH_WRITES_FAILED"
-            $ AE.object
-              [ "record_count" AE..= V.length records
-              , "pg_error" AE..= show @Text ePg
-              , "tf_error" AE..= show @Text eTf
-              ]
-          throwIO eTf
-    else void $ bulkInsertOtelLogsAndSpans records
+      classify pgRes tfRes
+    else do
+      pgRes <- retryHasqlWrite 10 "pg" (bulkInsertOtelLogsAndSpans records)
+      case pgRes of
+        Right bir -> pure (Right (V.map (\(r, e) -> (r, RowPoisonInfo (Just e) Nothing)) bir.poisonRows))
+        Left e -> do
+          Log.logAttention "PG_WRITE_FAILED"
+            $ AE.object ["record_count" AE..= V.length records, "error" AE..= show @Text e]
+          pure (Left (This e))
   where
-    -- Retry only transient HasqlException; non-Hasql exceptions (e.g. InvalidOtelRowIdException
-    -- from bad UUIDs, encode panics) are programmer bugs and must propagate immediately.
-    -- Do NOT widen to tryAny-style retry — that would re-raise programmer bugs in a loop.
-    retryTimefusion n recs =
-      tryAny (labeled @"timefusion" @Hasql $ bulkInsertOtelLogsAndSpans recs) >>= \case
-        Right count -> Log.logTrace "TimeFusion write succeeded" $ AE.object [("rows_inserted", AE.toJSON count)]
-        Left e
-          -- TimeFusion's PGWire returns TuplesOk (a row-count tuple) instead of
-          -- CommandOk for some INSERT shapes (multi-row VALUES via the extended
-          -- query protocol). The data does land — only the wire-protocol tag is
-          -- wrong — so swallow the spurious error rather than retry the write
-          -- (which would duplicate rows in TF).
-          | "TuplesOk" `T.isInfixOf` show e ->
-              Log.logTrace "TimeFusion write succeeded (TuplesOk wire-mismatch ignored)" $ AE.object [("record_count", AE.toJSON $ V.length recs)]
-          | n > 0
-          , Hasql.isTransientException e -> do
-              let attempt = 11 - n -- attempts: 1..10
-                  delayMicros = min 5000000 (100000 * (2 ^ (attempt - 1) :: Int)) -- 100ms,200ms,...,cap 5s
-              Log.logAttention "Retrying bulkInsertOtelLogsAndSpans"
-                $ AE.object [("attempt", AE.toJSON attempt), ("max_attempts", AE.toJSON (10 :: Int)), ("backoff_us", AE.toJSON delayMicros), ("error", AE.toJSON $ show @Text e)]
-              threadDelay delayMicros
-              retryTimefusion (n - 1) recs
-        Left e -> throwIO e
+    classify (Right pgBir) (Right tfBir) = pure (Right (combinePoison pgBir tfBir))
+    classify (Left ePg) (Right _) = do
+      Log.logAttention "PG_WRITE_FAILED"
+        $ AE.object ["record_count" AE..= V.length records, "error" AE..= show @Text ePg]
+      pure (Left (This ePg))
+    classify (Right _) (Left eTf) = do
+      Log.logAttention "TF_WRITE_FAILED"
+        $ AE.object ["record_count" AE..= V.length records, "error" AE..= show @Text eTf]
+      pure (Left (That eTf))
+    classify (Left ePg) (Left eTf) = do
+      Log.logAttention "BOTH_WRITES_FAILED"
+        $ AE.object
+          [ "record_count" AE..= V.length records
+          , "pg_error" AE..= show @Text ePg
+          , "tf_error" AE..= show @Text eTf
+          ]
+      pure (Left (These ePg eTf))
+
+    -- Per-row attribution: a row appears in the result iff at least one side
+    -- rejected it. Rows accepted by both stores are silently absent (full success).
+    combinePoison :: BulkInsertResult -> BulkInsertResult -> V.Vector (OtelLogsAndSpans, RowPoisonInfo)
+    combinePoison pg tf =
+      let pgMap = HM.fromList [(r.id, (r, e)) | (r, e) <- V.toList pg.poisonRows]
+          tfMap = HM.fromList [(r.id, (r, e)) | (r, e) <- V.toList tf.poisonRows]
+       in V.fromList
+            [ (row, RowPoisonInfo (fmap snd pgEntry) (fmap snd tfEntry))
+            | rid <- HM.keys (HM.union (() <$ pgMap) (() <$ tfMap))
+            , let pgEntry = HM.lookup rid pgMap
+                  tfEntry = HM.lookup rid tfMap
+                  row = maybe (fst (fromJust tfEntry)) fst pgEntry
+            ]
 
 
 -- | Persist `records` to Postgres (+TimeFusion when enabled) and hand each
@@ -947,14 +1048,23 @@ insertAndHandOff
      )
   => Bool
   -> EW.WorkerState OtelLogsAndSpans
+  -- ^ NB: returns 'Left WriteFailure' if either store failed. Hand-off to the
+  -- extraction worker only happens on full success; a failed batch goes to DLQ.
   -> HM.HashMap Projects.ProjectId Projects.ProjectCache
   -> V.Vector OtelLogsAndSpans
-  -> Eff es ()
+  -> Eff es (Either WriteFailure (V.Vector (OtelLogsAndSpans, RowPoisonInfo)))
 insertAndHandOff enableTf worker caches records
-  | V.null records = pass
-  | otherwise = do
-      bulkInsertOtelLogsAndSpansTF enableTf records
-      liftIO $ handOffBatches worker caches records
+  | V.null records = pure (Right V.empty)
+  | otherwise =
+      bulkInsertOtelLogsAndSpansTF enableTf records >>= \case
+        Left wf -> pure (Left wf)
+        Right rowPoison -> do
+          -- Hand off only the fully-successful rows — don't let downstream
+          -- extraction observe records that landed in only one store.
+          let poisonIds = HS.fromList [r.id | (r, _) <- V.toList rowPoison]
+              fullyOk = V.filter (\r -> not (HS.member r.id poisonIds)) records
+          liftIO $ handOffBatches worker caches fullyOk
+          pure (Right rowPoison)
 
 
 -- | Group `records` by `project_id`, build one `ExtractionBatch` per group, and
@@ -1018,30 +1128,34 @@ bisectCap = 2 ^ maxBisectDepth
 --
 -- >>> bisectCap * length otelColumns <= 65535  -- libpq Bind param ceiling
 -- True
-bulkInsertOtelLogsAndSpans :: (Hasql :> es, IOE :> es, Log :> es) => V.Vector OtelLogsAndSpans -> Eff es Int64
-bulkInsertOtelLogsAndSpans = fmap Relude.sum . traverse insertSlice . VS.chunksOf bisectCap
+bulkInsertOtelLogsAndSpans :: (Hasql :> es, IOE :> es, Log :> es) => V.Vector OtelLogsAndSpans -> Eff es BulkInsertResult
+bulkInsertOtelLogsAndSpans = fmap mconcat . traverse insertSlice . VS.chunksOf bisectCap
   where
     insertSlice rs = V.mapM (\r -> (r,) <$> otelRowSnippet r) rs >>= go maxBisectDepth
 
     go d pairs =
       tryAny (Hasql.use $ HSession.statement () (stmt pairs)) >>= \case
-        Right n -> pure n
+        Right n -> pure (BulkInsertResult n V.empty)
         Left e
           | Hasql.isTransientException e -> throwIO e
-          | V.length pairs == 1 ->
+          | V.length pairs == 1 -> do
+              -- Single row failed non-transiently: surface as poison so caller
+              -- can DLQ. Previous behaviour was to drop + log (silent loss).
               Log.logAttention
-                "POISON_ROW_DROPPED"
+                "ROW_INSERT_FAILED"
                 (AE.object ["id" AE..= (fst (V.head pairs)).id, "error" AE..= show @Text e])
-                $> 0
-          | d <= 0 ->
+              pure (BulkInsertResult 0 (V.map (\(r, _) -> (r, e)) pairs))
+          | d <= 0 -> do
+              -- Couldn't isolate within bisect budget. Treat the whole
+              -- remaining slice as poison so the rows still reach the DLQ.
               Log.logAttention
                 "BISECT_DEPTH_EXHAUSTED"
                 (AE.object ["record_count" AE..= V.length pairs, "error" AE..= show @Text e])
-                >> throwIO e
+              pure (BulkInsertResult 0 (V.map (\(r, _) -> (r, e)) pairs))
           | otherwise ->
               -- <*> is sequential in Eff: a throw from the left short-circuits the right. Do not parallelize.
               let (l, r) = V.splitAt (V.length pairs `div` 2) pairs
-               in (+) <$> go (d - 1) l <*> go (d - 1) r
+               in (<>) <$> go (d - 1) l <*> go (d - 1) r
 
     stmt pairs =
       toPreparableStatement
@@ -1598,7 +1712,10 @@ insertSystemLog
   -> Eff es ()
 insertSystemLog enableTf otelLog = do
   minted <- mintOtelLogIds (V.singleton otelLog)
-  bulkInsertOtelLogsAndSpansTF enableTf minted
+  -- System logs are best-effort: failure here would just shadow whatever
+  -- caused the original log. Discard the WriteFailure rather than throw or
+  -- propagate — it's already been logAttention'd by bulkInsertOtelLogsAndSpansTF.
+  void $ bulkInsertOtelLogsAndSpansTF enableTf minted
 
 
 -- | Generate summary array for an OtelLogsAndSpans record

--- a/src/Models/Telemetry/Telemetry.hs
+++ b/src/Models/Telemetry/Telemetry.hs
@@ -85,7 +85,6 @@ import Data.List qualified as L (groupBy)
 import Data.List.Extra (chunksOf)
 import Data.List.NonEmpty qualified as NE
 import Data.Map qualified as Map
-import Data.HashSet qualified as HS
 import Data.Set qualified as S
 import Data.Text qualified as T
 import Data.Text.Display (Display)

--- a/src/Models/Telemetry/Telemetry.hs
+++ b/src/Models/Telemetry/Telemetry.hs
@@ -47,7 +47,8 @@ module Models.Telemetry.Telemetry (
   writeFailureDlqHeaders,
   PoisonMsg,
   BulkInsertResult (..),
-  RowPoisonInfo (..),
+  RowPoisonInfo,
+  poisonReason,
   handOffBatches,
   mintOtelLogIds,
   getMetricChartListData,
@@ -869,13 +870,21 @@ type PoisonMsg =
   -- ^ @(ackId, rawBytes, errorReason)@
 
 
--- | Per-row outcome from a dual-write. At least one of @pgError@ / @tfError@ is
--- 'Just'; if a row is fully successful it never appears here.
-data RowPoisonInfo = RowPoisonInfo
-  { pgError :: Maybe SomeException
-  , tfError :: Maybe SomeException
-  }
-  deriving stock (Generic)
+-- | Per-row outcome from a dual-write. @This pgErr@ = PG-only failure;
+-- @That tfErr@ = TF-only failure; @These pgErr tfErr@ = both failed. A row
+-- accepted by both stores never appears here, so the no-error case is
+-- structurally absent (no need for a defensive Nothing-Nothing branch in callers).
+type RowPoisonInfo = These SomeException SomeException
+
+
+-- | Human-readable per-row error reason for DLQ payload. Threads exception
+-- detail through so DLQ operators can triage without cross-referencing logs.
+poisonReason :: RowPoisonInfo -> Text
+poisonReason =
+  These.these
+    (\pg -> "row insert failed (pg-only): " <> show pg)
+    (\tf -> "row insert failed (tf-only): " <> show tf)
+    (\pg tf -> "row insert failed (both): pg=" <> show pg <> "; tf=" <> show tf)
 
 
 -- | Result of a single-side ('bulkInsertOtelLogsAndSpans') bulk write. Rows
@@ -936,8 +945,11 @@ retryHasqlWrite maxAttempts store act = go 1
         Right a -> pure (Right a)
         Left e
           | "TuplesOk" `T.isInfixOf` show e -> do
-              -- Rows DID land; we just lack the row count (mempty is a safe
-              -- approximation since the caller cares about poison, not the count).
+              -- Rows DID land — only the PGWire status tag is wrong. We return
+              -- 'mempty' because we lack the count; the poison-rows field is
+              -- correctly empty. Any caller that watches @rowsInserted@ for
+              -- monitoring will see 0 here on TF batches; treat that as
+              -- "wire-mismatch swallowed", not "zero rows inserted".
               Log.logTrace "retryHasqlWrite: TuplesOk wire-mismatch ignored" $ AE.object ["store" AE..= store]
               pure (Right mempty)
           | attempt < maxAttempts
@@ -987,7 +999,7 @@ bulkInsertOtelLogsAndSpansTF enableTf records = do
     else do
       pgRes <- retryHasqlWrite 10 "pg" (bulkInsertOtelLogsAndSpans records)
       case pgRes of
-        Right bir -> pure (Right (V.map (\(r, e) -> (r, RowPoisonInfo (Just e) Nothing)) bir.poisonRows))
+        Right bir -> pure (Right (V.map (\(r, e) -> (r, This e)) bir.poisonRows))
         Left e -> do
           Log.logAttention "PG_WRITE_FAILED"
             $ AE.object ["record_count" AE..= V.length records, "error" AE..= show @Text e]
@@ -1018,9 +1030,9 @@ bulkInsertOtelLogsAndSpansTF enableTf records = do
       let mkMap bir = HM.fromList [(r.id, (r, e)) | (r, e) <- V.toList bir.poisonRows]
           pgMap = mkMap pg
           tfMap = mkMap tf
-          both = HM.intersectionWith (\(r, pe) (_, te) -> (r, RowPoisonInfo (Just pe) (Just te))) pgMap tfMap
-          pgOnly = HM.map (\(r, e) -> (r, RowPoisonInfo (Just e) Nothing)) (pgMap `HM.difference` tfMap)
-          tfOnly = HM.map (\(r, e) -> (r, RowPoisonInfo Nothing (Just e))) (tfMap `HM.difference` pgMap)
+          both = HM.intersectionWith (\(r, pe) (_, te) -> (r, These pe te)) pgMap tfMap
+          pgOnly = HM.map (\(r, e) -> (r, This e)) (pgMap `HM.difference` tfMap)
+          tfOnly = HM.map (\(r, e) -> (r, That e)) (tfMap `HM.difference` pgMap)
        in V.fromList $ HM.elems (both <> pgOnly <> tfOnly)
 
 

--- a/src/Models/Telemetry/Telemetry.hs
+++ b/src/Models/Telemetry/Telemetry.hs
@@ -124,6 +124,7 @@ import Pkg.DeriveUtils (AesonText (..), DB, UUIDId (..), WrappedEnum (..), Wrapp
 import Pkg.ExtractionWorker qualified as EW
 import Relude hiding (ask)
 import Relude.Extra.Enum (safeToEnum)
+import Relude.Extra.Tuple (traverseToSnd)
 import System.IO (hPutStrLn)
 import System.Logging qualified as Log
 import System.Tracing (forkWithCtx)
@@ -877,14 +878,17 @@ type PoisonMsg =
 type RowPoisonInfo = These SomeException SomeException
 
 
--- | Human-readable per-row error reason for DLQ payload. Threads exception
--- detail through so DLQ operators can triage without cross-referencing logs.
+-- | Human-readable per-row error reason for DLQ payload. Capped at 2 KiB per
+-- side so a multi-MB nested exception can't blow past broker message limits;
+-- the full stack stays in the logAttention emitted at the write site.
 poisonReason :: RowPoisonInfo -> Text
 poisonReason =
   These.these
-    (\pg -> "row insert failed (pg-only): " <> show pg)
-    (\tf -> "row insert failed (tf-only): " <> show tf)
-    (\pg tf -> "row insert failed (both): pg=" <> show pg <> "; tf=" <> show tf)
+    (\pg -> "row insert failed (pg-only): " <> truncErr pg)
+    (\tf -> "row insert failed (tf-only): " <> truncErr tf)
+    (\pg tf -> "row insert failed (both): pg=" <> truncErr pg <> "; tf=" <> truncErr tf)
+  where
+    truncErr = T.take 2048 . toText . displayException
 
 
 -- | Result of a single-side ('bulkInsertOtelLogsAndSpans') bulk write. Rows
@@ -945,11 +949,9 @@ retryHasqlWrite maxAttempts store act = go 1
         Right a -> pure (Right a)
         Left e
           | "TuplesOk" `T.isInfixOf` show e -> do
-              -- Rows DID land — only the PGWire status tag is wrong. We return
-              -- 'mempty' because we lack the count; the poison-rows field is
-              -- correctly empty. Any caller that watches @rowsInserted@ for
-              -- monitoring will see 0 here on TF batches; treat that as
-              -- "wire-mismatch swallowed", not "zero rows inserted".
+              -- Rows landed; only the PGWire status tag is wrong. Returning
+              -- 'mempty' loses the row count — callers watching rowsInserted
+              -- here see 0 for "wire-mismatch swallowed", not "zero inserted".
               Log.logTrace "retryHasqlWrite: TuplesOk wire-mismatch ignored" $ AE.object ["store" AE..= store]
               pure (Right mempty)
           | attempt < maxAttempts
@@ -999,7 +1001,7 @@ bulkInsertOtelLogsAndSpansTF enableTf records = do
     else do
       pgRes <- retryHasqlWrite 10 "pg" (bulkInsertOtelLogsAndSpans records)
       case pgRes of
-        Right bir -> pure (Right (V.map (\(r, e) -> (r, This e)) bir.poisonRows))
+        Right bir -> pure (Right (V.map (second This) bir.poisonRows))
         Left e -> do
           Log.logAttention "PG_WRITE_FAILED"
             $ AE.object ["record_count" AE..= V.length records, "error" AE..= show @Text e]
@@ -1024,16 +1026,23 @@ bulkInsertOtelLogsAndSpansTF enableTf records = do
       pure (Left (These ePg eTf))
 
     -- Per-row attribution: a row appears in the result iff at least one side
-    -- rejected it. Rows accepted by both stores are silently absent (full success).
+    -- rejected it. Rows accepted by both stores are silently absent (full
+    -- success). The two single-side branches short-circuit the HashMap
+    -- machinery for the common case where only one store rejected rows
+    -- (and the empty-both case which runs on every successful batch).
     combinePoison :: BulkInsertResult -> BulkInsertResult -> V.Vector (OtelLogsAndSpans, RowPoisonInfo)
-    combinePoison pg tf =
-      let mkMap bir = HM.fromList [(r.id, (r, e)) | (r, e) <- V.toList bir.poisonRows]
-          pgMap = mkMap pg
-          tfMap = mkMap tf
-          both = HM.intersectionWith (\(r, pe) (_, te) -> (r, These pe te)) pgMap tfMap
-          pgOnly = HM.map (\(r, e) -> (r, This e)) (pgMap `HM.difference` tfMap)
-          tfOnly = HM.map (\(r, e) -> (r, That e)) (tfMap `HM.difference` pgMap)
-       in V.fromList $ HM.elems (both <> pgOnly <> tfOnly)
+    combinePoison pg tf
+      | V.null pg.poisonRows && V.null tf.poisonRows = V.empty
+      | V.null tf.poisonRows = V.map (second This) pg.poisonRows
+      | V.null pg.poisonRows = V.map (second That) tf.poisonRows
+      | otherwise =
+          let mkMap bir = HM.fromList [(r.id, (r, e)) | (r, e) <- V.toList bir.poisonRows]
+              pgMap = mkMap pg
+              tfMap = mkMap tf
+              both = HM.intersectionWith (\(r, pe) (_, te) -> (r, These pe te)) pgMap tfMap
+              pgOnly = HM.map (second This) (pgMap `HM.difference` tfMap)
+              tfOnly = HM.map (second That) (tfMap `HM.difference` pgMap)
+           in V.fromList $ HM.elems (both <> pgOnly <> tfOnly)
 
 
 -- | Persist `records` to Postgres (+TimeFusion when enabled) and hand each
@@ -1136,7 +1145,7 @@ bisectCap = 2 ^ maxBisectDepth
 bulkInsertOtelLogsAndSpans :: (Hasql :> es, IOE :> es, Log :> es) => V.Vector OtelLogsAndSpans -> Eff es BulkInsertResult
 bulkInsertOtelLogsAndSpans = fmap mconcat . traverse insertSlice . VS.chunksOf bisectCap
   where
-    insertSlice rs = V.mapM (\r -> (r,) <$> otelRowSnippet r) rs >>= go maxBisectDepth
+    insertSlice rs = V.mapM (traverseToSnd otelRowSnippet) rs >>= go maxBisectDepth
 
     go d pairs =
       tryAny (Hasql.use $ HSession.statement () (stmt pairs)) >>= \case

--- a/src/Models/Telemetry/Telemetry.hs
+++ b/src/Models/Telemetry/Telemetry.hs
@@ -933,6 +933,13 @@ writeFailureDlqHeaders wf =
 --
 -- Generic over PG vs TF: both call sites are symmetric. Programmer-bug
 -- exceptions (non-Hasql) propagate as Left without retry.
+-- | Cap on retry attempts per store inside 'retryHasqlWrite'. ~25s of wall
+-- time at the exponential backoff used here. Both PG and TF call sites pass
+-- this so a future tuning change moves both in lock-step.
+maxWriteAttempts :: Int
+maxWriteAttempts = 10
+
+
 retryHasqlWrite
   :: (Concurrent :> es, IOE :> es, Log :> es, Monoid a)
   => Int
@@ -994,12 +1001,12 @@ bulkInsertOtelLogsAndSpansTF enableTf records = do
     $ AE.object [("record_count", AE.toJSON $ V.length records), ("enableTimefusionWrites", AE.toJSON enableTf)]
   if enableTf
     then Ki.scoped \scope -> do
-      pgThread <- forkWithCtx scope $ retryHasqlWrite 10 "pg" (bulkInsertOtelLogsAndSpans records)
-      tfThread <- forkWithCtx scope $ retryHasqlWrite 10 "tf" (labeled @"timefusion" @Hasql $ bulkInsertOtelLogsAndSpans records)
+      pgThread <- forkWithCtx scope $ retryHasqlWrite maxWriteAttempts "pg" (bulkInsertOtelLogsAndSpans records)
+      tfThread <- forkWithCtx scope $ retryHasqlWrite maxWriteAttempts "tf" (labeled @"timefusion" @Hasql $ bulkInsertOtelLogsAndSpans records)
       (pgRes, tfRes) <- Ki.atomically $ (,) <$> Ki.await pgThread <*> Ki.await tfThread
       classify pgRes tfRes
     else do
-      pgRes <- retryHasqlWrite 10 "pg" (bulkInsertOtelLogsAndSpans records)
+      pgRes <- retryHasqlWrite maxWriteAttempts "pg" (bulkInsertOtelLogsAndSpans records)
       case pgRes of
         Right bir -> pure (Right (V.map (second This) bir.poisonRows))
         Left e -> do
@@ -1027,9 +1034,8 @@ bulkInsertOtelLogsAndSpansTF enableTf records = do
 
     -- Per-row attribution: a row appears in the result iff at least one side
     -- rejected it. Rows accepted by both stores are silently absent (full
-    -- success). The two single-side branches short-circuit the HashMap
-    -- machinery for the common case where only one store rejected rows
-    -- (and the empty-both case which runs on every successful batch).
+    -- success). Result order is HashMap-iteration order — DLQ consumers
+    -- process entries independently, so order is irrelevant downstream.
     combinePoison :: BulkInsertResult -> BulkInsertResult -> V.Vector (OtelLogsAndSpans, RowPoisonInfo)
     combinePoison pg tf
       | V.null pg.poisonRows && V.null tf.poisonRows = V.empty
@@ -1042,7 +1048,7 @@ bulkInsertOtelLogsAndSpansTF enableTf records = do
               both = HM.intersectionWith (\(r, pe) (_, te) -> (r, These pe te)) pgMap tfMap
               pgOnly = HM.map (second This) (pgMap `HM.difference` tfMap)
               tfOnly = HM.map (second That) (tfMap `HM.difference` pgMap)
-           in V.fromList $ HM.elems (both <> pgOnly <> tfOnly)
+           in V.fromList $ HM.elems (HM.unions [both, pgOnly, tfOnly])
 
 
 -- | Persist `records` to Postgres (+TimeFusion when enabled) and hand each

--- a/src/Models/Telemetry/Telemetry.hs
+++ b/src/Models/Telemetry/Telemetry.hs
@@ -81,11 +81,11 @@ import Data.Default (Default (..))
 import Data.Effectful.UUID (UUIDEff, genUUID)
 import Data.Generics.Labels ()
 import Data.HashMap.Strict qualified as HM
+import Data.HashSet qualified as HS
 import Data.List qualified as L (groupBy)
 import Data.List.Extra (chunksOf)
 import Data.List.NonEmpty qualified as NE
 import Data.Map qualified as Map
-import Data.HashSet qualified as HS
 import Data.Maybe (fromJust)
 import Data.Set qualified as S
 import Data.Text qualified as T
@@ -866,7 +866,8 @@ type WriteFailure = These SomeException SomeException
 -- | A message that couldn't be parsed/converted. Callers MUST publish these to
 -- the DLQ before committing source-topic offsets so the bytes are preserved
 -- for manual investigation (never silent-drop).
-type PoisonMsg = (Text, ByteString, Text)
+type PoisonMsg =
+  (Text, ByteString, Text)
   -- ^ @(ackId, rawBytes, errorReason)@
 
 
@@ -946,7 +947,8 @@ retryHasqlWrite maxAttempts store act = go 1
               -- approximation since the caller cares about poison, not the count).
               Log.logTrace "retryHasqlWrite: TuplesOk wire-mismatch ignored" $ AE.object ["store" AE..= store]
               pure (Right mempty)
-          | attempt < maxAttempts, Hasql.isTransientException e -> do
+          | attempt < maxAttempts
+          , Hasql.isTransientException e -> do
               let delayMicros = min 5000000 (100000 * (2 ^ (attempt - 1) :: Int)) -- 100ms,200ms,…cap 5s
               Log.logAttention "retryHasqlWrite: transient error, retrying"
                 $ AE.object

--- a/src/Opentelemetry/OtlpServer.hs
+++ b/src/Opentelemetry/OtlpServer.hs
@@ -274,16 +274,10 @@ dualWriteWithPoisonMapping appCtx label caches perMsg = do
       Left wf -> Left wf
       Right rowPoison ->
         Right
-          [ (ackId, raw, reasonFor info)
+          [ (ackId, raw, Telemetry.poisonReason info)
           | (r, info) <- V.toList rowPoison
           , Just (ackId, raw) <- [HM.lookup r.id idToSource]
           ]
-  where
-    reasonFor info = case (info.pgError, info.tfError) of
-      (Just pg, Just tf) -> "row insert failed (both): pg=" <> show pg <> "; tf=" <> show tf
-      (Just pg, Nothing) -> "row insert failed (pg-only): " <> show pg
-      (Nothing, Just tf) -> "row insert failed (tf-only): " <> show tf
-      (Nothing, Nothing) -> "row insert failed (unknown — both sides null)"
 
 
 -- | Boundary adapter: convert a 'WriteFailure' to a gRPC INTERNAL error.
@@ -400,7 +394,7 @@ processList msgs !attrs =
 
 processBatchPipeline
   :: forall req res es
-   . (DB es, Eff.Reader AuthContext :> es, Log :> es, Message req)
+   . (DB es, Eff.Reader AuthContext :> es, Log :> es, Message req, Time.Time :> es)
   => Text
   -> [(Text, ByteString)]
   -> AuthContext
@@ -443,8 +437,14 @@ processBatchPipeline !label msgs appCtx fallbackTime extractKeys extractIds conv
 
     if allEmpty
       then pure (Right (writeAckIds, decodePoison))
-      else
-        dbInsert projectCachesMap writeReady <&> \case
+      else do
+        -- Emit dbInsert duration as a separate trace line so dashboards that
+        -- alert on per-batch DB latency keep working. The outer processList
+        -- log records overall batch duration; this carries the dbInsert slice.
+        (result, dbDur) <- Log.timeAction (dbInsert projectCachesMap writeReady)
+        Log.logTrace "processBatchPipeline: dbInsert complete"
+          $ AE.object ["label" AE..= label, "db_insert_ms" AE..= (round (dbDur * 1000) :: Int)]
+        pure $ case result of
           Left wf -> Left wf
           Right writePoison ->
             -- Successfully-written rows are acked; write-poisoned rows are removed

--- a/src/Opentelemetry/OtlpServer.hs
+++ b/src/Opentelemetry/OtlpServer.hs
@@ -17,7 +17,7 @@ module Opentelemetry.OtlpServer (
 ) where
 
 import Control.Concurrent (forkIO, threadDelay)
-import Control.Exception (throwIO)
+import Control.Exception (ErrorCall (..), throwIO)
 import Control.Exception.Annotated (checkpoint)
 import Data.Aeson qualified as AE
 import Data.Aeson.Key qualified as AEK
@@ -266,6 +266,14 @@ dualWriteWithPoisonMapping appCtx label caches perMsg = do
       !perRecordSource = concat [replicate (V.length rs) (ackId, raw) | (ackId, raw, rs) <- perMsg]
   stamped <- stampOrPassthrough appCtx allRecords
   minted <- Telemetry.mintOtelLogIds stamped
+  -- Guard the 1:1 ordering invariant explicitly: if either upstream step ever
+  -- drops or reorders records, silent zipWith misalignment would associate the
+  -- wrong (ackId, raw) with a record. Fail loud at the boundary instead.
+  when (length perRecordSource /= V.length minted)
+    $ liftIO
+    $ throwIO
+    $ ErrorCall
+      ("dualWriteWithPoisonMapping: record count mismatch after stamp/mint (sources=" <> show (length perRecordSource) <> ", minted=" <> show (V.length minted) <> ")")
   let !idToSource = HM.fromList (zipWith (\(ackId, raw) r -> (r.id, (ackId, raw))) perRecordSource (V.toList minted))
   checkpoint
     (fromString $ "processList:" <> toString label <> ":bulkInsert")

--- a/src/Opentelemetry/OtlpServer.hs
+++ b/src/Opentelemetry/OtlpServer.hs
@@ -35,9 +35,9 @@ import Data.HashSet qualified as HS
 import Data.List qualified as L
 import Data.Map qualified as Map
 import Data.ProtoLens.Encoding (decodeMessage, encodeMessage)
-import Data.These (These (..))
 import Data.Scientific (fromFloatDigits)
 import Data.Text qualified as T
+import Data.These (These (..))
 import Data.Time (UTCTime, diffUTCTime, getCurrentTime)
 import Data.Time.Clock.POSIX (posixSecondsToUTCTime)
 import Data.UUID qualified as UUID
@@ -267,7 +267,8 @@ dualWriteWithPoisonMapping appCtx label caches perMsg = do
   stamped <- stampOrPassthrough appCtx allRecords
   minted <- Telemetry.mintOtelLogIds stamped
   let !idToSource = HM.fromList (zipWith (\(ackId, raw) r -> (r.id, (ackId, raw))) perRecordSource (V.toList minted))
-  checkpoint (fromString $ "processList:" <> toString label <> ":bulkInsert")
+  checkpoint
+    (fromString $ "processList:" <> toString label <> ":bulkInsert")
     (Telemetry.insertAndHandOff appCtx.env.enableTimefusionWrites appCtx.extractionWorker caches minted)
     <&> \case
       Left wf -> Left wf
@@ -442,14 +443,15 @@ processBatchPipeline !label msgs appCtx fallbackTime extractKeys extractIds conv
 
     if not anyRows
       then pure (Right (writeAckIds, decodePoison))
-      else dbInsert projectCachesMap writeReady <&> \case
-        Left wf -> Left wf
-        Right writePoison ->
-          -- Successfully-written rows are acked; write-poisoned rows are removed
-          -- from acks and added to the poison list (Pkg.Queue DLQs them).
-          let writePoisonAcks = HS.fromList [a | (a, _, _) <- writePoison]
-              successAcks = filter (\a -> not (HS.member a writePoisonAcks)) writeAckIds
-           in Right (successAcks, decodePoison <> writePoison)
+      else
+        dbInsert projectCachesMap writeReady <&> \case
+          Left wf -> Left wf
+          Right writePoison ->
+            -- Successfully-written rows are acked; write-poisoned rows are removed
+            -- from acks and added to the poison list (Pkg.Queue DLQs them).
+            let writePoisonAcks = HS.fromList [a | (a, _, _) <- writePoison]
+                successAcks = filter (\a -> not (HS.member a writePoisonAcks)) writeAckIds
+             in Right (successAcks, decodePoison <> writePoison)
   where
     cp suffix = fromString $ toString $ "processList:" <> label <> suffix
 

--- a/src/Opentelemetry/OtlpServer.hs
+++ b/src/Opentelemetry/OtlpServer.hs
@@ -423,8 +423,8 @@ processBatchPipeline !label msgs appCtx fallbackTime extractKeys extractIds conv
               $ liftIO
               $ HM.fromList
               <$> forM projectIds \pid -> do
-                !cache <- Cache.fetchWithCache appCtx.projectCache pid \pid' ->
-                  fromMaybe Projects.defaultProjectCache <$> Projects.projectCacheByIdIO appCtx.hasqlJobsPool pid'
+                !cache <- Cache.fetchWithCache appCtx.projectCache pid
+                  $ fmap (fromMaybe Projects.defaultProjectCache) . Projects.projectCacheByIdIO appCtx.hasqlJobsPool
                 pure (pid, cache)
           pure (keyToId, projectCaches)
 
@@ -438,9 +438,8 @@ processBatchPipeline !label msgs appCtx fallbackTime extractKeys extractIds conv
     if allEmpty
       then pure (Right (writeAckIds, decodePoison))
       else do
-        -- Emit dbInsert duration as a separate trace line so dashboards that
-        -- alert on per-batch DB latency keep working. The outer processList
-        -- log records overall batch duration; this carries the dbInsert slice.
+        -- dbInsert duration is emitted as a separate trace line so dashboards
+        -- alerting on per-batch DB latency keep their metric.
         (result, dbDur) <- Log.timeAction (dbInsert projectCachesMap writeReady)
         Log.logTrace "processBatchPipeline: dbInsert complete"
           $ AE.object ["label" AE..= label, "db_insert_ms" AE..= (round (dbDur * 1000) :: Int)]

--- a/src/Opentelemetry/OtlpServer.hs
+++ b/src/Opentelemetry/OtlpServer.hs
@@ -423,8 +423,10 @@ processBatchPipeline !label msgs appCtx fallbackTime extractKeys extractIds conv
               $ liftIO
               $ HM.fromList
               <$> forM projectIds \pid -> do
-                !cache <- Cache.fetchWithCache appCtx.projectCache pid
-                  $ fmap (fromMaybe Projects.defaultProjectCache) . Projects.projectCacheByIdIO appCtx.hasqlJobsPool
+                !cache <-
+                  Cache.fetchWithCache appCtx.projectCache pid
+                    $ fmap (fromMaybe Projects.defaultProjectCache)
+                    . Projects.projectCacheByIdIO appCtx.hasqlJobsPool
                 pure (pid, cache)
           pure (keyToId, projectCaches)
 

--- a/src/Opentelemetry/OtlpServer.hs
+++ b/src/Opentelemetry/OtlpServer.hs
@@ -35,6 +35,7 @@ import Data.HashSet qualified as HS
 import Data.List qualified as L
 import Data.Map qualified as Map
 import Data.ProtoLens.Encoding (decodeMessage, encodeMessage)
+import Data.These (These (..))
 import Data.Scientific (fromFloatDigits)
 import Data.Text qualified as T
 import Data.Time (UTCTime, diffUTCTime, getCurrentTime)
@@ -236,20 +237,90 @@ stampOrPassthrough appCtx v =
       pure v
 
 
--- | Process a list of messages
-processList :: (Concurrent :> es, DB es, Eff.Reader AuthContext :> es, Ki.StructuredConcurrency :> es, Labeled "timefusion" Hasql.Hasql :> es, Log :> es, Time.Time :> es, Tracing :> es, UUIDEff :> es) => [(Text, ByteString)] -> HM.HashMap Text Text -> Eff es [Text]
-processList [] _ = pure []
+-- | The dbInsert callback for the logs/traces paths in 'processBatchPipeline'.
+-- Flattens per-msg records for the dual-write, then maps any per-row poison
+-- back to its source @(ackId, rawBytes)@ so Pkg.Queue can DLQ those exact
+-- source messages (not the bulk batch).
+--
+-- Index-alignment assumes 'stampOrPassthrough' and 'mintOtelLogIds' preserve
+-- record order and length (both are V-mapped 1:1 today).
+dualWriteWithPoisonMapping
+  :: ( Concurrent :> es
+     , Hasql.Hasql :> es
+     , IOE :> es
+     , Ki.StructuredConcurrency :> es
+     , Labeled "timefusion" Hasql.Hasql :> es
+     , Log :> es
+     , Time.Time :> es
+     , UUIDEff :> es
+     )
+  => AuthContext
+  -> Text
+  -- ^ label for checkpoint ("logs" / "traces")
+  -> HM.HashMap Projects.ProjectId Projects.ProjectCache
+  -> [(Text, ByteString, V.Vector Telemetry.OtelLogsAndSpans)]
+  -- ^ per source-message records
+  -> Eff es (Either Telemetry.WriteFailure [Telemetry.PoisonMsg])
+dualWriteWithPoisonMapping appCtx label caches perMsg = do
+  let !allRecords = V.concat [rs | (_, _, rs) <- perMsg]
+      !perRecordSource = concat [replicate (V.length rs) (ackId, raw) | (ackId, raw, rs) <- perMsg]
+  stamped <- stampOrPassthrough appCtx allRecords
+  minted <- Telemetry.mintOtelLogIds stamped
+  let !idToSource = HM.fromList (zipWith (\(ackId, raw) r -> (r.id, (ackId, raw))) perRecordSource (V.toList minted))
+  checkpoint (fromString $ "processList:" <> toString label <> ":bulkInsert")
+    (Telemetry.insertAndHandOff appCtx.env.enableTimefusionWrites appCtx.extractionWorker caches minted)
+    <&> \case
+      Left wf -> Left wf
+      Right rowPoison ->
+        Right
+          [ (ackId, raw, reasonFor info)
+          | (r, info) <- V.toList rowPoison
+          , Just (ackId, raw) <- [HM.lookup r.id idToSource]
+          ]
+  where
+    reasonFor info = case (info.pgError, info.tfError) of
+      (Just pg, Just tf) -> "row insert failed (both): pg=" <> show pg <> "; tf=" <> show tf
+      (Just pg, Nothing) -> "row insert failed (pg-only): " <> show pg
+      (Nothing, Just tf) -> "row insert failed (tf-only): " <> show tf
+      (Nothing, Nothing) -> "row insert failed (unknown — both sides null)"
+
+
+-- | Boundary adapter: convert a 'WriteFailure' to a gRPC INTERNAL error.
+-- Used at the gRPC handler edge where clients expect status codes via throw,
+-- not Either. Internal pipeline code stays Either-based.
+throwOnWriteFailure :: (IOE :> es, Log :> es) => Either Telemetry.WriteFailure (V.Vector (Telemetry.OtelLogsAndSpans, Telemetry.RowPoisonInfo)) -> Eff es ()
+throwOnWriteFailure = \case
+  Right rowPoison
+    | V.null rowPoison -> pass
+    | otherwise ->
+        -- Whole-side write succeeded but some rows had per-row failures (TF
+        -- rejected a row PG accepted, or vice versa). gRPC clients can't act
+        -- on per-row state — log loudly so the discrepancy is visible.
+        Log.logAttention "OTLP_GRPC_ROW_POISON_BUT_RETURNING_OK"
+          $ AE.object ["poison_count" AE..= V.length rowPoison]
+  Left wf ->
+    liftIO
+      $ throwIO
+      $ GrpcException
+        { grpcError = GrpcInternal
+        , grpcErrorMessage = Just $ "OTLP write failed: " <> Telemetry.writeFailureSummary wf
+        , grpcErrorMetadata = []
+        , grpcErrorDetails = Nothing
+        }
+
+
+-- | Process a list of OTLP-encoded messages. On success, returns
+-- @(writeAckIds, poisonMsgs)@: writeAckIds are the messages that landed in
+-- both stores; poisonMsgs are decode failures whose raw bytes must be DLQ'd
+-- by Pkg.Queue before committing offsets. On dual-write failure, returns
+-- 'Left WriteFailure'. Never throws on write/decode failure.
+processList :: (Concurrent :> es, DB es, Eff.Reader AuthContext :> es, Ki.StructuredConcurrency :> es, Labeled "timefusion" Hasql.Hasql :> es, Log :> es, Time.Time :> es, Tracing :> es, UUIDEff :> es) => [(Text, ByteString)] -> HM.HashMap Text Text -> Eff es (Either Telemetry.WriteFailure ([Text], [Telemetry.PoisonMsg]))
+processList [] _ = pure (Right ([], []))
 processList msgs !attrs =
   withSpan_ "otlp.process_list" (batchSpanAttrs (length msgs) attrs)
     $ checkpoint "processList" do
       startTime <- Time.currentTime
-      -- Exceptions from `process` (most importantly dbInsert / TF write failures)
-      -- MUST propagate so Pkg.Queue's batch-failure handler can route the batch:
-      -- Hasql-transient → no ack (broker redelivers); anything else → DLQ via
-      -- publishToDeadLetterQueue, ack only if DLQ accepted. Wrapping in
-      -- onException + returning ackIds here would silently drop the entire
-      -- batch (see TimefusionWriteFailureSpec for the regression).
-      (result, processingTime, dbInsertTime) <- process startTime
+      result <- process startTime
       endTime <- Time.currentTime
 
       let duration = diffUTCTime endTime startTime
@@ -260,8 +331,7 @@ processList msgs !attrs =
             , "event_count" AE..= length msgs
             , "duration_seconds" AE..= realToFrac @_ @Double duration
             , "duration_ms" AE..= (round (duration * 1000) :: Int)
-            , "processing_ms" AE..= processingTime
-            , "db_insert_ms" AE..= dbInsertTime
+            , "outcome" AE..= either Telemetry.writeFailureSummary (const "ok") result
             ]
         )
       pure result
@@ -283,12 +353,7 @@ processList msgs !attrs =
                     !pids = V.fromList [(k, pid) | (k, pid) <- HM.toList keyToId, k `V.elem` pkeys]
                  in V.concatMap (V.fromList . convertResourceLogsToOtelLogs ft caches pids) rls
             )
-            ( \caches v -> do
-                stamped <- stampOrPassthrough appCtx v
-                Telemetry.mintOtelLogIds stamped
-                  >>= checkpoint "processList:logs:bulkInsert"
-                  . Telemetry.insertAndHandOff appCtx.env.enableTimefusionWrites appCtx.extractionWorker caches
-            )
+            (dualWriteWithPoisonMapping appCtx "logs")
         Just "org.opentelemetry.otlp.traces.v1" ->
           processBatchPipeline @TS.ExportTraceServiceRequest
             "traces"
@@ -303,12 +368,7 @@ processList msgs !attrs =
                     !pids = V.fromList [(k, pid) | (k, pid) <- HM.toList keyToId, k `V.elem` pkeys]
                  in V.fromList $ convertResourceSpansToOtelLogs ft caches pids rss
             )
-            ( \caches v -> do
-                stamped <- stampOrPassthrough appCtx v
-                Telemetry.mintOtelLogIds stamped
-                  >>= checkpoint "processList:traces:bulkInsert"
-                  . Telemetry.insertAndHandOff appCtx.env.enableTimefusionWrites appCtx.extractionWorker caches
-            )
+            (dualWriteWithPoisonMapping appCtx "traces")
         Just "org.opentelemetry.otlp.metrics.v1" ->
           processBatchPipeline @MS.ExportMetricsServiceRequest
             "metrics"
@@ -323,15 +383,23 @@ processList msgs !attrs =
                     !pid2M = Projects.projectIdFromText =<< getMetricAttributeValue "at-project-id" rms
                  in maybe V.empty (\pid -> V.fromList $ convertResourceMetricsToMetricRecords ft caches pid rms) (pidM <|> pid2M)
             )
-            (\_caches -> checkpoint "processList:metrics:bulkInsert" . Telemetry.bulkInsertMetrics)
+            ( \_caches perMsg ->
+                -- Metrics don't dual-write yet; surface a whole-batch Left on
+                -- failure (no per-row poison). Per-row attribution comes when
+                -- metrics adopts the dual-write path.
+                let flat = V.concat [recs | (_, _, recs) <- perMsg]
+                 in tryAny (checkpoint "processList:metrics:bulkInsert" $ Telemetry.bulkInsertMetrics flat) <&> \case
+                      Right _ -> Right []
+                      Left e -> Left (This e)
+            )
         _ -> do
           Log.logAttention "processList: unsupported opentelemetry data type" (AE.object ["ce-type" AE..= HM.lookup "ce-type" attrs])
-          pure ([], 0, 0)
+          pure (Right ([], []))
 
 
 processBatchPipeline
   :: forall req res es
-   . (DB es, Eff.Reader AuthContext :> es, Log :> es, Message req, Time.Time :> es)
+   . (DB es, Eff.Reader AuthContext :> es, Log :> es, Message req)
   => Text
   -> [(Text, ByteString)]
   -> AuthContext
@@ -339,56 +407,49 @@ processBatchPipeline
   -> (req -> V.Vector Text) -- extract project keys
   -> (req -> [Projects.ProjectId]) -- extract project IDs
   -> (UTCTime -> HM.HashMap Projects.ProjectId Projects.ProjectCache -> HM.HashMap Text Projects.ProjectId -> req -> V.Vector res) -- per-message converter
-  -> (HM.HashMap Projects.ProjectId Projects.ProjectCache -> V.Vector res -> Eff es ()) -- DB insert (caches threaded for worker hand-off)
-  -> Eff es ([Text], Int, Int)
+  -> (HM.HashMap Projects.ProjectId Projects.ProjectCache -> [(Text, ByteString, V.Vector res)] -> Eff es (Either Telemetry.WriteFailure [Telemetry.PoisonMsg])) -- DB insert; returns per-row poison resolved to source ackId+raw
+  -> Eff es (Either Telemetry.WriteFailure ([Text], [Telemetry.PoisonMsg]))
 processBatchPipeline !label msgs appCtx fallbackTime extractKeys extractIds convert dbInsert =
   checkpoint (cp "") do
-    ((ackIds, dbInsertDuration), processingDuration) <- Log.timeAction do
-      let !decodedMsgs = [(ackId, decodeMessage msg :: Either String req) | (ackId, msg) <- msgs]
-          !allProjectKeys = V.concat [extractKeys req | (_, Right req) <- decodedMsgs]
-          !uniqueProjectKeys = V.fromList $ toList $ HS.fromList $ V.toList allProjectKeys
-          !atIds = concatMap extractIds [req | (_, Right req) <- decodedMsgs]
+    let !decodedMsgs = [(ackId, msg, decodeMessage msg :: Either String req) | (ackId, msg) <- msgs]
+        !allProjectKeys = V.concat [extractKeys req | (_, _, Right req) <- decodedMsgs]
+        !uniqueProjectKeys = V.fromList $ toList $ HS.fromList $ V.toList allProjectKeys
+        !atIds = concatMap extractIds [req | (_, _, Right req) <- decodedMsgs]
 
-      (!keyToIdMap, !projectCachesMap) <-
-        if V.null uniqueProjectKeys
-          then pure (HM.empty, HM.empty)
-          else do
-            !projectIdsAndKeys <- checkpoint (cp ":getProjectIds") $ ProjectApiKeys.projectIdsByProjectApiKeys uniqueProjectKeys
-            let !keyToId = HM.fromList $ V.toList projectIdsAndKeys
-                -- fold values directly to avoid HM.elems intermediate list
-                !projectIds = HS.toList $ HM.foldr' HS.insert (HS.fromList atIds) keyToId
-            !projectCaches <-
-              checkpoint (cp ":getProjectCaches")
-                $ liftIO
-                $ HM.fromList
-                <$> forM projectIds \pid -> do
-                  !cache <- Cache.fetchWithCache appCtx.projectCache pid \pid' ->
-                    fromMaybe Projects.defaultProjectCache <$> Projects.projectCacheByIdIO appCtx.hasqlJobsPool pid'
-                  pure (pid, cache)
-            pure (keyToId, projectCaches)
+    (!keyToIdMap, !projectCachesMap) <-
+      if V.null uniqueProjectKeys
+        then pure (HM.empty, HM.empty)
+        else do
+          !projectIdsAndKeys <- checkpoint (cp ":getProjectIds") $ ProjectApiKeys.projectIdsByProjectApiKeys uniqueProjectKeys
+          let !keyToId = HM.fromList $ V.toList projectIdsAndKeys
+              !projectIds = HS.toList $ HM.foldr' HS.insert (HS.fromList atIds) keyToId
+          !projectCaches <-
+            checkpoint (cp ":getProjectCaches")
+              $ liftIO
+              $ HM.fromList
+              <$> forM projectIds \pid -> do
+                !cache <- Cache.fetchWithCache appCtx.projectCache pid \pid' ->
+                  fromMaybe Projects.defaultProjectCache <$> Projects.projectCacheByIdIO appCtx.hasqlJobsPool pid'
+                pure (pid, cache)
+          pure (keyToId, projectCaches)
 
-      let !processedMsgs =
-            [ case decodeResult of
-                Left _ -> (ackId, V.empty)
-                Right req -> let !out = convert fallbackTime projectCachesMap keyToIdMap req in (ackId, out)
-            | (ackId, decodeResult) <- decodedMsgs
-            ]
+    let !decodePoison = [(ackId, raw, toText err) | (ackId, raw, Left err) <- decodedMsgs]
+        !writeReady = [(ackId, raw, convert fallbackTime projectCachesMap keyToIdMap req) | (ackId, raw, Right req) <- decodedMsgs]
+        !writeAckIds = [ackId | (ackId, _, _) <- writeReady]
+        !anyRows = any (not . V.null) [recs | (_, _, recs) <- writeReady]
 
-      forM_ [(idx, err) | (idx, (_, Left err)) <- zip [0 ..] decodedMsgs] \(idx, err) ->
-        recordProtoError label err (snd $ msgs L.!! idx) Log.logAttention
+    forM_ decodePoison \(_, raw, err) -> recordProtoError label (toString err) raw Log.logAttention
 
-      let !results = V.fromList processedMsgs
-          (!ackIdsV, !outputVectors) = V.unzip results
-          !allOutput = V.concatMap Relude.id outputVectors
-
-      -- dbInsert exceptions intentionally PROPAGATE: Pkg.Queue.{kafka,pubsub}Service
-      -- catches them and routes Hasql-transient → no-ack (broker redelivers),
-      -- anything else → DLQ via publishToDeadLetterQueue, ack only on DLQ success.
-      -- Do NOT wrap in tryAny here — that would re-introduce the silent-drop bug.
-      (_, dbDur) <- Log.timeAction $ unless (V.null allOutput) $ dbInsert projectCachesMap allOutput
-      pure (V.toList ackIdsV, dbDur)
-
-    pure (ackIds, round (processingDuration * 1000), round (dbInsertDuration * 1000))
+    if not anyRows
+      then pure (Right (writeAckIds, decodePoison))
+      else dbInsert projectCachesMap writeReady <&> \case
+        Left wf -> Left wf
+        Right writePoison ->
+          -- Successfully-written rows are acked; write-poisoned rows are removed
+          -- from acks and added to the poison list (Pkg.Queue DLQs them).
+          let writePoisonAcks = HS.fromList [a | (a, _, _) <- writePoison]
+              successAcks = filter (\a -> not (HS.member a writePoisonAcks)) writeAckIds
+           in Right (successAcks, decodePoison <> writePoison)
   where
     cp suffix = fromString $ toString $ "processList:" <> label <> suffix
 
@@ -1456,6 +1517,7 @@ processTraceRequest metadataApiKey req = do
     stampedSpans <- stampOrPassthrough appCtx spans'
     mintedSpans <- Telemetry.mintOtelLogIds stampedSpans
     Telemetry.insertAndHandOff appCtx.env.enableTimefusionWrites appCtx.extractionWorker projectCaches mintedSpans
+      >>= throwOnWriteFailure
     Log.logTrace
       "Traces: Successfully inserted spans into database"
       (AE.object ["inserted_count" AE..= V.length mintedSpans])
@@ -1527,6 +1589,7 @@ processLogsRequest metadataApiKey req = do
     stampedLogs <- stampOrPassthrough appCtx logs
     mintedLogs <- Telemetry.mintOtelLogIds stampedLogs
     Telemetry.insertAndHandOff appCtx.env.enableTimefusionWrites appCtx.extractionWorker projectCaches mintedLogs
+      >>= throwOnWriteFailure
     Log.logTrace
       "Logs: Successfully inserted logs into database"
       (AE.object ["inserted_count" AE..= V.length mintedLogs])

--- a/src/Opentelemetry/OtlpServer.hs
+++ b/src/Opentelemetry/OtlpServer.hs
@@ -437,11 +437,11 @@ processBatchPipeline !label msgs appCtx fallbackTime extractKeys extractIds conv
     let !decodePoison = [(ackId, raw, toText err) | (ackId, raw, Left err) <- decodedMsgs]
         !writeReady = [(ackId, raw, convert fallbackTime projectCachesMap keyToIdMap req) | (ackId, raw, Right req) <- decodedMsgs]
         !writeAckIds = [ackId | (ackId, _, _) <- writeReady]
-        !anyRows = any (not . V.null) [recs | (_, _, recs) <- writeReady]
+        !allEmpty = all (\(_, _, recs) -> V.null recs) writeReady
 
     forM_ decodePoison \(_, raw, err) -> recordProtoError label (toString err) raw Log.logAttention
 
-    if not anyRows
+    if allEmpty
       then pure (Right (writeAckIds, decodePoison))
       else
         dbInsert projectCachesMap writeReady <&> \case

--- a/src/Opentelemetry/OtlpServer.hs
+++ b/src/Opentelemetry/OtlpServer.hs
@@ -44,7 +44,7 @@ import Data.Vector qualified as V
 import Data.Vector.Unboxed qualified as VU
 import Effectful
 import Effectful.Concurrent (Concurrent)
-import Effectful.Exception (onException, try)
+import Effectful.Exception (try)
 import Effectful.Ki qualified as Ki
 import Effectful.Labeled (Labeled)
 import Effectful.Log (Log)
@@ -243,7 +243,13 @@ processList msgs !attrs =
   withSpan_ "otlp.process_list" (batchSpanAttrs (length msgs) attrs)
     $ checkpoint "processList" do
       startTime <- Time.currentTime
-      (result, processingTime, dbInsertTime) <- process startTime `onException` handleException
+      -- Exceptions from `process` (most importantly dbInsert / TF write failures)
+      -- MUST propagate so Pkg.Queue's batch-failure handler can route the batch:
+      -- Hasql-transient → no ack (broker redelivers); anything else → DLQ via
+      -- publishToDeadLetterQueue, ack only if DLQ accepted. Wrapping in
+      -- onException + returning ackIds here would silently drop the entire
+      -- batch (see TimefusionWriteFailureSpec for the regression).
+      (result, processingTime, dbInsertTime) <- process startTime
       endTime <- Time.currentTime
 
       let duration = diffUTCTime endTime startTime
@@ -260,10 +266,6 @@ processList msgs !attrs =
         )
       pure result
   where
-    handleException = checkpoint "processList:exception" do
-      Log.logAttention "processList: caught exception" (AE.object ["ce-type" AE..= HM.lookup "ce-type" attrs, "msg_count" AE..= length msgs, "attrs" AE..= attrs])
-      pure (map fst msgs, 0, 0)
-
     process fallbackTime = do
       appCtx <- ask @AuthContext
       case HM.lookup "ce-type" attrs of
@@ -379,6 +381,10 @@ processBatchPipeline !label msgs appCtx fallbackTime extractKeys extractIds conv
           (!ackIdsV, !outputVectors) = V.unzip results
           !allOutput = V.concatMap Relude.id outputVectors
 
+      -- dbInsert exceptions intentionally PROPAGATE: Pkg.Queue.{kafka,pubsub}Service
+      -- catches them and routes Hasql-transient → no-ack (broker redelivers),
+      -- anything else → DLQ via publishToDeadLetterQueue, ack only on DLQ success.
+      -- Do NOT wrap in tryAny here — that would re-introduce the silent-drop bug.
       (_, dbDur) <- Log.timeAction $ unless (V.null allOutput) $ dbInsert projectCachesMap allOutput
       pure (V.toList ackIdsV, dbDur)
 

--- a/src/Pages/Anomalies.hs
+++ b/src/Pages/Anomalies.hs
@@ -531,8 +531,10 @@ anomalyDetailPage pid issue tr spanRecs errM now isFirst members tp sampleOverri
               Just summary
                 | not (V.null summary) ->
                     renderSample $ div_ [class_ "flex flex-wrap items-center gap-1 p-4 max-h-80 overflow-y-auto"] $ renderSummaryChips_ summary
-              _ -> whenJust (sampleMessage >>= \m -> if T.strip m == T.strip logPattern then Nothing else Just m)
-                (renderSample . renderLogContent_)
+              _ ->
+                whenJust
+                  (sampleMessage >>= \m -> if T.strip m == T.strip logPattern then Nothing else Just m)
+                  (renderSample . renderLogContent_)
       div_ [class_ "flex flex-wrap gap-2 items-center"] do
         severityBadge issue.severity
         issueTypeLabel issue.issueType issue.critical

--- a/src/Pages/Anomalies.hs
+++ b/src/Pages/Anomalies.hs
@@ -531,8 +531,8 @@ anomalyDetailPage pid issue tr spanRecs errM now isFirst members tp sampleOverri
               Just summary
                 | not (V.null summary) ->
                     renderSample $ div_ [class_ "flex flex-wrap items-center gap-1 p-4 max-h-80 overflow-y-auto"] $ renderSummaryChips_ summary
-              _ -> whenJust (sampleMessage >>= \m -> if T.strip m == T.strip logPattern then Nothing else Just m) \msg ->
-                renderSample (renderLogContent_ msg)
+              _ -> whenJust (sampleMessage >>= \m -> if T.strip m == T.strip logPattern then Nothing else Just m)
+                (renderSample . renderLogContent_)
       div_ [class_ "flex flex-wrap gap-2 items-center"] do
         severityBadge issue.severity
         issueTypeLabel issue.issueType issue.critical

--- a/src/Pages/Replay.hs
+++ b/src/Pages/Replay.hs
@@ -413,7 +413,7 @@ fetchEventArray bucket objKey gzipped = fst <<$>> loadJsonArray bucket objKey gz
 -- Avoids re-encoding events during merge — raw bytes go directly to the output.
 fetchRawForMerge :: Minio.Bucket -> Minio.Object -> Bool -> Minio.Minio (Either String (Double, BL.ByteString))
 fetchRawForMerge bucket objKey gzipped =
-  (\(arr, raw) -> (firstEventTimestamp arr, raw)) <<$>> loadJsonArray bucket objKey gzipped
+  first firstEventTimestamp <<$>> loadJsonArray bucket objKey gzipped
 
 
 -- | Concatenate pre-sorted raw JSON array byte strings into one flat JSON array

--- a/src/Pages/Replay.hs
+++ b/src/Pages/Replay.hs
@@ -3,7 +3,6 @@ module Pages.Replay (replayPostH, ReplayPost (..), processReplayEvents, replaySe
 import Codec.Compression.GZip qualified as GZip
 import Conduit (runConduit)
 import Control.Exception (throwIO, try)
-import Models.Telemetry.Telemetry qualified as Telemetry
 import Data.Aeson qualified as AE
 import Data.Aeson.Key qualified as AEKey
 import Data.Aeson.KeyMap qualified as KM
@@ -32,6 +31,7 @@ import Effectful.Time (Time)
 import Effectful.Time qualified as Time
 import Hasql.Interpolate qualified as HI
 import Models.Projects.Projects qualified as Projects
+import Models.Telemetry.Telemetry qualified as Telemetry
 import Network.Minio (MinioErr (..), ServiceErr (..))
 import Network.Minio qualified as Minio
 import OddJobs.Job (createJob)
@@ -310,15 +310,16 @@ processReplayEvents msgs _attrs = do
 
     -- Returns @(acks, poison)@ for one chunk so the caller can DLQ poison and
     -- ack only the successfully-saved + DLQ'd ackIds.
-    handleChunk envCfg jobsPool chunk = mconcat <$> forM chunk \(!ackId, !body) ->
-      case splitReplayPayload (stripJsonNullEscapes body) of
-        Left err -> do
-          Metrics.bumpErrorCounter "replay:decode_error"
-          pure ([], [(ackId, body, "replay:decode_error: " <> toText err)])
-        Right payload ->
-          saveReplayMinio envCfg jobsPool ackId payload <&> \case
-            Just acked -> ([acked], [])
-            Nothing -> ([], [])
+    handleChunk envCfg jobsPool chunk =
+      mconcat <$> forM chunk \(!ackId, !body) ->
+        case splitReplayPayload (stripJsonNullEscapes body) of
+          Left err -> do
+            Metrics.bumpErrorCounter "replay:decode_error"
+            pure ([], [(ackId, body, "replay:decode_error: " <> toText err)])
+          Right payload ->
+            saveReplayMinio envCfg jobsPool ackId payload <&> \case
+              Just acked -> ([acked], [])
+              Nothing -> ([], [])
 
 
 -- | Retrieve a legacy single-object replay blob. Returns `Left` on transport

--- a/src/Pages/Replay.hs
+++ b/src/Pages/Replay.hs
@@ -3,6 +3,7 @@ module Pages.Replay (replayPostH, ReplayPost (..), processReplayEvents, replaySe
 import Codec.Compression.GZip qualified as GZip
 import Conduit (runConduit)
 import Control.Exception (throwIO, try)
+import Models.Telemetry.Telemetry qualified as Telemetry
 import Data.Aeson qualified as AE
 import Data.Aeson.Key qualified as AEKey
 import Data.Aeson.KeyMap qualified as KM
@@ -284,14 +285,20 @@ skipStringBody =
 -- per-message handoff so finished messages are GC-eligible immediately.
 -- Drop counts feed `OtlpServer.bumpErrorCounter` so they roll up in the same
 -- minute-cadence summary as wire/UTF-8 parse errors — no per-event log spam.
-processReplayEvents :: [(Text, ByteString)] -> HashMap Text Text -> ATBackgroundCtx [Text]
-processReplayEvents [] _ = pure []
+-- | Replay doesn't dual-write so it can't surface a 'Telemetry.WriteFailure'.
+-- Oversize + decode-failed messages are returned as 'PoisonMsg' so Pkg.Queue
+-- can DLQ their raw bytes before committing offsets (no silent drop). S3/Minio
+-- transport errors still propagate as exceptions through the outer tryAny.
+processReplayEvents :: [(Text, ByteString)] -> HashMap Text Text -> ATBackgroundCtx (Either Telemetry.WriteFailure ([Text], [Telemetry.PoisonMsg]))
+processReplayEvents [] _ = pure (Right ([], []))
 processReplayEvents msgs _attrs = do
   ctx <- Effectful.Reader.Static.ask @AuthContext
   let envCfg = ctx.config
       (oversized, valid) = partition (\(_, b) -> BS.length b > maxReplayMessageBytes) msgs
+      oversizePoison = [(ackId, body, "replay:oversize_message") | (ackId, body) <- oversized]
   traverse_ (\_ -> Metrics.bumpErrorCounter "replay:oversize_message") oversized
-  fmap concat $ mapM (handleChunk envCfg ctx.jobsPool) (chunkByBytes valid)
+  (acks, decodePoison) <- mconcat <$> mapM (handleChunk envCfg ctx.jobsPool) (chunkByBytes valid)
+  pure $ Right (acks, oversizePoison <> decodePoison)
   where
     chunkByBytes = go 0 [] []
       where
@@ -301,14 +308,17 @@ processReplayEvents msgs _attrs = do
               go (BS.length (snd m)) [m] (reverse chunk : chunks) rest
           | otherwise = go (sz + BS.length (snd m)) (m : chunk) chunks rest
 
-    handleChunk envCfg jobsPool chunk = fmap catMaybes $ forM chunk $ \(!ackId, !body) ->
+    -- Returns @(acks, poison)@ for one chunk so the caller can DLQ poison and
+    -- ack only the successfully-saved + DLQ'd ackIds.
+    handleChunk envCfg jobsPool chunk = mconcat <$> forM chunk \(!ackId, !body) ->
       case splitReplayPayload (stripJsonNullEscapes body) of
-        Left _ -> do
-          -- Counter only — under a flood of corrupt payloads, a per-message
-          -- log call would be the heap-pressure source we just eliminated.
+        Left err -> do
           Metrics.bumpErrorCounter "replay:decode_error"
-          pure (Just ackId)
-        Right payload -> saveReplayMinio envCfg jobsPool ackId payload
+          pure ([], [(ackId, body, "replay:decode_error: " <> toText err)])
+        Right payload ->
+          saveReplayMinio envCfg jobsPool ackId payload <&> \case
+            Just acked -> ([acked], [])
+            Nothing -> ([], [])
 
 
 -- | Retrieve a legacy single-object replay blob. Returns `Left` on transport

--- a/src/Pages/Settings.hs
+++ b/src/Pages/Settings.hs
@@ -50,7 +50,7 @@ import Data.Default
 import Data.Effectful.Hasql qualified as Hasql
 import Data.Effectful.Notify qualified as Notify
 import Data.Text qualified as T
-import Data.Time (Day, UTCTime (..), addUTCTime, getZonedTime)
+import Data.Time (Day, UTCTime (..), addDays, addUTCTime, getZonedTime)
 import Data.Time.Clock.POSIX (utcTimeToPOSIXSeconds)
 import Data.Time.Format (defaultTimeLocale, formatTime)
 import Data.UUID qualified as UUID
@@ -995,7 +995,7 @@ pastCyclesSection_ isFree basePrice cycles = div_ [class_ "border-t border-strok
       tbody_ do
         forM_ cycles \(cs, ce, reqs, bytes) -> do
           -- ce is exclusive end; subtract 1 day for the human-facing label.
-          let endLabel = toText (formatTime defaultTimeLocale "%b %-d" (pred ce))
+          let endLabel = toText (formatTime defaultTimeLocale "%b %-d" (addDays (-1) ce))
               startLabel = toText (formatTime defaultTimeLocale "%b %-d, %Y" cs)
               overage = max 0 (reqs - 20_000_000)
               cost = fromIntegral basePrice + (fromIntegral overage / 1_000_000 :: Double)

--- a/src/Pkg/Mail.hs
+++ b/src/Pkg/Mail.hs
@@ -450,10 +450,16 @@ mkSlackLogPatternRateChangePayload patternText issueUrl logLevel serviceName dir
         ]
     ]
   where
-    icon = if isError then ":rotating_light:" else if direction == "spike" then ":chart_with_upwards_trend:" else ":chart_with_downwards_trend:"
+    icon
+      | isError = ":rotating_light:"
+      | direction == "spike" = ":chart_with_upwards_trend:"
+      | otherwise = ":chart_with_downwards_trend:"
     sign = if direction == "spike" then "+" else "-"
     errPrefix = if isError then "Error " else "" :: Text
-    color = if isError then "#ef4444" else if direction == "spike" then "#eab308" else "#3b82f6"
+    color
+      | isError = "#ef4444"
+      | direction == "spike" = "#eab308"
+      | otherwise = "#3b82f6"
 
 
 discordReportAlert :: Text -> Text -> Text -> Int -> Int -> V.Vector (Text, Int, Int) -> Text -> Text -> Text -> Text -> AE.Value

--- a/src/Pkg/Parser.hs
+++ b/src/Pkg/Parser.hs
@@ -1,5 +1,5 @@
 -- Parser implemented with help and code from: https://markkarpov.com/tutorial/megaparsec.html
-module Pkg.Parser (queryASTToComponents, parseQueryToComponents, getProcessedColumns, fixedUTCTime, parseQuery, sectionsToComponents, defSqlQueryCfg, defPid, SqlQueryCfg (..), QueryComponents (..), NormalizedQuery (..), normalizeQuery, buildDateRange, buildGroupBy, buildOrderBy, buildLimit, buildWhereCondition, listToColNames, colsNoAsClause, defaultSelectSqlQuery, pSource, parseQueryToAST, ToQueryText (..), calculateAutoBinWidth, replacePlaceholders, variablePresets, variablePresetsKQL, constantToSQLList, constantToKQLList, defaultQueryLimit) where
+module Pkg.Parser (queryASTToComponents, parseQueryToComponents, getProcessedColumns, fixedUTCTime, parseQuery, sectionsToComponents, defSqlQueryCfg, defPid, SqlQueryCfg (..), QueryComponents (..), NormalizedQuery (..), normalizeQuery, buildDateRange, buildGroupBy, buildOrderBy, buildLimit, buildWhereCondition, listToColNames, colsNoAsClause, defaultSelectSqlQuery, pSource, parseQueryToAST, ToQueryText (..), calculateAutoBinWidth, replacePlaceholders, variablePresets, variablePresetsKQL, constantToSQLList, constantToKQLList, defaultQueryLimit, wrapForRowExtraction) where
 
 import Control.Error (hush)
 import Data.Default (Default (def))
@@ -536,6 +536,18 @@ colsNoAsClause = mapMaybe (\x -> Safe.headMay $ T.strip <$> T.splitOn "as" x)
 
 instance HasField "toColNames" QueryComponents [Text] where
   getField qc = qc.finalColumns
+
+
+-- | Wrap an inner SELECT producing N columns in a single jsonb-array projection.
+-- Replaces the legacy `json_agg(json_each(row_to_json(sub.*)) WITH ORDINALITY)`
+-- idiom: both Postgres and TimeFusion ship `jsonb_build_array(VARIADIC any)`,
+-- and derived-column aliases (`sub(c1..cN)`) decouple us from the inner SELECT
+-- expression shapes. Same wire output as the legacy wrapper but avoids the
+-- JSON-parser hazard on TEXT columns containing NULL bytes or lone surrogates.
+wrapForRowExtraction :: Int -> Text -> Text
+wrapForRowExtraction n inner =
+  let aliases = T.intercalate "," [ "c" <> show i | i <- [1 .. n] ]
+   in "SELECT jsonb_build_array(" <> aliases <> ") FROM (" <> inner <> ") sub(" <> aliases <> ")"
 
 
 -- | Replace all occurrences of {{key}} in the input text using the provided mapping.

--- a/src/Pkg/Parser.hs
+++ b/src/Pkg/Parser.hs
@@ -546,7 +546,7 @@ instance HasField "toColNames" QueryComponents [Text] where
 -- JSON-parser hazard on TEXT columns containing NULL bytes or lone surrogates.
 wrapForRowExtraction :: Int -> Text -> Text
 wrapForRowExtraction n inner =
-  let aliases = T.intercalate "," [ "c" <> show i | i <- [1 .. n] ]
+  let aliases = T.intercalate "," ["c" <> show i | i <- [1 .. n]]
    in "SELECT jsonb_build_array(" <> aliases <> ") FROM (" <> inner <> ") sub(" <> aliases <> ")"
 
 

--- a/src/Pkg/Parser.hs
+++ b/src/Pkg/Parser.hs
@@ -1,5 +1,5 @@
 -- Parser implemented with help and code from: https://markkarpov.com/tutorial/megaparsec.html
-module Pkg.Parser (queryASTToComponents, parseQueryToComponents, getProcessedColumns, fixedUTCTime, parseQuery, sectionsToComponents, defSqlQueryCfg, defPid, SqlQueryCfg (..), QueryComponents (..), NormalizedQuery (..), normalizeQuery, buildDateRange, buildGroupBy, buildOrderBy, buildLimit, buildWhereCondition, listToColNames, colsNoAsClause, defaultSelectSqlQuery, pSource, parseQueryToAST, ToQueryText (..), calculateAutoBinWidth, replacePlaceholders, variablePresets, variablePresetsKQL, constantToSQLList, constantToKQLList, defaultQueryLimit, wrapForRowExtraction) where
+module Pkg.Parser (queryASTToComponents, parseQueryToComponents, getProcessedColumns, fixedUTCTime, parseQuery, sectionsToComponents, defSqlQueryCfg, defPid, SqlQueryCfg (..), QueryComponents (..), NormalizedQuery (..), normalizeQuery, buildDateRange, buildGroupBy, buildOrderBy, buildLimit, buildWhereCondition, listToColNames, colsNoAsClause, defaultSelectSqlQuery, pSource, parseQueryToAST, ToQueryText (..), calculateAutoBinWidth, replacePlaceholders, variablePresets, variablePresetsKQL, constantToSQLList, constantToKQLList, defaultQueryLimit) where
 
 import Control.Error (hush)
 import Data.Default (Default (def))
@@ -536,18 +536,6 @@ colsNoAsClause = mapMaybe (\x -> Safe.headMay $ T.strip <$> T.splitOn "as" x)
 
 instance HasField "toColNames" QueryComponents [Text] where
   getField qc = qc.finalColumns
-
-
--- | Wrap an inner SELECT producing N columns in a single jsonb-array projection.
--- Replaces the legacy `json_agg(json_each(row_to_json(sub.*)) WITH ORDINALITY)`
--- idiom: both Postgres and TimeFusion ship `jsonb_build_array(VARIADIC any)`,
--- and derived-column aliases (`sub(c1..cN)`) decouple us from the inner SELECT
--- expression shapes. Same wire output as the legacy wrapper but avoids the
--- JSON-parser hazard on TEXT columns containing NULL bytes or lone surrogates.
-wrapForRowExtraction :: Int -> Text -> Text
-wrapForRowExtraction n inner =
-  let aliases = T.intercalate "," ["c" <> show i | i <- [1 .. n]]
-   in "SELECT jsonb_build_array(" <> aliases <> ") FROM (" <> inner <> ") sub(" <> aliases <> ")"
 
 
 -- | Replace all occurrences of {{key}} in the input text using the provided mapping.

--- a/src/Pkg/Parser.hs
+++ b/src/Pkg/Parser.hs
@@ -2,6 +2,7 @@
 module Pkg.Parser (queryASTToComponents, parseQueryToComponents, getProcessedColumns, fixedUTCTime, parseQuery, sectionsToComponents, defSqlQueryCfg, defPid, SqlQueryCfg (..), QueryComponents (..), NormalizedQuery (..), normalizeQuery, buildDateRange, buildGroupBy, buildOrderBy, buildLimit, buildWhereCondition, listToColNames, colsNoAsClause, defaultSelectSqlQuery, pSource, parseQueryToAST, ToQueryText (..), calculateAutoBinWidth, replacePlaceholders, variablePresets, variablePresetsKQL, constantToSQLList, constantToKQLList, defaultQueryLimit) where
 
 import Control.Error (hush)
+import Data.Char (isAlphaNum)
 import Data.Default (Default (def))
 import Data.Map.Strict qualified as Map
 import Data.Text qualified as T
@@ -14,7 +15,6 @@ import Pkg.Parser.Expr
 import Pkg.Parser.Stats
 import PyF (fmt)
 import Relude
-import Safe qualified
 import Text.Megaparsec (errorBundlePretty, parse)
 import Utils (formatUTC)
 
@@ -522,16 +522,37 @@ defaultSelectSqlQuery (Just SSpans) =
   ]
 
 
+-- | Split on a *trailing* @ as <ident>@ — leaves internal @as@ untouched
+-- (so @CAST(x AS VARCHAR)@ and @'$.id as ref'@ inside literals are safe).
+--
+-- >>> splitTrailingAlias "JSONB_ARRAY_LENGTH(errors) as errors_count"
+-- ("JSONB_ARRAY_LENGTH(errors)",Just "errors_count")
+-- >>> splitTrailingAlias "CAST(x AS VARCHAR)"
+-- ("CAST(x AS VARCHAR)",Nothing)
+splitTrailingAlias :: Text -> (Text, Maybe Text)
+splitTrailingAlias (T.strip -> t) = case T.breakOnEnd asNeedle t of
+  (pre, T.strip -> alias)
+    | not (T.null pre)
+    , not (T.null alias)
+    , T.all (\c -> isAlphaNum c || c == '_') alias ->
+        (T.strip $ T.dropEnd (T.length asNeedle) pre, Just alias)
+  _ -> (t, Nothing)
+  where
+    asNeedle = " as "
+
+
 -- >>> listToColNames ["id", "JSONB_ARRAY_LENGTH(errors) as errors_count"]
 -- ["id","errors_count"]
 listToColNames :: [Text] -> [Text]
-listToColNames = map \x -> T.strip $ last $ "" :| T.splitOn "as" x
+listToColNames = map \x -> case splitTrailingAlias x of
+  (expr, Nothing) -> expr
+  (_, Just alias) -> alias
 
 
 -- >>> colsNoAsClause ["id", "JSONB_ARRAY_LENGTH(errors) as errors_count"]
 -- ["id","JSONB_ARRAY_LENGTH(errors)"]
 colsNoAsClause :: [Text] -> [Text]
-colsNoAsClause = mapMaybe (\x -> Safe.headMay $ T.strip <$> T.splitOn "as" x)
+colsNoAsClause = map (fst . splitTrailingAlias)
 
 
 instance HasField "toColNames" QueryComponents [Text] where

--- a/src/Pkg/Queue.hs
+++ b/src/Pkg/Queue.hs
@@ -9,7 +9,6 @@ import Data.Annotation (toAnnotation)
 import Data.ByteString.Char8 qualified as BC
 import Data.ByteString.Lazy.Base64 qualified as LB64
 import Data.Effectful.Hasql qualified as Hasql
-import Models.Telemetry.Telemetry qualified as Telemetry
 import Data.Generics.Product (field)
 import Data.HashMap.Strict qualified as HM
 import Data.Map.Strict qualified as Map
@@ -27,6 +26,7 @@ import Kafka.Consumer qualified as K
 import Kafka.Producer qualified as KP
 import Log (LogLevel (..), Logger, runLogT)
 import Log qualified as LogBase
+import Models.Telemetry.Telemetry qualified as Telemetry
 import OpenTelemetry.Attributes qualified as OA
 import OpenTelemetry.Trace (TracerProvider)
 import Relude
@@ -154,7 +154,8 @@ pubsubService appLogger appCtx tp topics fn = checkpoint "pubsubService" do
                         setStatus sp (Error summary)
                         pure (Left wf)
             )
-            >>= liftIO . routeBatchOutcome appLogger appCtx "pubsub-service" topic validMsgs (maybeToMonoid firstAttrs)
+            >>= liftIO
+            . routeBatchOutcome appLogger appCtx "pubsub-service" topic validMsgs (maybeToMonoid firstAttrs)
 
         let acknowlegReq = PubSub.newAcknowledgeRequest & field @"ackIds" L..~ Just msgIds
         unless (null msgIds) $ void $ PubSub.newPubSubProjectsSubscriptionsAcknowledge acknowlegReq subscription & Google.send env

--- a/src/Pkg/Queue.hs
+++ b/src/Pkg/Queue.hs
@@ -9,6 +9,7 @@ import Data.Annotation (toAnnotation)
 import Data.ByteString.Char8 qualified as BC
 import Data.ByteString.Lazy.Base64 qualified as LB64
 import Data.Effectful.Hasql qualified as Hasql
+import Models.Telemetry.Telemetry qualified as Telemetry
 import Data.Generics.Product (field)
 import Data.HashMap.Strict qualified as HM
 import Data.Map.Strict qualified as Map
@@ -35,7 +36,7 @@ import System.Tracing (SpanStatus (..), addEvent, setStatus, withSpan)
 import System.Types (ATBackgroundCtx, runBackground)
 import UnliftIO (throwIO)
 import UnliftIO.Async (pooledForConcurrentlyN)
-import UnliftIO.Exception (bracket, try, tryAny)
+import UnliftIO.Exception (bracket, tryAny)
 import UnliftIO.MVar (modifyMVar)
 
 
@@ -96,7 +97,7 @@ closeSharedKafkaProducer = modifyMVar sharedKafkaProducer $ \case
 -- pubsubService connects to the pubsub service and listens for  messages,
 -- then it calls the processMessage function to process the messages, and
 -- acknoleges the list message in one request.
-pubsubService :: Log.Logger -> AuthContext -> TracerProvider -> [Text] -> ([(Text, ByteString)] -> HM.HashMap Text Text -> ATBackgroundCtx [Text]) -> IO ()
+pubsubService :: Log.Logger -> AuthContext -> TracerProvider -> [Text] -> ([(Text, ByteString)] -> HM.HashMap Text Text -> ATBackgroundCtx (Either Telemetry.WriteFailure ([Text], [Telemetry.PoisonMsg]))) -> IO ()
 pubsubService appLogger appCtx tp topics fn = checkpoint "pubsubService" do
   let envConfig = appCtx.config
   env <- case envConfig.googleServiceAccountB64 of
@@ -141,36 +142,19 @@ pubsubService appLogger appCtx tp topics fn = checkpoint "pubsubService" do
                   ]
                   \sp -> do
                     addEvent sp "batch.started" []
-                    result <- try $ fn validMsgs (maybeToMonoid firstAttrs)
-                    case result of
-                      Left (e :: SomeException) -> do
-                        let !errText = toText $ show e
-                        addEvent sp "batch.failed" [("error", OA.toAttribute errText)]
-                        setStatus sp (Error errText)
-                        throwIO e
-                      Right ids -> do
-                        addEvent sp "batch.completed" [("processed_count", OA.toAttribute (length ids))]
+                    res <- fn validMsgs (maybeToMonoid firstAttrs)
+                    case res of
+                      Right (ids, poison) -> do
+                        addEvent sp "batch.completed" [("processed_count", OA.toAttribute (length ids)), ("poison_count", OA.toAttribute (length poison))]
                         setStatus sp Ok
-                        pure ids
+                        pure (Right (ids, poison))
+                      Left wf -> do
+                        let !summary = Telemetry.writeFailureSummary wf
+                        addEvent sp "batch.write_failed" [("write_failure", OA.toAttribute summary)]
+                        setStatus sp (Error summary)
+                        pure (Left wf)
             )
-            >>= \case
-              Left e -> do
-                let !errText = toText $ show e
-                liftIO
-                  $ runLogT "pubsub-service" appLogger LogAttention
-                  $ LogBase.logAttention "pubsubService: error processing batch"
-                  $ AE.object ["error" AE..= errText, "topic" AE..= topic, "message_count" AE..= length validMsgs]
-                -- Transient (Hasql infra) → ack nothing; PubSub redelivers
-                -- after the ack deadline. Anything else is treated as poison
-                -- → park in DLQ; ack only if DLQ accepted.
-                if Hasql.isTransientException e
-                  then pure []
-                  else do
-                    dlqRes <- liftIO $ publishToDeadLetterQueue appLogger appCtx validMsgs (maybeToMonoid firstAttrs) errText
-                    case dlqRes of
-                      Right _ -> pure $ map fst validMsgs
-                      Left _ -> pure []
-              Right ids -> pure ids
+            >>= liftIO . routeBatchOutcome appLogger appCtx "pubsub-service" topic validMsgs (maybeToMonoid firstAttrs)
 
         let acknowlegReq = PubSub.newAcknowledgeRequest & field @"ackIds" L..~ Just msgIds
         unless (null msgIds) $ void $ PubSub.newPubSubProjectsSubscriptionsAcknowledge acknowlegReq subscription & Google.send env
@@ -208,7 +192,7 @@ publishJSONToKafka appCtx topicName jsonData attributes = checkpoint "publishJSO
     Right res -> pure res
 
 
-kafkaService :: Log.Logger -> AuthContext -> TracerProvider -> [Text] -> Int -> ([(Text, ByteString)] -> HM.HashMap Text Text -> ATBackgroundCtx [Text]) -> IO ()
+kafkaService :: Log.Logger -> AuthContext -> TracerProvider -> [Text] -> Int -> ([(Text, ByteString)] -> HM.HashMap Text Text -> ATBackgroundCtx (Either Telemetry.WriteFailure ([Text], [Telemetry.PoisonMsg]))) -> IO ()
 kafkaService appLogger appCtx tp kafkaTopics batchSize fn = checkpoint "kafkaService" do
   instanceUuid <- UUID.toText <$> UUID.nextRandom
   let clientId = "monoscope-" <> T.take 8 instanceUuid
@@ -263,32 +247,23 @@ kafkaService appLogger appCtx tp kafkaTopics batchSize fn = checkpoint "kafkaSer
                           ]
                         $ \sp -> do
                           addEvent sp "batch.started" []
-                          res <- try $ fn allRecords attributes
+                          res <- fn allRecords attributes
                           case res of
-                            Left (e :: SomeException) -> do
-                              let !errText = toText $ show e
-                              addEvent sp "batch.failed" [("error", OA.toAttribute errText)]
-                              setStatus sp (Error errText)
-                              throwIO e
-                            Right ids -> do
-                              addEvent sp "batch.completed" [("processed_count", OA.toAttribute (length ids))]
+                            Right (ids, poison) -> do
+                              addEvent sp "batch.completed" [("processed_count", OA.toAttribute (length ids)), ("poison_count", OA.toAttribute (length poison))]
                               setStatus sp Ok
-                              pure ids
-                      case result of
-                        Right _ -> pure successTps
-                        Left e -> do
-                          let !errText = toText $ show e
-                          LogBase.logAttention "kafkaService: error processing batch" (AE.object ["error" AE..= errText, "attributes" AE..= attributes])
-                          -- Hasql transient → don't commit (lag grows, librdkafka
-                          -- redelivers). Anything else is poison → park in DLQ
-                          -- and commit only if the DLQ publish succeeded.
-                          if Hasql.isTransientException e
-                            then pure []
-                            else do
-                              dlqRes <- liftIO $ publishToDeadLetterQueue appLogger appCtx allRecords attributes errText
-                              pure $ case dlqRes of
-                                Right _ -> successTps
-                                Left _ -> []
+                              pure (Right (ids, poison))
+                            Left wf -> do
+                              let !summary = Telemetry.writeFailureSummary wf
+                              addEvent sp "batch.write_failed" [("write_failure", OA.toAttribute summary)]
+                              setStatus sp (Error summary)
+                              pure (Left wf)
+                      -- Empty ack list = no commit (broker redelivers); non-empty
+                      -- = all source offsets in this (topic, partition) group are
+                      -- durable (either written or DLQ'd). Kafka can't partial-ack
+                      -- within a partition so we commit all-or-nothing here.
+                      acks <- liftIO $ routeBatchOutcome appLogger appCtx "kafka-service" topic allRecords attributes result
+                      pure $ if null acks then [] else successTps
               -- Bound must stay well under the hasql pool (shared with web) —
               -- AcquisitionTimeout (→ Hasql.isTransientException → no commit →
               -- redelivery storm) is the failure mode to avoid. Single committer
@@ -386,3 +361,62 @@ publishToDeadLetterQueue appLogger appCtx messages attributes errorReason = do
   -- sequence_ over [Either Text ()] yields the FIRST Left (and pure ()
   -- otherwise). Subsequent failures only appear in the dlq log above.
   pure $ sequence_ results
+
+
+-- | Decide which source-topic acks to commit given a batch's outcome.
+-- Returns an empty list when nothing should be committed (broker redelivers).
+--
+-- Semantics:
+--   * Right (writeAcks, []) — happy path; commit writeAcks.
+--   * Right (writeAcks, poison) — DLQ poison first; commit writeAcks ++ poisonAckIds
+--     only if DLQ accepted. On DLQ failure, commit nothing → broker redelivers.
+--   * Left WriteFailure — bounded retries exhausted inside retryHasqlWrite.
+--     DLQ the whole batch with side-tracking headers; commit only if DLQ accepted.
+--   * Left SomeException (non-write) — Hasql-transient: no commit, broker redelivers.
+--     Otherwise: DLQ the whole batch as opaque poison; commit only if DLQ accepted.
+routeBatchOutcome
+  :: Log.Logger
+  -> AuthContext
+  -> Text
+  -- ^ service name for log context ("pubsub-service" / "kafka-service")
+  -> Text
+  -- ^ topic for log context
+  -> [(Text, ByteString)]
+  -- ^ original validMsgs (used when we have to DLQ the whole batch)
+  -> HM.HashMap Text Text
+  -- ^ base attrs (ce-type etc.)
+  -> Either SomeException (Either Telemetry.WriteFailure ([Text], [Telemetry.PoisonMsg]))
+  -> IO [Text]
+routeBatchOutcome appLogger appCtx svc topic validMsgs attrs = \case
+  Right (Right (writeAcks, [])) -> pure writeAcks
+  Right (Right (writeAcks, poison)) -> do
+    let poisonBytes = [(ackId, raw) | (ackId, raw, _) <- poison]
+        poisonAckIds = [ackId | (ackId, _, _) <- poison]
+        firstReason = case poison of (_, _, r) : _ -> r
+        poisonAttrs = attrs <> HM.singleton "monoscope-poison-reason" firstReason
+    runLogT svc appLogger LogAttention
+      $ LogBase.logAttention "routeBatchOutcome: poison messages → DLQ"
+      $ AE.object ["topic" AE..= topic, "poison_count" AE..= length poison, "write_acks" AE..= length writeAcks]
+    publishToDeadLetterQueue appLogger appCtx poisonBytes poisonAttrs firstReason >>= \case
+      Right _ -> pure (writeAcks <> poisonAckIds)
+      Left _ -> pure [] -- broker redelivers; on retry the writes are repeated (need idempotency)
+  Right (Left wf) -> do
+    let summary = Telemetry.writeFailureSummary wf
+        dlqAttrs = attrs <> Telemetry.writeFailureDlqHeaders wf
+    runLogT svc appLogger LogAttention
+      $ LogBase.logAttention "routeBatchOutcome: write failure → DLQ"
+      $ AE.object ["topic" AE..= topic, "write_failure" AE..= summary, "message_count" AE..= length validMsgs]
+    publishToDeadLetterQueue appLogger appCtx validMsgs dlqAttrs summary >>= \case
+      Right _ -> pure (map fst validMsgs)
+      Left _ -> pure []
+  Left e -> do
+    let errText = toText (show e)
+    runLogT svc appLogger LogAttention
+      $ LogBase.logAttention "routeBatchOutcome: non-write exception"
+      $ AE.object ["topic" AE..= topic, "error" AE..= errText, "message_count" AE..= length validMsgs]
+    if Hasql.isTransientException e
+      then pure []
+      else
+        publishToDeadLetterQueue appLogger appCtx validMsgs attrs errText >>= \case
+          Right _ -> pure (map fst validMsgs)
+          Left _ -> pure []

--- a/src/Pkg/Queue.hs
+++ b/src/Pkg/Queue.hs
@@ -393,8 +393,8 @@ routeBatchOutcome appLogger appCtx svc topic validMsgs attrs = \case
   Right (Right (writeAcks, poison)) -> do
     let poisonBytes = [(ackId, raw) | (ackId, raw, _) <- poison]
         poisonAckIds = [ackId | (ackId, _, _) <- poison]
-        firstReason = case poison of (_, _, r) : _ -> r
-        poisonAttrs = attrs <> HM.singleton "monoscope-poison-reason" firstReason
+        firstReason = maybe "" (\(_, _, r) -> r) (listToMaybe poison)
+        poisonAttrs = attrs <> one ("monoscope-poison-reason", firstReason)
     runLogT svc appLogger LogAttention
       $ LogBase.logAttention "routeBatchOutcome: poison messages → DLQ"
       $ AE.object ["topic" AE..= topic, "poison_count" AE..= length poison, "write_acks" AE..= length writeAcks]

--- a/src/ProcessMessage.hs
+++ b/src/ProcessMessage.hs
@@ -1,5 +1,10 @@
 {-# LANGUAGE PartialTypeSignatures #-}
 {-# LANGUAGE StrictData #-}
+{-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
+-- processMessages uses @pure $!@ to force the (ackId, raw, span) tuple to
+-- WHNF immediately, preventing thunk accumulation across forM. hlint flags
+-- it as "Redundant $!" but it's load-bearing here.
+{-# HLINT ignore "Redundant $!" #-}
 
 module ProcessMessage (
   processMessages,

--- a/src/ProcessMessage.hs
+++ b/src/ProcessMessage.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE PartialTypeSignatures #-}
 {-# LANGUAGE StrictData #-}
 {-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
+
 -- processMessages uses @pure $!@ to force the (ackId, raw, span) tuple to
 -- WHNF immediately, preventing thunk accumulation across forM. hlint flags
 -- it as "Redundant $!" but it's load-bearing here.

--- a/src/ProcessMessage.hs
+++ b/src/ProcessMessage.hs
@@ -36,12 +36,12 @@ import Data.Effectful.Hasql qualified as Hasql
 import Data.Effectful.UUID (UUIDEff)
 import Data.Effectful.UUID qualified as UUID
 import Data.HashMap.Strict qualified as HM
+import Data.HashSet qualified as HS
 import Data.HashTable.Class qualified as HTC
 import Data.HashTable.ST.Cuckoo qualified as HT
 import Data.Text qualified as T
 import Data.Time (addUTCTime, zonedTimeToUTC)
 import Data.Time.LocalTime (ZonedTime)
-import Data.HashSet qualified as HS
 import Data.Tuple.Extra (fst3)
 import Data.UUID qualified as UUID
 import Data.Vector qualified as V

--- a/src/ProcessMessage.hs
+++ b/src/ProcessMessage.hs
@@ -69,6 +69,7 @@ import Pkg.SchemaLearning.Catalog qualified as Catalog
 import Pkg.SchemaLearning.Catalog qualified as Fields
 import Pkg.SchemaLearning.Hot qualified as SchemaHot
 import Relude hiding (ask)
+import Relude.Extra.Tuple (toSnd)
 import Relude.Unsafe qualified as Unsafe
 import System.Config (AuthContext (..), EnvConfig (..))
 import System.Logging qualified as Log
@@ -482,7 +483,7 @@ extractObservation canonicalTemplates otelSpan =
       -> V.Vector (Text, V.Vector AE.Value)
       -> [(Text, V.Vector (AE.Value, Maybe Text), Fields.FieldCategoryEnum)]
     tagWalk cat fields0 =
-      [ (path, V.map (\v -> (v, formatHint v)) vs, cat)
+      [ (path, V.map (toSnd formatHint) vs, cat)
       | (path, vs) <- V.toList fields0
       ]
 

--- a/src/ProcessMessage.hs
+++ b/src/ProcessMessage.hs
@@ -190,7 +190,7 @@ processMessages msgs attrs =
         Metrics.timed Metrics.ingestWriteHist []
           $ Telemetry.insertAndHandOff appCtx.env.enableTimefusionWrites appCtx.extractionWorker projectCaches (V.map (\(_, _, s) -> s) paired)
 
-    let pairedSpans = case mWrite of Just (_, p) -> p; Nothing -> V.empty
+    let pairedSpans = maybe V.empty snd mWrite
         idToSource = HM.fromList [(s.id, (a, r)) | (a, r, s) <- V.toList pairedSpans]
     pure $ case writeRes of
       Left wf -> Left wf

--- a/src/ProcessMessage.hs
+++ b/src/ProcessMessage.hs
@@ -41,6 +41,7 @@ import Data.HashTable.ST.Cuckoo qualified as HT
 import Data.Text qualified as T
 import Data.Time (addUTCTime, zonedTimeToUTC)
 import Data.Time.LocalTime (ZonedTime)
+import Data.HashSet qualified as HS
 import Data.Tuple.Extra (fst3)
 import Data.UUID qualified as UUID
 import Data.Vector qualified as V
@@ -136,18 +137,22 @@ processMessages
   :: (Concurrent :> es, DB es, Eff.Reader AuthContext :> es, Ki.StructuredConcurrency :> es, Labeled "timefusion" Hasql.Hasql :> es, Log :> es, Tracing :> es, UUIDEff :> es)
   => [(Text, ByteString)]
   -> HM.HashMap Text Text
-  -> Eff es [Text]
-processMessages [] _ = pure []
+  -> Eff es (Either Telemetry.WriteFailure ([Text], [Telemetry.PoisonMsg]))
+processMessages [] _ = pure (Right ([], []))
 processMessages msgs attrs =
   withSpan_ "pubsub.process_messages" (batchSpanAttrs (length msgs) attrs) do
     appCtx <- Eff.ask @AuthContext
-    (rMsgs, mWrite) <- Metrics.timed Metrics.ingestDecodeHist [] do
-      rMsgs <-
-        catMaybes <$> forM msgs \(ackId, msg) -> case AE.eitherDecodeStrict (BS.filter (/= 0) msg) of
-          Left err -> Nothing <$ Log.logAttention "Error parsing json msgs" (object ["AckId" .= ackId, "Error" .= err, "OriginalMsg" .= decodeUtf8 @Text msg])
-          Right m -> pure $ Just (ackId, BS.length msg, m)
+    (rAckIds, poison, mWrite) <- Metrics.timed Metrics.ingestDecodeHist [] do
+      let decoded =
+            [ (ackId, msg, AE.eitherDecodeStrict (BS.filter (/= 0) msg))
+            | (ackId, msg) <- msgs
+            ]
+          rMsgs = [(ackId, msg, m) | (ackId, msg, Right m) <- decoded]
+          poison = [(ackId, msg, toText err) | (ackId, msg, Left err) <- decoded]
+      forM_ poison \(ackId, msg, err) ->
+        Log.logAttention "Error parsing json msgs" (object ["AckId" .= ackId, "Error" .= err, "OriginalMsg" .= decodeUtf8 @Text msg])
       if null rMsgs
-        then pure (rMsgs, Nothing)
+        then pure (map (\(a, _, _) -> a) rMsgs, poison, Nothing)
         else do
           projectCaches <-
             liftIO $ HM.fromList <$> forM (ordNub $ (\(_, _, m) -> UUIDId m.projectId) <$> rMsgs) \pid -> do
@@ -157,24 +162,40 @@ processMessages msgs attrs =
                   . Projects.projectCacheByIdIO appCtx.hasqlJobsPool
               pure (pid, cache)
 
-          spans <- forM rMsgs \(_, rawSize, msg) -> runMaybeT do
+          -- Track (ackId, raw) alongside each emitted span so we can map any
+          -- per-row write poison back to the source message for DLQ routing.
+          paired <- forM rMsgs \(ackId, raw, msg) -> runMaybeT do
             let pid = UUIDId msg.projectId
-                !msgSize = fromIntegral rawSize
+                !msgSize = fromIntegral (BS.length raw)
             cache <- hoistMaybe $ HM.lookup pid projectCaches
             let !totalDailyEvents = fromIntegral cache.dailyEventCount + fromIntegral cache.dailyMetricCount
                 !isFreeTier = cache.paymentPlan == "Free"
             guard $ not (isFreeTier && totalDailyEvents >= freeTierDailyMaxEvents)
             spanId <- lift UUID.genUUID
             trId <- lift $ UUID.toText <$> UUID.genUUID
-            pure $! convertRequestMessageToSpan msg msgSize (spanId, trId)
+            pure $! (ackId, raw, convertRequestMessageToSpan msg msgSize (spanId, trId))
 
-          pure (rMsgs, Just (projectCaches, V.fromList (catMaybes spans)))
+          pure (map (\(a, _, _) -> a) rMsgs, poison, Just (projectCaches, V.fromList (catMaybes paired)))
 
-    forM_ mWrite \(projectCaches, spanVec) ->
-      Metrics.timed Metrics.ingestWriteHist []
-        $ Telemetry.insertAndHandOff appCtx.env.enableTimefusionWrites appCtx.extractionWorker projectCaches spanVec
+    writeRes <- case mWrite of
+      Nothing -> pure (Right V.empty)
+      Just (projectCaches, paired) ->
+        Metrics.timed Metrics.ingestWriteHist []
+          $ Telemetry.insertAndHandOff appCtx.env.enableTimefusionWrites appCtx.extractionWorker projectCaches (V.map (\(_, _, s) -> s) paired)
 
-    pure $ map fst3 rMsgs
+    let pairedSpans = case mWrite of Just (_, p) -> p; Nothing -> V.empty
+        idToSource = HM.fromList [(s.id, (a, r)) | (a, r, s) <- V.toList pairedSpans]
+    pure $ case writeRes of
+      Left wf -> Left wf
+      Right rowPoison ->
+        let writePoison =
+              [ (ackId, raw, "row insert failed")
+              | (s, _) <- V.toList rowPoison
+              , Just (ackId, raw) <- [HM.lookup s.id idToSource]
+              ]
+            poisonAcks = HS.fromList [a | (a, _, _) <- writePoison]
+            successAcks = filter (\a -> not (HS.member a poisonAcks)) rAckIds
+         in Right (successAcks, poison <> writePoison)
 
 
 -- | Process a single span to extract entities for hash-stamping.

--- a/src/ProcessMessage.hs
+++ b/src/ProcessMessage.hs
@@ -158,7 +158,7 @@ processMessages msgs attrs =
       forM_ poison \(ackId, msg, err) ->
         Log.logAttention "Error parsing json msgs" (object ["AckId" .= ackId, "Error" .= err, "OriginalMsg" .= decodeUtf8 @Text msg])
       if null rMsgs
-        then pure (map (\(a, _, _) -> a) rMsgs, poison, Nothing)
+        then pure ([], poison, Nothing)
         else do
           projectCaches <-
             liftIO $ HM.fromList <$> forM (ordNub $ (\(_, _, m) -> UUIDId m.projectId) <$> rMsgs) \pid -> do
@@ -195,8 +195,8 @@ processMessages msgs attrs =
       Left wf -> Left wf
       Right rowPoison ->
         let writePoison =
-              [ (ackId, raw, "row insert failed")
-              | (s, _) <- V.toList rowPoison
+              [ (ackId, raw, Telemetry.poisonReason info)
+              | (s, info) <- V.toList rowPoison
               , Just (ackId, raw) <- [HM.lookup s.id idToSource]
               ]
             poisonAcks = HS.fromList [a | (a, _, _) <- writePoison]

--- a/src/System/Logging.hs
+++ b/src/System/Logging.hs
@@ -87,7 +87,7 @@ makeLogger dest action = inner dest (action . tolerantLogger)
 -- and Warp's onException — taking the whole process down. Wrapping at the
 -- `Logger` boundary protects every log site at once.
 tolerantLogger :: Logger -> Logger
-tolerantLogger l = l{loggerWriteMessage = \m -> void $ Safe.tryAny (loggerWriteMessage l m)}
+tolerantLogger l = l{loggerWriteMessage = void . Safe.tryAny . loggerWriteMessage l}
 
 
 newtype FileBackendConfig = FileBackendConfig

--- a/src/Web/I18n.hs
+++ b/src/Web/I18n.hs
@@ -45,9 +45,7 @@ languageCode Es = "es"
 -- | Translate a key in the given language. Missing keys return the key itself
 -- so typos surface visibly in the UI (rather than rendering empty strings).
 t :: Language -> Text -> Text
-t lang key = case Map.lookup key (dict lang) of
-  Just v -> v
-  Nothing -> key
+t lang key = fromMaybe key (Map.lookup key (dict lang))
 
 
 dict :: Language -> Map.Map Text Text

--- a/test/integration/MonitoringSpec.hs
+++ b/test/integration/MonitoringSpec.hs
@@ -76,7 +76,9 @@ spec = aroundAll withTestResources do
             , ("m5", toStrict $ AE.encode reqMsg2)
             ]
       r <- runTestBg frozenTime tr $ processMessages msgs HashMap.empty
-      r `shouldBe` ["m1", "m2", "m4", "m5", "m5"]
+      case r of
+        Right (ids, _poison) -> ids `shouldBe` ["m1", "m2", "m4", "m5", "m5"]
+        Left _ -> expectationFailure "processMessages returned Left WriteFailure"
 
       pendingJobs <- getPendingBackgroundJobs tr.trATCtx
       logBackgroundJobsInfo tr.trLogger pendingJobs

--- a/test/integration/Opentelemetry/TimefusionWriteFailureSpec.hs
+++ b/test/integration/Opentelemetry/TimefusionWriteFailureSpec.hs
@@ -1,0 +1,134 @@
+-- | Regression for the silent data-loss bug where `processList` swallowed
+-- every exception from the write path and returned ackIds of a failed batch.
+-- The Kafka/PubSub consumers in `Pkg.Queue` commit offsets for whatever
+-- ackIds processList returns, so a successful return on a failed write =
+-- lost data (observed 40-min outage 2026-06-10).
+--
+-- Fix: remove the swallowing `onException` in `processList`. Pkg.Queue's
+-- batch-failure handler (Queue.hs:163-172) already does the right thing on
+-- exception: Hasql-transient → no ack (broker redelivers), anything else →
+-- publishToDeadLetterQueue + ack only if DLQ accepted.
+module Opentelemetry.TimefusionWriteFailureSpec (spec) where
+
+import Data.HashMap.Strict qualified as HM
+import Data.List qualified as L
+import Data.ProtoLens (encodeMessage)
+import Data.UUID qualified as UUID
+import Models.Projects.Projects qualified as Projects
+import Opentelemetry.OtlpServer qualified as OtlpServer
+import Pkg.DeriveUtils (UUIDId (..), mkHasqlPool)
+import Pkg.TestUtils
+import Relude
+import UnliftIO.Exception (try)
+import System.Config (AuthContext (..), EnvConfig (..))
+import Test.Hspec (Spec, SpecWith, aroundAll, beforeWith, describe, expectationFailure, it, shouldBe)
+
+
+-- | A closed loopback port. Pool acquire fails with ECONNREFUSED so we
+-- exercise the TF-write-failure path without standing up a second DB.
+badTfConnStr :: ByteString
+badTfConnStr = "postgresql://postgres:postgres@127.0.0.1:1/postgres"
+
+
+-- | Route attrs that pin the batch to the OTLP-logs decoder.
+logsAttrs :: HM.HashMap Text Text
+logsAttrs = HM.fromList [("ce-type", "org.opentelemetry.otlp.logs.v1")]
+
+
+-- | One valid logs proto bound to a real (DB-resident) API key so processBatchPipeline
+-- actually emits rows to write. Without a real key, `projectIdsByProjectApiKeys`
+-- returns empty, the convert step yields zero rows, and dbInsert is never called —
+-- making the TF-down case look like a successful no-op.
+validLogMsg :: Text -> Text -> (Text, ByteString)
+validLogMsg apiKey ackId =
+  (ackId, encodeMessage $ createOtelLogAtTime apiKey ["valid record from " <> ackId] frozenTime)
+
+
+-- | A bytestring that's NOT a valid OTLP logs proto — exercise the decode-fail
+-- path. processBatchPipeline buckets these as "no-work" and acks them so they
+-- don't poison the queue forever.
+corruptMsg :: Text -> (Text, ByteString)
+corruptMsg ackId = (ackId, "this is not a valid protobuf payload")
+
+
+demoProjectId :: Projects.ProjectId
+demoProjectId = UUIDId UUID.nil
+
+
+-- | Wrap a test in a TestResources whose labeled "timefusion" pool points at a
+-- closed port — every TF write attempt fails fast.
+withBrokenTf :: TestResources -> (TestResources -> IO ()) -> IO ()
+withBrokenTf tr k = do
+  badTfPool <- mkHasqlPool 1 badTfConnStr
+  let origCtx = tr.trATCtx
+      ctxBadTf =
+        origCtx
+          { hasqlTimefusionPool = badTfPool
+          , env = origCtx.env {enableTimefusionWrites = True}
+          , config = origCtx.config {enableTimefusionWrites = True}
+          }
+  k tr {trATCtx = ctxBadTf}
+
+
+-- | Bind a fresh API key to the demo project before each spec so the
+-- decode/convert path actually produces rows to write. Returns @(TestResources, apiKey)@.
+mkResWithKey :: TestResources -> IO (TestResources, Text)
+mkResWithKey tr = do
+  key <- createTestAPIKey tr demoProjectId "tf-write-failure-spec"
+  pure (tr, key)
+
+
+-- | Run processList, expecting it to THROW. Returns Right on exception
+-- (correct behaviour: Pkg.Queue will see the throw and DLQ-or-redeliver) and
+-- Left on a non-throwing return (bug: ackIds get committed, batch dropped).
+expectProcessListThrows :: TestResources -> [(Text, ByteString)] -> HM.HashMap Text Text -> IO ()
+expectProcessListThrows tr msgs attrs = do
+  res <- try @_ @SomeException $ runTestBg frozenTime tr $ OtlpServer.processList msgs attrs
+  case res of
+    Left _ -> pass
+    Right ackIds ->
+      expectationFailure
+        $ "processList returned successfully when an exception was expected; "
+        <> "Pkg.Queue would commit these ackIds and drop the batch: "
+        <> show ackIds
+
+
+spec :: SpecWith ()
+spec = aroundAll withTestResources $ beforeWith mkResWithKey do
+  describe "processList exception propagation (Pkg.Queue handles DLQ-or-redeliver)" do
+    it "writes succeed → all ackIds returned, nothing thrown" \(tr, key) -> do
+      let msgs = [validLogMsg key "ack-good-1", validLogMsg key "ack-good-2"]
+      ackIds <- runTestBg frozenTime tr $ OtlpServer.processList msgs logsAttrs
+      L.sort ackIds `shouldBe` ["ack-good-1", "ack-good-2"]
+
+    it "all good msgs + TF down → exception PROPAGATES (Queue.hs will DLQ or no-ack)" \(tr, key) ->
+      withBrokenTf tr \tr' -> do
+        let msgs = [validLogMsg key "ack-good-1", validLogMsg key "ack-good-2"]
+        expectProcessListThrows tr' msgs logsAttrs
+
+    it "single good msg + TF down → exception propagates (original 40-min-data-loss bug repro)" \(tr, key) ->
+      withBrokenTf tr \tr' -> do
+        tr'.trATCtx.env.enableTimefusionWrites `shouldBe` True
+        expectProcessListThrows tr' [validLogMsg key "kafka-ack-1"] logsAttrs
+
+    it "mixed batch (good + corrupt) + TF down → exception propagates (whole batch DLQ'd by Queue.hs)" \(tr, key) ->
+      withBrokenTf tr \tr' -> do
+        -- All-or-nothing: Pkg.Queue receives the throw and routes the entire
+        -- batch (good + corrupt) to the DLQ. Manual investigation can split
+        -- them apart later. No partial-ack at this layer — bulk write is atomic.
+        let msgs = [validLogMsg key "ack-good", corruptMsg "ack-poison"]
+        expectProcessListThrows tr' msgs logsAttrs
+
+    -- TODO(dlq-decode-failures): currently decode-failed messages are
+    -- log-and-acked rather than DLQ'd. This is pre-existing behaviour, not a
+    -- regression — but the user's stated policy is "manual investigation for
+    -- anything unprocessable", which means decode failures should route through
+    -- the DLQ too. Tracked separately; see memory note `processBatchPipeline_dlq_decode_failures`.
+    it "corrupt-only batch + TF healthy → corrupt acked + logged (KNOWN GAP: should be DLQ'd)" \(tr, _) -> do
+      ackIds <- runTestBg frozenTime tr $ OtlpServer.processList [corruptMsg "ack-poison"] logsAttrs
+      ackIds `shouldBe` ["ack-poison"]
+
+    it "mixed batch (good + corrupt) + TF healthy → both acked, corrupt logged" \(tr, key) -> do
+      let msgs = [validLogMsg key "ack-good", corruptMsg "ack-poison"]
+      ackIds <- runTestBg frozenTime tr $ OtlpServer.processList msgs logsAttrs
+      L.sort ackIds `shouldBe` ["ack-good", "ack-poison"]

--- a/test/integration/Opentelemetry/TimefusionWriteFailureSpec.hs
+++ b/test/integration/Opentelemetry/TimefusionWriteFailureSpec.hs
@@ -3,10 +3,6 @@
 -- pubsubService pattern-match on the result and route 'Left' to the DLQ with
 -- side-tracking headers (which side(s) succeeded / failed) so the replay tool
 -- can rewrite only the missing side.
---
--- Regression target: the 2026-06-10 40-min outage where the previous
--- onException + return-all-ackIds path silently dropped every batch whose TF
--- write failed.
 module Opentelemetry.TimefusionWriteFailureSpec (spec) where
 
 import Control.Exception (ErrorCall (..), evaluate)

--- a/test/integration/Opentelemetry/TimefusionWriteFailureSpec.hs
+++ b/test/integration/Opentelemetry/TimefusionWriteFailureSpec.hs
@@ -1,52 +1,50 @@
--- | Regression for the silent data-loss bug where `processList` swallowed
--- every exception from the write path and returned ackIds of a failed batch.
--- The Kafka/PubSub consumers in `Pkg.Queue` commit offsets for whatever
--- ackIds processList returns, so a successful return on a failed write =
--- lost data (observed 40-min outage 2026-06-10).
+-- | processList must surface dual-write outcomes via 'Either WriteFailure',
+-- never as a swallowed exception or a silent ack. Pkg.Queue.kafkaService /
+-- pubsubService pattern-match on the result and route 'Left' to the DLQ with
+-- side-tracking headers (which side(s) succeeded / failed) so the replay tool
+-- can rewrite only the missing side.
 --
--- Fix: remove the swallowing `onException` in `processList`. Pkg.Queue's
--- batch-failure handler (Queue.hs:163-172) already does the right thing on
--- exception: Hasql-transient → no ack (broker redelivers), anything else →
--- publishToDeadLetterQueue + ack only if DLQ accepted.
+-- Regression target: the 2026-06-10 40-min outage where the previous
+-- onException + return-all-ackIds path silently dropped every batch whose TF
+-- write failed.
 module Opentelemetry.TimefusionWriteFailureSpec (spec) where
 
+import Control.Exception (ErrorCall (..), evaluate)
+import UnliftIO.Exception (try)
 import Data.HashMap.Strict qualified as HM
 import Data.List qualified as L
 import Data.ProtoLens (encodeMessage)
+import Data.These (These (..))
+import Data.These.Combinators (isThat, isThese, isThis)
 import Data.UUID qualified as UUID
 import Models.Projects.Projects qualified as Projects
+import Models.Telemetry.Telemetry qualified as Telemetry
 import Opentelemetry.OtlpServer qualified as OtlpServer
 import Pkg.DeriveUtils (UUIDId (..), mkHasqlPool)
 import Pkg.TestUtils
 import Relude
-import UnliftIO.Exception (try)
 import System.Config (AuthContext (..), EnvConfig (..))
-import Test.Hspec (Spec, SpecWith, aroundAll, beforeWith, describe, expectationFailure, it, shouldBe)
+import Test.Hspec (HasCallStack, SpecWith, aroundAll, beforeWith, describe, expectationFailure, it, pendingWith, shouldBe)
 
 
 -- | A closed loopback port. Pool acquire fails with ECONNREFUSED so we
--- exercise the TF-write-failure path without standing up a second DB.
-badTfConnStr :: ByteString
-badTfConnStr = "postgresql://postgres:postgres@127.0.0.1:1/postgres"
+-- exercise the write-failure path without standing up a second DB.
+badConnStr :: ByteString
+badConnStr = "postgresql://postgres:postgres@127.0.0.1:1/postgres"
 
 
--- | Route attrs that pin the batch to the OTLP-logs decoder.
 logsAttrs :: HM.HashMap Text Text
 logsAttrs = HM.fromList [("ce-type", "org.opentelemetry.otlp.logs.v1")]
 
 
--- | One valid logs proto bound to a real (DB-resident) API key so processBatchPipeline
--- actually emits rows to write. Without a real key, `projectIdsByProjectApiKeys`
--- returns empty, the convert step yields zero rows, and dbInsert is never called —
--- making the TF-down case look like a successful no-op.
+-- | A valid logs proto bound to a real (DB-resident) API key. Without one,
+-- projectIdsByProjectApiKeys returns empty, the convert step yields zero rows,
+-- and dbInsert is never called — making "TF down" look like a healthy no-op.
 validLogMsg :: Text -> Text -> (Text, ByteString)
 validLogMsg apiKey ackId =
   (ackId, encodeMessage $ createOtelLogAtTime apiKey ["valid record from " <> ackId] frozenTime)
 
 
--- | A bytestring that's NOT a valid OTLP logs proto — exercise the decode-fail
--- path. processBatchPipeline buckets these as "no-work" and acks them so they
--- don't poison the queue forever.
 corruptMsg :: Text -> (Text, ByteString)
 corruptMsg ackId = (ackId, "this is not a valid protobuf payload")
 
@@ -55,80 +53,158 @@ demoProjectId :: Projects.ProjectId
 demoProjectId = UUIDId UUID.nil
 
 
--- | Wrap a test in a TestResources whose labeled "timefusion" pool points at a
--- closed port — every TF write attempt fails fast.
 withBrokenTf :: TestResources -> (TestResources -> IO ()) -> IO ()
 withBrokenTf tr k = do
-  badTfPool <- mkHasqlPool 1 badTfConnStr
+  badPool <- mkHasqlPool 1 badConnStr
   let origCtx = tr.trATCtx
-      ctxBadTf =
+      ctx =
         origCtx
-          { hasqlTimefusionPool = badTfPool
+          { hasqlTimefusionPool = badPool
           , env = origCtx.env {enableTimefusionWrites = True}
           , config = origCtx.config {enableTimefusionWrites = True}
           }
-  k tr {trATCtx = ctxBadTf}
+  k tr {trATCtx = ctx}
 
 
--- | Bind a fresh API key to the demo project before each spec so the
--- decode/convert path actually produces rows to write. Returns @(TestResources, apiKey)@.
+-- | Override the main Hasql pool with one that can't connect. Pins down "PG
+-- is mandatory" — the previous log-and-continue branch silently lost the PG
+-- side, leaving dashboards short rows.
+withBrokenPg :: TestResources -> (TestResources -> IO ()) -> IO ()
+withBrokenPg tr k = do
+  badPool <- mkHasqlPool 1 badConnStr
+  let origCtx = tr.trATCtx
+      ctx =
+        origCtx
+          { hasqlPool = badPool
+          , env = origCtx.env {enableTimefusionWrites = True}
+          , config = origCtx.config {enableTimefusionWrites = True}
+          }
+  k tr {trATCtx = ctx}
+
+
 mkResWithKey :: TestResources -> IO (TestResources, Text)
 mkResWithKey tr = do
   key <- createTestAPIKey tr demoProjectId "tf-write-failure-spec"
   pure (tr, key)
 
 
--- | Run processList, expecting it to THROW. Returns Right on exception
--- (correct behaviour: Pkg.Queue will see the throw and DLQ-or-redeliver) and
--- Left on a non-throwing return (bug: ackIds get committed, batch dropped).
-expectProcessListThrows :: TestResources -> [(Text, ByteString)] -> HM.HashMap Text Text -> IO ()
-expectProcessListThrows tr msgs attrs = do
-  res <- try @_ @SomeException $ runTestBg frozenTime tr $ OtlpServer.processList msgs attrs
-  case res of
-    Left _ -> pass
-    Right ackIds ->
-      expectationFailure
-        $ "processList returned successfully when an exception was expected; "
-        <> "Pkg.Queue would commit these ackIds and drop the batch: "
-        <> show ackIds
+expectLeftMatching
+  :: HasCallStack
+  => Text
+  -> (Telemetry.WriteFailure -> Bool)
+  -> Either Telemetry.WriteFailure ([Text], [Telemetry.PoisonMsg])
+  -> IO ()
+expectLeftMatching what predicate = \case
+  Right (acks, poison) ->
+    expectationFailure
+      $ toString
+      $ "expected " <> what <> " (Left WriteFailure); got Right with acks="
+      <> show acks
+      <> " poison="
+      <> show (map (\(a, _, _) -> a) poison)
+  Left wf
+    | predicate wf -> pass
+    | otherwise ->
+        expectationFailure
+          $ toString
+          $ "expected " <> what <> "; got Left with summary: " <> Telemetry.writeFailureSummary wf
 
 
 spec :: SpecWith ()
 spec = aroundAll withTestResources $ beforeWith mkResWithKey do
-  describe "processList exception propagation (Pkg.Queue handles DLQ-or-redeliver)" do
-    it "writes succeed → all ackIds returned, nothing thrown" \(tr, key) -> do
+  describe "processList Either contract (dual-write outcome surfaces to Pkg.Queue)" do
+    it "writes succeed → Right (acks, no poison)" \(tr, key) -> do
       let msgs = [validLogMsg key "ack-good-1", validLogMsg key "ack-good-2"]
-      ackIds <- runTestBg frozenTime tr $ OtlpServer.processList msgs logsAttrs
-      L.sort ackIds `shouldBe` ["ack-good-1", "ack-good-2"]
+      res <- runTestBg frozenTime tr $ OtlpServer.processList msgs logsAttrs
+      case res of
+        Right (acks, poison) -> do
+          L.sort acks `shouldBe` ["ack-good-1", "ack-good-2"]
+          poison `shouldBe` []
+        Left wf ->
+          expectationFailure
+            $ "expected Right; got Left " <> toString (Telemetry.writeFailureSummary wf)
 
-    it "all good msgs + TF down → exception PROPAGATES (Queue.hs will DLQ or no-ack)" \(tr, key) ->
-      withBrokenTf tr \tr' -> do
-        let msgs = [validLogMsg key "ack-good-1", validLogMsg key "ack-good-2"]
-        expectProcessListThrows tr' msgs logsAttrs
-
-    it "single good msg + TF down → exception propagates (original 40-min-data-loss bug repro)" \(tr, key) ->
+    it "TF down → Left (That tfErr) — TF-only failure" \(tr, key) ->
       withBrokenTf tr \tr' -> do
         tr'.trATCtx.env.enableTimefusionWrites `shouldBe` True
-        expectProcessListThrows tr' [validLogMsg key "kafka-ack-1"] logsAttrs
+        res <- runTestBg frozenTime tr' $ OtlpServer.processList [validLogMsg key "ack-1"] logsAttrs
+        expectLeftMatching "TF-only failure" isThat res
 
-    it "mixed batch (good + corrupt) + TF down → exception propagates (whole batch DLQ'd by Queue.hs)" \(tr, key) ->
+    -- PG-down trips the project-key lookup before any write attempt. With
+    -- queryProjectIdByKey now propagating Hasql errors (silent-swallow fix),
+    -- processList THROWS HasqlException rather than returning Left WriteFailure.
+    -- Pkg.Queue's outer tryAny catches and routes via DLQ-or-redeliver.
+    it "PG down → processList throws (Pkg.Queue routes to DLQ)" \(tr, key) ->
+      withBrokenPg tr \tr' -> do
+        res <- try @_ @SomeException $ runTestBg frozenTime tr' $ OtlpServer.processList [validLogMsg key "ack-1"] logsAttrs
+        case res of
+          Left _ -> pass
+          Right v -> expectationFailure $ "expected exception; got " <> show v
+
+    it "both down → processList throws (lookup fails first, Pkg.Queue DLQs)" \(tr, key) -> do
+      badPool1 <- mkHasqlPool 1 badConnStr
+      badPool2 <- mkHasqlPool 1 badConnStr
+      let origCtx = tr.trATCtx
+          ctx =
+            origCtx
+              { hasqlPool = badPool1
+              , hasqlTimefusionPool = badPool2
+              , env = origCtx.env {enableTimefusionWrites = True}
+              , config = origCtx.config {enableTimefusionWrites = True}
+              }
+          tr' = tr {trATCtx = ctx}
+      res <- try @_ @SomeException $ runTestBg frozenTime tr' $ OtlpServer.processList [validLogMsg key "ack-1"] logsAttrs
+      case res of
+        Left _ -> pass
+        Right v -> expectationFailure $ "expected exception; got " <> show v
+
+    it "mixed batch (good + corrupt) + TF down → Left wf (whole batch DLQ'd)" \(tr, key) ->
       withBrokenTf tr \tr' -> do
-        -- All-or-nothing: Pkg.Queue receives the throw and routes the entire
-        -- batch (good + corrupt) to the DLQ. Manual investigation can split
-        -- them apart later. No partial-ack at this layer — bulk write is atomic.
         let msgs = [validLogMsg key "ack-good", corruptMsg "ack-poison"]
-        expectProcessListThrows tr' msgs logsAttrs
+        res <- runTestBg frozenTime tr' $ OtlpServer.processList msgs logsAttrs
+        expectLeftMatching "TF-only failure on mixed batch" isThat res
 
-    -- TODO(dlq-decode-failures): currently decode-failed messages are
-    -- log-and-acked rather than DLQ'd. This is pre-existing behaviour, not a
-    -- regression — but the user's stated policy is "manual investigation for
-    -- anything unprocessable", which means decode failures should route through
-    -- the DLQ too. Tracked separately; see memory note `processBatchPipeline_dlq_decode_failures`.
-    it "corrupt-only batch + TF healthy → corrupt acked + logged (KNOWN GAP: should be DLQ'd)" \(tr, _) -> do
-      ackIds <- runTestBg frozenTime tr $ OtlpServer.processList [corruptMsg "ack-poison"] logsAttrs
-      ackIds `shouldBe` ["ack-poison"]
+    -- TODO(dlq-decode-failures): pre-existing gap — decode failures are
+    -- log-and-acked rather than DLQ'd. See feedback memory
+    -- `data-loss-must-be-manual` for the policy this still needs to satisfy.
+    it "corrupt-only batch + TF healthy → Right ([], [poison]); Pkg.Queue DLQs it" \(tr, _) -> do
+      res <- runTestBg frozenTime tr $ OtlpServer.processList [corruptMsg "ack-poison"] logsAttrs
+      case res of
+        Right (acks, poison) -> do
+          acks `shouldBe` []
+          map (\(a, _, _) -> a) poison `shouldBe` ["ack-poison"]
+        Left wf -> expectationFailure $ "expected Right; got Left " <> toString (Telemetry.writeFailureSummary wf)
 
-    it "mixed batch (good + corrupt) + TF healthy → both acked, corrupt logged" \(tr, key) -> do
+    it "mixed batch (good + corrupt) + TF healthy → Right (good acked, corrupt in poison list)" \(tr, key) -> do
       let msgs = [validLogMsg key "ack-good", corruptMsg "ack-poison"]
-      ackIds <- runTestBg frozenTime tr $ OtlpServer.processList msgs logsAttrs
-      L.sort ackIds `shouldBe` ["ack-good", "ack-poison"]
+      res <- runTestBg frozenTime tr $ OtlpServer.processList msgs logsAttrs
+      case res of
+        Right (acks, poison) -> do
+          acks `shouldBe` ["ack-good"]
+          map (\(a, _, _) -> a) poison `shouldBe` ["ack-poison"]
+        Left wf ->
+          expectationFailure
+            $ "expected Right; got Left " <> toString (Telemetry.writeFailureSummary wf)
+
+  describe "DLQ side-tracking headers (writeFailureDlqHeaders)" do
+    it "PG-only failure → pg-succeeded=false, tf-succeeded=true" \(_, _) -> do
+      pgErr <- toException <$> evaluate (ErrorCall "synthetic pg")
+      let hdrs = Telemetry.writeFailureDlqHeaders (This pgErr)
+      HM.lookup "monoscope-write-failure" hdrs `shouldBe` Just "pg-failed"
+      HM.lookup "monoscope-pg-succeeded" hdrs `shouldBe` Just "false"
+      HM.lookup "monoscope-tf-succeeded" hdrs `shouldBe` Just "true"
+
+    it "TF-only failure → pg-succeeded=true, tf-succeeded=false" \(_, _) -> do
+      tfErr <- toException <$> evaluate (ErrorCall "synthetic tf")
+      let hdrs = Telemetry.writeFailureDlqHeaders (That tfErr)
+      HM.lookup "monoscope-write-failure" hdrs `shouldBe` Just "tf-failed"
+      HM.lookup "monoscope-pg-succeeded" hdrs `shouldBe` Just "true"
+      HM.lookup "monoscope-tf-succeeded" hdrs `shouldBe` Just "false"
+
+    it "both failed → both sides false" \(_, _) -> do
+      pgErr <- toException <$> evaluate (ErrorCall "synthetic pg")
+      tfErr <- toException <$> evaluate (ErrorCall "synthetic tf")
+      let hdrs = Telemetry.writeFailureDlqHeaders (These pgErr tfErr)
+      HM.lookup "monoscope-write-failure" hdrs `shouldBe` Just "both-failed"
+      HM.lookup "monoscope-pg-succeeded" hdrs `shouldBe` Just "false"
+      HM.lookup "monoscope-tf-succeeded" hdrs `shouldBe` Just "false"

--- a/test/integration/Opentelemetry/TimefusionWriteFailureSpec.hs
+++ b/test/integration/Opentelemetry/TimefusionWriteFailureSpec.hs
@@ -160,9 +160,6 @@ spec = aroundAll withTestResources $ beforeWith mkResWithKey do
         res <- runTestBg frozenTime tr' $ OtlpServer.processList msgs logsAttrs
         expectLeftMatching "TF-only failure on mixed batch" isThat res
 
-    -- TODO(dlq-decode-failures): pre-existing gap — decode failures are
-    -- log-and-acked rather than DLQ'd. See feedback memory
-    -- `data-loss-must-be-manual` for the policy this still needs to satisfy.
     it "corrupt-only batch + TF healthy → Right ([], [poison]); Pkg.Queue DLQs it" \(tr, _) -> do
       res <- runTestBg frozenTime tr $ OtlpServer.processList [corruptMsg "ack-poison"] logsAttrs
       case res of

--- a/test/integration/ProcessMessageSpec.hs
+++ b/test/integration/ProcessMessageSpec.hs
@@ -12,7 +12,7 @@ import Pkg.TestUtils
 import ProcessMessage (processMessages)
 import Relude
 import Relude.Unsafe qualified as Unsafe
-import Test.Hspec (Spec, aroundAll, describe, it, shouldBe, shouldContain)
+import Test.Hspec (Spec, aroundAll, describe, expectationFailure, it, shouldBe, shouldContain)
 
 
 pid :: Projects.ProjectId
@@ -28,7 +28,9 @@ spec = aroundAll withTestResources do
       let jsonMsg = "{\"duration\":737639,\"host\":\"3.228.92.161\",\"method\":\"POST\",\"path_params\":{\"0\":\"/service/extension/backup/mboximport\"},\"project_id\":\"00000000-0000-0000-0000-000000000000\",\"proto_minor\":1,\"proto_major\":1,\"query_params\":{\"account-name\":[\"admin\"],\"account-status\":[\"1\"],\"ow\":[\"cmd\"]},\"raw_url\":\"/service/extension/backup/mboximport?account-name=admin&account-status=1&ow=cmd\",\"referer\":\"\",\"request_body\":\"e30=\",\"request_headers\":{\"connection\":[\"upgrade\"],\"host\":[\"3.228.92.161\"],\"x-real-ip\":[\"172.31.5.55\"],\"x-forwarded-for\":[\"138.199.34.206, 172.31.5.55\"],\"content-length\":[\"716\"],\"x-forwarded-proto\":[\"http\"],\"x-forwarded-port\":[\"80\"],\"x-amzn-trace-id\":[\"Root=1-65e01ff0-22108e1659ac458930d6e9b0\"],\"user-agent\":[\"Mozilla/5.0 (Windows NT 6.3; Win64; x64; rv:92.0) Gecko/20100101 Firefox/92.0\"],\"accept-encoding\":[\"gzip, deflate\"],\"content-type\":[\"application/x-www-form-urlencoded\"]},\"response_body\":\"Tm90IEZvdW5k\",\"response_headers\":{\"x-powered-by\":[\"Express\"],\"vary\":[\"Origin\"],\"access-control-allow-credentials\":[\"true\"],\"content-type\":[\"text/html; charset=utf-8\"],\"content-length\":[\"9\"],\"etag\":[\"W/\\\"9-0gXL1ngzMqISxa6S1zx3F4wtLyg\\\"\"]},\"sdk_type\":\"JsExpress\",\"status_code\":404,\"timestamp\":\"" <> toString nowTxt <> "\",\"url_path\":\"/service/extension/backup/mboximport\",\"errors\":[],\"tags\":[],\"msg_id\":\"fdadc75d-5710-49cd-adfd-2d7547c9ab17\"}"
       let msgs = [("m1", encodeUtf8 jsonMsg)]
       resp <- runTestBg frozenTime tr $ processMessages msgs HashMap.empty
-      resp `shouldBe` ["m1"]
+      case resp of
+        Right (ids, _poison) -> ids `shouldBe` ["m1"]
+        Left _ -> expectationFailure "processMessages returned Left WriteFailure"
 
     it "should save the request" $ \tr -> do
       currentTime <- getCurrentTime
@@ -40,7 +42,9 @@ spec = aroundAll withTestResources do
             , ("m2", toStrict $ AE.encode reqMsg2)
             ]
       resp <- runTestBg frozenTime tr $ processMessages msgs HashMap.empty
-      resp `shouldBe` ["m1", "m2"]
+      case resp of
+        Right (ids, _poison) -> ids `shouldBe` ["m1", "m2"]
+        Left _ -> expectationFailure "processMessages returned Left WriteFailure"
 
     it "We should expect 2 endpoints, albeit unacknowleged." $ \tr -> do
       currentTime <- getCurrentTime

--- a/test/integration/ReplaySpec.hs
+++ b/test/integration/ReplaySpec.hs
@@ -18,7 +18,7 @@ import Pkg.ErrorMetrics (wireTypeErrorsRef)
 import Pkg.DeriveUtils (UUIDId (..))
 import Pkg.TestUtils
 import Relude
-import Test.Hspec (Spec, aroundAll, describe, expectationFailure, it, pendingWith, shouldBe, shouldSatisfy)
+import Test.Hspec (Spec, aroundAll, describe, expectationFailure, it, pendingWith, shouldBe, shouldContain, shouldSatisfy)
 
 
 pid :: Projects.ProjectId
@@ -246,13 +246,17 @@ spec = aroundAll withTestResources do
             , ("ack-oversized", oversize)
             ]
           frozen = UTCTime (fromGregorian 2026 5 8) 0
-      acked <- runTestBg frozen tr $ processReplayEvents batch HM.empty
+      ackedRes <- runTestBg frozen tr $ processReplayEvents batch HM.empty
       decodeAfter <- readCounter "replay:decode_error"
       oversizeAfter <- readCounter "replay:oversize_message"
-      -- Parser-valid messages (good + empty-strings) AND the corrupt one are
-      -- all acknowledged. Oversized is dropped pre-parse and not in the
-      -- returned ack list (pre-existing behavior; redelivered by kafka).
-      sort acked `shouldBe` sort ["ack-good", "ack-empty-strings", "ack-corrupt"]
+      -- Parser-valid messages (good + empty-strings) land in the ack list;
+      -- the truly corrupt one goes to the poison list so Pkg.Queue can DLQ
+      -- it (no silent drop). Oversized is also poison.
+      case ackedRes of
+        Right (acked, poison) -> do
+          sort acked `shouldBe` sort ["ack-good", "ack-empty-strings"]
+          sort (map (\(a, _, _) -> a) poison) `shouldContain` ["ack-corrupt"]
+        Left _ -> expectationFailure "processReplayEvents returned Left; replay path never surfaces WriteFailure"
       -- The load-bearing assertion: only the truly-corrupt JSON bumped the
       -- decode counter. Before the fix this would be 2.
       decodeAfter - decodeBefore `shouldBe` 1
@@ -265,7 +269,11 @@ spec = aroundAll withTestResources do
       acked <- runTestBg frozen tr $ processReplayEvents [] HM.empty
       decodeAfter <- readCounter "replay:decode_error"
       oversizeAfter <- readCounter "replay:oversize_message"
-      acked `shouldBe` []
+      case acked of
+        Right (ids, poison) -> do
+          ids `shouldBe` []
+          poison `shouldBe` []
+        Left _ -> expectationFailure "processReplayEvents returned Left WriteFailure"
       decodeAfter `shouldBe` decodeBefore
       oversizeAfter `shouldBe` oversizeBefore
 
@@ -325,7 +333,9 @@ spec = aroundAll withTestResources do
         sid <- UUID.fromWords 0 0 0 100 & pure
         clearSessionRow tr sid
         acked <- runTestBg frozen tr $ processReplayEvents [("ack-1", mkBody sid nonEmptyEvents)] HM.empty
-        acked `shouldBe` ["ack-1"]
+        case acked of
+          Right (ids, _poison) -> ids `shouldBe` ["ack-1"]
+          Left _ -> expectationFailure "processReplayEvents returned Left WriteFailure"
         events <- fetchEventsFor tr sid
         -- Ingested array must come back byte-equivalent (rrweb relies on
         -- exact event objects + timestamp ordering).
@@ -341,7 +351,9 @@ spec = aroundAll withTestResources do
         sid <- UUID.fromWords 0 0 0 101 & pure
         clearSessionRow tr sid
         acked <- runTestBg frozen tr $ processReplayEvents [("ack-empty", mkBody sid emptyStringEvents)] HM.empty
-        acked `shouldBe` ["ack-empty"]
+        case acked of
+          Right (ids, _poison) -> ids `shouldBe` ["ack-empty"]
+          Left _ -> expectationFailure "processReplayEvents returned Left WriteFailure"
         events <- fetchEventsFor tr sid
         AE.Array events `shouldBe` emptyStringEvents
         clearSessionRow tr sid


### PR DESCRIPTION
## Summary

Builds on top of PR #422, depends on TimeFusion PR #49 (`WildcardFnArgExpander`).

With qualifier-wildcard expansion working on both backends, the row-extraction wrapper collapses to a single one-line shape:

```sql
SELECT jsonb_build_array(sub.*) FROM (<inner>) sub
```

That lets us:

- Drop the `Int` column-count parameter from `executeArbitraryQuery`.
- Drop the `+ fromEnum queryComponents.hasCountOver` accounting in `selectLogTable` (PG's `*` expansion already covers the synthetic `count(*) OVER()` column).
- Drop the `colCount <= 0 → V.empty` guard (no parameter to guard against).
- Retire the legacy `json_each(row_to_json(*)) WITH ORDINALITY` wrapper that `executeSecuredQuery` still carried, along with its TODO. `executeSecuredQuery` now just LIMIT-wraps the user query and delegates to `executeArbitraryQuery`.

Net: −22 lines, one wrapper shape across all four call sites (`selectLogTable`, `fetchEventExamples`, `Pages.Dashboards.processVariable` / `processConstant`, `Pkg.AI.executeSqlQuery`).

## Order of operations

1. Land TF PR #49 (analyzer rule).
2. Deploy TF dev cluster with #49.
3. Land PR #422 (this PR's parent — `executeArbitraryQuery` with `c1..cN` aliases; safe under either TF version).
4. Land this PR after TF #49 is live in dev.

## Test plan

- [x] `cabal build lib:monoscope` — clean compile.
- [ ] Manual: run the original failing log-explorer query against the dev TimeFusion cluster (depends on TF #49 deploy).
- [ ] PG regression suite still passes (`jsonb_build_array(sub.*)` is native in PG).