### PR TITLE
fix(log-list): coerce non-string summary elements instead of throwing

### DIFF
--- a/web-components/src/log-list.ts
+++ b/web-components/src/log-list.ts
@@ -1581,7 +1581,9 @@ export class LogList extends LitElement {
   private parseSummaryData(dataArr: any[]): string[] {
     const cim = this._renderOverrides?.colIdxMap ?? this.colIdxMap;
     const summary = lookupVecValue<string[] | string>(dataArr, cim, 'summary');
-    if (Array.isArray(summary)) return summary;
+    // Coerce non-string elements (e.g. a TF to_jsonb that re-parsed JSON-looking
+    // text) so one bad element can't throw and blank the whole row.
+    if (Array.isArray(summary)) return summary.map((e) => (typeof e === 'string' ? e : JSON.stringify(e)));
     try {
       return typeof summary === 'string' ? JSON.parse(summary) : [];
     } catch (err) {

--- a/web-components/src/log-list.ts
+++ b/web-components/src/log-list.ts
@@ -1583,7 +1583,7 @@ export class LogList extends LitElement {
     const summary = lookupVecValue<string[] | string>(dataArr, cim, 'summary');
     // Coerce non-string elements (e.g. a TF to_jsonb that re-parsed JSON-looking
     // text) so one bad element can't throw and blank the whole row.
-    if (Array.isArray(summary)) return summary.map((e) => (typeof e === 'string' ? e : JSON.stringify(e)));
+    if (Array.isArray(summary)) return summary.map((e) => (typeof e === 'string' ? e : JSON.stringify(e) ?? ''));
     try {
       return typeof summary === 'string' ? JSON.parse(summary) : [];
     } catch (err) {


### PR DESCRIPTION
When TimeFusion reads are enabled, `to_jsonb(summary)` re-parses JSON-looking `text[]` elements into objects (root cause fixed in monoscope-tech/timefusion#53). `parseSummaryElement` then calls `.indexOf` on a non-string and the whole row renders as "Error rendering row: e.indexOf is not a function".

`parseSummaryData` now stringifies non-string elements — `JSON.stringify` of the mis-parsed value reproduces the original element text, so rows render correctly even against TF binaries that predate the upstream fix.