### PR TITLE
kafka: DLQ replay consumer — requeue carousel with attempt counts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,12 +40,15 @@ live-test-reload-all:
 # Integration tests with lib+test in ONE GHCi target (Jade's "cabal test-dev" trick).
 # `:reload` crosses src/<->test/ boundaries — no relink between iterations.
 # `-osuf dyn_o -hisuf dyn_hi` reuses .dyn_o artifacts cabal already wrote.
-# Filter with: TEST_MATCH=/MonitoringSpec/ make live-test-dev
+# Filter with: TEST_MATCH=Monitoring make live-test-dev
+# (hspec-discover node names drop the module's "Spec" suffix)
+# NB: GHCi's :main only strips quotes at token start, so `--match="X"` would
+# pass the quote chars to hspec and silently match nothing — keep the space form.
 TEST_MATCH ?=
 live-test-dev:
 	USE_EXTERNAL_DB=true LOG_LEVEL=attention \
 	ghcid --command 'cabal repl monoscope:test:test-dev --ghc-options="-osuf dyn_o -hisuf dyn_hi -O0" --with-compiler=$(GHC)' \
-		--test ':main $(if $(TEST_MATCH),--match="$(TEST_MATCH)")' --warnings 2>&1 | tee build-test-dev.log
+		--test ':main $(if $(TEST_MATCH),--match "$(TEST_MATCH)")' --warnings 2>&1 | tee build-test-dev.log
 
 hot-reload:
 	livereload -f reload.trigger static/public/ & \

--- a/src/Opentelemetry/OtlpServer.hs
+++ b/src/Opentelemetry/OtlpServer.hs
@@ -409,7 +409,10 @@ processList msgs !attrs =
             )
         _ -> do
           Log.logAttention "processList: unsupported opentelemetry data type" (AE.object ["ce-type" AE..= HM.lookup "ce-type" attrs])
-          pure (Right ([], []))
+          -- Poison (→ DLQ) instead of Right ([], []): empty acks never
+          -- commit/ack, which would stall the partition on these records
+          -- forever (hot redelivery loop).
+          pure (Right ([], [(ackId, raw, "unsupported ce-type") | (ackId, raw) <- msgs]))
 
 
 processBatchPipeline

--- a/src/Pkg/Queue.hs
+++ b/src/Pkg/Queue.hs
@@ -1,4 +1,4 @@
-module Pkg.Queue (pubsubService, kafkaService, publishJSONToKafka, publishToDeadLetterQueue, closeSharedKafkaProducer) where
+module Pkg.Queue (pubsubService, kafkaService, KafkaRole (..), publishJSONToKafka, publishToDeadLetterQueue, closeSharedKafkaProducer) where
 
 import Control.Exception.Annotated (checkpoint)
 import Control.Lens ((^?), _Just)
@@ -36,6 +36,7 @@ import System.Tracing (SpanStatus (..), addEvent, setStatus, withSpan)
 import System.Types (ATBackgroundCtx, runBackground)
 import UnliftIO (throwIO)
 import UnliftIO.Async (pooledForConcurrentlyN)
+import UnliftIO.Concurrent (threadDelay)
 import UnliftIO.Exception (bracket, tryAny)
 import UnliftIO.MVar (modifyMVar)
 
@@ -193,13 +194,21 @@ publishJSONToKafka appCtx topicName jsonData attributes = checkpoint "publishJSO
     Right res -> pure res
 
 
-kafkaService :: Log.Logger -> AuthContext -> TracerProvider -> [Text] -> Int -> ([(Text, ByteString)] -> HM.HashMap Text Text -> ATBackgroundCtx (Either Telemetry.WriteFailure ([Text], [Telemetry.PoisonMsg]))) -> IO ()
-kafkaService appLogger appCtx tp kafkaTopics batchSize fn = checkpoint "kafkaService" do
+-- | Which consumer loop this is. 'KafkaDlqReplay' consumes the dead-letter
+-- topic under its own consumer group (\"\<kafkaGroupId\>_dlq\" — a shared group
+-- would rebalance DLQ partitions onto primary consumers). Failures there
+-- republish to the DLQ tail with a bumped @monoscope-attempt-count@ header and
+-- commit, so every message retries in a loop and none is ever dropped; a
+-- growing DLQ with rising attempt counts is the signal for an engineer to
+-- inspect and prune manually.
+data KafkaRole = KafkaPrimary | KafkaDlqReplay
+  deriving stock (Eq)
+
+
+kafkaService :: Log.Logger -> AuthContext -> TracerProvider -> KafkaRole -> [Text] -> Int -> ([(Text, ByteString)] -> HM.HashMap Text Text -> ATBackgroundCtx (Either Telemetry.WriteFailure ([Text], [Telemetry.PoisonMsg]))) -> IO ()
+kafkaService appLogger appCtx tp role kafkaTopics batchSize fn = checkpoint "kafkaService" do
   instanceUuid <- UUID.toText <$> UUID.nextRandom
   let clientId = "monoscope-" <> T.take 8 instanceUuid
-      -- DLQ is intentionally NOT subscribed: re-consuming our own dead letters
-      -- in the live loop just amplifies pain during a sustained downstream
-      -- outage. Drain it via a separate one-off script when needed.
       consumerSub = K.topics (map K.TopicName kafkaTopics) <> K.offsetReset K.Earliest
 
   -- Single LogT context for the whole service; client_id (and other static
@@ -208,7 +217,7 @@ kafkaService appLogger appCtx tp kafkaTopics batchSize fn = checkpoint "kafkaSer
   runLogT "kafka-service" appLogger LogInfo
     $ LogBase.localData
       [ "client_id" AE..= clientId
-      , "group_id" AE..= appCtx.config.kafkaGroupId
+      , "group_id" AE..= groupId
       ]
       do
         LogBase.logInfo "Starting Kafka consumer service" (AE.object ["topics" AE..= kafkaTopics, "brokers" AE..= appCtx.config.kafkaBrokers])
@@ -229,26 +238,26 @@ kafkaService appLogger appCtx tp kafkaTopics batchSize fn = checkpoint "kafkaSer
               -- groups stall only their own partition's commits.
               -- Map (not HashMap): KP.PartitionId has Ord but no Hashable instance.
               let byTP = foldr (\r -> Map.insertWith (<>) (r.crTopic.unTopicName, r.crPartition) (r :| [])) Map.empty rightRecords
-                  processGroup ((topic, _partition), neRecords@(recc :| _)) = do
-                    let headers = consumerRecordHeadersToHashMap recc
-                        ceType = ceTypeFor appCtx.config.kafkaDeadLetterTopic topic headers
-                        attributes = HM.insert "ce-type" ceType headers
-                        allRecords = consumerRecordToTuple <$> toList neRecords
-                        successTps = tpsFor topic neRecords
-                    LogBase.localData ["topic" AE..= topic, "ce_type" AE..= ceType, "record_count" AE..= length allRecords] do
+                  attrsFor topic r = let h = consumerRecordHeadersToHashMap r in HM.insert "ce-type" (ceTypeFor appCtx.config.kafkaDeadLetterTopic topic h) h
+                  -- One fn invocation + outcome routing for records sharing one
+                  -- header set. True ⇔ every record is durable (written or DLQ'd)
+                  -- and its offset may advance.
+                  runChunk topic records attrs = do
+                    let ceType = HM.lookupDefault "" "ce-type" attrs
+                    LogBase.localData ["topic" AE..= topic, "ce_type" AE..= ceType, "record_count" AE..= length records] do
                       result <- liftIO
                         $ tryAny
                         $ runBackground appLogger appCtx tp
                         $ withSpan
                           "kafka.process_batch"
                           [ ("topic", OA.toAttribute topic)
-                          , ("message_count", OA.toAttribute (length allRecords))
+                          , ("message_count", OA.toAttribute (length records))
                           , ("ce-type", OA.toAttribute ceType)
                           , ("client_id", OA.toAttribute clientId)
                           ]
                         $ \sp -> do
                           addEvent sp "batch.started" []
-                          res <- fn allRecords attributes
+                          res <- fn records attrs
                           case res of
                             Right (ids, poison) -> do
                               addEvent sp "batch.completed" [("processed_count", OA.toAttribute (length ids)), ("poison_count", OA.toAttribute (length poison))]
@@ -260,23 +269,46 @@ kafkaService appLogger appCtx tp kafkaTopics batchSize fn = checkpoint "kafkaSer
                               setStatus sp (Error summary)
                               pure (Left wf)
                       -- Empty ack list = no commit (broker redelivers); non-empty
-                      -- = all source offsets in this (topic, partition) group are
-                      -- durable (either written or DLQ'd). Kafka can't partial-ack
-                      -- within a partition so we commit all-or-nothing here.
-                      acks <- liftIO $ routeBatchOutcome appLogger appCtx "kafka-service" topic allRecords attributes result
-                      pure $ if null acks then [] else successTps
+                      -- = durable. Kafka can't partial-ack within a partition so
+                      -- processGroup commits all-or-nothing per partition group.
+                      not . null <$> liftIO (routeBatchOutcome appLogger appCtx "kafka-service" topic records attrs result)
+                  processGroup ((topic, _partition), neRecords@(recc :| _)) = do
+                    committable <- case role of
+                      KafkaPrimary -> runChunk topic (consumerRecordToTuple <$> toList neRecords) (attrsFor topic recc)
+                      -- DLQ partitions interleave requeues from different source
+                      -- topics (round-robin publish), so one batch-level ce-type
+                      -- would mis-decode the minority and bake the wrong ce-type
+                      -- into their requeued headers. Process per record under its
+                      -- own headers; short-circuit on the first non-durable record
+                      -- (the rest redelivers with it — duplicates over loss).
+                      KafkaDlqReplay -> allM (\r -> runChunk topic [consumerRecordToTuple r] (attrsFor topic r)) (toList neRecords)
+                    pure $ if committable then tpsFor topic neRecords else []
               -- Bound must stay well under the hasql pool (shared with web) —
               -- AcquisitionTimeout (→ Hasql.isTransientException → no commit →
               -- redelivery storm) is the failure mode to avoid. Single committer
               -- (this thread) below — no concurrent commitPartitionsOffsets.
               tps <- concat <$> pooledForConcurrentlyN appCtx.config.kafkaGroupConcurrency (Map.toList byTP) processGroup
 
-              -- No poll-thread backoff: lag growth is the outage signal under
-              -- per-partition commits. A reintroduced `threadDelay` here races
-              -- max.poll.interval.ms and triggers cooperative-sticky rebalances.
+              -- No poll-thread backoff on primary topics: lag growth is the outage
+              -- signal under per-partition commits. A reintroduced `threadDelay`
+              -- here races max.poll.interval.ms and triggers cooperative-sticky
+              -- rebalances.
               unless (null tps)
                 $ whenJustM (K.commitPartitionsOffsets K.OffsetCommitAsync consumer tps) throwIO
+
+              -- DLQ replay is a requeue carousel: failures republish to the tail
+              -- and commit, so on a short queue a poison message would otherwise
+              -- cycle consume→fail→requeue several times a second. Pause when the
+              -- poll came back short (at the tail, i.e. mostly just-requeued
+              -- records); full batches — a real backlog drain — run at full
+              -- speed. 30s stays well under max.poll.interval.ms (300s).
+              when (role == KafkaDlqReplay && length rightRecords < batchSize)
+                $ threadDelay 30_000_000
   where
+    groupId = case role of
+      KafkaPrimary -> appCtx.config.kafkaGroupId
+      KafkaDlqReplay -> appCtx.config.kafkaGroupId <> "_dlq"
+
     consumerRecordToTuple :: K.ConsumerRecord (Maybe ByteString) (Maybe ByteString) -> (Text, ByteString)
     consumerRecordToTuple record = (record.crTopic.unTopicName, fromMaybe "" record.crValue)
 
@@ -306,7 +338,7 @@ kafkaService appLogger appCtx tp kafkaTopics batchSize fn = checkpoint "kafkaSer
     consumerProps :: EnvConfig -> Text -> K.ConsumerProperties
     consumerProps cfg clientId =
       K.brokersList (map K.BrokerAddress cfg.kafkaBrokers)
-        <> K.groupId (K.ConsumerGroupId cfg.kafkaGroupId)
+        <> K.groupId (K.ConsumerGroupId groupId)
         <> K.clientId (K.ClientId clientId)
         <> K.extraProp "security.protocol" "sasl_plaintext"
         <> K.extraProp "sasl.mechanism" "SCRAM-SHA-256"
@@ -328,6 +360,33 @@ kafkaService appLogger appCtx tp kafkaTopics batchSize fn = checkpoint "kafkaSer
       _ -> ""
 
 
+-- | Headers stamped on every DLQ publish. Left-biased '<>' keeps first-failure
+-- forensics (original-topic, original-ack-id, failed-at) intact across
+-- DLQ-replay requeues, while attempt-count, error-reason and last-failed-at
+-- refresh on every pass — an engineer inspecting a growing DLQ sees how often
+-- and why each message keeps failing.
+--
+-- >>> let requeued = dlqHeaders "tf down" "t1" "otlp_logs" mempty
+-- >>> let again = dlqHeaders "pg down" "t2" "monoscope-dlq" requeued
+-- >>> (HM.lookup "monoscope-attempt-count" again, HM.lookup "error-reason" again, HM.lookup "last-failed-at" again)
+-- (Just "2",Just "pg down",Just "t2")
+-- >>> (HM.lookup "original-topic" again, HM.lookup "failed-at" again)
+-- (Just "otlp_logs",Just "t1")
+dlqHeaders :: Text -> Text -> Text -> HM.HashMap Text Text -> HM.HashMap Text Text
+dlqHeaders errorReason failedAt origTopicOrAckId attributes =
+  HM.fromList
+    [ ("monoscope-attempt-count", show (1 + fromMaybe 0 (readMaybe . toString =<< HM.lookup "monoscope-attempt-count" attributes) :: Int))
+    , ("error-reason", errorReason)
+    , ("last-failed-at", failedAt)
+    ]
+    <> attributes
+    <> HM.fromList
+      [ ("original-topic", origTopicOrAckId)
+      , ("original-ack-id", origTopicOrAckId)
+      , ("failed-at", failedAt)
+      ]
+
+
 -- | Publish failed messages to dead letter queue. Returns the first Left if
 -- any individual publish failed so the caller can refuse to advance the
 -- upstream offset/ack — otherwise a broken DLQ silently drops poison data.
@@ -343,14 +402,7 @@ publishToDeadLetterQueue appLogger appCtx messages attributes errorReason = do
   let deadLetterTopic = appCtx.config.kafkaDeadLetterTopic
   currentTime <- getCurrentTime
   results <- forM messages \(origTopicOrAckId, msgData) -> do
-    let deadLetterAttrs =
-          attributes
-            <> HM.fromList
-              [ ("original-topic", origTopicOrAckId)
-              , ("original-ack-id", origTopicOrAckId)
-              , ("error-reason", errorReason)
-              , ("failed-at", toText $ show currentTime)
-              ]
+    let deadLetterAttrs = dlqHeaders errorReason (toText $ show currentTime) origTopicOrAckId attributes
     result <- publishJSONToKafka appCtx deadLetterTopic (BC.unpack msgData) deadLetterAttrs
     case result of
       Left err -> do

--- a/src/System/Config.hs
+++ b/src/System/Config.hs
@@ -126,6 +126,11 @@ data EnvConfig = EnvConfig
   , enableTimefusionReads :: Bool
   , enableTimefusionWrites :: Bool
   , kafkaDeadLetterTopic :: Text
+  , enableKafkaDeadLetterService :: Bool
+  -- ^ Consume 'kafkaDeadLetterTopic' back through processList under its own
+  -- consumer group. Failures requeue to the DLQ tail with a bumped
+  -- attempt-count header — messages loop until they succeed or an engineer
+  -- prunes them manually.
   , enableFreetier :: Bool
   , enableBrowserMonitoring :: Bool
   , enableSessionReplay :: Bool
@@ -219,6 +224,7 @@ instance DefConfig EnvConfig where
       , openaiModel = "gpt-5.4-mini"
       , openaiSmallModel = "gpt-5.4-nano"
       , kafkaGroupConcurrency = 4
+      , enableKafkaDeadLetterService = True
       , extractionWorkerShards = 4
       , extractionQueueCapacity = 64
       , drainFlushBatchSize = 1000

--- a/src/System/Server.hs
+++ b/src/System/Server.hs
@@ -142,9 +142,12 @@ runServer appLogger env tp = do
         , guard env.config.enablePubsubService $> async (supervise logExc "pubsub" $ Queue.pubsubService appLogger env tp env.config.requestPubsubTopics processMessages)
         , Just $ async $ supervise logExc "background-jobs" bgJobWorker
         , Just $ async $ supervise logExc "otlp-grpc" $ OtlpServer.runServer appLogger env tp
-        , guard (env.config.enableKafkaService && not (any T.null env.config.kafkaTopics)) $> async (supervise logExc "kafka" $ Queue.kafkaService appLogger env tp env.config.kafkaTopics env.config.messagesPerPubsubPullBatch OtlpServer.processList)
-        , guard (env.config.enableKafkaService && not (any T.null env.config.kafkaTopics)) $> async (supervise logExc "kafka" $ Queue.kafkaService appLogger env tp env.config.kafkaTopics env.config.messagesPerPubsubPullBatch OtlpServer.processList)
-        , guard env.config.enableReplayService $> async (supervise logExc "kafka-replay" $ Queue.kafkaService appLogger env tp env.config.rrwebTopics effectiveReplayBatch processReplayEvents)
+        , guard (env.config.enableKafkaService && not (any T.null env.config.kafkaTopics)) $> async (supervise logExc "kafka" $ Queue.kafkaService appLogger env tp Queue.KafkaPrimary env.config.kafkaTopics env.config.messagesPerPubsubPullBatch OtlpServer.processList)
+        , guard (env.config.enableKafkaService && not (any T.null env.config.kafkaTopics)) $> async (supervise logExc "kafka" $ Queue.kafkaService appLogger env tp Queue.KafkaPrimary env.config.kafkaTopics env.config.messagesPerPubsubPullBatch OtlpServer.processList)
+        , -- Small batch: DLQ replay is a retry carousel, not steady-state ingest;
+          -- a poison-heavy batch should not stall a large offset window.
+          guard (env.config.enableKafkaService && env.config.enableKafkaDeadLetterService && not (T.null env.config.kafkaDeadLetterTopic)) $> async (supervise logExc "kafka-dlq" $ Queue.kafkaService appLogger env tp Queue.KafkaDlqReplay [env.config.kafkaDeadLetterTopic] 50 OtlpServer.processList)
+        , guard env.config.enableReplayService $> async (supervise logExc "kafka-replay" $ Queue.kafkaService appLogger env tp Queue.KafkaPrimary env.config.rrwebTopics effectiveReplayBatch processReplayEvents)
         ]
       <> fmap Just workerFibers
   void $ liftIO $ waitAnyCancel asyncs

--- a/test/integration/Opentelemetry/TimefusionWriteFailureSpec.hs
+++ b/test/integration/Opentelemetry/TimefusionWriteFailureSpec.hs
@@ -160,6 +160,18 @@ spec = aroundAll withTestResources $ beforeWith mkResWithKey do
         res <- runTestBg frozenTime tr' $ OtlpServer.processList msgs logsAttrs
         expectLeftMatching "TF-only failure on mixed batch" isThat res
 
+    -- Regression: this used to return Right ([], []) — no acks, no poison —
+    -- which never commits/acks and stalls the partition on these records
+    -- forever (hot redelivery loop, hit by DLQ replay of e.g. rrweb messages).
+    it "unsupported ce-type → whole batch poisoned (→ DLQ), never an uncommittable no-op" \(tr, key) -> do
+      let msgs = [validLogMsg key "ack-unsup-1", corruptMsg "ack-unsup-2"]
+      res <- runTestBg frozenTime tr $ OtlpServer.processList msgs (HM.fromList [("ce-type", "org.rrweb.events.v1")])
+      case res of
+        Right (acks, poison) -> do
+          acks `shouldBe` []
+          map (\(a, _, r) -> (a, r)) poison `shouldBe` [("ack-unsup-1", "unsupported ce-type"), ("ack-unsup-2", "unsupported ce-type")]
+        Left wf -> expectationFailure $ "expected Right; got Left " <> toString (Telemetry.writeFailureSummary wf)
+
     it "corrupt-only batch + TF healthy → Right ([], [poison]); Pkg.Queue DLQs it" \(tr, _) -> do
       res <- runTestBg frozenTime tr $ OtlpServer.processList [corruptMsg "ack-poison"] logsAttrs
       case res of


### PR DESCRIPTION
## Summary

Replaces the DLQ half of #419, rewritten on top of the `routeBatchOutcome` refactor (#402/#412). Design: the DLQ is a retry carousel — every message is constantly retried, failures requeue to the tail with an attempt counter, and **nothing is ever dropped**. When the queue grows, an engineer inspects the headers and prunes manually.

- **DLQ replay consumer**: new `KafkaDlqReplay` role in `kafkaService`; a `kafka-dlq` fiber drains `kafkaDeadLetterTopic` through `processList` under consumer group `<kafkaGroupId>_dlq` (own group so DLQ partitions never rebalance onto primary consumers). Gated by `enableKafkaDeadLetterService` (default on).
- **Requeue loop**: `routeBatchOutcome` already republishes failures to the DLQ and commits — pointed at the DLQ topic that *is* the carousel. Each publish now stamps `monoscope-attempt-count` (incremented per pass) and refreshes `error-reason`/`last-failed-at`, while preserving first-failure forensics (`original-topic`, `failed-at`). Extracted as doctested `dlqHeaders`.
- **Per-record processing on the DLQ consumer**: DLQ partitions interleave source topics (round-robin publish), so batch-level ce-type would mis-decode the minority and bake the wrong ce-type into their requeued headers. Each record runs under its own headers; commits stay all-or-nothing per partition.
- **Pacing**: short polls (at the tail — mostly just-requeued poison) sleep 30s so a lone poison message cycles ~2×/min instead of several times a second; full-batch backlog drains run at full speed. 30s ≪ max.poll.interval.ms (300s).
- **Liveness fix**: `processList` returned `Right ([], [])` for unsupported ce-types — no acks, no poison — which never commits/acks and stalls the partition in a hot redelivery loop (latent on the pubsub path too). Now reported as poison so they enter the requeue loop. Regression test in `TimefusionWriteFailureSpec`.
- **Makefile fix**: `TEST_MATCH=... make live-test-dev` was silently running 0 tests — GHCi's `:main` only strips quotes at token start, so `--match="X"` passed literal quote chars to hspec. Switched to the space form; hspec node names drop the "Spec" suffix.

Known limitation: rrweb/replay messages that land in the DLQ poison-cycle (unsupported by `processList`) with rising attempt counts until pruned — visible, never lost. Routing them through `processReplayEvents` is a possible follow-up.

The usage-submission backoff half of #419 will follow as its own PR; #419 can be closed once this lands.

## Test plan
- [x] `TimefusionWriteFailureSpec`: 11 examples, 0 failures (includes new unsupported-ce-type regression)
- [x] Doctests: 641/641 (includes new `dlqHeaders` attempt-count/header-precedence examples)
- [ ] Staging: verify `kafka-dlq` fiber joins as `<kafkaGroupId>_dlq` and primary consumer assignment is unaffected
- [ ] Staging: publish a poison message to the DLQ topic; confirm it requeues with incrementing `monoscope-attempt-count` at ~30s cadence and partition offsets keep advancing