### PR TITLE
refactor: consolidate duplicated code to reduce LOC (~570 net)

### DIFF
--- a/src/BackgroundJobs.hs
+++ b/src/BackgroundJobs.hs
@@ -110,7 +110,7 @@ import System.Logging qualified as Log
 import System.Tracing (SpanStatus (..), Tracing, addEvent, forkWithCtx, setStatus, withSpan)
 import System.Types (ATBackgroundCtx, DB, runBackground)
 import UnliftIO.Exception (bracket, catch, throwIO, try, tryAny)
-import Utils (calculateCycleStartDate, formatUTC, freeTierDailyMaxEvents, toXXHash)
+import Utils (calculateCycleStartDate, formatUTC, formatUTCMicros, freeTierDailyMaxEvents, toXXHash)
 
 
 data BgJobs
@@ -2322,8 +2322,8 @@ sendReportForProject pid rType = do
     Log.logInfo "Completed report generation for" pid
     unless ((typTxt == "daily" && not pr.dailyNotif) || (typTxt == "weekly" && not pr.weeklyNotif)) $ do
       Log.logInfo "Sending report notifications for" pid
-      let stmTxt = toText $ formatTime defaultTimeLocale "%Y-%m-%dT%H:%M:%S%6QZ" startTime
-          currentTimeTxt = toText $ formatTime defaultTimeLocale "%Y-%m-%dT%H:%M:%S%6QZ" currentTime
+      let stmTxt = formatUTCMicros startTime
+          currentTimeTxt = formatUTCMicros currentTime
           reportUrl = ctx.env.hostUrl <> "p/" <> pid.toText <> "/reports/" <> report.id.toText
           eventsWidget = RP.eventsWidget
           errorsWidget = RP.errorsWidget

--- a/src/CLI/Commands.hs
+++ b/src/CLI/Commands.hs
@@ -387,11 +387,11 @@ renderSearchResult validatedOpts mode val = do
       normalized = case decodeEvents val of
         Nothing -> val
         Just d -> normalizeDecoded d validatedOpts.fields
-      sliced = if firstOnly then takeFirstEvent normalized else normalized
+      sliced = if firstOnly then takeFirst "events" normalized else normalized
       -- Mirror --first into the raw envelope so table mode also shows
       -- one row instead of all-of-them (the JSON path used to slice and
       -- the table path didn't, leading to inconsistent output).
-      valForTable = if firstOnly then takeFirstRow val else val
+      valForTable = if firstOnly then takeFirst "logsData" val else val
   if validatedOpts.idOnly
     -- C11: --id-only short-circuits to a bare id on stdout — the natural
     -- input for "search → get" pipelines, no jq required.
@@ -555,12 +555,11 @@ resolveOffsetPair now = map (second resolve)
       Nothing -> t
 
 
--- | Trim the normalised events envelope to the first event only, preserving
--- @count@/@cursor@/@has_more@ semantics for downstream pagination. The
--- raw-envelope variant 'takeFirstRow' targets @logsData@ for table mode.
-takeFirstEvent, takeFirstRow :: AE.Value -> AE.Value
-takeFirstEvent v = v & AL.key "events" . AL._Array %~ V.take 1
-takeFirstRow v = v & AL.key "logsData" . AL._Array %~ V.take 1
+-- | Trim an envelope to its first array element under key @k@, preserving
+-- @count@/@cursor@/@has_more@ semantics for downstream pagination. Use
+-- @"events"@ for the normalised envelope and @"logsData"@ for table mode.
+takeFirst :: AE.Key -> AE.Value -> AE.Value
+takeFirst k v = v & AL.key k . AL._Array %~ V.take 1
 
 
 -- | Print the first event's @id@ to stdout; exit non-zero if there isn't one.

--- a/src/CLI/Core.hs
+++ b/src/CLI/Core.hs
@@ -2,9 +2,6 @@ module CLI.Core (
   OutputMode (..),
   detectOutputMode,
   isInteractiveTTY,
-  -- | Deprecated; kept as an alias for back-compat in case any caller still
-  -- imports it. Always returns False — the CLI no longer auto-detects agents.
-  isAgentMode,
   setOutputMode,
   getOutputMode,
   renderJSON,
@@ -100,13 +97,6 @@ isInteractiveTTY = do
     else liftIO $ ANSI.hSupportsANSIColor stdout
 
 
--- | Deprecated. Old code paths that branched on agent mode now branch on
--- 'isJsonOutput' (set once per command via the mode cache below). Kept as
--- @pure False@ so any straggler import compiles.
-isAgentMode :: Eff es Bool
-isAgentMode = pure False
-
-
 -- | Process-wide cache of the resolved 'OutputMode'. Set once by @main@ before
 -- any command handler runs; read by 'printError' / 'printDebug' / table
 -- renderers that need to know "am I in JSON mode?" without threading the mode
@@ -160,7 +150,7 @@ renderWith mode v tableAction = case mode of
 
 
 -- | Legacy plain-Text renderer. Retained so unmigrated commands still work,
--- but new code should call 'CLI.Table.renderRichTable' for the Unicode
+-- but new code should call 'CLI.Table.renderRichTableWith' for the Unicode
 -- box-drawing + per-cell color output. Suppresses ANSI in JSON mode so a
 -- non-TTY pipe never sees escape codes.
 renderTable :: IOE :> es => [Text] -> [[Text]] -> Eff es ()
@@ -395,13 +385,14 @@ decodeBody (Right bs)
 
 
 -- | Fetch JSON from API endpoint and apply a handler, printing errors on failure.
+-- Decode failures (including empty bodies) surface through 'apiGetJson' /
+-- 'decodeBody' as @APIError 0@, rendered by 'renderAPIError' as the bare
+-- message — same as the connection-error branch.
 withAPIResult :: (Environment :> es, HTTP :> es, IOE :> es) => CLIConfig -> Text -> [(Text, Text)] -> (AE.Value -> Eff es ()) -> Eff es ()
 withAPIResult cfg path params onSuccess =
-  apiGet cfg path params >>= \case
+  apiGetJson @_ @AE.Value cfg path params >>= \case
     Left err -> printError (renderAPIError err) >> liftIO exitFailure
-    Right bs -> case AE.eitherDecode @AE.Value bs of
-      Left err -> printError (toText err) >> liftIO exitFailure
-      Right val -> onSuccess val
+    Right val -> onSuccess val
 
 
 addAuth :: Maybe Text -> W.Options -> W.Options

--- a/src/CLI/Resource.hs
+++ b/src/CLI/Resource.hs
@@ -23,7 +23,6 @@ module CLI.Resource (
   resourceIdPath,
   withResult,
   runAPI,
-  normalizeList,
 ) where
 
 import Relude
@@ -116,23 +115,15 @@ runAPI mode act = withResult act renderAPIError (renderByMode mode Nothing)
 -- In table mode the per-resource column set in 'buildResourceTable' decides
 -- which fields show, plus a "… N more" pagination cue below.
 runList :: (Environment :> es, HTTP :> es, IOE :> es) => CLIConfig -> ResourceKind -> [(Text, Text)] -> OutputMode -> Eff es ()
-runList cfg k params mode =
-  apiGetJson @_ @AE.Value cfg (resourcePath k) params >>= \case
-    Left e -> printError (renderAPIError e) >> liftIO exitFailure
-    Right v -> case normalizeListE v of
-      Right normalised -> renderListPayload k mode normalised
-      Left (raw, reason) -> do
-        -- Server returned an envelope shape we don't recognise. This is
-        -- always-on stderr (not printDebug): an agent expecting
-        -- {data, pagination} would silently get a broken shape otherwise.
-        printError $ "list " <> resourcePath k <> ": " <> reason
-        renderByMode mode Nothing raw
+runList cfg k = runListVia cfg k (resourcePath k)
 
 
--- | Variant of 'runList' for resources whose URL differs from 'resourcePath'
--- (e.g. issues hits the legacy @apiGetJson \@_ \@AE.Value@ flow from Main.hs
--- with custom query params). Re-uses the same normalisation + table builder
--- so the per-kind columns are defined in one place.
+-- | Fetch + normalise a list endpoint at an explicit @url@ (which may differ
+-- from 'resourcePath', e.g. issues hits the legacy @apiGetJson \@_ \@AE.Value@
+-- flow from Main.hs with custom query params). 'runList' delegates here with
+-- @resourcePath k@. Server envelope shapes we don't recognise go to always-on
+-- stderr (not printDebug): an agent expecting {data, pagination} would
+-- silently get a broken shape otherwise.
 runListVia :: (Environment :> es, HTTP :> es, IOE :> es) => CLIConfig -> ResourceKind -> Text -> [(Text, Text)] -> OutputMode -> Eff es ()
 runListVia cfg k url params mode =
   apiGetJson @_ @AE.Value cfg url params >>= \case
@@ -319,13 +310,6 @@ normalizeListE v
   | otherwise = Left (v, "response is neither Object nor Array")
   where
     hasKey k = has (AL.key k) v
-
-
--- | Pure normaliser kept for direct use; falls through to the original value
--- on shape mismatch (without warning). Prefer 'normalizeListE' from new code
--- so the caller can flag unexpected payloads.
-normalizeList :: AE.Value -> AE.Value
-normalizeList = either fst id . normalizeListE
 
 
 runGet :: (Environment :> es, HTTP :> es, IOE :> es) => CLIConfig -> ResourceKind -> Text -> OutputMode -> Eff es ()

--- a/src/CLI/Table.hs
+++ b/src/CLI/Table.hs
@@ -20,11 +20,8 @@ module CLI.Table (
   numeric,
   muted,
   brand,
-  success,
-  failure,
 
   -- * Rendering
-  renderRichTable,
   renderRichTableWith,
   RichTableOpts (..),
   defaultRichTableOpts,
@@ -74,13 +71,11 @@ data Align = AlignLeft | AlignRight | AlignCenter
 type Cell = (CellStyle, Text)
 
 
-plain, numeric, muted, brand, success, failure :: Text -> Cell
+plain, numeric, muted, brand :: Text -> Cell
 plain t = (Plain, t)
 numeric t = (Numeric, t)
 muted t = (Muted, t)
 brand t = (Brand, t)
-success t = (Success, t)
-failure t = (Failure, t)
 
 
 -- | Wrap a severity-typed cell. Lower-cased input is tolerated.
@@ -108,12 +103,6 @@ defaultRichTableOpts :: RichTableOpts
 defaultRichTableOpts = RichTableOpts{alignments = [], maxWidth = Nothing, wrapRightmost = True}
 
 
--- | The vanilla renderer: defaults for alignment + width. Use this for most
--- list commands.
-renderRichTable :: IOE :> es => [Text] -> [[Cell]] -> Eff es ()
-renderRichTable = renderRichTableWith defaultRichTableOpts
-
-
 -- | Render with explicit knobs.
 --
 -- - In JSON/YAML mode this is a no-op (rendering goes through 'renderJSON'
@@ -133,12 +122,12 @@ renderRichTableWith opts headers rows = do
       let cap = fromMaybe termW opts.maxWidth
           aligns = zipWith const (opts.alignments <> repeat AlignLeft) headers
           (widths, normalized) = layout opts.wrapRightmost cap headers rows
-      liftIO $ putTextLn (topBorder widths)
+      liftIO $ putTextLn (border ("╭", "┬", "╮") widths)
       liftIO $ putTextLn (renderHeaderRow ansi aligns widths headers)
-      liftIO $ putTextLn (midBorder widths)
+      liftIO $ putTextLn (border ("├", "┼", "┤") widths)
       forM_ normalized $ \r ->
         liftIO $ putTextLn (renderRow ansi aligns widths r)
-      liftIO $ putTextLn (bottomBorder widths)
+      liftIO $ putTextLn (border ("╰", "┴", "╯") widths)
 
 
 -- | One line of muted text, intended for "… N more — use --limit / --cursor"
@@ -195,10 +184,8 @@ truncateCell w t
 
 -- Borders
 
-topBorder, midBorder, bottomBorder :: [Int] -> Text
-topBorder ws = "╭" <> T.intercalate "┬" [T.replicate (w + 2) "─" | w <- ws] <> "╮"
-midBorder ws = "├" <> T.intercalate "┼" [T.replicate (w + 2) "─" | w <- ws] <> "┤"
-bottomBorder ws = "╰" <> T.intercalate "┴" [T.replicate (w + 2) "─" | w <- ws] <> "╯"
+border :: (Text, Text, Text) -> [Int] -> Text
+border (l, j, r) ws = l <> T.intercalate j [T.replicate (w + 2) "─" | w <- ws] <> r
 
 
 -- Rows

--- a/src/CLI/Validate.hs
+++ b/src/CLI/Validate.hs
@@ -2,9 +2,7 @@
 -- Catching malformed input here gives agents a clear, actionable error
 -- message instead of an opaque server-side HTTP 400.
 module CLI.Validate (
-  validateDuration,
   validateDurationFor,
-  validateUuid,
   validateKind,
   normalizeKind,
   validateOrDie,
@@ -16,7 +14,7 @@ module CLI.Validate (
 import Relude
 
 import CLI.Core (printError)
-import Data.Char (isDigit, isHexDigit)
+import Data.Char (isDigit)
 import Data.Text qualified as T
 import Effectful
 import Pkg.Parser (parseQueryToAST)
@@ -48,30 +46,6 @@ validateDurationFor flag t
        in if T.null digits || T.toLower suffix `notElem` ["ms", "s", "m", "h", "d"]
             then Left $ flag <> " must match Ns|Nm|Nh|Nd|Nms (e.g. 30m, 2h, 7d); got '" <> t <> "'"
             else Right trimmed
-
-
--- | Back-compat alias defaulting to @--since@.
-validateDuration :: Text -> Either Text Text
-validateDuration = validateDurationFor "--since"
-
-
--- | Loose UUID syntax check (8-4-4-4-12 hex). Lets us fail fast on @--project foo@
--- etc. rather than waiting for the server to return a 4xx.
---
--- >>> validateUuid "00000000-0000-0000-0000-000000000000"
--- Right "00000000-0000-0000-0000-000000000000"
--- >>> validateUuid "not-a-uuid"
--- Left "expected UUID (8-4-4-4-12 hex); got 'not-a-uuid'"
--- >>> validateUuid ""
--- Left "expected UUID; got empty string"
-validateUuid :: Text -> Either Text Text
-validateUuid t
-  | T.null t = Left "expected UUID; got empty string"
-  | otherwise =
-      let parts = T.splitOn "-" t
-       in if map T.length parts == [8, 4, 4, 4, 12] && T.all isHexDigit (T.concat parts)
-            then Right t
-            else Left $ "expected UUID (8-4-4-4-12 hex); got '" <> t <> "'"
 
 
 -- | Whitelist for @--kind@ values accepted at the CLI surface.

--- a/src/Data/Effectful/LLM.hs
+++ b/src/Data/Effectful/LLM.hs
@@ -11,6 +11,7 @@ module Data.Effectful.LLM (
 import Control.Lens ((^?))
 import Data.Aeson qualified as AE
 import Data.Aeson.Lens (key)
+import Data.Effectful.Wreq (withGoldenCache)
 import Data.Text qualified as T
 import Data.Vector qualified as V
 import Effectful
@@ -24,26 +25,13 @@ import Langchain.LLM.OpenAI qualified as OpenAI
 import OpenAI.V1.Chat.Completions qualified as OpenAIV1
 import OpenAI.V1.Models qualified as Models
 import Relude
-import System.Directory (createDirectoryIfMissing, doesFileExist)
-import System.FilePath ((</>))
 
 
--- Manual JSON instances for LLMCore.Message (can't use Generic due to type structure)
-instance AE.ToJSON LLMCore.Message where
-  toJSON msg =
-    AE.object
-      [ "role" AE..= LLMCore.role msg
-      , "content" AE..= LLMCore.content msg
-      , "messageData" AE..= LLMCore.messageData msg
-      ]
-
-
-instance AE.FromJSON LLMCore.Message where
-  parseJSON = AE.withObject "Message" \o ->
-    LLMCore.Message
-      <$> (o AE..: "role")
-      <*> (o AE..: "content")
-      <*> (o AE..: "messageData")
+-- Generic-derived JSON for LLMCore.Message (record field names match the prior
+-- hand-written keys, so this is byte-identical to the old manual instances).
+deriving stock instance Generic LLMCore.Message
+deriving anyclass instance AE.ToJSON LLMCore.Message
+deriving anyclass instance AE.FromJSON LLMCore.Message
 
 
 -- Cache entry for agentic chat calls
@@ -110,35 +98,10 @@ data LLMResponse = LLMResponse
 
 -- | Get or create a golden response for an LLM call
 getOrCreateGoldenResponse :: FilePath -> Text -> Text -> Text -> IO (Either Text Text)
-getOrCreateGoldenResponse goldenDir model prompt apiKey = do
-  let fileName = promptToFilename prompt
-      filePath = goldenDir </> fileName
-  exists <- doesFileExist filePath
-  updateGolden <- isJust <$> lookupEnv "UPDATE_GOLDEN"
-
-  if exists && not updateGolden
-    then do
-      -- Read cached response
-      content <- readFileLBS filePath
-      case AE.decode content of
-        Just (llmResp :: LLMResponse) -> return llmResp.llmResponse
-        Nothing -> error $ fromString $ "Failed to decode LLM response from file: " <> filePath
-    else
-      if not exists && not updateGolden
-        then
-          error
-            $ fromString
-            $ "Golden file not found: "
-            <> filePath
-            <> "\nRun tests with UPDATE_GOLDEN=true to create it:\n"
-            <> "  UPDATE_GOLDEN=true USE_EXTERNAL_DB=true cabal test integration-tests"
-        else do
-          -- UPDATE_GOLDEN=true: create or update golden file
-          createDirectoryIfMissing True goldenDir
-          response <- callOpenAIAPI model prompt apiKey
-          let llmResp = LLMResponse{llmPrompt = prompt, llmResponse = response}
-          writeFileLBS filePath (AE.encode llmResp)
-          return response
+getOrCreateGoldenResponse goldenDir model prompt apiKey =
+  withGoldenCache goldenDir (promptToFilename prompt) (\fp -> "Failed to decode LLM response from file: " <> fp) (.llmResponse) $ do
+    response <- callOpenAIAPI model prompt apiKey
+    pure (LLMResponse{llmPrompt = prompt, llmResponse = response}, response)
 
 
 -- | Actual OpenAI API call implementation
@@ -192,37 +155,15 @@ hasToolsInParams p = isJust $ AE.toJSON p ^? key "tools"
 
 -- | Get or create a golden response for an agentic chat call
 getOrCreateAgenticGoldenResponse :: FilePath -> LLMCore.ChatHistory -> OpenAIV1.CreateChatCompletion -> Text -> IO (Either Text LLMCore.Message)
-getOrCreateAgenticGoldenResponse goldenDir history params apiKey = do
-  let historyMessages = toList history
-      hasTools = hasToolsInParams params
-      cacheKey = cacheKeyFromQuery historyMessages hasTools
-      fileName = cacheKey <> ".json"
-      filePath = goldenDir </> fileName
-  exists <- doesFileExist filePath
-  updateGolden <- isJust <$> lookupEnv "UPDATE_GOLDEN"
-  if exists && not updateGolden
-    then do
-      content <- readFileLBS filePath
-      case AE.decode content of
-        Just (cached :: AgenticChatCache) -> return cached.accResponse
-        Nothing -> error $ toText $ "Failed to decode agentic chat cache from: " <> filePath
-    else
-      if not exists && not updateGolden
-        then
-          error
-            $ toText
-            $ "Golden file not found: "
-            <> filePath
-            <> "\nRun tests with UPDATE_GOLDEN=true to create it:\n"
-            <> "  UPDATE_GOLDEN=true USE_EXTERNAL_DB=true cabal test integration-tests"
-        else do
-          createDirectoryIfMissing True goldenDir
-          let openAI = OpenAI.OpenAI{apiKey, callbacks = [], baseUrl = Nothing}
-              Models.Model modelName = params.model
-          response <- first show <$> LLMCore.chat openAI history (Just params)
-          let cached = AgenticChatCache{accHistory = historyMessages, accModel = modelName, accHasTools = hasTools, accResponse = response}
-          writeFileLBS filePath (AE.encode cached)
-          return response
+getOrCreateAgenticGoldenResponse goldenDir history params apiKey =
+  withGoldenCache goldenDir (cacheKeyFromQuery historyMessages hasTools <> ".json") (\fp -> "Failed to decode agentic chat cache from: " <> fp) (.accResponse) $ do
+    let openAI = OpenAI.OpenAI{apiKey, callbacks = [], baseUrl = Nothing}
+        Models.Model modelName = params.model
+    response <- first show <$> LLMCore.chat openAI history (Just params)
+    pure (AgenticChatCache{accHistory = historyMessages, accModel = modelName, accHasTools = hasTools, accResponse = response}, response)
+  where
+    historyMessages = toList history
+    hasTools = hasToolsInParams params
 
 
 -- Embedding golden cache
@@ -235,29 +176,10 @@ data EmbeddingCache = EmbeddingCache
 
 
 getOrCreateEmbeddingGoldenResponse :: FilePath -> EmbOAI.OpenAIEmbeddings -> [DocLoader.Document] -> IO (Either Text [[Float]])
-getOrCreateEmbeddingGoldenResponse goldenDir config docs = do
-  let texts = map (toStrict . DocLoader.pageContent) docs
-      cacheKey = "emb_" <> sanitizeForFilename (T.intercalate "__" $ take 3 texts) <> "_n" <> show (length docs)
-      filePath = goldenDir </> cacheKey <> ".json"
-  exists <- doesFileExist filePath
-  updateGolden <- isJust <$> lookupEnv "UPDATE_GOLDEN"
-  if exists && not updateGolden
-    then do
-      content <- readFileLBS filePath
-      case AE.decode content of
-        Just (cached :: EmbeddingCache) -> return cached.result
-        Nothing -> error $ fromString $ "Failed to decode embedding cache from: " <> filePath
-    else
-      if not exists && not updateGolden
-        then
-          error
-            $ fromString
-            $ "Golden file not found: "
-            <> filePath
-            <> "\nRun tests with UPDATE_GOLDEN=true to create it:\n"
-            <> "  UPDATE_GOLDEN=true USE_EXTERNAL_DB=true cabal test integration-tests"
-        else do
-          createDirectoryIfMissing True goldenDir
-          result <- first show <$> EmbCore.embedDocuments config docs
-          writeFileLBS filePath $ AE.encode EmbeddingCache{texts, result}
-          return result
+getOrCreateEmbeddingGoldenResponse goldenDir config docs =
+  withGoldenCache goldenDir (cacheKey <> ".json") (\fp -> "Failed to decode embedding cache from: " <> fp) (.result) $ do
+    result <- first show <$> EmbCore.embedDocuments config docs
+    pure (EmbeddingCache{texts, result}, result)
+  where
+    texts = map (toStrict . DocLoader.pageContent) docs
+    cacheKey = "emb_" <> sanitizeForFilename (T.intercalate "__" $ take 3 texts) <> "_n" <> show (length docs)

--- a/src/Data/Effectful/LLM.hs
+++ b/src/Data/Effectful/LLM.hs
@@ -99,7 +99,7 @@ data LLMResponse = LLMResponse
 -- | Get or create a golden response for an LLM call
 getOrCreateGoldenResponse :: FilePath -> Text -> Text -> Text -> IO (Either Text Text)
 getOrCreateGoldenResponse goldenDir model prompt apiKey =
-  withGoldenCache goldenDir (promptToFilename prompt) (\fp -> "Failed to decode LLM response from file: " <> fp) (.llmResponse) $ do
+  withGoldenCache goldenDir (promptToFilename prompt) ("Failed to decode LLM response from file: " <>) (.llmResponse) $ do
     response <- callOpenAIAPI model prompt apiKey
     pure (LLMResponse{llmPrompt = prompt, llmResponse = response}, response)
 
@@ -156,7 +156,7 @@ hasToolsInParams p = isJust $ AE.toJSON p ^? key "tools"
 -- | Get or create a golden response for an agentic chat call
 getOrCreateAgenticGoldenResponse :: FilePath -> LLMCore.ChatHistory -> OpenAIV1.CreateChatCompletion -> Text -> IO (Either Text LLMCore.Message)
 getOrCreateAgenticGoldenResponse goldenDir history params apiKey =
-  withGoldenCache goldenDir (cacheKeyFromQuery historyMessages hasTools <> ".json") (\fp -> "Failed to decode agentic chat cache from: " <> fp) (.accResponse) $ do
+  withGoldenCache goldenDir (cacheKeyFromQuery historyMessages hasTools <> ".json") ("Failed to decode agentic chat cache from: " <>) (.accResponse) $ do
     let openAI = OpenAI.OpenAI{apiKey, callbacks = [], baseUrl = Nothing}
         Models.Model modelName = params.model
     response <- first show <$> LLMCore.chat openAI history (Just params)
@@ -177,7 +177,7 @@ data EmbeddingCache = EmbeddingCache
 
 getOrCreateEmbeddingGoldenResponse :: FilePath -> EmbOAI.OpenAIEmbeddings -> [DocLoader.Document] -> IO (Either Text [[Float]])
 getOrCreateEmbeddingGoldenResponse goldenDir config docs =
-  withGoldenCache goldenDir (cacheKey <> ".json") (\fp -> "Failed to decode embedding cache from: " <> fp) (.result) $ do
+  withGoldenCache goldenDir (cacheKey <> ".json") ("Failed to decode embedding cache from: " <>) (.result) $ do
     result <- first show <$> EmbCore.embedDocuments config docs
     pure (EmbeddingCache{texts, result}, result)
   where

--- a/src/Data/Effectful/Wreq.hs
+++ b/src/Data/Effectful/Wreq.hs
@@ -24,6 +24,7 @@ module Data.Effectful.Wreq (
   Postable,
   Putable,
   Patchable,
+  withGoldenCache,
 ) where
 
 import Data.Aeson qualified as AE
@@ -177,19 +178,35 @@ toWreqResponse wr =
     }
 
 
-getOrCreateGoldenResponse :: FilePath -> String -> IO (W.Response LBS.ByteString) -> IO (W.Response LBS.ByteString)
-getOrCreateGoldenResponse goldenDir fileName action = do
+-- | Generic golden-cache read-or-create. When the golden file exists (and we're
+-- not refreshing) it's decoded into the cache type @c@ and projected to the
+-- result via @decodeResult@; if the file is missing it errors with the standard
+-- UPDATE_GOLDEN hint; on UPDATE_GOLDEN it runs @action@ to produce the cache
+-- value and the live result, encodes the cache value, and returns the live
+-- result (so capture-path behaviour matches each caller, not the round-trip).
+withGoldenCache
+  :: (AE.FromJSON c, AE.ToJSON c)
+  => FilePath
+  -- ^ golden dir
+  -> String
+  -- ^ file name (within dir)
+  -> (FilePath -> String)
+  -- ^ build the decode-failure message from the file path
+  -> (c -> a)
+  -- ^ project cached value to result (cached-read path)
+  -> IO (c, a)
+  -- ^ produce the cache value (to persist) and the live result (to return)
+  -> IO a
+withGoldenCache goldenDir fileName decodeErr decodeResult action = do
   let filePath = goldenDir </> fileName
   exists <- doesFileExist filePath
   updateGolden <- isJust <$> lookupEnv "UPDATE_GOLDEN"
-
   if exists && not updateGolden
     then do
-      -- Read cached response
       content <- readFileLBS filePath
       case AE.decode content of
-        Just response -> return $ toWreqResponse response
-        Nothing -> error $ fromString $ "Failed to decode response from file: " <> filePath
+        Just cached -> return $ decodeResult cached
+        Nothing -> error $ fromString $ decodeErr filePath
     else
       if not exists && not updateGolden
         then
@@ -200,15 +217,21 @@ getOrCreateGoldenResponse goldenDir fileName action = do
             <> "\nRun tests with UPDATE_GOLDEN=true to create it:\n"
             <> "  UPDATE_GOLDEN=true USE_EXTERNAL_DB=true cabal test integration-tests"
         else do
-          -- UPDATE_GOLDEN=true: create or update golden file
           createDirectoryIfMissing True goldenDir
-          -- Catch HTTP exceptions and convert them to responses
-          result <- try action
-          response <- case result of
-            Right resp -> return resp
-            Left (HttpExceptionRequest _ (StatusCodeException resp body)) ->
-              -- Convert 4xx/5xx responses to normal responses for golden files
-              return resp{responseBody = fromStrict body}
-            Left (ex :: HttpException) -> throwIO ex -- Re-throw other exceptions
-          writeFileLBS filePath (AE.encode $ fromWreqResponse response)
-          return response
+          (cached, result) <- action
+          writeFileLBS filePath (AE.encode cached)
+          return result
+
+
+getOrCreateGoldenResponse :: FilePath -> String -> IO (W.Response LBS.ByteString) -> IO (W.Response LBS.ByteString)
+getOrCreateGoldenResponse goldenDir fileName action =
+  withGoldenCache goldenDir fileName (\fp -> "Failed to decode response from file: " <> fp) toWreqResponse $ do
+    -- Catch HTTP exceptions and convert them to responses
+    result <- try action
+    response <- case result of
+      Right resp -> return resp
+      Left (HttpExceptionRequest _ (StatusCodeException resp body)) ->
+        -- Convert 4xx/5xx responses to normal responses for golden files
+        return resp{responseBody = fromStrict body}
+      Left (ex :: HttpException) -> throwIO ex -- Re-throw other exceptions
+    pure (fromWreqResponse response, response)

--- a/src/Data/Effectful/Wreq.hs
+++ b/src/Data/Effectful/Wreq.hs
@@ -225,7 +225,7 @@ withGoldenCache goldenDir fileName decodeErr decodeResult action = do
 
 getOrCreateGoldenResponse :: FilePath -> String -> IO (W.Response LBS.ByteString) -> IO (W.Response LBS.ByteString)
 getOrCreateGoldenResponse goldenDir fileName action =
-  withGoldenCache goldenDir fileName (\fp -> "Failed to decode response from file: " <> fp) toWreqResponse $ do
+  withGoldenCache goldenDir fileName ("Failed to decode response from file: " <>) toWreqResponse $ do
     -- Catch HTTP exceptions and convert them to responses
     result <- try action
     response <- case result of

--- a/src/Models/Apis/Integrations.hs
+++ b/src/Models/Apis/Integrations.hs
@@ -110,21 +110,26 @@ getDiscordDataByProjectId :: DB es => Projects.ProjectId -> Eff es (Maybe Discor
 getDiscordDataByProjectId pid = Hasql.interpOne [HI.sql|SELECT project_id, guild_id FROM apis.discord WHERE project_id = #{pid} |]
 
 
+-- | Shared (d.title, d.id::text) dashboard lookup; each caller supplies the
+-- platform-specific JOIN + WHERE fragment (Slack/Discord share the same shape).
+dashboardsByProjectJoin :: DB es => HI.Sql -> Eff es [(Text, Text)]
+dashboardsByProjectJoin joinWhere = Hasql.interp ([HI.sql|SELECT d.title, d.id::text FROM projects.dashboards d |] <> joinWhere)
+
+
 getDashboardsForSlack :: DB es => Text -> Eff es [(Text, Text)]
-getDashboardsForSlack teamId = Hasql.interp [HI.sql|SELECT d.title, d.id::text FROM projects.dashboards d JOIN apis.slack s ON d.project_id = s.project_id WHERE s.team_id = #{teamId}|]
+getDashboardsForSlack teamId = dashboardsByProjectJoin [HI.sql|JOIN apis.slack s ON d.project_id = s.project_id WHERE s.team_id = #{teamId}|]
 
 
 getDashboardsForWhatsapp :: DB es => Text -> Eff es [(Text, Text)]
 getDashboardsForWhatsapp number =
-  Hasql.interp
-    [HI.sql|SELECT d.title, d.id::text FROM projects.dashboards d
-            JOIN projects.teams t ON t.project_id = d.project_id
+  dashboardsByProjectJoin
+    [HI.sql|JOIN projects.teams t ON t.project_id = d.project_id
             WHERE t.is_everyone = TRUE AND t.deleted_at IS NULL
               AND #{number} = ANY(t.phone_numbers)|]
 
 
 getDashboardsForDiscord :: DB es => Text -> Eff es [(Text, Text)]
-getDashboardsForDiscord guildId = Hasql.interp [HI.sql|SELECT d.title, d.id::text FROM projects.dashboards d JOIN apis.discord dd ON d.project_id = dd.project_id where guild_id=#{guildId}|]
+getDashboardsForDiscord guildId = dashboardsByProjectJoin [HI.sql|JOIN apis.discord dd ON d.project_id = dd.project_id where guild_id=#{guildId}|]
 
 
 deleteSlackData :: DB es => Projects.ProjectId -> Eff es Int64

--- a/src/Models/Apis/Monitors.hs
+++ b/src/Models/Apis/Monitors.hs
@@ -186,10 +186,15 @@ monitorToggleActiveById mid = do
         where id=#{mid}|]
 
 
+-- | Shared shape for the "stamp a single timestamptz column, guarded by IS NULL" updates
+-- (deactivate / soft-delete). Each caller supplies the column-specific SQL given @now@.
+setTimestampColByIds :: (DB es, Time :> es) => (UTCTime -> HI.Sql) -> Eff es Int64
+setTimestampColByIds mkSql = Time.currentTime >>= Hasql.interpExecute . mkSql
+
+
 monitorDeactivateByIds :: (DB es, Time :> es) => [QueryMonitorId] -> Eff es Int64
-monitorDeactivateByIds ids = do
-  now <- Time.currentTime
-  Hasql.interpExecute [HI.sql| UPDATE monitors.query_monitors SET deactivated_at = #{now} WHERE id = ANY(#{ids}::uuid[]) AND deactivated_at IS NULL |]
+monitorDeactivateByIds ids =
+  setTimestampColByIds \now -> [HI.sql| UPDATE monitors.query_monitors SET deactivated_at = #{now} WHERE id = ANY(#{ids}::uuid[]) AND deactivated_at IS NULL |]
 
 
 monitorReactivateByIds :: DB es => [QueryMonitorId] -> Eff es Int64
@@ -216,9 +221,8 @@ monitorResolveByIds ids =
 
 
 monitorSoftDeleteByIds :: (DB es, Time :> es) => [QueryMonitorId] -> Eff es Int64
-monitorSoftDeleteByIds ids = do
-  now <- Time.currentTime
-  Hasql.interpExecute [HI.sql| UPDATE monitors.query_monitors SET deleted_at = #{now} WHERE id = ANY(#{ids}::uuid[]) AND deleted_at IS NULL |]
+monitorSoftDeleteByIds ids =
+  setTimestampColByIds \now -> [HI.sql| UPDATE monitors.query_monitors SET deleted_at = #{now} WHERE id = ANY(#{ids}::uuid[]) AND deleted_at IS NULL |]
 
 
 queryMonitorsAll :: DB es => Projects.ProjectId -> Eff es [QueryMonitor]

--- a/src/Models/Telemetry/Telemetry.hs
+++ b/src/Models/Telemetry/Telemetry.hs
@@ -80,6 +80,7 @@ import Control.Lens ((.~))
 import Data.Aeson qualified as AE
 import Data.Aeson.Key qualified as AEK
 import Data.Aeson.KeyMap qualified as KEM
+import Data.Scientific (toBoundedInteger)
 import Data.ByteString.Base16 qualified as B16
 import Data.Default (Default (..))
 import Data.Effectful.UUID (UUIDEff, genUUID)
@@ -100,11 +101,9 @@ import Data.Time.Clock (addUTCTime)
 import Data.UUID qualified as UUID
 import Data.Vector qualified as V
 import Data.Vector.Split qualified as VS
-import Database.PostgreSQL.Simple (ResultError (ConversionFailed))
-
 import Data.Effectful.Hasql (Hasql)
 import Data.Effectful.Hasql qualified as Hasql
-import Database.PostgreSQL.Simple.FromField (Conversion (..), FromField (..), returnError)
+import Database.PostgreSQL.Simple.FromField (Conversion, FromField (..))
 import Database.PostgreSQL.Simple.FromRow
 import Database.PostgreSQL.Simple.Newtypes (Aeson (..))
 import Database.PostgreSQL.Simple.ToField (ToField (toField))
@@ -124,17 +123,16 @@ import Hasql.Interpolate qualified as HI
 import Hasql.Session qualified as HSession
 import Models.Apis.ErrorPatterns qualified as ErrorPatterns
 import Models.Projects.Projects qualified as Projects
-import Pkg.DeriveUtils (AesonText (..), DB, UUIDId (..), WrappedEnum (..), WrappedEnumSC (..), encodeEnumSC, idFromText, textArrayEnc, unAesonTextMaybe)
+import Pkg.DeriveUtils (AesonText (..), DB, UUIDId (..), WrappedEnum (..), WrappedEnumInt (..), WrappedEnumSC (..), encodeEnumSC, idFromText, textArrayEnc, unAesonTextMaybe)
 import Pkg.ExtractionWorker qualified as EW
 import Relude hiding (ask)
-import Relude.Extra.Enum (safeToEnum)
 import Relude.Extra.Tuple (traverseToSnd)
 import System.IO (hPutStrLn)
 import System.Logging qualified as Log
 import System.Tracing (forkWithCtx)
 import Text.Regex.TDFA.Text ()
 import UnliftIO (throwIO, tryAny)
-import Utils (extractMessageFromLog, getDurationNSMS, lookupValueText)
+import Utils (extractMessageFromLog, getDurationNSMS, lookupValueText, scrubNulText, scrubNulValue)
 
 
 -- Helper function to get nested value from a map using dot notation
@@ -149,29 +147,13 @@ getNestedValue ks@(k : rest) m =
       _ -> Nothing
 
 
--- Helper function to clean null bytes from text
-cleanNullBytes :: Text -> Text
-cleanNullBytes !t =
-  if T.any (== '\NUL') t
-    then T.filter (/= '\NUL') t
-    else t
-
-
--- Helper function to clean null bytes from JSON values
-cleanNullBytesFromJSON :: AE.Value -> AE.Value
-cleanNullBytesFromJSON (AE.String t) = AE.String $ cleanNullBytes t
-cleanNullBytesFromJSON (AE.Object o) = AE.Object $ KEM.map cleanNullBytesFromJSON o
-cleanNullBytesFromJSON (AE.Array a) = AE.Array $ V.map cleanNullBytesFromJSON a
-cleanNullBytesFromJSON v = v
-
-
 -- Lens-like access helpers for Map Text AE.Value fields
 atMapText :: Text -> Maybe (Map Text AE.Value) -> Maybe Text
 atMapText key maybeMap = do
   m <- maybeMap
   val <- getNestedValue (T.split (== '.') key) m
   case val of
-    AE.String t -> Just $ cleanNullBytes t
+    AE.String t -> Just $ scrubNulText t
     AE.Number n -> Just $ show n
     _ -> Nothing
 
@@ -181,7 +163,7 @@ atMapInt key maybeMap = do
   m <- maybeMap
   val <- getNestedValue (T.split (== '.') key) m
   case val of
-    AE.Number n -> Just $ round n
+    AE.Number n -> toBoundedInteger n
     AE.String t -> readMaybe $ toString t
     _ -> Nothing
 
@@ -251,28 +233,13 @@ instance AE.ToJSON ByteString where
   toJSON = AE.String . decodeUtf8 . B16.encode
 
 
--- Custom FromField instance for Map Text AE.Value that handles both JSONB and varchar/text
+-- JSONB/text decode for Map Text Value reuses the generic AesonText decoder in DeriveUtils.
 instance FromField (Map Text AE.Value) where
-  fromField f mdata = do
-    -- Try to parse as JSONB first
-    let tryJsonb = do
-          v <- fromField f mdata :: Conversion AE.Value
-          case v of
-            AE.Object o -> pure $ KEM.toMapText o
-            _ -> returnError ConversionFailed f "Expected a JSON object"
-    -- If that fails, try parsing as text/varchar
-    let tryText = do
-          txt <- fromField f mdata :: Conversion Text
-          case AE.eitherDecodeStrict (encodeUtf8 txt) of
-            Right (AE.Object o) -> return $ KEM.toMapText o
-            Right _ -> returnError ConversionFailed f "Expected a JSON object"
-            Left err -> returnError ConversionFailed f ("Failed to parse JSON from text: " ++ err)
-    tryJsonb <|> tryText
+  fromField f mdata = coerce (fromField f mdata :: Conversion (AesonText (Map Text AE.Value)))
 
 
--- Custom ToField instance for Map Text AE.Value
 instance ToField (Map Text AE.Value) where
-  toField = toField . AE.Object . KEM.fromMapText
+  toField = toField . AesonText
 
 
 data SpanRecord = SpanRecord
@@ -518,17 +485,7 @@ data AggregationTemporality = ATUnspecified | ATDelta | ATCumulative
   deriving (Bounded, Enum, Eq, Generic, Read, Show)
   deriving anyclass (NFData)
   deriving (AE.FromJSON, AE.ToJSON) via DAE.Snake AggregationTemporality
-
-
-instance ToField AggregationTemporality where toField = toField . fromEnum
-instance HI.EncodeValue AggregationTemporality where encodeValue = contramap fromEnum HI.encodeValue
-
-
-instance FromField AggregationTemporality where
-  fromField f bs =
-    fromField @Int f bs
-      >>= \n -> maybe (returnError ConversionFailed f ("Invalid aggregation_temporality: " <> show n)) pure (safeToEnum n)
-instance HI.DecodeValue AggregationTemporality where decodeValue = fromMaybe minBound . safeToEnum <$> HI.decodeValue
+  deriving (FromField, HI.DecodeValue, HI.EncodeValue, ToField) via WrappedEnumInt AggregationTemporality
 
 
 data MetricDataPoint = MetricDataPoint
@@ -596,6 +553,17 @@ otelSpanColsSql =
   -- is absorbed by the Maybe on the 'hashes' field instead.
   [HI.sql|project_id, id::text, timestamp, observed_timestamp, context, level, severity, body, attributes, resource,
           hashes, kind, status_code, status_message, COALESCE(start_time, timestamp), end_time, events, links, duration, name, parent_id, summary, date::timestamptz, errors, COALESCE(message_size_bytes, 0)|]
+
+
+-- | Shared SELECT prefix for span fetchers: full column list, project + timestamp window.
+-- The caller appends its own trailing clause, including the leading @AND@ for any extra
+-- predicate (so an empty @predSql@ still yields valid SQL).
+selectOtelSpans :: Text -> UTCTime -> UTCTime -> HI.Sql -> HI.Sql
+selectOtelSpans pidTxt lo hi predSql =
+  [HI.sql|SELECT |]
+    <> otelSpanColsSql
+    <> [HI.sql| FROM otel_logs_and_spans WHERE project_id=#{pidTxt} AND timestamp BETWEEN #{lo} AND #{hi} |]
+    <> predSql
 
 
 lookupOtelRecord :: DB es => Maybe Text -> UTCTime -> UUID.UUID -> Eff es (Maybe OtelLogsAndSpans)
@@ -666,22 +634,12 @@ getSpanRecordsByTraceId pid trId tme now = do
       (wideStart, wideEnd) = (addUTCTime (-86400) baseT, addUTCTime 86400 baseT)
       resolveHop ids =
         Hasql.interp
-          $ [HI.sql|SELECT |]
-          <> otelSpanColsSql
-          <> [HI.sql| FROM otel_logs_and_spans
-                       WHERE project_id=#{pid.toText}
-                         AND timestamp BETWEEN #{wideStart} AND #{wideEnd}
-                         AND context___trace_id=#{trId}
-                         AND context___span_id = ANY(#{ids})|]
+          $ selectOtelSpans pid.toText wideStart wideEnd
+            [HI.sql| AND context___trace_id=#{trId} AND context___span_id = ANY(#{ids})|]
   initial :: [OtelLogsAndSpans] <-
     Hasql.interp
-      $ [HI.sql|SELECT |]
-      <> otelSpanColsSql
-      <> [HI.sql| FROM otel_logs_and_spans
-                   WHERE project_id=#{pid.toText}
-                     AND timestamp BETWEEN #{start} AND #{end}
-                     AND context___trace_id=#{trId}
-                   ORDER BY start_time ASC|]
+      $ selectOtelSpans pid.toText start end
+        [HI.sql| AND context___trace_id=#{trId} ORDER BY start_time ASC|]
   -- Resolve missing parents iteratively: a parent ingested outside ±5min
   -- (clock skew, late ingestion, async batch) is looked up via
   -- context___span_id within ±24h. Recovered spans may themselves have a
@@ -715,14 +673,8 @@ getSpanRecordsByTraceIds pid traceIds tme = do
         Just ts -> (addUTCTime (-300) ts, addUTCTime 300 ts)
       traceIdsList = V.toList traceIds
   Hasql.interp
-    $ [HI.sql|SELECT |]
-    <> otelSpanColsSql
-    <> [HI.sql| FROM otel_logs_and_spans
-                 WHERE project_id = #{pid.toText}
-                   AND timestamp >= #{start}
-                   AND timestamp <= #{end'}
-                   AND context___trace_id = ANY(#{traceIdsList})
-                 ORDER BY context___trace_id ASC, start_time ASC|]
+    $ selectOtelSpans pid.toText start end'
+      [HI.sql| AND context___trace_id = ANY(#{traceIdsList}) ORDER BY context___trace_id ASC, start_time ASC|]
 
 
 spanRecordByProjectAndId :: DB es => Projects.ProjectId -> UTCTime -> UUID.UUID -> Eff es (Maybe OtelLogsAndSpans)
@@ -1281,13 +1233,13 @@ otelColumns =
       aI8 k c = param (fmap (fromIntegral :: Int -> Int64) (atMapInt k c.am))
       rT k c = param (atMapText k c.rm)
       top f c = f c.row
-      txt g = top (param . fmap cleanNullBytes . g)
+      txt g = top (param . fmap scrubNulText . g)
       jp :: AE.ToJSON a => (OtelLogsAndSpans -> Maybe a) -> OtelRowCtx -> Snippet
-      jp g = top (param . fmap (cleanNullBytesFromJSON . AE.toJSON) . g)
-      aeson g = top (param . fmap cleanNullBytesFromJSON . unAesonTextMaybe . g)
-      arr g = top (encoderAndParam (E.nonNullable textArrayEnc) . V.map cleanNullBytes . g)
-      ctxT f = top (\e -> param (fmap cleanNullBytes (e.context >>= f)))
-      sevText e = e.severity >>= \s -> cleanNullBytes . toText . encodeEnumSC @"SL" <$> s.severity_text
+      jp g = top (param . fmap (scrubNulValue . AE.toJSON) . g)
+      aeson g = top (param . fmap scrubNulValue . unAesonTextMaybe . g)
+      arr g = top (encoderAndParam (E.nonNullable textArrayEnc) . V.map scrubNulText . g)
+      ctxT f = top (\e -> param (fmap scrubNulText (e.context >>= f)))
+      sevText e = e.severity >>= \s -> scrubNulText . toText . encodeEnumSC @"SL" <$> s.severity_text
       sevNum :: OtelLogsAndSpans -> Maybe Int32
       sevNum e = fromIntegral . severity_number <$> e.severity
    in [ ("timestamp", top (param . (.timestamp)))
@@ -1315,7 +1267,7 @@ otelColumns =
       , ("context___is_remote", (.isRemoteP))
       , ("events", aeson (.events))
       , ("links", txt (.links))
-      , ("attributes", \c -> param (fmap (cleanNullBytesFromJSON . AE.Object . KEM.fromMapText) c.am))
+      , ("attributes", \c -> param (fmap (scrubNulValue . AE.Object . KEM.fromMapText) c.am))
       , ("attributes___client___address", aT "client.address")
       , ("attributes___client___port", aI "client.port")
       , ("attributes___server___address", aT "server.address")
@@ -1365,7 +1317,7 @@ otelColumns =
       , ("attributes___user___full_name", aT "user.full_name")
       , ("attributes___user___name", aT "user.name")
       , ("attributes___user___hash", aT "user.hash")
-      , ("resource", \c -> param (fmap (cleanNullBytesFromJSON . AE.Object . KEM.fromMapText) c.rm))
+      , ("resource", \c -> param (fmap (scrubNulValue . AE.Object . KEM.fromMapText) c.rm))
       , ("resource___service___name", rT "service.name")
       , ("resource___service___version", rT "service.version")
       , ("resource___service___instance___id", rT "service.instance.id")
@@ -1374,7 +1326,7 @@ otelColumns =
       , ("resource___telemetry___sdk___name", rT "telemetry.sdk.name")
       , ("resource___telemetry___sdk___version", rT "telemetry.sdk.version")
       , ("resource___user_agent___original", rT "user_agent.original")
-      , ("project_id", top (param . cleanNullBytes . (.project_id)))
+      , ("project_id", top (param . scrubNulText . (.project_id)))
       , ("summary", arr (.summary))
       , ("date", top (param . (.date)))
       , ("message_size_bytes", top (param . (.message_size_bytes)))

--- a/src/Models/Telemetry/Telemetry.hs
+++ b/src/Models/Telemetry/Telemetry.hs
@@ -163,7 +163,7 @@ atMapInt key maybeMap = do
   m <- maybeMap
   val <- getNestedValue (T.split (== '.') key) m
   case val of
-    AE.Number n -> toBoundedInteger n
+    AE.Number n -> Just $ round n
     AE.String t -> readMaybe $ toString t
     _ -> Nothing
 

--- a/src/Models/Telemetry/Telemetry.hs
+++ b/src/Models/Telemetry/Telemetry.hs
@@ -80,9 +80,10 @@ import Control.Lens ((.~))
 import Data.Aeson qualified as AE
 import Data.Aeson.Key qualified as AEK
 import Data.Aeson.KeyMap qualified as KEM
-import Data.Scientific (toBoundedInteger)
 import Data.ByteString.Base16 qualified as B16
 import Data.Default (Default (..))
+import Data.Effectful.Hasql (Hasql)
+import Data.Effectful.Hasql qualified as Hasql
 import Data.Effectful.UUID (UUIDEff, genUUID)
 import Data.Generics.Labels ()
 import Data.HashMap.Strict qualified as HM
@@ -91,6 +92,7 @@ import Data.List qualified as L (groupBy)
 import Data.List.Extra (chunksOf)
 import Data.List.NonEmpty qualified as NE
 import Data.Map qualified as Map
+import Data.Scientific (toBoundedInteger)
 import Data.Set qualified as S
 import Data.Text qualified as T
 import Data.Text.Display (Display)
@@ -101,8 +103,6 @@ import Data.Time.Clock (addUTCTime)
 import Data.UUID qualified as UUID
 import Data.Vector qualified as V
 import Data.Vector.Split qualified as VS
-import Data.Effectful.Hasql (Hasql)
-import Data.Effectful.Hasql qualified as Hasql
 import Database.PostgreSQL.Simple.FromField (Conversion, FromField (..))
 import Database.PostgreSQL.Simple.FromRow
 import Database.PostgreSQL.Simple.Newtypes (Aeson (..))
@@ -634,11 +634,17 @@ getSpanRecordsByTraceId pid trId tme now = do
       (wideStart, wideEnd) = (addUTCTime (-86400) baseT, addUTCTime 86400 baseT)
       resolveHop ids =
         Hasql.interp
-          $ selectOtelSpans pid.toText wideStart wideEnd
+          $ selectOtelSpans
+            pid.toText
+            wideStart
+            wideEnd
             [HI.sql| AND context___trace_id=#{trId} AND context___span_id = ANY(#{ids})|]
   initial :: [OtelLogsAndSpans] <-
     Hasql.interp
-      $ selectOtelSpans pid.toText start end
+      $ selectOtelSpans
+        pid.toText
+        start
+        end
         [HI.sql| AND context___trace_id=#{trId} ORDER BY start_time ASC|]
   -- Resolve missing parents iteratively: a parent ingested outside ±5min
   -- (clock skew, late ingestion, async batch) is looked up via
@@ -673,7 +679,10 @@ getSpanRecordsByTraceIds pid traceIds tme = do
         Just ts -> (addUTCTime (-300) ts, addUTCTime 300 ts)
       traceIdsList = V.toList traceIds
   Hasql.interp
-    $ selectOtelSpans pid.toText start end'
+    $ selectOtelSpans
+      pid.toText
+      start
+      end'
       [HI.sql| AND context___trace_id = ANY(#{traceIdsList}) ORDER BY context___trace_id ASC, start_time ASC|]
 
 

--- a/src/Opentelemetry/OtlpServer.hs
+++ b/src/Opentelemetry/OtlpServer.hs
@@ -23,6 +23,7 @@ module Opentelemetry.OtlpServer (
 
 import Control.Concurrent (forkIO, threadDelay)
 import Control.Exception.Annotated (checkpoint)
+import Data.Annotation (toAnnotation)
 import Data.Aeson qualified as AE
 import Data.Aeson.Key qualified as AEK
 import Data.Aeson.KeyMap qualified as KEM
@@ -198,12 +199,19 @@ getApiKeyAttr kvs =
     <|> getNestedAttr "http.headers" "x-api-key" kvs
 
 
+-- | Per-resource attribute lookup: resource-level attrs, falling back to the
+-- first record's attrs that carries the key. Parameterized by the resource-attrs
+-- accessor and the flattened per-record attrs accessor so spans/logs share it.
+resourceAttributeValue :: (r -> [PC.KeyValue]) -> (r -> [[PC.KeyValue]]) -> Text -> V.Vector r -> V.Vector Text
+resourceAttributeValue resAttrs recAttrs !attribute =
+  V.mapMaybe (\r -> getAttr attribute (resAttrs r) <|> listToMaybe (mapMaybe (getAttr attribute) (recAttrs r)))
+
+
 getSpanAttributeValue :: Text -> V.Vector PT.ResourceSpans -> V.Vector Text
-getSpanAttributeValue !attribute = V.mapMaybe (\rs -> getAttr attribute (rs ^. PTF.resource . PRF.attributes) <|> getSpanAttr rs)
-  where
-    getSpanAttr rs =
-      let spans = V.fromList (rs ^. PTF.scopeSpans) >>= (\s -> V.fromList (s ^. PTF.spans))
-       in V.mapMaybe (getAttr attribute . (^. PTF.attributes)) spans V.!? 0
+getSpanAttributeValue =
+  resourceAttributeValue
+    (^. PTF.resource . PRF.attributes)
+    (\rs -> [s' ^. PTF.attributes | ss <- rs ^. PTF.scopeSpans, s' <- ss ^. PTF.spans])
 
 
 getSpanApiKey :: V.Vector PT.ResourceSpans -> V.Vector Text
@@ -211,11 +219,10 @@ getSpanApiKey = V.mapMaybe (\rs -> getApiKeyAttr (rs ^. PTF.resource . PRF.attri
 
 
 getLogAttributeValue :: Text -> V.Vector PL.ResourceLogs -> V.Vector Text
-getLogAttributeValue !attribute = V.mapMaybe (\rl -> getAttr attribute (rl ^. PLF.resource . PRF.attributes) <|> getLogAttr rl)
-  where
-    getLogAttr rl =
-      let logs = V.fromList (rl ^. PLF.scopeLogs) >>= (\s -> V.fromList (s ^. PLF.logRecords))
-       in V.mapMaybe (getAttr attribute . (^. PLF.attributes)) logs V.!? 0
+getLogAttributeValue =
+  resourceAttributeValue
+    (^. PLF.resource . PRF.attributes)
+    (\rl -> [r' ^. PLF.attributes | sl <- rl ^. PLF.scopeLogs, r' <- sl ^. PLF.logRecords])
 
 
 getLogApiKey :: V.Vector PL.ResourceLogs -> V.Vector Text
@@ -223,9 +230,7 @@ getLogApiKey = V.mapMaybe (\rl -> getApiKeyAttr (rl ^. PLF.resource . PRF.attrib
 
 
 getMetricAttributeValue :: Text -> V.Vector PM.ResourceMetrics -> Maybe Text
-getMetricAttributeValue !attribute !rms = V.mapMaybe getResourceAttr rms V.!? 0
-  where
-    getResourceAttr rm = getAttr attribute (rm ^. PMF.resource . PRF.attributes)
+getMetricAttributeValue !attribute !rms = V.mapMaybe (\rm -> getAttr attribute (rm ^. PMF.resource . PRF.attributes)) rms V.!? 0
 
 
 getMetricApiKey :: V.Vector PM.ResourceMetrics -> Maybe Text
@@ -843,21 +848,15 @@ deriveClientAddress kvMap
         [] -> ""
 
 
--- Extract structured information from protobuf decoding errors
-createProtoErrorInfo :: String -> ByteString -> AE.Value
-createProtoErrorInfo err msg =
-  case T.splitOn ":" (toText err) of
-    (firstPart : details) ->
-      let fieldPath = T.takeWhile (/= ':') (T.strip (unwords details))
-          errorType = T.takeWhileEnd (/= ':') (T.strip (unwords details))
-       in AE.object ["err_type" AE..= errorType, "field_path" AE..= fieldPath, "full_err" AE..= err, "msg_size" AE..= BS.length msg]
-    _ -> AE.object ["full_err" AE..= err, "msg_size" AE..= BS.length msg]
-
-
 -- | Record a protobuf decode error, categorizing wire type, UTF-8, and EOF errors
 recordProtoError :: MonadIO m => Text -> String -> ByteString -> (Text -> AE.Value -> m ()) -> m ()
 recordProtoError prefix err msg logFn = do
-  let errorInfo = createProtoErrorInfo err msg
+  let errorInfo = case T.splitOn ":" (toText err) of
+        (firstPart : details) ->
+          let fieldPath = T.takeWhile (/= ':') (T.strip (unwords details))
+              errorType = T.takeWhileEnd (/= ':') (T.strip (unwords details))
+           in AE.object ["err_type" AE..= errorType, "field_path" AE..= fieldPath, "full_err" AE..= err, "msg_size" AE..= BS.length msg]
+        _ -> AE.object ["full_err" AE..= err, "msg_size" AE..= BS.length msg]
       categorize
         | "Unknown wire type" `L.isInfixOf` err = Just (prefix <> ":wire_type_error")
         | "Cannot decode byte" `L.isInfixOf` err && "Invalid UTF-8 stream" `L.isInfixOf` err = Just (prefix <> ":utf8_decode_error")
@@ -881,17 +880,17 @@ nanosecondsToUTC :: Word64 -> UTCTime
 nanosecondsToUTC !ns = posixSecondsToUTCTime (fromIntegral ns / 1e9)
 
 
+-- | Convert a nanosecond timestamp to UTC, falling back when it's unset/invalid
+-- (before the Year-2000 floor or exactly zero).
+validTsOr :: UTCTime -> Word64 -> UTCTime
+validTsOr fallback ns = if ns >= minValidTimestampNanos && ns /= 0 then nanosecondsToUTC ns else fallback
+
+
 -- | Get a valid timestamp with fallback logic
 -- Priority: timestamp -> observed_timestamp -> fallback time
 getValidTimestamp :: UTCTime -> Word64 -> Word64 -> UTCTime
 getValidTimestamp !fallbackTime !timeNano !observedTimeNano =
-  let isValid ns = ns >= minValidTimestampNanos && ns /= 0
-   in if isValid timeNano
-        then nanosecondsToUTC timeNano
-        else
-          if isValid observedTimeNano
-            then nanosecondsToUTC observedTimeNano
-            else fallbackTime
+  validTsOr (validTsOr fallbackTime observedTimeNano) timeNano
 
 
 -- Convert ByteString to hex Text
@@ -1054,10 +1053,7 @@ convertLogRecordToOtelLog !fallbackTime !pid resourceM scopeM logRecord =
       !severityText = logRecord ^. PLF.severityText
       !severityNumber = fromEnum (logRecord ^. PLF.severityNumber)
       !validTimestamp = getValidTimestamp fallbackTime timeNano observedTimeNano
-      !validObservedTimestamp =
-        if observedTimeNano >= minValidTimestampNanos && observedTimeNano /= 0
-          then nanosecondsToUTC observedTimeNano
-          else fallbackTime
+      !validObservedTimestamp = validTsOr fallbackTime observedTimeNano
 
       !parentId = hexIdMaybe (logRecord ^. PLF.spanId)
 
@@ -1149,14 +1145,8 @@ convertSpanToOtelLog :: UTCTime -> Projects.ProjectId -> Maybe PR.Resource -> Ma
 convertSpanToOtelLog !fallbackTime !pid resourceM scopeM pSpan =
   let !startTimeNano = pSpan ^. PTF.startTimeUnixNano
       !endTimeNano = pSpan ^. PTF.endTimeUnixNano
-      !validStartTime =
-        if startTimeNano >= minValidTimestampNanos && startTimeNano /= 0
-          then nanosecondsToUTC startTimeNano
-          else fallbackTime
-      !validEndTime =
-        if endTimeNano >= minValidTimestampNanos && endTimeNano /= 0
-          then nanosecondsToUTC endTimeNano
-          else validStartTime -- If end time is invalid, use start time
+      !validStartTime = validTsOr fallbackTime startTimeNano
+      !validEndTime = validTsOr validStartTime endTimeNano -- If end time is invalid, use start time
       !durationNanos =
         if startTimeNano > 0 && endTimeNano > startTimeNano
           then endTimeNano - startTimeNano
@@ -1193,11 +1183,7 @@ convertSpanToOtelLog !fallbackTime !pid resourceM scopeM pSpan =
                     ( \ev ->
                         AE.object
                           [ "event_name" AE..= (ev ^. PTF.name)
-                          , "event_time"
-                              AE..= let evTimeNano = ev ^. PTF.timeUnixNano
-                                     in if evTimeNano >= minValidTimestampNanos && evTimeNano /= 0
-                                          then nanosecondsToUTC evTimeNano
-                                          else fallbackTime
+                          , "event_time" AE..= validTsOr fallbackTime (ev ^. PTF.timeUnixNano)
                           , "event_attributes" AE..= keyValueToJSON (ev ^. PTF.attributes)
                           , "event_dropped_attributes_count" AE..= (ev ^. PTF.droppedAttributesCount)
                           ]
@@ -1389,7 +1375,7 @@ convertMetricToMetricRecords fallbackTime pid resourceM scopeM metric =
       Just scope -> AE.object ["scope" AE..= (scope ^. PCF.name)]
       Nothing -> AE.Null
 
-    pointTime timeNano = if timeNano >= minValidTimestampNanos && timeNano /= 0 then nanosecondsToUTC timeNano else fallbackTime
+    pointTime = validTsOr fallbackTime
     pointAttrs point = keyValueToJSON (V.toList $ point ^. PMF.vec'attributes)
 
     mkRecord validTime attrs mType mValue fls temporality_ monotonic_ payloadBytes =
@@ -1489,16 +1475,42 @@ runServer appLogger appCtx tp = do
 
 -- | Process trace request with optional API key from gRPC metadata (extracted for testing)
 processTraceRequest :: (Concurrent :> es, DB es, Eff.Reader AuthContext :> es, Ki.StructuredConcurrency :> es, Labeled "timefusion" Hasql.Hasql :> es, Log :> es, Time.Time :> es, UUIDEff :> es) => Maybe Text -> TS.ExportTraceServiceRequest -> Eff es ()
-processTraceRequest metadataApiKey req = do
-  Log.logTrace "Received trace export request" AE.Null
+processTraceRequest metadataApiKey req =
+  let !resourceSpans = V.fromList $ req ^. TSF.resourceSpans
+   in processSignalRequest "Traces" "traces" "Received trace export request" "spans" "span_count" metadataApiKey (getSpanApiKey resourceSpans) (V.toList $ getSpanAttributeValue "at-project-id" resourceSpans) $ \currentTime projectCaches projectIdsAndKeys ->
+        V.fromList $ convertResourceSpansToOtelLogs currentTime projectCaches projectIdsAndKeys resourceSpans
+
+-- | Process logs request with optional API key from gRPC metadata (extracted for testing)
+processLogsRequest :: (Concurrent :> es, DB es, Eff.Reader AuthContext :> es, Ki.StructuredConcurrency :> es, Labeled "timefusion" Hasql.Hasql :> es, Log :> es, Time.Time :> es, UUIDEff :> es) => Maybe Text -> LS.ExportLogsServiceRequest -> Eff es ()
+processLogsRequest metadataApiKey req =
+  let !resourceLogs = V.fromList $ req ^. PLF.resourceLogs
+   in processSignalRequest "Logs" "logs" "Received logs export request" "logs" "log_count" metadataApiKey (getLogApiKey resourceLogs) (V.toList $ getLogAttributeValue "at-project-id" resourceLogs) $ \currentTime projectCaches projectIdsAndKeys ->
+        V.fromList $ concatMap (convertResourceLogsToOtelLogs currentTime projectCaches projectIdsAndKeys) (V.toList resourceLogs)
+
+-- | Shared gRPC-direct ingestion pipeline for traces and logs: auth-verify, cache-fetch,
+-- convert (via the signal-specific converter), then stamp/mint/insert. Throws GrpcUnauthenticated
+-- on bad auth and throwOnWriteFailure on write failure. @label@ is the human log prefix
+-- ("Traces"/"Logs"), @signal@ the checkpoint/span label ("traces"/"logs"), @noun@/@countKey@
+-- the converted/inserted record noun and its log count key ("spans"/"span_count").
+processSignalRequest
+  :: (Concurrent :> es, DB es, Eff.Reader AuthContext :> es, Ki.StructuredConcurrency :> es, Labeled "timefusion" Hasql.Hasql :> es, Log :> es, Time.Time :> es, UUIDEff :> es)
+  => Text
+  -> Text
+  -> Text
+  -> Text
+  -> AE.Key
+  -> Maybe Text
+  -> V.Vector Text
+  -> [Text]
+  -> (UTCTime -> HM.HashMap Projects.ProjectId Projects.ProjectCache -> V.Vector (Text, Projects.ProjectId) -> V.Vector OtelLogsAndSpans)
+  -> Eff es ()
+processSignalRequest label signal receivedMsg noun countKey metadataApiKey projectKeys atIds' convert = do
+  Log.logTrace receivedMsg AE.Null
 
   currentTime <- liftIO getCurrentTime
   appCtx <- ask @AuthContext
 
-  let !resourceSpans = V.fromList $ req ^. TSF.resourceSpans
-      !projectKeys = getSpanApiKey resourceSpans
-      atIds' = getSpanAttributeValue "at-project-id" resourceSpans
-      atIds = V.catMaybes $ Projects.projectIdFromText <$> atIds'
+  let atIds = V.catMaybes $ Projects.projectIdFromText <$> V.fromList atIds'
 
       -- Combine API key from metadata with keys from resource attributes
       !allApiKeys = case metadataApiKey of
@@ -1519,14 +1531,14 @@ processTraceRequest metadataApiKey req = do
         , grpcErrorDetails = Nothing
         }
     Log.logTrace
-      "Traces: Authentication successful"
+      (label <> ": Authentication successful")
       (AE.object ["project_ids" AE..= map unUUIDId allProjectIds, "project_keys" AE..= V.toList allApiKeys, "metadata_auth" AE..= isJust metadataApiKey])
 
   projectIdsAndKeys <-
-    checkpoint "processList:traces:getProjectIds"
+    checkpoint (toAnnotation $ "processList:" <> signal <> ":getProjectIds")
       $ ProjectApiKeys.projectIdsByProjectApiKeys allApiKeys
   -- Fetch project caches for limit checking
-  projectCaches <- checkpoint "processList:traces:getProjectCaches" $ do
+  projectCaches <- checkpoint (toAnnotation $ "processList:" <> signal <> ":getProjectCaches") $ do
     let projectIds = toList . HS.fromList $ V.toList atIds <> [pid | (_, pid) <- V.toList projectIdsAndKeys]
 
     caches <- forM projectIds $ \pid -> do
@@ -1535,20 +1547,20 @@ processTraceRequest metadataApiKey req = do
         pure $ fromMaybe Projects.defaultProjectCache mpjCache
       pure (pid, cache)
     pure $ HM.fromList caches
-  let !spans' = V.fromList $ convertResourceSpansToOtelLogs currentTime projectCaches projectIdsAndKeys resourceSpans
+  let !records = convert currentTime projectCaches projectIdsAndKeys
 
   Log.logTrace
-    "Traces: Converted resource spans to OtelLogs"
-    (AE.object ["span_count" AE..= V.length spans'])
+    (label <> ": Converted resource " <> noun <> " to OtelLogs")
+    (AE.object [countKey AE..= V.length records])
 
-  unless (V.null spans') do
-    stampedSpans <- stampOrPassthrough appCtx spans'
-    mintedSpans <- Telemetry.mintOtelLogIds stampedSpans
-    Telemetry.insertAndHandOff appCtx.env.enableTimefusionWrites appCtx.extractionWorker projectCaches mintedSpans
+  unless (V.null records) do
+    stamped <- stampOrPassthrough appCtx records
+    minted <- Telemetry.mintOtelLogIds stamped
+    Telemetry.insertAndHandOff appCtx.env.enableTimefusionWrites appCtx.extractionWorker projectCaches minted
       >>= throwOnWriteFailure
     Log.logTrace
-      "Traces: Successfully inserted spans into database"
-      (AE.object ["inserted_count" AE..= V.length mintedSpans])
+      (label <> ": Successfully inserted " <> noun <> " into database")
+      (AE.object ["inserted_count" AE..= V.length minted])
 
 
 -- | Trace service handler (Export)
@@ -1576,68 +1588,6 @@ traceServiceExport appLogger appCtx tp (Proto req) = do
   _ <- runBackground appLogger appCtx tp $ processTraceRequest Nothing req
   -- Return an empty response
   pure defMessage
-
-
--- | Process logs request with optional API key from gRPC metadata (extracted for testing)
-processLogsRequest :: (Concurrent :> es, DB es, Eff.Reader AuthContext :> es, Ki.StructuredConcurrency :> es, Labeled "timefusion" Hasql.Hasql :> es, Log :> es, Time.Time :> es, UUIDEff :> es) => Maybe Text -> LS.ExportLogsServiceRequest -> Eff es ()
-processLogsRequest metadataApiKey req = do
-  Log.logTrace "Received logs export request" AE.Null
-  currentTime <- liftIO getCurrentTime
-  appCtx <- ask @AuthContext
-
-  let !resourceLogs = V.fromList $ req ^. PLF.resourceLogs
-      !projectKeys = getLogApiKey resourceLogs
-      atIds' = getLogAttributeValue "at-project-id" resourceLogs
-      atIds = V.catMaybes $ Projects.projectIdFromText <$> atIds'
-
-      -- Combine API key from metadata with keys from resource attributes
-      !allApiKeys = case metadataApiKey of
-        Just key -> V.cons key projectKeys
-        Nothing -> projectKeys
-
-  -- Verify authentication: if project keys or IDs are present, they must resolve to valid projects
-  when (not (V.null allApiKeys) || not (V.null atIds)) $ do
-    projectIdsAndKeys <- ProjectApiKeys.projectIdsByProjectApiKeys allApiKeys
-    let allProjectIds = toList . HS.fromList $ V.toList atIds <> [pid | (_, pid) <- V.toList projectIdsAndKeys]
-    when (null allProjectIds)
-      $ liftIO
-      $ throwIO
-      $ GrpcException
-        { grpcError = GrpcUnauthenticated
-        , grpcErrorMessage = Just "Invalid or missing project API key"
-        , grpcErrorMetadata = []
-        , grpcErrorDetails = Nothing
-        }
-    Log.logTrace
-      "Logs: Authentication successful"
-      (AE.object ["project_ids" AE..= map unUUIDId allProjectIds, "project_keys" AE..= V.toList allApiKeys, "metadata_auth" AE..= isJust metadataApiKey])
-
-  projectIdsAndKeys <- ProjectApiKeys.projectIdsByProjectApiKeys allApiKeys
-
-  -- Fetch project caches using cache pattern
-  projectCaches <- checkpoint "processList:logs:getProjectCaches" $ do
-    let projectIds = toList . HS.fromList $ V.toList atIds <> [pid | (_, pid) <- V.toList projectIdsAndKeys]
-    caches <- forM projectIds $ \pid -> do
-      cache <- liftIO $ Cache.fetchWithCache appCtx.projectCache pid $ \pid' -> do
-        mpjCache <- Projects.projectCacheByIdIO appCtx.hasqlJobsPool pid'
-        pure $ fromMaybe Projects.defaultProjectCache mpjCache
-      pure (pid, cache)
-    pure $ HM.fromList caches
-
-  let !logs = V.fromList $ concatMap (convertResourceLogsToOtelLogs currentTime projectCaches projectIdsAndKeys) (V.toList resourceLogs)
-
-  Log.logTrace
-    "Logs: Converted resource logs to OtelLogs"
-    (AE.object ["log_count" AE..= V.length logs])
-
-  unless (V.null logs) do
-    stampedLogs <- stampOrPassthrough appCtx logs
-    mintedLogs <- Telemetry.mintOtelLogIds stampedLogs
-    Telemetry.insertAndHandOff appCtx.env.enableTimefusionWrites appCtx.extractionWorker projectCaches mintedLogs
-      >>= throwOnWriteFailure
-    Log.logTrace
-      "Logs: Successfully inserted logs into database"
-      (AE.object ["inserted_count" AE..= V.length mintedLogs])
 
 
 -- | Logs service handler (Export)
@@ -1741,55 +1691,63 @@ isFreeTierExceededCached appCtx = \case
           Nothing -> False
 
 
--- | RpcHandler for trace service with metadata access
-traceServiceRpcHandler :: Logger -> AuthContext -> TracerProvider -> RpcHandler IO (Protobuf TS.TraceService "export")
-traceServiceRpcHandler appLogger appCtx tp = mkRpcHandler $ \call -> do
+-- | Shared skeleton for the three OTLP export RpcHandlers: read metadata/api-key,
+-- recv the request, and either reject (free-tier exceeded) with a per-signal
+-- partialSuccess response or dispatch the per-signal processing in the background.
+-- The per-signal parts are the rejected-count fn, the rejection-response builder,
+-- the dispatch label, and the process fn.
+mkOtlpRpcHandler
+  :: ( Message (Output (Protobuf service meth))
+     , Input (Protobuf service meth) ~ Proto req
+     , RequestMetadata (Protobuf service meth) ~ OtlpRequestMetadata
+     , ResponseInitialMetadata (Protobuf service meth) ~ NoMetadata
+     , ResponseTrailingMetadata (Protobuf service meth) ~ NoMetadata
+     )
+  => Logger
+  -> AuthContext
+  -> TracerProvider
+  -> Text
+  -> (req -> Int64)
+  -> (Int64 -> Output (Protobuf service meth))
+  -> (Maybe Text -> req -> ATBackgroundCtx ())
+  -> RpcHandler IO (Protobuf service meth)
+mkOtlpRpcHandler appLogger appCtx tp label countFn rejectResp process = mkRpcHandler $ \call -> do
   metadata <- getRequestMetadata call
   let apiKey = otlpApiKey metadata
   Proto req <- recvFinalInput call
   exceeded <- isFreeTierExceededCached appCtx apiKey
   if exceeded
-    then do
-      let count = fromIntegral $ sum [length (ss ^. PTF.spans) | rs <- req ^. TSF.resourceSpans, ss <- rs ^. PTF.scopeSpans]
-          resp = defMessage & TSF.partialSuccess .~ (defMessage & TSF.rejectedSpans .~ count & TSF.errorMessage .~ "Free tier daily event limit exceeded")
-      sendFinalOutput call (resp, NoMetadata)
+    then sendFinalOutput call (rejectResp (countFn req), NoMetadata)
     else do
-      grpcRunBackground appLogger appCtx tp "traces" $ processTraceRequest apiKey req
+      grpcRunBackground appLogger appCtx tp label $ process apiKey req
       sendFinalOutput call (defMessage, NoMetadata)
+
+
+-- | RpcHandler for trace service with metadata access
+traceServiceRpcHandler :: Logger -> AuthContext -> TracerProvider -> RpcHandler IO (Protobuf TS.TraceService "export")
+traceServiceRpcHandler appLogger appCtx tp =
+  mkOtlpRpcHandler appLogger appCtx tp "traces"
+    (\req -> fromIntegral $ sum [length (ss ^. PTF.spans) | rs <- req ^. TSF.resourceSpans, ss <- rs ^. PTF.scopeSpans])
+    (\count -> defMessage & TSF.partialSuccess .~ (defMessage & TSF.rejectedSpans .~ count & TSF.errorMessage .~ "Free tier daily event limit exceeded"))
+    processTraceRequest
 
 
 -- | RpcHandler for logs service with metadata access
 logsServiceRpcHandler :: Logger -> AuthContext -> TracerProvider -> RpcHandler IO (Protobuf LS.LogsService "export")
-logsServiceRpcHandler appLogger appCtx tp = mkRpcHandler $ \call -> do
-  metadata <- getRequestMetadata call
-  let apiKey = otlpApiKey metadata
-  Proto req <- recvFinalInput call
-  exceeded <- isFreeTierExceededCached appCtx apiKey
-  if exceeded
-    then do
-      let count = fromIntegral $ sum [length (sl ^. PLF.logRecords) | rl <- req ^. LSF.resourceLogs, sl <- rl ^. PLF.scopeLogs]
-          resp = defMessage & LSF.partialSuccess .~ (defMessage & LSF.rejectedLogRecords .~ count & LSF.errorMessage .~ "Free tier daily event limit exceeded")
-      sendFinalOutput call (resp, NoMetadata)
-    else do
-      grpcRunBackground appLogger appCtx tp "logs" $ processLogsRequest apiKey req
-      sendFinalOutput call (defMessage, NoMetadata)
+logsServiceRpcHandler appLogger appCtx tp =
+  mkOtlpRpcHandler appLogger appCtx tp "logs"
+    (\req -> fromIntegral $ sum [length (sl ^. PLF.logRecords) | rl <- req ^. LSF.resourceLogs, sl <- rl ^. PLF.scopeLogs])
+    (\count -> defMessage & LSF.partialSuccess .~ (defMessage & LSF.rejectedLogRecords .~ count & LSF.errorMessage .~ "Free tier daily event limit exceeded"))
+    processLogsRequest
 
 
 -- | RpcHandler for metrics service with metadata access
 metricsServiceRpcHandler :: Logger -> AuthContext -> TracerProvider -> RpcHandler IO (Protobuf MS.MetricsService "export")
-metricsServiceRpcHandler appLogger appCtx tp = mkRpcHandler $ \call -> do
-  metadata <- getRequestMetadata call
-  let apiKey = otlpApiKey metadata
-  Proto req <- recvFinalInput call
-  exceeded <- isFreeTierExceededCached appCtx apiKey
-  if exceeded
-    then do
-      let count = fromIntegral $ sum [length (sm ^. PMF.metrics) | rm <- req ^. MSF.resourceMetrics, sm <- rm ^. PMF.scopeMetrics]
-          resp = defMessage & MSF.partialSuccess .~ (defMessage & MSF.rejectedDataPoints .~ count & MSF.errorMessage .~ "Free tier daily event limit exceeded")
-      sendFinalOutput call (resp, NoMetadata)
-    else do
-      grpcRunBackground appLogger appCtx tp "metrics" $ processMetricsRequest apiKey req
-      sendFinalOutput call (defMessage, NoMetadata)
+metricsServiceRpcHandler appLogger appCtx tp =
+  mkOtlpRpcHandler appLogger appCtx tp "metrics"
+    (\req -> fromIntegral $ sum [length (sm ^. PMF.metrics) | rm <- req ^. MSF.resourceMetrics, sm <- rm ^. PMF.scopeMetrics])
+    (\count -> defMessage & MSF.partialSuccess .~ (defMessage & MSF.rejectedDataPoints .~ count & MSF.errorMessage .~ "Free tier daily event limit exceeded"))
+    processMetricsRequest
 
 
 -- | Run a background task for gRPC handlers, catching exceptions to prevent server crash.

--- a/src/Opentelemetry/OtlpServer.hs
+++ b/src/Opentelemetry/OtlpServer.hs
@@ -23,10 +23,10 @@ module Opentelemetry.OtlpServer (
 
 import Control.Concurrent (forkIO, threadDelay)
 import Control.Exception.Annotated (checkpoint)
-import Data.Annotation (toAnnotation)
 import Data.Aeson qualified as AE
 import Data.Aeson.Key qualified as AEK
 import Data.Aeson.KeyMap qualified as KEM
+import Data.Annotation (toAnnotation)
 import Data.Base64.Types qualified as B64
 import Data.ByteString qualified as BS
 import Data.ByteString.Base16 qualified as B16
@@ -1480,12 +1480,14 @@ processTraceRequest metadataApiKey req =
    in processSignalRequest "Traces" "traces" "Received trace export request" "spans" "span_count" metadataApiKey (getSpanApiKey resourceSpans) (V.toList $ getSpanAttributeValue "at-project-id" resourceSpans) $ \currentTime projectCaches projectIdsAndKeys ->
         V.fromList $ convertResourceSpansToOtelLogs currentTime projectCaches projectIdsAndKeys resourceSpans
 
+
 -- | Process logs request with optional API key from gRPC metadata (extracted for testing)
 processLogsRequest :: (Concurrent :> es, DB es, Eff.Reader AuthContext :> es, Ki.StructuredConcurrency :> es, Labeled "timefusion" Hasql.Hasql :> es, Log :> es, Time.Time :> es, UUIDEff :> es) => Maybe Text -> LS.ExportLogsServiceRequest -> Eff es ()
 processLogsRequest metadataApiKey req =
   let !resourceLogs = V.fromList $ req ^. PLF.resourceLogs
    in processSignalRequest "Logs" "logs" "Received logs export request" "logs" "log_count" metadataApiKey (getLogApiKey resourceLogs) (V.toList $ getLogAttributeValue "at-project-id" resourceLogs) $ \currentTime projectCaches projectIdsAndKeys ->
         V.fromList $ concatMap (convertResourceLogsToOtelLogs currentTime projectCaches projectIdsAndKeys) (V.toList resourceLogs)
+
 
 -- | Shared gRPC-direct ingestion pipeline for traces and logs: auth-verify, cache-fetch,
 -- convert (via the signal-specific converter), then stamp/mint/insert. Throws GrpcUnauthenticated
@@ -1697,8 +1699,8 @@ isFreeTierExceededCached appCtx = \case
 -- The per-signal parts are the rejected-count fn, the rejection-response builder,
 -- the dispatch label, and the process fn.
 mkOtlpRpcHandler
-  :: ( Message (Output (Protobuf service meth))
-     , Input (Protobuf service meth) ~ Proto req
+  :: ( Input (Protobuf service meth) ~ Proto req
+     , Message (Output (Protobuf service meth))
      , RequestMetadata (Protobuf service meth) ~ OtlpRequestMetadata
      , ResponseInitialMetadata (Protobuf service meth) ~ NoMetadata
      , ResponseTrailingMetadata (Protobuf service meth) ~ NoMetadata
@@ -1726,7 +1728,11 @@ mkOtlpRpcHandler appLogger appCtx tp label countFn rejectResp process = mkRpcHan
 -- | RpcHandler for trace service with metadata access
 traceServiceRpcHandler :: Logger -> AuthContext -> TracerProvider -> RpcHandler IO (Protobuf TS.TraceService "export")
 traceServiceRpcHandler appLogger appCtx tp =
-  mkOtlpRpcHandler appLogger appCtx tp "traces"
+  mkOtlpRpcHandler
+    appLogger
+    appCtx
+    tp
+    "traces"
     (\req -> fromIntegral $ sum [length (ss ^. PTF.spans) | rs <- req ^. TSF.resourceSpans, ss <- rs ^. PTF.scopeSpans])
     (\count -> defMessage & TSF.partialSuccess .~ (defMessage & TSF.rejectedSpans .~ count & TSF.errorMessage .~ "Free tier daily event limit exceeded"))
     processTraceRequest
@@ -1735,7 +1741,11 @@ traceServiceRpcHandler appLogger appCtx tp =
 -- | RpcHandler for logs service with metadata access
 logsServiceRpcHandler :: Logger -> AuthContext -> TracerProvider -> RpcHandler IO (Protobuf LS.LogsService "export")
 logsServiceRpcHandler appLogger appCtx tp =
-  mkOtlpRpcHandler appLogger appCtx tp "logs"
+  mkOtlpRpcHandler
+    appLogger
+    appCtx
+    tp
+    "logs"
     (\req -> fromIntegral $ sum [length (sl ^. PLF.logRecords) | rl <- req ^. LSF.resourceLogs, sl <- rl ^. PLF.scopeLogs])
     (\count -> defMessage & LSF.partialSuccess .~ (defMessage & LSF.rejectedLogRecords .~ count & LSF.errorMessage .~ "Free tier daily event limit exceeded"))
     processLogsRequest
@@ -1744,7 +1754,11 @@ logsServiceRpcHandler appLogger appCtx tp =
 -- | RpcHandler for metrics service with metadata access
 metricsServiceRpcHandler :: Logger -> AuthContext -> TracerProvider -> RpcHandler IO (Protobuf MS.MetricsService "export")
 metricsServiceRpcHandler appLogger appCtx tp =
-  mkOtlpRpcHandler appLogger appCtx tp "metrics"
+  mkOtlpRpcHandler
+    appLogger
+    appCtx
+    tp
+    "metrics"
     (\req -> fromIntegral $ sum [length (sm ^. PMF.metrics) | rm <- req ^. MSF.resourceMetrics, sm <- rm ^. PMF.scopeMetrics])
     (\count -> defMessage & MSF.partialSuccess .~ (defMessage & MSF.rejectedDataPoints .~ count & MSF.errorMessage .~ "Free tier daily event limit exceeded"))
     processMetricsRequest

--- a/src/Pages/Anomalies.hs
+++ b/src/Pages/Anomalies.hs
@@ -1288,7 +1288,7 @@ toolDataToDataset json = flip parseMaybe json $ AE.withObject "RawData" \obj -> 
 aiChatHistoryView_ :: Projects.ProjectId -> [Issues.AIChatMessage] -> Html ()
 aiChatHistoryView_ pid msgs = forM_ (pairUserAssistant msgs) \(u, a) -> do
   let (explanation, widgets) = parseStoredContent a.content a.widgets
-  aiChatResponse_ pid u.content explanation widgets (a.metadata >>= parseMaybe AE.parseJSON . getAeson) Nothing
+  aiChatResponse_ pid u.content explanation widgets (parseStoredJSON @[AI.ToolCallInfo] a.metadata) Nothing
 
 
 -- | Render chat history with system prompt as first message
@@ -1310,12 +1310,17 @@ pairUserAssistant (_ : rest) = pairUserAssistant rest
 pairUserAssistant [] = []
 
 
+-- | Decode a stored JSONB value (anomaly metadata, widget lists) into a typed payload.
+parseStoredJSON :: AE.FromJSON a => Maybe (Aeson AE.Value) -> Maybe a
+parseStoredJSON = (>>= parseMaybe AE.parseJSON . getAeson)
+
+
 -- | Parse stored content - try JSON format first (stripping code blocks), fall back to plain text
 parseStoredContent :: Text -> Maybe (Aeson AE.Value) -> (Text, Maybe [Widget.Widget])
 parseStoredContent content storedWidgets =
   case AI.parseLLMResponse content of
     Right aiResp -> (fromMaybe "" aiResp.explanation, if null aiResp.widgets then Nothing else Just aiResp.widgets)
-    Left _ -> (content, storedWidgets >>= parseMaybe AE.parseJSON . getAeson)
+    Left _ -> (content, parseStoredJSON @[Widget.Widget] storedWidgets)
 
 
 -- | AI Chat body (response container + input bar, no header)

--- a/src/Pages/Anomalies.hs
+++ b/src/Pages/Anomalies.hs
@@ -3,9 +3,7 @@ module Pages.Anomalies (
   anomalyBulkActionsPostH,
   escapedQueryPartial,
   acknowledgeAnomalyGetH,
-  unAcknowledgeAnomalyGetH,
   archiveAnomalyGetH,
-  unArchiveAnomalyGetH,
   anomalyDetailGetH,
   AnomalyBulkForm (..),
   AnomalyListGet (..),
@@ -109,45 +107,36 @@ newtype AnomalyBulkForm = AnomalyBulk
   deriving anyclass (FromForm)
 
 
-acknowledgeAnomalyGetH :: Projects.ProjectId -> Anomalies.AnomalyId -> Maybe Text -> ATAuthCtx (RespHeaders AnomalyAction)
-acknowledgeAnomalyGetH pid aid hostM = do
+-- | Acknowledge (on=True) or un-acknowledge (on=False) an anomaly/issue.
+-- The acknowledge path cascades via the model helpers; the clear path resets the columns directly.
+acknowledgeAnomalyGetH :: Projects.ProjectId -> Bool -> Anomalies.AnomalyId -> Maybe Text -> ATAuthCtx (RespHeaders AnomalyAction)
+acknowledgeAnomalyGetH pid enable aid _hostM = do
   (sess, project) <- Projects.sessionAndProject pid
-  appCtx <- ask @AuthContext
   let issueId = UUIDId aid.unUUIDId
-  _ <- Issues.acknowledgeIssue issueId sess.user.id
-  Issues.logIssueActivity issueId Issues.IEAcknowledged (Just sess.user.id) Nothing
-  let text_id = V.fromList [UUID.toText aid.unUUIDId]
-  v <- Anomalies.acknowledgeAnomalies sess.user.id text_id
-  _ <- Anomalies.acknowlegeCascade sess.user.id (V.fromList v)
-  addRespHeaders $ Acknowlege pid (UUIDId aid.unUUIDId) True
+  if enable
+    then do
+      _ <- Issues.acknowledgeIssue issueId sess.user.id
+      Issues.logIssueActivity issueId Issues.IEAcknowledged (Just sess.user.id) Nothing
+      let text_id = V.fromList [UUID.toText aid.unUUIDId]
+      v <- Anomalies.acknowledgeAnomalies sess.user.id text_id
+      _ <- Anomalies.acknowlegeCascade sess.user.id (V.fromList v)
+      pass
+    else do
+      _ <- Hasql.interpExecute [HI.sql| update apis.issues set acknowledged_by=null, acknowledged_at=null where id=#{aid} |]
+      _ <- Hasql.interpExecute [HI.sql| update apis.anomalies set acknowledged_by=null, acknowledged_at=null where id=#{aid} |]
+      Issues.logIssueActivity issueId Issues.IEUnacknowledged (Just sess.user.id) Nothing
+  addRespHeaders $ Acknowlege pid issueId enable
 
 
-unAcknowledgeAnomalyGetH :: Projects.ProjectId -> Anomalies.AnomalyId -> ATAuthCtx (RespHeaders AnomalyAction)
-unAcknowledgeAnomalyGetH pid aid = do
+-- | Archive (on=True) or un-archive (on=False) an anomaly/issue.
+archiveAnomalyGetH :: Projects.ProjectId -> Bool -> Anomalies.AnomalyId -> ATAuthCtx (RespHeaders AnomalyAction)
+archiveAnomalyGetH pid enable aid = do
   (sess, project) <- Projects.sessionAndProject pid
-  _ <- Hasql.interpExecute [HI.sql| update apis.issues set acknowledged_by=null, acknowledged_at=null where id=#{aid} |]
-  _ <- Hasql.interpExecute [HI.sql| update apis.anomalies set acknowledged_by=null, acknowledged_at=null where id=#{aid} |]
-  Issues.logIssueActivity (UUIDId aid.unUUIDId) Issues.IEUnacknowledged (Just sess.user.id) Nothing
-  addRespHeaders $ Acknowlege pid (UUIDId aid.unUUIDId) False
-
-
-archiveAnomalyGetH :: Projects.ProjectId -> Anomalies.AnomalyId -> ATAuthCtx (RespHeaders AnomalyAction)
-archiveAnomalyGetH pid aid = do
-  (sess, project) <- Projects.sessionAndProject pid
-  now <- Time.currentTime
-  _ <- Hasql.interpExecute [HI.sql| update apis.issues set archived_at=#{now} where id=#{aid} |]
-  _ <- Hasql.interpExecute [HI.sql| update apis.anomalies set archived_at=#{now} where id=#{aid} |]
-  Issues.logIssueActivity (UUIDId aid.unUUIDId) Issues.IEArchived (Just sess.user.id) Nothing
-  addRespHeaders $ Archive pid (UUIDId aid.unUUIDId) True
-
-
-unArchiveAnomalyGetH :: Projects.ProjectId -> Anomalies.AnomalyId -> ATAuthCtx (RespHeaders AnomalyAction)
-unArchiveAnomalyGetH pid aid = do
-  (sess, project) <- Projects.sessionAndProject pid
-  _ <- Hasql.interpExecute [HI.sql| update apis.issues set archived_at=null where id=#{aid} |]
-  _ <- Hasql.interpExecute [HI.sql| update apis.anomalies set archived_at=null where id=#{aid} |]
-  Issues.logIssueActivity (UUIDId aid.unUUIDId) Issues.IEUnarchived (Just sess.user.id) Nothing
-  addRespHeaders $ Archive pid (UUIDId aid.unUUIDId) False
+  archivedAt <- if enable then Just <$> Time.currentTime else pure Nothing
+  _ <- Hasql.interpExecute [HI.sql| update apis.issues set archived_at=#{archivedAt} where id=#{aid} |]
+  _ <- Hasql.interpExecute [HI.sql| update apis.anomalies set archived_at=#{archivedAt} where id=#{aid} |]
+  Issues.logIssueActivity (UUIDId aid.unUUIDId) (if enable then Issues.IEArchived else Issues.IEUnarchived) (Just sess.user.id) Nothing
+  addRespHeaders $ Archive pid (UUIDId aid.unUUIDId) enable
 
 
 data AnomalyAction
@@ -284,27 +273,39 @@ anomalyDetailCore pid firstM sinceM fetchIssue = do
 -- element stays as a single chip even if its value contains internal
 -- whitespace (user-agent, page title). Right-rail metadata renders with a
 -- subdued style so the primary fields stay visually dominant.
+-- | Unescape JSON-ish whitespace/quotes embedded in summary tokens.
+unescSummary :: Text -> Text
+unescSummary = T.replace "\\\"" "\"" . T.replace "\\n" " " . T.replace "\\t" " "
+
+
+-- | Style->class mapping shared by the chip and inline-text summary renderers.
+-- When @wrap@ is True (chips) the classes gain whitespace-pre-wrap/break-* suffixes.
+summaryTokenClass :: Bool -> Text -> Text
+summaryTokenClass wrap style = case style of
+  s | "badge-" `T.isPrefixOf` s -> "cbadge-sm " <> s <> badgeWrap
+  "neutral" -> "cbadge-sm badge-neutral" <> badgeWrap
+  "text-textWeak" -> "text-textWeak text-xs" <> textWrap
+  "text-weak" -> "text-textWeak text-xs" <> textWrap
+  "text-textStrong" -> "text-textStrong text-xs font-medium" <> textWrap
+  _ -> "cbadge-sm badge-neutral" <> badgeWrap
+  where
+    badgeWrap = if wrap then " whitespace-pre-wrap break-all" else ""
+    textWrap = if wrap then " whitespace-pre-wrap break-words" else ""
+
+
 renderSummaryChips_ :: Monad m => V.Vector Text -> HtmlT m ()
 renderSummaryChips_ summary = V.forM_ summary \token ->
   case T.breakOn "\8658" token of
-    (_, "") -> span_ [class_ "text-textWeak text-xs whitespace-pre-wrap break-words"] $ toHtml $ unesc token
+    (_, "") -> span_ [class_ "text-textWeak text-xs whitespace-pre-wrap break-words"] $ toHtml $ unescSummary token
     (left, rest) -> do
-      let value = unesc $ T.drop 1 rest
+      let value = unescSummary $ T.drop 1 rest
           (field, style) = case T.breakOn ";" left of
             (f, s) | not (T.null s) -> (f, T.drop 1 s)
             _ -> ("", left)
           baseStyle = fromMaybe style $ T.stripPrefix "right-" style
-          cls = case baseStyle of
-            s | "badge-" `T.isPrefixOf` s -> "cbadge-sm " <> s <> " whitespace-pre-wrap break-all"
-            "neutral" -> "cbadge-sm badge-neutral whitespace-pre-wrap break-all"
-            "text-textWeak" -> "text-textWeak text-xs whitespace-pre-wrap break-words"
-            "text-weak" -> "text-textWeak text-xs whitespace-pre-wrap break-words"
-            "text-textStrong" -> "text-textStrong text-xs font-medium whitespace-pre-wrap break-words"
-            _ -> "cbadge-sm badge-neutral whitespace-pre-wrap break-all"
+          cls = summaryTokenClass True baseStyle
           tipAttr = [term "data-tippy-content" field | not (T.null field)]
       span_ ([class_ $ cls <> " inline-block max-w-full"] <> tipAttr) $ toHtml value
-  where
-    unesc = T.replace "\\\"" "\"" . T.replace "\\n" " " . T.replace "\\t" " "
 
 
 -- | Smart default time range based on anomaly age.
@@ -495,6 +496,14 @@ activityPanel_ pid issueId extraClass spans = do
       $ loadingIndicator_ LdSM LdDots
 
 
+-- | One labelled icon+value row used in the Error/Endpoint detail panels.
+detailItem_ :: (Text, Text, Text, Text) -> Html ()
+detailItem_ (icn, iconColor, lbl, value) = div_ [class_ "flex items-center gap-1.5 whitespace-nowrap"] do
+  faSprite_ icn "regular" $ "w-3 h-3 " <> iconColor
+  span_ [class_ "text-xs text-textWeak"] $ toHtml lbl <> ":"
+  span_ [class_ "text-xs font-medium"] $ toHtml value
+
+
 anomalyDetailPage :: Projects.ProjectId -> Issues.Issue -> Maybe Telemetry.Trace -> V.Vector Telemetry.SpanRecord -> Maybe ErrorPatterns.ErrorPatternL -> UTCTime -> Bool -> V.Vector ProjectMembers.ProjectMemberVM -> TimePicker.TimePicker -> Maybe (V.Vector Text) -> Html ()
 anomalyDetailPage pid issue tr spanRecs errM now isFirst members tp sampleOverride = do
   let (_, _, currentRange) = TimePicker.parseTimeRange now tp
@@ -595,10 +604,6 @@ anomalyDetailPage pid issue tr spanRecs errM now isFirst members tp sampleOverri
           let trimmedStack = T.strip exceptionData.stackTrace
               hasStack = not $ T.null trimmedStack
               errorFirstLine = if hasStack then fromMaybe trimmedStack $ viaNonEmpty head $ lines trimmedStack else exceptionData.errorMessage
-              detailItem (icn, iconColor, lbl, value) = div_ [class_ "flex items-center gap-1.5 whitespace-nowrap"] do
-                faSprite_ icn "regular" $ "w-3 h-3 " <> iconColor
-                span_ [class_ "text-xs text-textWeak"] $ toHtml lbl <> ":"
-                span_ [class_ "text-xs font-medium"] $ toHtml value
           -- Chart + Error Details in one row
           div_ [class_ "flex flex-col lg:flex-row gap-4 lg:items-start"] do
             div_ [class_ "min-w-0 flex-1"] $ volumeChart_ "Error Frequency"
@@ -618,13 +623,13 @@ anomalyDetailPage pid issue tr spanRecs errM now isFirst members tp sampleOverri
                       [ ("calendar" :: Text, "text-fillBrand-strong" :: Text, "First seen" :: Text, compactTimeAgo $ toText $ prettyTimeAuto now (zonedTimeToUTC err.createdAt))
                       , ("calendar" :: Text, "text-fillBrand-strong" :: Text, "Last seen" :: Text, compactTimeAgo $ toText $ prettyTimeAuto now (zonedTimeToUTC err.updatedAt))
                       ]
-                      detailItem
+                      detailItem_
                   div_ [class_ "flex flex-wrap items-center gap-x-5 gap-y-2"]
                     $ forM_
                       [ ("code" :: Text, "text-fillWarning-strong" :: Text, "Stack" :: Text, fromMaybe "Unknown stack" err.errorData.runtime)
                       , ("server" :: Text, "text-fillSuccess-strong" :: Text, "Service" :: Text, fromMaybe "Unknown service" err.errorData.serviceName)
                       ]
-                      detailItem
+                      detailItem_
           -- Stack trace + Activity (Activity column merges User Journey + issue events)
           div_ [class_ "flex flex-col lg:flex-row gap-4 lg:items-start"] do
             div_ [class_ "min-w-0 flex-1"]
@@ -658,11 +663,7 @@ anomalyDetailPage pid issue tr spanRecs errM now isFirst members tp sampleOverri
             span_ [class_ "text-xs text-textWeak mb-2 block font-semibold uppercase tracking-wide"] "Query"
             div_ [class_ "bg-fillInformation-weak border border-strokeInformation-weak rounded-lg p-3 text-sm font-mono text-fillInformation-strong max-w-2xl overflow-x-auto"] $ toHtml alertData.queryExpression
         Issues.ApiChange -> withIssueDataH @Issues.APIChangeData issue.issueData \d -> do
-          let detailItem (icn, iconColor, lbl, value) = div_ [class_ "flex items-center gap-1.5 whitespace-nowrap"] do
-                faSprite_ icn "regular" $ "w-3 h-3 " <> iconColor
-                span_ [class_ "text-xs text-textWeak"] $ toHtml lbl <> ":"
-                span_ [class_ "text-xs font-medium"] $ toHtml value
-              fieldChip color f = span_ [class_ $ "font-mono text-xs px-2 py-0.5 rounded bg-fillWeaker " <> color] $ toHtml f
+          let fieldChip color f = span_ [class_ $ "font-mono text-xs px-2 py-0.5 rounded bg-fillWeaker " <> color] $ toHtml f
               fieldList :: Text -> Text -> Text -> V.Vector Text -> Html ()
               fieldList lbl color icn fields
                 | V.null fields = pass
@@ -694,13 +695,13 @@ anomalyDetailPage pid issue tr spanRecs errM now isFirst members tp sampleOverri
                     [ ("calendar" :: Text, "text-fillBrand-strong" :: Text, "First seen" :: Text, compactTimeAgo $ toText $ prettyTimeAuto now (zonedTimeToUTC issue.createdAt))
                     , ("calendar" :: Text, "text-fillBrand-strong" :: Text, "Last seen" :: Text, compactTimeAgo $ toText $ prettyTimeAuto now (zonedTimeToUTC issue.updatedAt))
                     ]
-                    detailItem
+                    detailItem_
                 div_ [class_ "flex flex-wrap items-center gap-x-5 gap-y-2"]
                   $ forM_
                     [ ("server" :: Text, "text-fillSuccess-strong" :: Text, "Service" :: Text, fromMaybe "Unknown service" issue.service)
                     , ("hashtag" :: Text, "text-fillBrand-strong" :: Text, "Requests" :: Text, formatWithCommas (fromIntegral issue.affectedRequests :: Double))
                     ]
-                    detailItem
+                    detailItem_
           -- Field changes (or "new endpoint" hint) + Activity panel
           div_ [class_ "flex flex-col lg:flex-row gap-4 lg:items-start"] do
             div_ [class_ "min-w-0 flex-1"]
@@ -1251,10 +1252,6 @@ toolCallView_ tc =
     unless (T.null tc.resultPreview) $ div_ [class_ "text-xs text-textWeak font-mono pl-4 whitespace-pre-wrap break-all"] $ toHtml $ "→ " <> tc.resultPreview
 
 
-parseStoredJSON :: AE.FromJSON a => Maybe (Aeson AE.Value) -> Maybe a
-parseStoredJSON = (>>= parseMaybe AE.parseJSON . getAeson)
-
-
 withIssueDataH :: (AE.FromJSON a, Applicative m) => Aeson AE.Value -> (a -> m ()) -> m ()
 withIssueDataH d f = case AE.fromJSON (getAeson d) of
   AE.Success v -> f v
@@ -1270,15 +1267,11 @@ processWidgetsWithToolData toolCalls = map \w -> case w.query >>= findToolCallDa
 
 -- | Find matching tool call data for a widget query
 findToolCallData :: [AI.ToolCallInfo] -> Text -> Maybe AE.Value
-findToolCallData toolCalls widgetQuery = listToMaybe [rd | tc <- toolCalls, tc.name == "run_query", Just q <- [Map.lookup "query" tc.args >>= getText], normalizeQuery q == normalizeQuery widgetQuery, Just rd <- [tc.rawData]]
+findToolCallData toolCalls widgetQuery = listToMaybe [rd | tc <- toolCalls, tc.name == "run_query", Just q <- [Map.lookup "query" tc.args >>= getText], norm q == norm widgetQuery, Just rd <- [tc.rawData]]
   where
     getText (AE.String t) = Just t
     getText _ = Nothing
-
-
--- | Normalize query for comparison (remove whitespace variations)
-normalizeQuery :: Text -> Text
-normalizeQuery = unwords . words
+    norm = unwords . words -- normalize for comparison (whitespace-insensitive)
 
 
 -- | Convert tool call raw data to WidgetDataset
@@ -1295,7 +1288,7 @@ toolDataToDataset json = flip parseMaybe json $ AE.withObject "RawData" \obj -> 
 aiChatHistoryView_ :: Projects.ProjectId -> [Issues.AIChatMessage] -> Html ()
 aiChatHistoryView_ pid msgs = forM_ (pairUserAssistant msgs) \(u, a) -> do
   let (explanation, widgets) = parseStoredContent a.content a.widgets
-  aiChatResponse_ pid u.content explanation widgets (parseStoredJSON @[AI.ToolCallInfo] a.metadata) Nothing
+  aiChatResponse_ pid u.content explanation widgets (a.metadata >>= parseMaybe AE.parseJSON . getAeson) Nothing
 
 
 -- | Render chat history with system prompt as first message
@@ -1322,7 +1315,7 @@ parseStoredContent :: Text -> Maybe (Aeson AE.Value) -> (Text, Maybe [Widget.Wid
 parseStoredContent content storedWidgets =
   case AI.parseLLMResponse content of
     Right aiResp -> (fromMaybe "" aiResp.explanation, if null aiResp.widgets then Nothing else Just aiResp.widgets)
-    Left _ -> (content, parseStoredJSON @[Widget.Widget] storedWidgets)
+    Left _ -> (content, storedWidgets >>= parseMaybe AE.parseJSON . getAeson)
 
 
 -- | AI Chat body (response container + input bar, no header)
@@ -1596,23 +1589,15 @@ renderLogContent_ txt =
 renderSummaryText_ :: Monad m => Text -> HtmlT m ()
 renderSummaryText_ txt = forM_ (words txt) \token ->
   case T.breakOn "⇒" token of
-    (_, "") -> span_ [class_ "mr-1"] $ toHtml $ unesc token
+    (_, "") -> span_ [class_ "mr-1"] $ toHtml $ unescSummary token
     (left, rest) -> do
-      let value = unesc $ T.drop 1 rest
+      let value = unescSummary $ T.drop 1 rest
           (field, style) = case T.breakOn ";" left of
             (f, s) | not (T.null s) -> (f, T.drop 1 s)
             _ -> ("", left)
-          cls = case style of
-            s | "badge-" `T.isPrefixOf` s -> "cbadge-sm " <> s
-            "neutral" -> "cbadge-sm badge-neutral"
-            "text-textWeak" -> "text-textWeak text-xs"
-            "text-weak" -> "text-textWeak text-xs"
-            "text-textStrong" -> "text-textStrong text-xs font-medium"
-            _ -> "cbadge-sm badge-neutral"
+          cls = summaryTokenClass False style
           tipAttr = [term "data-tippy-content" field | not (T.null field)]
       span_ ([class_ $ cls <> " mr-1 inline-block"] <> tipAttr) $ toHtml value
-  where
-    unesc = T.replace "\\\"" "\"" . T.replace "\\n" " " . T.replace "\\t" " "
 
 
 renderIssueTitle_ :: Issues.IssueL -> Html ()
@@ -1730,13 +1715,12 @@ issuePreview_ Issues.IssueL{base} = div_ [class_ "flex items-center gap-2 min-w-
         logPatternPreview d.logPattern d.sampleMessage
       Issues.ApiChange -> withIssueDataH @Issues.APIChangeData base.issueData \d ->
         previewSnippet $ d.endpointMethod <> " " <> d.endpointPath <> if T.null d.endpointHost then "" else " on " <> d.endpointHost
-    previewSnippet txt = span_ [class_ "font-mono truncate min-w-0", term "data-tippy-content" txt] $ renderWithPlaceholders_ $ unescapeJson txt
+    previewSnippet txt = span_ [class_ "font-mono truncate min-w-0", term "data-tippy-content" txt] $ renderWithPlaceholders_ $ unescSummary txt
     summaryPreview txt = span_ [class_ "truncate min-w-0"] $ renderSummaryText_ txt
     logPatternPreview pat sampleMsg
       | "⇒" `T.isInfixOf` pat = summaryPreview pat
       | Just msg <- sampleMsg, not (T.null msg) = previewSnippet msg
       | otherwise = previewSnippet pat
-    unescapeJson = T.replace "\\\"" "\"" . T.replace "\\n" " " . T.replace "\\t" " "
 
 
 anomalyAcknowledgeButton :: Projects.ProjectId -> Issues.IssueId -> Bool -> Text -> Html ()

--- a/src/Pages/Bots/Slack.hs
+++ b/src/Pages/Bots/Slack.hs
@@ -197,7 +197,7 @@ slackInteractionsH interaction = do
       let dashboards = V.fromList dashboardsList
       when (V.null dashboards) $ throwError err400{errBody = "No dashboards found for this project"}
       slackDataM <- withSlackDataByTeam "/dashboard" interaction.team_id \slackData ->
-        triggerSlackModal slackData.botToken "open" $ AE.object ["trigger_id" AE..= interaction.trigger_id, "view" AE..= dashboardView interaction.channel_id (V.fromList [dashboardViewOne dashboards])]
+        triggerSlackModal slackData.botToken "open" $ AE.object ["trigger_id" AE..= interaction.trigger_id, "view" AE..= dashboardView interaction.channel_id (V.fromList [dashboardSelectBlock "dashboard-select" "*Select dashboard*" dashboards])]
       case slackDataM of
         Nothing -> throwError err400{errBody = "This Slack workspace is not linked to a Monoscope project. Please reinstall the Monoscope app."}
         Just () -> do
@@ -421,7 +421,7 @@ slackActionsH action = do
               channelId = fromMaybe "" $ viaNonEmpty head $ T.splitOn "___" slackAction.view.private_metadata
               pMeta = channelId <> "___" <> dashboardVM.projectId.toText <> "___" <> baseTemplate
           void $ withProjectSlackDataLogged "slackActionsH.updateDashboardModal" dashboardVM.projectId \sd ->
-            triggerSlackModal sd.botToken "update" $ AE.object ["view_id" AE..= slackAction.view.id, "view" AE..= dashboardView pMeta (V.fromList [dashboardViewOne widgets, dashboardViewTwo widgets])]
+            triggerSlackModal sd.botToken "update" $ AE.object ["view_id" AE..= slackAction.view.id, "view" AE..= dashboardView pMeta (V.fromList [dashboardSelectBlock "dashboard-select" "*Select dashboard*" widgets, dashboardSelectBlock "widget-select" "*Select widget*" widgets])]
       pure $ AE.object ["text" AE..= ("Selected dashboard: " <> show dashboardText), "replace_original" AE..= True, "delete_original" AE..= True]
 
     updateWidgetModal authCtx slackAction widgetTitle = do
@@ -440,7 +440,7 @@ slackActionsH action = do
               widget = find (\w -> fromMaybe "Untitled-" w.title == widgetTitle) dashboard.widgets
           whenJust widget $ \w -> whenJust (idFromText pid) $ \projectId -> do
             chartUrl' <- widgetPngUrl authCtx.env.apiKeyEncryptionSecretKey authCtx.env.hostUrl projectId w Nothing Nothing Nothing
-            let blocks = V.fromList [dashboardViewOne widgets, dashboardViewTwo widgets, dashboardWidgetView chartUrl' widgetTitle]
+            let blocks = V.fromList [dashboardSelectBlock "dashboard-select" "*Select dashboard*" widgets, dashboardSelectBlock "widget-select" "*Select widget*" widgets, dashboardWidgetView chartUrl' widgetTitle]
                 privateMeta = channelId <> "___" <> pid <> "___" <> baseTemplate <> "___" <> chartUrl'
             void $ withProjectSlackDataLogged "slackActionsH.updateWidgetModal" projectId \sd ->
               triggerSlackModal sd.botToken "update" $ AE.object ["view_id" AE..= slackAction.view.id, "view" AE..= dashboardView privateMeta blocks]
@@ -545,15 +545,15 @@ dashboardView privateData blocks =
     ]
 
 
-dashboardViewOne :: V.Vector (Text, Text) -> AE.Value
-dashboardViewOne options =
+dashboardSelectBlock :: Text -> Text -> V.Vector (Text, Text) -> AE.Value
+dashboardSelectBlock selectId heading options =
   AE.object
     [ "type" AE..= "section"
-    , "block_id" AE..= "dashboard-select"
-    , "text" AE..= AE.object ["type" AE..= "mrkdwn", "text" AE..= "*Select dashboard*"]
+    , "block_id" AE..= selectId
+    , "text" AE..= AE.object ["type" AE..= "mrkdwn", "text" AE..= heading]
     , "accessory"
         AE..= AE.object
-          [ "action_id" AE..= "dashboard-select"
+          [ "action_id" AE..= selectId
           , "type" AE..= "static_select"
           , "placeholder" AE..= AE.object ["type" AE..= "plain_text", "text" AE..= "Select a dashboard template"]
           , "options" AE..= AE.Array opts
@@ -561,24 +561,6 @@ dashboardViewOne options =
     ]
   where
     opts = V.map (\(text, value) -> AE.object ["text" AE..= AE.object ["type" AE..= "plain_text", "text" AE..= if T.null text then "Untitled" else text], "value" AE..= value]) options
-
-
-dashboardViewTwo :: V.Vector (Text, Text) -> AE.Value
-dashboardViewTwo options =
-  AE.object
-    [ "type" AE..= "section"
-    , "block_id" AE..= "widget-select"
-    , "text" AE..= AE.object ["type" AE..= "mrkdwn", "text" AE..= "*Select widget*"]
-    , "accessory"
-        AE..= AE.object
-          [ "action_id" AE..= "widget-select"
-          , "type" AE..= "static_select"
-          , "placeholder" AE..= AE.object ["type" AE..= "plain_text", "text" AE..= "Select a dashboard template"]
-          , "options" AE..= AE.Array opts
-          ]
-    ]
-  where
-    opts = V.map (\(text, value) -> AE.object ["text" AE..= AE.object ["type" AE..= "plain_text", "text" AE..= text], "value" AE..= value]) options
 
 
 dashboardWidgetView :: Text -> Text -> AE.Value

--- a/src/Pages/Bots/Utils.hs
+++ b/src/Pages/Bots/Utils.hs
@@ -349,13 +349,20 @@ processReportQuery pid reportType envCfg = do
       pure $ Right (report, eventsUrl, errorsUrl)
 
 
--- | Format report for Slack
-formatReportForSlack :: Reports.Report -> Projects.ProjectId -> EnvConfig -> Text -> Text -> Text -> AE.Value
-formatReportForSlack report pid envCfg eventsUrl errorsUrl channelId =
+-- | Shared report-render preamble: (reportUrl, startTxt, endTxt, totalEvents, totalErrors)
+reportHeader :: Reports.Report -> Projects.ProjectId -> EnvConfig -> (Text, Text, Text, Int, Int)
+reportHeader report pid envCfg =
   let reportUrl = envCfg.hostUrl <> "p/" <> pid.toText <> "/reports/" <> report.id.toText
       startTxt = T.take 10 $ toText $ formatTime defaultTimeLocale "%Y-%m-%d" report.startTime
       endTxt = T.take 10 $ toText $ formatTime defaultTimeLocale "%Y-%m-%d" report.endTime
       (totalEvents, totalErrors) = parseReportStats report.reportJson
+   in (reportUrl, startTxt, endTxt, totalEvents, totalErrors)
+
+
+-- | Format report for Slack
+formatReportForSlack :: Reports.Report -> Projects.ProjectId -> EnvConfig -> Text -> Text -> Text -> AE.Value
+formatReportForSlack report pid envCfg eventsUrl errorsUrl channelId =
+  let (reportUrl, startTxt, endTxt, totalEvents, totalErrors) = reportHeader report pid envCfg
    in AE.object
         [ "blocks"
             AE..= AE.Array
@@ -378,10 +385,7 @@ formatReportForSlack report pid envCfg eventsUrl errorsUrl channelId =
 -- | Format report for Discord
 formatReportForDiscord :: Reports.Report -> Projects.ProjectId -> EnvConfig -> Text -> Text -> AE.Value
 formatReportForDiscord report pid envCfg eventsUrl errorsUrl =
-  let reportUrl = envCfg.hostUrl <> "p/" <> pid.toText <> "/reports/" <> report.id.toText
-      startTxt = T.take 10 $ toText $ formatTime defaultTimeLocale "%Y-%m-%d" report.startTime
-      endTxt = T.take 10 $ toText $ formatTime defaultTimeLocale "%Y-%m-%d" report.endTime
-      (totalEvents, totalErrors) = parseReportStats report.reportJson
+  let (reportUrl, startTxt, endTxt, totalEvents, totalErrors) = reportHeader report pid envCfg
    in AE.object
         [ "flags" AE..= (32768 :: Int)
         , "components"
@@ -408,10 +412,7 @@ formatReportForDiscord report pid envCfg eventsUrl errorsUrl =
 -- | Format report for WhatsApp
 formatReportForWhatsApp :: Reports.Report -> Projects.ProjectId -> EnvConfig -> Text
 formatReportForWhatsApp report pid envCfg =
-  let reportUrl = envCfg.hostUrl <> "p/" <> pid.toText <> "/reports/" <> report.id.toText
-      startTxt = T.take 10 $ toText $ formatTime defaultTimeLocale "%Y-%m-%d" report.startTime
-      endTxt = T.take 10 $ toText $ formatTime defaultTimeLocale "%Y-%m-%d" report.endTime
-      (totalEvents, totalErrors) = parseReportStats report.reportJson
+  let (reportUrl, startTxt, endTxt, totalEvents, totalErrors) = reportHeader report pid envCfg
    in "📊 " <> T.toTitle report.reportType <> " Report\nPeriod: " <> startTxt <> " - " <> endTxt <> "\nTotal Events: " <> show totalEvents <> "\nTotal Errors: " <> show totalErrors <> "\nView: " <> reportUrl
 
 

--- a/src/Pages/Components.hs
+++ b/src/Pages/Components.hs
@@ -1,4 +1,4 @@
-module Pages.Components (drawer_, emptyState_, resizer_, dateTime, paymentPlanPicker, navBar, modal_, modalCloseButton_, primaryButton_, headerRow_, headerRowPad_, sectionHeader_, chartSkeleton_, FieldSize (..), FieldCfg (..), formField_, formSelectField_, formCheckbox_, PanelCfg (..), panel_, tagInput_, formActionsModal_, connectionBadge_, confirmModal_, BadgeColor (..), iconBadge_, iconBadgeLg_, iconBadgeXs_, iconBadgeWith_, ModalCfg (..), modalWith_, colorChip_, metadataChip_, getTargetPage, settingsSection_, settingsH2_, sectionLabel_, infoBanner_, settingsNavLink_, dirtyFormSaveAttr_, sparkline_, periodToggle_, abbreviateUnit, compactTimeAgo) where
+module Pages.Components (drawer_, emptyState_, resizer_, dateTime, paymentPlanPicker, navBar, modal_, modalCloseButton_, primaryButton_, headerRow_, headerRowPad_, chartSkeleton_, FieldSize (..), FieldCfg (..), formField_, formSelectField_, formCheckbox_, PanelCfg (..), panel_, tagInput_, formActionsModal_, connectionBadge_, confirmModal_, BadgeColor (..), iconBadge_, iconBadgeLg_, iconBadgeXs_, iconBadgeWith_, ModalCfg (..), modalWith_, colorChip_, metadataChip_, getTargetPage, settingsSection_, settingsH2_, sectionLabel_, infoBanner_, settingsNavLink_, dirtyFormSaveAttr_, sparkline_, periodToggle_, abbreviateUnit, compactTimeAgo) where
 
 import Data.Default (Default (..))
 import Data.Text qualified as T
@@ -338,10 +338,6 @@ headerRow_ attrs = div_ (class_ " flex items-center justify-between " : attrs)
 
 headerRowPad_ :: Monad m => [Attribute] -> HtmlT m () -> HtmlT m ()
 headerRowPad_ attrs = div_ (class_ " flex items-center justify-between px-4 py-3 " : attrs)
-
-
-sectionHeader_ :: Monad m => [Attribute] -> HtmlT m () -> HtmlT m ()
-sectionHeader_ attrs = div_ (class_ " flex items-center justify-between mb-4 " : attrs)
 
 
 resizer_ :: Text -> Text -> Bool -> Html ()

--- a/src/Pages/LogExplorer/LogItem.hs
+++ b/src/Pages/LogExplorer/LogItem.hs
@@ -7,6 +7,7 @@ module Pages.LogExplorer.LogItem (
   getRequestDetails,
   spanHasErrors,
   spanBadge,
+  fetchIntoScript,
 ) where
 
 import Data.Aeson qualified as AE
@@ -16,7 +17,6 @@ import Data.Char (isSpace)
 import Data.Effectful.Hasql qualified as Hasql
 import Data.HashMap.Strict qualified as HM
 import Data.Map qualified as Map
-import Data.Scientific (toBoundedInteger)
 import Data.Text qualified as T
 import Data.Time (UTCTime)
 import Data.UUID qualified as UUID
@@ -53,68 +53,52 @@ getServiceColor s serviceColors = fromMaybe "bg-fillNeutral-strong" $ HM.lookup 
 getRequestDetails :: Maybe (Map Text AE.Value) -> Maybe (Text, Text, Text, Int)
 getRequestDetails spanRecord = do
   m <- spanRecord
-  case Map.lookup "http" m of
-    Just (AE.Object o) ->
+  if Map.member "http" m
+    then
       Just
         ( "HTTP"
-        , case KEM.lookup "request" o of
-            Just (AE.Object r) -> getText "method" r
-            _ -> ""
-        , case getUrl o of
-            Just u -> u
-            Nothing -> case Map.lookup "url" m of
-              Just (AE.Object p) -> fromMaybe "/" $ getUrl p
-              _ -> "/"
-        , case KEM.lookup "response" o of
-            Just (AE.Object r) -> getStatus r
-            _ -> 0
+        , txt "http.request.method"
+        , fromMaybe "/" $ url "http" <|> url "url"
+        , status "http.response"
         )
-    _ -> case Map.lookup "rpc" m of
-      Just (AE.Object o) -> Just ("GRPC", getText "service" o, getText "method" o, getStatus o)
-      _ -> case Map.lookup "db" m of
-        Just (AE.Object o) -> Just ("DB", getText "system" o, if T.null query then statement else query, getStatus o)
-          where
-            statement = getText "statement" o
-            query = getText "query" o
-        _ -> Nothing
+    else
+      if Map.member "rpc" m
+        then Just ("GRPC", txt "rpc.service", txt "rpc.method", status "rpc")
+        else
+          if Map.member "db" m
+            then Just ("DB", txt "db.system", if T.null query then txt "db.statement" else query, status "db")
+            else Nothing
   where
-    getText :: Text -> AE.Object -> Text
-    getText key v = case KEM.lookup (AEKey.fromText key) v of
-      Just (AE.String s) -> s
-      _ -> ""
-    getInt :: Text -> AE.Object -> Maybe Int
-    getInt key v = case KEM.lookup (AEKey.fromText key) v of
-      Just (AE.Number n) -> toBoundedInteger n
-      Just (AE.String s) -> readMaybe $ toString s
-      _ -> Nothing
-    getUrl :: AE.Object -> Maybe Text
-    getUrl v =
-      let opts = [getText "route" v, getText "path" v, getText "url" v, getText "target" v]
-       in viaNonEmpty head $ Relude.filter (not . T.null) opts
-    getStatus :: AE.Object -> Int
-    getStatus v = fromMaybe 0 $ getInt "status_code" v
+    txt k = fromMaybe "" $ atMapText k spanRecord
+    query = txt "db.query"
+    status pfx = fromMaybe 0 $ Telemetry.atMapInt (pfx <> ".status_code") spanRecord
+    url pfx = viaNonEmpty head $ Relude.filter (not . T.null) [txt (pfx <> "." <> k) | k <- ["route", "path", "url", "target"]]
+
+
+-- | Exception events (event_name == "exception") within a span's events array.
+getSpanErrors :: AE.Value -> [AE.Value]
+getSpanErrors (AE.Array a) = Relude.filter isExceptionEvent (V.toList a)
+  where
+    isExceptionEvent (AE.Object obj) = KEM.lookup "event_name" obj == Just (AE.String "exception")
+    isExceptionEvent _ = False
+getSpanErrors _ = []
 
 
 spanHasErrors :: Telemetry.SpanRecord -> Bool
-spanHasErrors spanRecord = case spanRecord.events of
-  AE.Array a ->
-    let hasExceptionEvent event = case event of
-          AE.Object obj -> KEM.lookup "event_name" obj == Just (AE.String "exception")
-          _ -> False
-     in Relude.any hasExceptionEvent (V.toList a)
-  _ -> False
+spanHasErrors = not . null . getSpanErrors . (.events)
 
 
-getSpanErrors :: AE.Value -> [AE.Value]
-getSpanErrors evs = case evs of
-  AE.Array a ->
-    let events = V.toList a
-        hasExceptionEvent :: AE.Value -> Bool
-        hasExceptionEvent event = case event of
-          AE.Object obj -> KEM.lookup "event_name" obj == Just (AE.String "exception")
-          _ -> False
-     in Relude.filter hasExceptionEvent events
-  _ -> []
+-- | Hyperscript tail that loads a spinner into @#target@, fetches @url@ and swaps
+-- the response in, then re-processes htmx/hyperscript/inline scripts. Shared by the
+-- trace-expand button (here) and the drawer-expand script (Pages.Telemetry).
+fetchIntoScript :: Text -> Text -> Text
+fetchIntoScript target url =
+  [text|set #$target.innerHTML to #loader-tmp.innerHTML
+        then fetch $url
+        then set #$target.innerHTML to it
+        then htmx.process(#$target)
+        then _hyperscript.processNode(#$target)
+        then window.evalScriptsFromContent(#$target)|]
 
 
 getErrorDetails :: AE.Value -> (Text, Text, Text)
@@ -300,6 +284,7 @@ expandedItemView pid item aptSp leftM rightM = do
         let createdAt = formatUTC item.timestamp
         whenJust (item.context >>= (.trace_id) >>= guarded (not . T.null)) $ \trId -> do
           let tracePath = "/p/" <> pid.toText <> "/traces/" <> trId <> "/?timestamp=" <> createdAt
+              fetchTail = fetchIntoScript "trace_expanded_view" tracePath
           button_
             ( actBtn
                 <> [ term "data-share-hide" "1"
@@ -307,11 +292,7 @@ expandedItemView pid item aptSp leftM rightM = do
                        "_"
                        [text|on click remove .hidden from #trace_expanded_view
                             then call updateUrlState('showTrace', "$trId/?timestamp=$createdAt")
-                            then set #trace_expanded_view.innerHTML to #loader-tmp.innerHTML
-                            then fetch $tracePath
-                            then set #trace_expanded_view.innerHTML to it
-                            then htmx.process(#trace_expanded_view)
-                            then _hyperscript.processNode(#trace_expanded_view) then window.evalScriptsFromContent(#trace_expanded_view)|]
+                            then $fetchTail|]
                    ]
             )
             do
@@ -407,29 +388,15 @@ expandedItemView pid item aptSp leftM rightM = do
                             _ -> AE.object []
                           _ -> AE.object []
                     jsonValueToHtmlTree b $ Just "body.response_body"
+                  let httpSub :: [AEKey.Key] -> Maybe AE.Value
+                      httpSub = foldlM (\v k -> case v of AE.Object o -> KEM.lookup k o; _ -> Nothing) (AE.Object $ maybe mempty (\case AE.Object o -> o; _ -> mempty) (unAesonTextMaybe cSp.attributes >>= Map.lookup "http"))
                   div_ [id_ "hed_content", class_ "hidden a-tab-content http"] do
-                    let reqHeaders = case unAesonTextMaybe cSp.attributes >>= Map.lookup "http" of
-                          Just (AE.Object httpAtts) -> case KEM.lookup "request" httpAtts of
-                            Just (AE.Object reqAtts) -> KEM.lookup "header" reqAtts
-                            _ -> Nothing
-                          _ -> Nothing
-                        resHeaders = case unAesonTextMaybe cSp.attributes >>= Map.lookup "http" of
-                          Just (AE.Object httpAtts) -> case KEM.lookup "response" httpAtts of
-                            Just (AE.Object resAtts) -> KEM.lookup "header" resAtts
-                            _ -> Nothing
-                          _ -> Nothing
+                    let reqHeaders = httpSub ["request", "header"]
+                        resHeaders = httpSub ["response", "header"]
                     jsonValueToHtmlTree (AE.object ["request_headers" AE..= fromMaybe AE.Null reqHeaders, "response_headers" AE..= fromMaybe AE.Null resHeaders]) Nothing
                   div_ [id_ "par_content", class_ "hidden a-tab-content http"] do
-                    let queryParams = case unAesonTextMaybe cSp.attributes >>= Map.lookup "http" of
-                          Just (AE.Object httpAtts) -> case KEM.lookup "request" httpAtts of
-                            Just (AE.Object reqAtts) -> KEM.lookup "query_params" reqAtts
-                            _ -> Nothing
-                          _ -> Nothing
-                        pathParams = case unAesonTextMaybe cSp.attributes >>= Map.lookup "http" of
-                          Just (AE.Object httpAtts) -> case KEM.lookup "request" httpAtts of
-                            Just (AE.Object reqAtts) -> KEM.lookup "path_params" reqAtts
-                            _ -> Nothing
-                          _ -> Nothing
+                    let queryParams = httpSub ["request", "query_params"]
+                        pathParams = httpSub ["request", "path_params"]
                     jsonValueToHtmlTree (AE.object ["query_params" AE..= fromMaybe AE.Null queryParams, "path_params" AE..= fromMaybe AE.Null pathParams]) Nothing
           _ -> pass
 

--- a/src/Pages/Projects.hs
+++ b/src/Pages/Projects.hs
@@ -44,7 +44,7 @@ module Pages.Projects (
 where
 
 import BackgroundJobs qualified
-import Control.Lens ((.~), (^.))
+import Control.Lens ((^.))
 import Data.Aeson qualified as AE
 import Data.CaseInsensitive (original)
 import Data.CaseInsensitive qualified as CI
@@ -80,7 +80,6 @@ import Models.Projects.ProjectMembers (TeamMemberVM (..), TeamVM (..))
 import Models.Projects.ProjectMembers qualified as ProjectMembers
 import Models.Projects.Projects qualified as Projects
 import NeatInterpolation (text)
-import Network.Wreq (getWith)
 import OddJobs.Job (createJob)
 import Pages.BodyWrapper (BWConfig (..), PageCtx (..), bodyWrapper, mkPageCtx, settingsContentTarget)
 import Pages.Bots.Discord qualified as Discord
@@ -252,7 +251,7 @@ integrationsSettingsGetH pid = do
           }
   slackInfo <- getProjectSlackData pid
   discordInfo <- getDiscordDataByProjectId pid
-  channels <- maybe (pure []) (\d -> maybe [] (fromMaybe [] . (.channels)) <$> SlackP.getSlackChannels d.botToken d.teamId) slackInfo
+  channels <- resolveSlackChannels slackInfo
   -- Converge @everyone.slack_channels with the OAuth-time default on every render.
   -- Idempotent (addSlackChannelToEveryoneTeam no-ops when present). Covers legacy
   -- installs that pre-date the OAuth-side add, plus out-of-band updates to
@@ -378,6 +377,29 @@ validateNotificationChannels pid enabledChannels phones = do
   slack <- requireIntegration "slack" "You need to connect Slack to this project first." enabledChannels (getProjectSlackData pid)
   let whatsapp = if "phone" `elem` enabledChannels && null phones then Left "Provide at least one whatsapp number" else Right ()
   pure $ discord *> slack *> whatsapp
+
+
+-- | Resolve the live Slack channel list for an (already-fetched) SlackData.
+resolveSlackChannels :: Maybe SlackData -> ATAuthCtx [BotUtils.Channel]
+resolveSlackChannels = maybe (pure []) \d -> maybe [] (fromMaybe [] . (.channels)) <$> SlackP.getSlackChannels d.botToken d.teamId
+
+projectSlackChannels :: Projects.ProjectId -> ATAuthCtx [BotUtils.Channel]
+projectSlackChannels pid = getProjectSlackData pid >>= resolveSlackChannels
+
+
+projectDiscordChannels :: EnvConfig -> Projects.ProjectId -> ATAuthCtx [BotUtils.Channel]
+projectDiscordChannels env pid = getDiscordDataByProjectId pid >>= maybe (pure []) (Discord.getDiscordChannels env.discordBotToken . (.guildId))
+
+
+-- | Shared prologue for the team list and team detail pages: project members
+-- plus the project's resolved Slack and Discord channels.
+teamPageData :: Projects.ProjectId -> ATAuthCtx (V.Vector ProjectMembers.ProjectMemberVM, [BotUtils.Channel], [BotUtils.Channel])
+teamPageData pid = do
+  appCtx <- ask @AuthContext
+  projMembers <- V.fromList <$> ProjectMembers.selectActiveProjectMembers pid
+  channels <- projectSlackChannels pid
+  discordChannels <- projectDiscordChannels appCtx.env pid
+  pure (projMembers, channels, discordChannels)
 
 
 -- | When @channel@ is toggled on, the corresponding integration row must exist.
@@ -808,10 +830,7 @@ instance ToHtml ManageTeams where
 manageTeamsGetH :: Projects.ProjectId -> Maybe Text -> ATAuthCtx (RespHeaders ManageTeams)
 manageTeamsGetH pid layoutM = do
   (_, _, bw) <- mkPageCtx pid
-  appCtx <- ask @AuthContext
-  projMembers <- V.fromList <$> ProjectMembers.selectActiveProjectMembers pid
-  channels <- Integrations.getProjectSlackData pid >>= maybe (pure []) \d -> maybe [] (fromMaybe [] . (.channels)) <$> SlackP.getSlackChannels d.botToken d.teamId
-  discordChannels <- Integrations.getDiscordDataByProjectId pid >>= maybe (pure []) (Discord.getDiscordChannels appCtx.env.discordBotToken . (.guildId))
+  (projMembers, channels, discordChannels) <- teamPageData pid
   teams <- V.fromList <$> ProjectMembers.getTeamsVM pid
   let bwconf = bw{pageTitle = "Team", isSettingsPage = True}
   case layoutM of
@@ -882,12 +901,9 @@ notifsCell team = div_ [class_ "flex items-center gap-2"] do
 
 teamGetH :: Projects.ProjectId -> Text -> Maybe Text -> ATAuthCtx (RespHeaders ManageTeams)
 teamGetH pid handle layoutM = do
-  (sess, _, bw) <- mkPageCtx pid
-  appCtx <- ask @AuthContext
+  (_, _, bw) <- mkPageCtx pid
   teamVm <- ProjectMembers.getTeamByHandle pid handle
-  projMembers <- V.fromList <$> ProjectMembers.selectActiveProjectMembers pid
-  channels <- Integrations.getProjectSlackData pid >>= maybe (pure []) \d -> maybe [] (fromMaybe [] . (.channels)) <$> SlackP.getSlackChannels d.botToken d.teamId
-  discordChannels <- Integrations.getDiscordDataByProjectId pid >>= maybe (pure []) (Discord.getDiscordChannels appCtx.env.discordBotToken . (.guildId))
+  (projMembers, channels, discordChannels) <- teamPageData pid
   case teamVm of
     Just team -> do
       let bwconf =
@@ -1135,7 +1151,9 @@ manageSubGetH pid = do
             Nothing -> toastError "Failed to create billing portal" mempty
         _ -> toastError "Customer ID not found" mempty
     Projects.LemonSqueezyProvider -> do
-      sub <- liftIO $ getSubscriptionPortalUrl project.subId envCfg.lemonSqueezyApiKey
+      sub <- case project.subId of
+        Nothing -> pure Nothing
+        Just sid -> lsGet @SubPortalDataVals envCfg.lemonSqueezyApiKey ("https://api.lemonsqueezy.com/v1/subscriptions/" <> sid)
       case sub of
         Nothing -> toastError "Subscription ID not found" mempty
         Just s -> redirectCS s.dataVal.attributes.urls.customerPortal >> addRespHeaders mempty
@@ -1171,17 +1189,19 @@ stripeCheckoutInitH pid form = do
     Nothing -> toastError "Failed to create checkout session" mempty
 
 
-getSubscriptionPortalUrl :: Maybe Text -> Text -> IO (Maybe SubPortalResponse)
-getSubscriptionPortalUrl subId apiKey = do
-  case subId of
-    Nothing -> return Nothing
-    Just sid -> do
-      let hds = W.header "Authorization" .~ ["Bearer " <> encodeUtf8 @Text @ByteString apiKey]
-      response <- liftIO $ Network.Wreq.getWith (defaults & hds) ("https://api.lemonsqueezy.com/v1/subscriptions/" <> toString sid)
-      let responseBdy = response ^. responseBody
-      case AE.eitherDecode responseBdy of
-        Right res -> return $ Just res
-        Left err -> return Nothing
+-- | Lemon Squeezy responses come wrapped in @{"data": ...}@. The Haskell
+-- field is @dataVal@ (since @data@ is a keyword); 'Rename' maps it to the
+-- on-the-wire key without a manual instance.
+newtype LSData a = LSData {dataVal :: a}
+  deriving stock (Generic, Show)
+  deriving (AE.FromJSON) via DAE.CustomJSON '[DAE.FieldLabelModifier '[DAE.Rename "dataVal" "data"]] (LSData a)
+
+
+-- | Bearer GET against api.lemonsqueezy.com, decoding the @{data: ...}@ wrapper.
+lsGet :: forall a es. (HTTP :> es, AE.FromJSON a) => Text -> Text -> Eff es (Maybe (LSData a))
+lsGet apiKey url = do
+  response <- W.getWith (Settings.lemonSqueezyOpts apiKey) (toString url)
+  pure $ rightToMaybe $ AE.eitherDecode $ response ^. responseBody
 
 
 data SubUrls = SubUrls
@@ -1200,14 +1220,6 @@ newtype SubPortalAttributes = SubPortalAttributes {urls :: SubUrls}
 newtype SubPortalDataVals = SubPortalDataVals {attributes :: SubPortalAttributes}
   deriving stock (Generic, Show)
   deriving (AE.FromJSON, AE.ToJSON) via DAE.CustomJSON '[DAE.FieldLabelModifier '[DAE.CamelToSnake]] SubPortalDataVals
-
-
--- | Lemon Squeezy responses come wrapped in @{"data": ...}@. The Haskell
--- field is @dataVal@ (since @data@ is a keyword); 'Rename' maps it to the
--- on-the-wire key without a manual instance.
-newtype SubPortalResponse = SubPortalResponse {dataVal :: SubPortalDataVals}
-  deriving stock (Generic, Show)
-  deriving (AE.FromJSON) via DAE.CustomJSON '[DAE.FieldLabelModifier '[DAE.Rename "dataVal" "data"]] SubPortalResponse
 
 
 --------------------------------------------------------------------------------
@@ -1370,22 +1382,10 @@ data SubDataVals = SubDataVals
   deriving (AE.FromJSON, AE.ToJSON) via DAE.CustomJSON '[DAE.FieldLabelModifier '[DAE.CamelToSnake]] SubDataVals
 
 
-newtype SubResponse = SubResponse {dataVal :: [SubDataVals]}
-  deriving stock (Generic, Show)
-  deriving (AE.FromJSON) via DAE.CustomJSON '[DAE.FieldLabelModifier '[DAE.Rename "dataVal" "data"]] SubResponse
-
-
-getSubscriptionId :: HTTP :> es => Maybe Text -> Text -> Eff es (Maybe SubResponse)
-getSubscriptionId orderId apiKey = do
-  case orderId of
-    Nothing -> pure Nothing
-    Just ordId -> do
-      let hds = W.header "Authorization" .~ ["Bearer " <> encodeUtf8 @Text @ByteString apiKey]
-      response <- W.getWith (defaults & hds) ("https://api.lemonsqueezy.com/v1/orders/" <> toString ordId <> "/subscriptions")
-      let responseBdy = response ^. responseBody
-      case AE.eitherDecode responseBdy of
-        Right res -> return $ Just res
-        Left err -> return Nothing
+getSubscriptionId :: HTTP :> es => Maybe Text -> Text -> Eff es (Maybe (LSData [SubDataVals]))
+getSubscriptionId orderId apiKey = case orderId of
+  Nothing -> pure Nothing
+  Just ordId -> lsGet apiKey ("https://api.lemonsqueezy.com/v1/orders/" <> ordId <> "/subscriptions")
 
 
 data PricingUpdateForm = PricingUpdateForm

--- a/src/Pages/Projects.hs
+++ b/src/Pages/Projects.hs
@@ -383,6 +383,7 @@ validateNotificationChannels pid enabledChannels phones = do
 resolveSlackChannels :: Maybe SlackData -> ATAuthCtx [BotUtils.Channel]
 resolveSlackChannels = maybe (pure []) \d -> maybe [] (fromMaybe [] . (.channels)) <$> SlackP.getSlackChannels d.botToken d.teamId
 
+
 projectSlackChannels :: Projects.ProjectId -> ATAuthCtx [BotUtils.Channel]
 projectSlackChannels pid = getProjectSlackData pid >>= resolveSlackChannels
 
@@ -1198,7 +1199,7 @@ newtype LSData a = LSData {dataVal :: a}
 
 
 -- | Bearer GET against api.lemonsqueezy.com, decoding the @{data: ...}@ wrapper.
-lsGet :: forall a es. (HTTP :> es, AE.FromJSON a) => Text -> Text -> Eff es (Maybe (LSData a))
+lsGet :: forall a es. (AE.FromJSON a, HTTP :> es) => Text -> Text -> Eff es (Maybe (LSData a))
 lsGet apiKey url = do
   response <- W.getWith (Settings.lemonSqueezyOpts apiKey) (toString url)
   pure $ rightToMaybe $ AE.eitherDecode $ response ^. responseBody

--- a/src/Pages/Reports.hs
+++ b/src/Pages/Reports.hs
@@ -43,7 +43,7 @@ import Pkg.EmailTemplates qualified as ET
 import Relude hiding (ask)
 import System.Config (AuthContext (..), EnvConfig (..))
 import System.Types (ATAuthCtx, RespHeaders, addRespHeaders, addSuccessToast)
-import Utils (FreeTierStatus, LoadingSize (..), LoadingType (..), checkFreeTierStatus, faSprite_, loadingIndicatorWith_)
+import Utils (FreeTierStatus, LoadingSize (..), LoadingType (..), checkFreeTierStatus, faSprite_, formatUTCMicros, loadingIndicatorWith_)
 
 
 data PerformanceReport = PerformanceReport
@@ -64,7 +64,7 @@ data StatData = StatData
   , change :: Double
   }
   deriving stock (Generic, Show)
-  deriving anyclass (AE.FromJSON)
+  deriving anyclass (AE.FromJSON, AE.ToJSON)
 
 
 data SpanTypeStats = SpanTypeStats
@@ -75,7 +75,7 @@ data SpanTypeStats = SpanTypeStats
   , durationChange :: Double
   }
   deriving stock (Generic, Show)
-  deriving anyclass (AE.FromJSON)
+  deriving anyclass (AE.FromJSON, AE.ToJSON)
 
 
 data DBQueryStat = DBQueryStat
@@ -84,7 +84,7 @@ data DBQueryStat = DBQueryStat
   , totalEvents :: Integer
   }
   deriving stock (Generic, Show)
-  deriving anyclass (AE.FromJSON)
+  deriving anyclass (AE.FromJSON, AE.ToJSON)
 
 
 data ReportData = ReportData
@@ -98,7 +98,7 @@ data ReportData = ReportData
   , issues :: [Issues.IssueSummary]
   }
   deriving stock (Generic, Show)
-  deriving anyclass (AE.FromJSON)
+  deriving anyclass (AE.FromJSON, AE.ToJSON)
 
 
 -- | Shared widget definitions for chart URL generation
@@ -122,19 +122,17 @@ anomalyTypeCounts getType =
 
 buildReportJson' :: Int -> Int -> Double -> Double -> V.Vector (Text, Int, Double, Int, Double) -> V.Vector (Text, Text, Text, Int64, Double, Int64, Double) -> V.Vector (Text, Int, Int) -> Charts.MetricsData -> Charts.MetricsData -> V.Vector Issues.IssueSummary -> AE.Value
 buildReportJson' totalEvents totalErrors eventsChange errorsChange spanTypeStatsDiff' endpointsPerformance slowDbQueries chartEv chartErr issues =
-  let spanStatsDiff = (\(t, e, chang, dur, durChange) -> AE.object ["spanType" AE..= t, "eventCount" AE..= e, "eventChange" AE..= chang, "averageDuration" AE..= dur, "durationChange" AE..= durChange]) <$> spanTypeStatsDiff'
-      perf = (\(u, m, p, d, dc, req, cc) -> AE.object ["host" AE..= u, "urlPath" AE..= p, "method" AE..= m, "averageDuration" AE..= d, "durationDiffPct" AE..= dc, "requestCount" AE..= req, "requestDiffPct" AE..= cc]) <$> V.take 10 endpointsPerformance
-      slowDbQueries' = (\(q, d, c) -> AE.object ["query" AE..= q, "averageDuration" AE..= d, "totalEvents" AE..= c]) <$> slowDbQueries
-   in AE.object
-        [ "endpoints" AE..= perf
-        , "events" AE..= AE.object ["total" AE..= totalEvents, "change" AE..= eventsChange]
-        , "errors" AE..= AE.object ["total" AE..= totalErrors, "change" AE..= errorsChange]
-        , "spanTypeStats" AE..= spanStatsDiff
-        , "slowDbQueries" AE..= slowDbQueries'
-        , "errorDataset" AE..= Widget.toWidgetDataset chartErr
-        , "eventsDataset" AE..= Widget.toWidgetDataset chartEv
-        , "issues" AE..= issues
-        ]
+  AE.toJSON
+    ReportData
+      { endpoints = (\(u, m, p, d, dc, req, cc) -> PerformanceReport{host = u, urlPath = p, method = m, averageDuration = fromIntegral d, durationDiffPct = dc, requestCount = fromIntegral req, requestDiffPct = cc}) <$> V.toList (V.take 10 endpointsPerformance)
+      , events = StatData{total = fromIntegral totalEvents, change = eventsChange}
+      , errors = StatData{total = fromIntegral totalErrors, change = errorsChange}
+      , spanTypeStats = (\(t, e, chang, dur, durChange) -> SpanTypeStats{spanType = t, eventCount = fromIntegral e, eventChange = chang, averageDuration = fromIntegral dur, durationChange = durChange}) <$> V.toList spanTypeStatsDiff'
+      , slowDbQueries = (\(q, d, c) -> DBQueryStat{query = q, averageDuration = fromIntegral d, totalEvents = fromIntegral c}) <$> V.toList slowDbQueries
+      , errorDataset = Widget.toWidgetDataset chartErr
+      , eventsDataset = Widget.toWidgetDataset chartEv
+      , issues = V.toList issues
+      }
 
 
 -- | Moved from BackgroundJobs
@@ -183,8 +181,8 @@ renderWeeklyEmail reportUrl project pid userName startTime endTime totalEvents t
   let reportUrl' = ctx.env.hostUrl <> reportUrl
       dayStart = show $ localDay (utcToLocalTimeTZ tz startTime)
       dayEnd = show $ localDay (utcToLocalTimeTZ tz endTime)
-      stmTxt = toText $ formatTime defaultTimeLocale "%Y-%m-%dT%H:%M:%S%6QZ" startTime
-      endTxt = toText $ formatTime defaultTimeLocale "%Y-%m-%dT%H:%M:%S%6QZ" endTime
+      stmTxt = formatUTCMicros startTime
+      endTxt = formatUTCMicros endTime
       (errTotal, apiTotal, qTotal, lpTotal, rcTotal) = anomalyTypeCounts (.issueType) anomalies
   eventsUrl <- Widget.widgetPngUrl ctx.env.apiKeyEncryptionSecretKey ctx.env.hostUrl pid eventsWidget Nothing (Just stmTxt) (Just endTxt)
   errorsUrl <- Widget.widgetPngUrl ctx.env.apiKeyEncryptionSecretKey ctx.env.hostUrl pid errorsWidget Nothing (Just stmTxt) (Just endTxt)

--- a/src/Pages/Telemetry.hs
+++ b/src/Pages/Telemetry.hs
@@ -88,17 +88,6 @@ data SpanMin = SpanMin
   deriving anyclass (AE.FromJSON, AE.ToJSON)
 
 
--- | Lookup a dotted attribute key — try flat key first, then nested-object traversal.
-attrLookup :: Text -> Maybe (Map Text AE.Value) -> Maybe Text
-attrLookup key attrs =
-  (attrs >>= Map.lookup key >>= textOfValue) <|> Telemetry.atMapText key attrs
-  where
-    textOfValue = \case
-      AE.String t -> Just t
-      AE.Number n -> Just (show n)
-      _ -> Nothing
-
-
 -- | Extract a human-readable label from span attributes (db query, http route, rpc method, messaging).
 -- Order matches semantic precedence: db query > http method+route > rpc > messaging > exception.
 spanDisplayLabel :: Maybe (Map Text AE.Value) -> Maybe Text
@@ -112,7 +101,7 @@ spanDisplayLabel attrs =
     <|> joinWith " " (look "messaging.operation") (look "messaging.destination.name" <|> look "messaging.destination")
     <|> look "exception.type"
   where
-    look k = attrLookup k attrs
+    look k = Telemetry.atMapText k attrs
     joinWith sep = liftA2 (\a b -> a <> sep <> b)
 
 
@@ -393,15 +382,29 @@ metricDetailUrl :: Projects.ProjectId -> Text -> Text -> Text
 metricDetailUrl pid metricName source = "/p/" <> pid.toText <> "/metrics/details/" <> metricName <> "/?source=" <> source
 
 
+-- | Shared WTTimeseriesLine widget for a metric. @mTitle@/@mId@/@mExpandBtn@/@mDescription@
+-- carry the per-callsite differences between the chart-list card and the details page.
+metricWidget :: Projects.ProjectId -> Text -> Text -> Maybe Text -> Maybe Text -> Maybe Text -> Maybe Text -> Widget.Widget
+metricWidget pid metricName metricUnit mTitle mId mExpandBtn mDescription =
+  def
+    { Widget.wType = Widget.WTTimeseriesLine
+    , Widget.title = mTitle
+    , Widget.query = Just $ "metrics | where metric_name == \"" <> metricName <> "\" | summarize avg(metric_value.contents.value) by bin_auto(timestamp),attributes"
+    , Widget.layout = Just $ Widget.Layout{x = Just 0, y = Just 0, w = Just 2, h = Just 1}
+    , Widget.unit = Just metricUnit
+    , Widget.hideLegend = Nothing
+    , Widget.eager = Just True
+    , Widget._projectId = Just pid
+    , Widget.id = mId
+    , Widget.expandBtnFn = mExpandBtn
+    , Widget.description = mDescription
+    }
+
+
 drawerExpandScript :: Text -> Text
 drawerExpandScript detailUrl =
-  [text|on pointerdown or click set #global-data-drawer.checked to true
-        then set #global-data-drawer-content.innerHTML to #loader-tmp.innerHTML
-        then fetch $detailUrl
-        then set #global-data-drawer-content.innerHTML to it
-        then htmx.process(#global-data-drawer-content)
-        then _hyperscript.processNode(#global-data-drawer-content)
-        then window.evalScriptsFromContent(#global-data-drawer-content)|]
+  let fetchTail = LogItem.fetchIntoScript "global-data-drawer-content" detailUrl
+   in [text|on pointerdown or click set #global-data-drawer.checked to true then $fetchTail|]
 
 
 chartList :: Projects.ProjectId -> Text -> V.Vector Telemetry.MetricChartListData -> Maybe Text -> Html ()
@@ -413,18 +416,7 @@ chartList pid source metricList nextUrl = do
       let lastSeenStr = formatTime defaultTimeLocale "%b %d, %Y %H:%M" metric.lastSeen
       div_ [class_ "h-52"]
         $ toHtml
-        $ def
-          { Widget.wType = Widget.WTTimeseriesLine
-          , Widget.title = Just metric.metricName
-          , Widget.query = Just $ "metrics | where metric_name == \"" <> metric.metricName <> "\" | summarize avg(metric_value.contents.value) by bin_auto(timestamp),attributes"
-          , Widget.layout = Just $ Widget.Layout{x = Just 0, y = Just 0, w = Just 2, h = Just 1}
-          , Widget.unit = Just metric.metricUnit
-          , Widget.hideLegend = Nothing
-          , Widget.eager = Just True
-          , Widget._projectId = Just pid
-          , Widget.expandBtnFn = Just expandBtn
-          , Widget.description = Just $ "Last seen: " <> toText lastSeenStr
-          }
+        $ metricWidget pid metric.metricName metric.metricUnit (Just metric.metricName) Nothing (Just expandBtn) (Just $ "Last seen: " <> toText lastSeenStr)
   whenJust nextUrl \url ->
     a_ [hxTrigger_ "intersect once", hxSwap_ "outerHTML", hxGet_ url] pass
 
@@ -536,18 +528,7 @@ metricsDetailsPage pid sources metric source currentRange = do
       div_ [class_ "flex items-center text-sm"] $ span_ [] $ toHtml metric.metricName
       div_ [class_ "h-64 w-full"]
         $ toHtml
-        $ def
-          { Widget.wType = Widget.WTTimeseriesLine
-          , Widget.title = Nothing
-          , Widget.query = Just $ "metrics | where metric_name == \"" <> metric.metricName <> "\" | summarize avg(metric_value.contents.value) by bin_auto(timestamp),attributes"
-          , Widget.layout = Just $ Widget.Layout{x = Just 0, y = Just 0, w = Just 2, h = Just 1}
-          , Widget.unit = Just metric.metricUnit
-          , Widget.hideLegend = Nothing
-          , Widget.eager = Just True
-          , Widget._projectId = Just pid
-          , Widget.id = Just $ "details_" <> T.replace "." "_" metric.metricName
-          , Widget.expandBtnFn = Nothing
-          }
+        $ metricWidget pid metric.metricName metric.metricUnit Nothing (Just $ "details_" <> T.replace "." "_" metric.metricName) Nothing Nothing
 
     div_ [class_ "flex flex-col gap-2 rounded-2xl border border-strokeWeak", id_ "metric-tabs-container"] $ do
       div_ [class_ "flex", [__|on click halt|]] $ do

--- a/src/Pkg/AI.hs
+++ b/src/Pkg/AI.hs
@@ -646,10 +646,6 @@ stripCodeBlock t
     stripped = T.strip t
 
 
-parseResponse :: Text -> Either Text LLMResponse
-parseResponse = parseLLMResponse . stripCodeBlock
-
-
 runAgenticQuery :: (DB es, ELLM.LLM :> es, Log :> es, Time.Time :> es, Tracing :> es) => AgenticConfig -> Text -> Text -> Text -> Eff es (Either Text LLMResponse)
 runAgenticQuery config userQuery model apiKey = do
   now <- Time.currentTime
@@ -663,7 +659,11 @@ runAgenticQuery config userQuery model apiKey = do
           , OpenAIV1.tools = Just $ V.fromList allToolDefs
           , OpenAIV1.messages = V.empty
           }
-  runAgenticLoop config apiKey chatHistory params 0
+  -- Parse the final text only (toolCalls stays Nothing): runAgenticQuery's consumers
+  -- (MCP, bots, log explorer) render explanation/query/widgets and never read toolCalls,
+  -- so injecting tool metadata here would only bloat their responses. The tool-data-reuse
+  -- path is runAgenticChatWithHistory -> AgenticChatResult (used by Anomalies).
+  (>>= parseLLMResponse . (.response)) <$> runAgenticLoopRaw config apiKey chatHistory params 0 []
 
 
 -- | Convert a DB chat message to an LLM message
@@ -750,33 +750,6 @@ mkToolCallInfo tc result =
     }
 
 
-runAgenticLoop :: (DB es, ELLM.LLM :> es, Log :> es, Time.Time :> es, Tracing :> es) => AgenticConfig -> Text -> LLM.ChatHistory -> OpenAIV1.CreateChatCompletion -> Int -> Eff es (Either Text LLMResponse)
-runAgenticLoop config apiKey chatHistory params iteration
-  | iteration >= config.maxIterations = do
-      Log.logTrace "AI agentic loop forcing final response" (AE.object ["iteration" AE..= iteration, "maxIterations" AE..= config.maxIterations])
-      ELLM.callAgenticChat chatHistory params{OpenAIV1.tools = Nothing} apiKey >>= either handleError \responseMsg -> do
-        Log.logTrace "AI final response" (AE.object ["iteration" AE..= iteration, "response" AE..= LLM.content responseMsg, "responseLength" AE..= T.length (LLM.content responseMsg)])
-        pure $ parseResponse $ LLM.content responseMsg
-  | otherwise = do
-      let userQuery = maybe "" LLM.content $ viaNonEmpty last $ filter (\m -> LLM.role m == LLM.User) $ toList chatHistory
-      Log.logTrace "AI agentic loop iteration" (AE.object ["iteration" AE..= iteration, "historySize" AE..= length chatHistory, "userQuery" AE..= userQuery])
-      ELLM.callAgenticChat chatHistory params apiKey >>= either handleError \responseMsg ->
-        maybe (logFinalResponse responseMsg) (processToolCalls responseMsg) (LLM.toolCalls $ LLM.messageData responseMsg)
-  where
-    handleError err = Log.logAttention "LLM API error" (AE.object ["error" AE..= show @Text err]) $> Left "LLM service temporarily unavailable"
-
-    logFinalResponse responseMsg = do
-      Log.logTrace "AI final response (no tool calls)" (AE.object ["iteration" AE..= iteration, "response" AE..= LLM.content responseMsg, "responseLength" AE..= T.length (LLM.content responseMsg)])
-      pure $ parseResponse $ LLM.content responseMsg
-
-    processToolCalls responseMsg toolCallList = do
-      Log.logTrace "AI requesting tool calls" (AE.object ["iteration" AE..= iteration, "tools" AE..= map (LLM.toolFunctionName . LLM.toolCallFunction) toolCallList])
-      toolResults <- traverse (executeToolCall config) toolCallList
-      Log.logTrace "AI tool calls completed" (AE.object ["iteration" AE..= iteration, "toolCount" AE..= length toolResults, "resultsPreview" AE..= map (\r -> T.take 200 r.formatted) toolResults])
-      newMessages <- liftIO $ addMessagesToMemory config.limits.maxTokenBuffer chatHistory (responseMsg : zipWith mkToolResultMsg toolCallList toolResults)
-      runAgenticLoop config apiKey newMessages params (iteration + 1)
-
-
 mkToolResultMsg :: LLM.ToolCall -> ToolResult -> LLM.Message
 mkToolResultMsg tc result =
   LLM.Message
@@ -825,23 +798,23 @@ executeGetFieldValues config args = case getTextArg "field" args of
   Just field -> do
     let lim = getLimitArg "limit" config.limits.maxFieldValues config.limits.defaultFieldLimit args
         kqlQuery = "| summarize count() by " <> field <> " | sort by count_ desc | take " <> show lim
-    runKqlAndFormat config kqlQuery [] $ \(results, _, _) ->
-      "Values for '" <> field <> "': " <> formatSummarizeResults results
+    (.formatted) <$> runKqlWithRawData config kqlQuery [] (\(results, _, _) ->
+      ("Values for '" <> field <> "': " <> formatSummarizeResults results, AE.Null))
   _ -> pure $ toolError "get_field_values" "missing 'field'" args
 
 
 executeGetServices :: (DB es, Log :> es, Time.Time :> es, Tracing :> es) => AgenticConfig -> Eff es Text
 executeGetServices config = do
   let kqlQuery = "| summarize count() by resource.service.name | sort by count_ desc | take " <> show config.limits.maxServices
-  runKqlAndFormat config kqlQuery [] $ \(results, _, _) ->
-    "Available services: " <> formatSummarizeResults results
+  (.formatted) <$> runKqlWithRawData config kqlQuery [] (\(results, _, _) ->
+    ("Available services: " <> formatSummarizeResults results, AE.Null))
 
 
 executeCountQuery :: (DB es, Log :> es, Time.Time :> es, Tracing :> es) => AgenticConfig -> Map.Map Text AE.Value -> Eff es Text
 executeCountQuery config args = case getTextArg "query" args of
   Just kqlQuery ->
-    runKqlAndFormat config kqlQuery [] $ \(_, _, count) ->
-      "Query '" <> kqlQuery <> "' matches " <> show count <> " entries"
+    (.formatted) <$> runKqlWithRawData config kqlQuery [] (\(_, _, count) ->
+      ("Query '" <> kqlQuery <> "' matches " <> show count <> " entries", AE.Null))
   _ -> pure $ toolError "count_query" "missing 'query'" args
 
 
@@ -851,8 +824,8 @@ executeSampleLogs config args = case getTextArg "query" args of
     let lim = getLimitArg "limit" config.limits.maxSampleLogs config.limits.defaultSampleLimit args
         fullQuery = if "| take" `T.isInfixOf` kqlQuery then kqlQuery else kqlQuery <> " | take " <> show lim
         sampleColumns = ["level", "name", "resource.service.name", "body"]
-    runKqlAndFormat config fullQuery sampleColumns $ \(results, _, _) ->
-      "Sample logs:\n" <> formatSampleLogs config.limits.maxBodyPreview results
+    (.formatted) <$> runKqlWithRawData config fullQuery sampleColumns (\(results, _, _) ->
+      ("Sample logs:\n" <> formatSampleLogs config.limits.maxBodyPreview results, AE.Null))
   _ -> pure $ toolError "sample_logs" "missing 'query'" args
 
 
@@ -893,11 +866,3 @@ executeSqlQuery config args = case getTextArg "query" args of
         let count = V.length results
          in formatQueryResults config.limits.maxDisplayRows results count
   _ -> pure $ toolError "run_sql_query" "missing 'query'" args
-
-
-runKqlAndFormat :: (DB es, Log :> es, Time.Time :> es, Tracing :> es) => AgenticConfig -> Text -> [Text] -> ((V.Vector (V.Vector AE.Value), [Text], Int) -> Text) -> Eff es Text
-runKqlAndFormat config kqlQuery cols formatResult = case parseQueryToAST kqlQuery of
-  Left parseErr -> pure $ "Error: Query parse failed - " <> show parseErr
-  Right queryAST -> do
-    resultE <- selectLogTable config.projectId queryAST kqlQuery Nothing config.timeRange cols Nothing Nothing
-    pure $ either ("Error: Query execution failed - " <>) formatResult resultE

--- a/src/Pkg/AI.hs
+++ b/src/Pkg/AI.hs
@@ -798,23 +798,41 @@ executeGetFieldValues config args = case getTextArg "field" args of
   Just field -> do
     let lim = getLimitArg "limit" config.limits.maxFieldValues config.limits.defaultFieldLimit args
         kqlQuery = "| summarize count() by " <> field <> " | sort by count_ desc | take " <> show lim
-    (.formatted) <$> runKqlWithRawData config kqlQuery [] (\(results, _, _) ->
-      ("Values for '" <> field <> "': " <> formatSummarizeResults results, AE.Null))
+    (.formatted)
+      <$> runKqlWithRawData
+        config
+        kqlQuery
+        []
+        ( \(results, _, _) ->
+            ("Values for '" <> field <> "': " <> formatSummarizeResults results, AE.Null)
+        )
   _ -> pure $ toolError "get_field_values" "missing 'field'" args
 
 
 executeGetServices :: (DB es, Log :> es, Time.Time :> es, Tracing :> es) => AgenticConfig -> Eff es Text
 executeGetServices config = do
   let kqlQuery = "| summarize count() by resource.service.name | sort by count_ desc | take " <> show config.limits.maxServices
-  (.formatted) <$> runKqlWithRawData config kqlQuery [] (\(results, _, _) ->
-    ("Available services: " <> formatSummarizeResults results, AE.Null))
+  (.formatted)
+    <$> runKqlWithRawData
+      config
+      kqlQuery
+      []
+      ( \(results, _, _) ->
+          ("Available services: " <> formatSummarizeResults results, AE.Null)
+      )
 
 
 executeCountQuery :: (DB es, Log :> es, Time.Time :> es, Tracing :> es) => AgenticConfig -> Map.Map Text AE.Value -> Eff es Text
 executeCountQuery config args = case getTextArg "query" args of
   Just kqlQuery ->
-    (.formatted) <$> runKqlWithRawData config kqlQuery [] (\(_, _, count) ->
-      ("Query '" <> kqlQuery <> "' matches " <> show count <> " entries", AE.Null))
+    (.formatted)
+      <$> runKqlWithRawData
+        config
+        kqlQuery
+        []
+        ( \(_, _, count) ->
+            ("Query '" <> kqlQuery <> "' matches " <> show count <> " entries", AE.Null)
+        )
   _ -> pure $ toolError "count_query" "missing 'query'" args
 
 
@@ -824,8 +842,14 @@ executeSampleLogs config args = case getTextArg "query" args of
     let lim = getLimitArg "limit" config.limits.maxSampleLogs config.limits.defaultSampleLimit args
         fullQuery = if "| take" `T.isInfixOf` kqlQuery then kqlQuery else kqlQuery <> " | take " <> show lim
         sampleColumns = ["level", "name", "resource.service.name", "body"]
-    (.formatted) <$> runKqlWithRawData config fullQuery sampleColumns (\(results, _, _) ->
-      ("Sample logs:\n" <> formatSampleLogs config.limits.maxBodyPreview results, AE.Null))
+    (.formatted)
+      <$> runKqlWithRawData
+        config
+        fullQuery
+        sampleColumns
+        ( \(results, _, _) ->
+            ("Sample logs:\n" <> formatSampleLogs config.limits.maxBodyPreview results, AE.Null)
+        )
   _ -> pure $ toolError "sample_logs" "missing 'query'" args
 
 

--- a/src/Pkg/Components/Widget.hs
+++ b/src/Pkg/Components/Widget.hs
@@ -253,6 +253,12 @@ encodeText :: AE.ToJSON a => a -> Text
 encodeText = decodeUtf8 . fromLazy . AE.encode
 
 
+-- | HTMX fetch URL for a (already eager-prepared) widget: the project-scoped
+-- /widget endpoint with the widget JSON url-encoded as a query param.
+widgetFetchUrl :: Widget -> Text
+widgetFetchUrl w = "/p/" <> maybe "" (.toText) w._projectId <> "/widget?widgetJSON=" <> decodeUtf8 (urlEncode True $ encodeUtf8 $ encodeText w)
+
+
 -- | Data attributes for table row click handling (delegated via global JS handler in widgets.ts)
 rowClickTableAttrs :: Widget -> [Attribute]
 rowClickTableAttrs widget = flip foldMap widget.onRowClick \action ->
@@ -576,56 +582,49 @@ renderLogsWidget widget = do
       ("" :: Text)
 
 
+-- | Shared sticky table @thead@ with sortable column headers. Each column is a
+-- (title, optional align-class) pair. When @sortable@ is True the @th@ gets the
+-- @window.sortTable@ onclick + a hover sort-arrow; otherwise it's a plain header.
+sortableTableHead_ :: Text -> Bool -> [(Text, Maybe Text)] -> Html ()
+sortableTableHead_ tableId sortable cols =
+  thead_ [class_ "sticky top-0 z-10 before:content-[''] before:absolute before:left-0 before:right-0 before:bottom-0 before:h-px before:bg-strokeWeak"]
+    $ tr_ []
+    $ ifor_ cols \idx (title, align) ->
+      th_
+        ( [ class_ $ "text-left bg-bgRaised sticky top-0 cursor-pointer hover:bg-fillWeak transition-colors group " <> fromMaybe "" align
+          , data_ "sort-direction" "none"
+          ]
+            <> [onclick_ $ "window.sortTable('" <> tableId <> "', " <> show (idx :: Int) <> ", this)" | sortable]
+        )
+        $ headerRow_ [] do
+          toHtml title
+          when sortable $ span_ [class_ "sort-arrow ml-1 text-iconNeutral opacity-0 group-hover:opacity-100", data_ "sort" "none"] "↕"
+
+
 renderTraceTable :: Widget -> Html ()
 renderTraceTable widget = do
-  let tableId = maybeToMonoid widget.id
-  let eagerWidget = widget & #eager ?~ True & #pngUrl .~ Nothing & #html .~ Nothing & #dataset .~ Nothing
-  let widgetJson = fromLazy $ AE.encode eagerWidget
-  withCardFrame True widget Nothing do
-    div_
-      [ class_ "h-full overflow-auto p-3"
-      , hxGet_ $ "/p/" <> maybe "" (.toText) widget._projectId <> "/widget?widgetJSON=" <> decodeUtf8 (urlEncode True widgetJson)
-      , hxTrigger_ "load, update-query from:window"
-      , hxTarget_ $ "#" <> tableId
-      , hxSelect_ $ "#" <> tableId
-      , hxSwap_ "outerHTML"
-      , hxExt_ "forward-page-params"
-      ]
-      do
-        case widget.html of
-          Just html -> toHtmlRaw html
-          Nothing ->
-            table_ [class_ "table table-zebra table-sm w-full relative", id_ tableId] do
-              thead_ [class_ "sticky top-0 z-10 before:content-[''] before:absolute before:left-0 before:right-0 before:bottom-0 before:h-px before:bg-strokeWeak"] do
-                tr_ [] do
-                  ifor_ (["Resource", "Span name", "Duration", "Latency breakdown"] :: [Text]) \idx col ->
-                    th_
-                      [ class_ "text-left bg-bgRaised sticky top-0 cursor-pointer hover:bg-fillWeak transition-colors group "
-                      , onclick_ $ "window.sortTable('" <> tableId <> "', " <> show (idx :: Int) <> ", this)"
-                      , data_ "sort-direction" "none"
-                      ]
-                      do
-                        headerRow_ [] do
-                          toHtml col
-                          span_ [class_ "sort-arrow ml-1 text-iconNeutral opacity-0 group-hover:opacity-100", data_ "sort" "none"] "↕"
-              tbody_ []
-                $ tr_ []
-                $ td_ [colspan_ "100", class_ "text-center py-8"]
-                $ loadingIndicator_ LdSM LdSpinner
-    script_ [type_ "text/javascript"] """htmx.process(".widget-target")"""
+  renderTableShell widget [(c, Nothing) | c <- ["Resource", "Span name", "Duration", "Latency breakdown"] :: [Text]] []
+  script_ [type_ "text/javascript"] """htmx.process(".widget-target")"""
 
 
 -- Table widget rendering
 -- class_ "progress-brand "
 renderTable :: Widget -> Html ()
-renderTable widget = do
+renderTable widget = renderTableShell widget [(col.title, col.align) | col <- fromMaybe [] widget.columns] (rowClickTableAttrs widget)
+
+
+-- | Shared eager-fetch shell for renderTable / renderTraceTable: HTMX-loaded
+-- card whose body is either the already-rendered @widget.html@ or a loading
+-- table whose @thead@ uses the given column headers (+ optional extra @table@
+-- attrs, e.g. row-click data attributes).
+renderTableShell :: Widget -> [(Text, Maybe Text)] -> [Attribute] -> Html ()
+renderTableShell widget headerCols tableAttrs = do
   let tableId = maybeToMonoid widget.id
       eagerWidget = widget & #eager ?~ True & #pngUrl .~ Nothing & #html .~ Nothing & #dataset .~ Nothing
-      widgetJson = encodeText eagerWidget
   withCardFrame True widget Nothing
     $ div_
       [ class_ "h-full overflow-auto p-3"
-      , hxGet_ $ "/p/" <> maybe "" (.toText) widget._projectId <> "/widget?widgetJSON=" <> widgetJson
+      , hxGet_ $ widgetFetchUrl eagerWidget
       , hxTrigger_ "load, update-query from:window"
       , hxTarget_ $ "#" <> tableId
       , hxSelect_ $ "#" <> tableId
@@ -637,20 +636,9 @@ renderTable widget = do
           Just html -> toHtmlRaw html
           Nothing ->
             table_
-              ([class_ "table table-zebra table-sm w-full relative", id_ tableId] <> rowClickTableAttrs widget)
+              ([class_ "table table-zebra table-sm w-full relative", id_ tableId] <> tableAttrs)
               do
-                thead_ [class_ "sticky top-0 z-10 before:content-[''] before:absolute before:left-0 before:right-0 before:bottom-0 before:h-px before:bg-strokeWeak"] do
-                  tr_ [] do
-                    ifor_ (fromMaybe [] widget.columns) \idx col ->
-                      th_
-                        [ class_ $ "text-left bg-bgRaised sticky top-0 cursor-pointer hover:bg-fillWeak transition-colors group " <> fromMaybe "" col.align
-                        , onclick_ $ "window.sortTable('" <> tableId <> "', " <> show (idx :: Int) <> ", this)"
-                        , data_ "sort-direction" "none"
-                        ]
-                        do
-                          headerRow_ [] do
-                            toHtml col.title
-                            span_ [class_ "sort-arrow ml-1 text-iconNeutral opacity-0 group-hover:opacity-100", data_ "sort" "none"] "↕"
+                sortableTableHead_ tableId True headerCols
                 tbody_ []
                   $ tr_ []
                   $ td_ [colspan_ "100", class_ "text-center py-8"]
@@ -666,12 +654,11 @@ renderStatContent widget chartId valueM = do
       paddingClass = "px-3 flex flex-col " <> bool "py-3 " "py-2 " (widget._isNested == Just True)
       -- Always use eager widget JSON for HTMX requests
       eagerWidget = widget & #eager ?~ True
-      widgetJson = fromLazy $ AE.encode eagerWidget
   -- Always include HTMX attributes for refresh capability
   div_
     [ id_ statContentId
     , class_ paddingClass
-    , hxGet_ $ "/p/" <> maybe "" (.toText) widget._projectId <> "/widget?widgetJSON=" <> decodeUtf8 (urlEncode True widgetJson)
+    , hxGet_ $ widgetFetchUrl eagerWidget
     , hxTrigger_ $ if hasData then "update-query from:window" else "load, update-query from:window"
     , hxTarget_ $ "#" <> statContentId
     , hxSelect_ $ "#" <> statContentId
@@ -835,6 +822,17 @@ extractSeriesNamesFromDataset (Just wd) = case wd.source of
 extractSeriesNamesFromDataset Nothing = []
 
 
+-- | JS expression formatting a numeric @value@ for a widget's unit: duration
+-- units convert+format, everything else uses formatNumber. Shared by the
+-- tooltip valueFormatter and the yAxis axisLabel formatter.
+unitValueExprJS :: Maybe Text -> Text
+unitValueExprJS unitM =
+  let durationUnits = [Just "ns", Just "μs", Just "us", Just "ms", Just "s", Just "m", Just "h"] :: [Maybe Text]
+   in if unitM `elem` durationUnits
+        then "formatDuration(convertToNanoseconds(value, '" <> fromMaybe "" unitM <> "'))"
+        else "formatNumber(value)"
+
+
 -- Function to convert Widget to ECharts options
 widgetToECharts :: Widget -> AE.Value
 widgetToECharts widget =
@@ -856,12 +854,7 @@ widgetToECharts widget =
                   AE..= AE.object
                     ["type" AE..= ("shadow" :: Text)]
               , "valueFormatter"
-                  AE..= let durationUnits = [Just "ns", Just "μs", Just "us", Just "ms", Just "s", Just "m", Just "h"] :: [Maybe Text]
-                            isDuration = widget.unit `elem` durationUnits
-                            unit = fromMaybe "" widget.unit
-                         in if isDuration
-                              then "function(value) { return formatDuration(convertToNanoseconds(value, '" <> unit <> "')); }"
-                              else "function(value) { return formatNumber(value); }"
+                  AE..= ("function(value) { return " <> unitValueExprJS widget.unit <> "; }")
               ]
         , "legend"
             AE..= AE.object
@@ -935,10 +928,7 @@ widgetToECharts widget =
                     [ "show" AE..= (axisVisibility && fromMaybe True (widget ^? #yAxis . _Just . #showAxisLabel . _Just))
                     , "inside" AE..= False
                     , "formatter"
-                        AE..= let durationUnits = [Just "ns", Just "μs", Just "us", Just "ms", Just "s", Just "m", Just "h"] :: [Maybe Text]
-                                  isDuration = widget.unit `elem` durationUnits
-                                  unit = fromMaybe "" widget.unit
-                                  fmt = if isDuration then "formatDuration(convertToNanoseconds(value, '" <> unit <> "'))" else "formatNumber(value)"
+                        AE..= let fmt = unitValueExprJS widget.unit
                                   showOnlyMax = fromMaybe False $ widget ^? #yAxis . _Just . #showOnlyMaxLabel . _Just
                                in if showOnlyMax
                                     then "function(value, index) { return (value === this.yAxis.max || value == 0) ? " <> fmt <> " : ''; }"
@@ -1082,18 +1072,7 @@ renderTableWithDataAndParams widget dataRows params = do
     )
     do
       -- Table header
-      thead_ [class_ "sticky top-0 z-10 before:content-[''] before:absolute before:left-0 before:right-0 before:bottom-0 before:h-px before:bg-strokeWeak"] do
-        tr_ [] do
-          ifor_ columns \idx col ->
-            th_
-              [ class_ $ "text-left bg-bgRaised sticky top-0 cursor-pointer hover:bg-fillWeak transition-colors group " <> fromMaybe "" col.align
-              , onclick_ $ "window.sortTable('" <> tableId <> "', " <> show (idx :: Int) <> ", this)"
-              , data_ "sort-direction" "none"
-              ]
-              do
-                headerRow_ [] do
-                  toHtml col.title
-                  span_ [class_ "sort-arrow ml-1 text-iconNeutral opacity-0 group-hover:opacity-100", data_ "sort" "none"] "↕"
+      sortableTableHead_ tableId True [(col.title, col.align) | col <- columns]
 
       -- Table body with data
       tbody_ [] do
@@ -1110,8 +1089,8 @@ renderTableWithDataAndParams widget dataRows params = do
 
         -- Render table rows
         V.forM_ dataRows \row -> do
-          let rowData = AE.object [(K.fromText col.field, AE.String $ getRowValue col idx row) | (col, idx) <- zip columns [0 ..]]
-          let firstColValue = maybe "" (\c -> getRowValue c 0 row) (listToMaybe columns)
+          let rowData = AE.object [(K.fromText col.field, AE.String $ getRowValue idx row) | (col, idx) <- zip columns [0 ..]]
+          let firstColValue = maybe "" (const $ getRowValue 0 row) (listToMaybe columns)
           let rowValue = case widget.onRowClick >>= (.value) of
                 Just tmpl -> T.replace "{{row.resource_name}}" firstColValue tmpl
                 Nothing -> firstColValue
@@ -1123,7 +1102,7 @@ renderTableWithDataAndParams widget dataRows params = do
             ]
             do
               ifor_ columns \idx col -> do
-                let value = getRowValue col idx row
+                let value = getRowValue idx row
                 td_ [class_ $ fromMaybe "" col.align <> if col.columnType `elem` [Just ("number" :: Text), Just ("duration" :: Text)] then " monospace" else ""] do
                   if isJust col.progress
                     then renderProgressCell col value maxValues valueWidths
@@ -1137,16 +1116,7 @@ renderTraceDataTable widget dataRows spGroup spansGrouped colorsJson = do
 
   -- Render complete table with data
   table_ [class_ "table table-sm w-full relative", id_ tableId] do
-    thead_ [class_ "sticky top-0 z-10 before:content-[''] before:absolute before:left-0 before:right-0 before:bottom-0 before:h-px before:bg-strokeWeak"] do
-      tr_ [] do
-        forM_ columns \col ->
-          th_
-            [ class_ $ "text-left bg-bgRaised sticky top-0 cursor-pointer hover:bg-fillWeak transition-colors group " <> fromMaybe "" col.align
-            , data_ "sort-direction" "none"
-            ]
-            do
-              headerRow_ [] do
-                toHtml col.title
+    sortableTableHead_ tableId False [(col.title, col.align) | col <- columns]
     tbody_ [] do
       V.forM_ dataRows \row -> do
         let val = V.last row
@@ -1161,7 +1131,7 @@ renderTraceDataTable widget dataRows spGroup spansGrouped colorsJson = do
         let clcFun = [text|on click toggle .hidden on the next <tr/> then call flameGraphChart($spjson, "$val", $colorsJson)|]
         tr_ [term "_" clcFun, class_ "cursor-pointer"] do
           ifor_ columns \idx col -> do
-            let value = getRowValue col idx row
+            let value = getRowValue idx row
             if col.field == "latency_breakdown"
               then td_ [class_ "py-2"] do
                 renderLatencyBreakdown cdrn
@@ -1223,9 +1193,9 @@ renderLatencyBreakdown groups = do
       div_ [class_ ("h-full absolute top-0 border  " <> color), title_ tooltip, style_ $ "width:" <> show width <> "px;" <> "left:" <> show left <> "px;"] pass
 
 
--- Helper to get row value by column index or field name
-getRowValue :: TableColumn -> Int -> V.Vector Text -> Text
-getRowValue col idx row = fromMaybe "" $ row V.!? idx
+-- Helper to get row value by column index
+getRowValue :: Int -> V.Vector Text -> Text
+getRowValue idx row = fromMaybe "" $ row V.!? idx
 
 
 -- Calculate max values for column percentage progress bars

--- a/src/Pkg/DeriveUtils.hs
+++ b/src/Pkg/DeriveUtils.hs
@@ -10,6 +10,7 @@ module Pkg.DeriveUtils (
   UUIDId (..),
   WrappedEnum (..),
   WrappedEnumSC (..),
+  WrappedEnumInt (..),
   encodeEnumSC,
   WrappedEnumShow (..),
   addKeepaliveParams,
@@ -73,6 +74,7 @@ import Language.Haskell.TH.Syntax qualified as THS
 import Numeric (showHex)
 import OpenTelemetry.Instrumentation.Hasql qualified as OHasql
 import Relude
+import Relude.Extra.Enum (safeToEnum)
 import Relude.Unsafe qualified as Unsafe
 import Servant (FromHttpApiData (..))
 import Text.Casing (fromSnake, quietSnake, toPascal)
@@ -308,24 +310,19 @@ instance (KnownSymbol prefix, Read a, Show a) => FromHttpApiData (WrappedEnumSC 
   parseUrlPiece t = maybe (Left $ "Invalid " <> fromString (symbolVal (Proxy @prefix)) <> " value: " <> t) (Right . WrappedEnumSC) $ decodeEnumSC @prefix (toString @Text t)
 
 
+-- | Shared enum value list for a 'WrappedEnumSC' OpenApi schema.
+enumSCValues :: forall prefix a. (Bounded a, Enum a, KnownSymbol prefix, Show a) => [AE.Value]
+enumSCValues = [AE.String (toText $ encodeEnumSC @prefix v) | v <- [minBound @a .. maxBound @a]]
+
+
 instance {-# OVERLAPPABLE #-} (Bounded a, Enum a, KnownSymbol prefix, Show a, Typeable a, Typeable qualType) => ToSchema (WrappedEnumSC qualType prefix a) where
   declareNamedSchema (_ :: proxy (WrappedEnumSC qualType prefix a)) =
-    pure
-      $ NamedSchema Nothing
-      $ mempty
-      & type_
-      ?~ OpenApi.OpenApiString
-        & enum_
-      ?~ [AE.String (toText $ encodeEnumSC @prefix v) | v <- [minBound @a .. maxBound @a]]
+    pure $ NamedSchema Nothing $ mempty & type_ ?~ OpenApi.OpenApiString & enum_ ?~ enumSCValues @prefix @a
 
 
 instance (Bounded a, Enum a, KnownSymbol prefix, Show a) => ToParamSchema (WrappedEnumSC qualType prefix a) where
   toParamSchema (_ :: proxy (WrappedEnumSC qualType prefix a)) =
-    mempty
-      & type_
-      ?~ OpenApi.OpenApiString
-        & enum_
-      ?~ [AE.String (toText $ encodeEnumSC @prefix v) | v <- [minBound @a .. maxBound @a]]
+    mempty & type_ ?~ OpenApi.OpenApiString & enum_ ?~ enumSCValues @prefix @a
 
 
 -- | DerivingVia wrapper: produces ToSchema with snake_case field names matching DAE.Snake's ToJSON output.
@@ -373,6 +370,30 @@ instance Show a => HI.EncodeValue (WrappedEnumShow a) where
 
 instance Read a => HI.DecodeValue (WrappedEnumShow a) where
   decodeValue = refineText "WrappedEnumShow" (fmap WrappedEnumShow . readMaybe . toString)
+
+
+-- | Encode a @Bounded@/@Enum@ type as its 'fromEnum' 'Int' for INT columns / JSON-less
+-- DB round-trips. Use via @deriving (ToField, FromField, HI.EncodeValue, HI.DecodeValue) via WrappedEnumInt Foo@.
+newtype WrappedEnumInt a = WrappedEnumInt a
+  deriving (Generic)
+
+
+instance Enum a => ToField (WrappedEnumInt a) where
+  toField (WrappedEnumInt a) = toField (fromEnum a)
+
+
+instance (Bounded a, Enum a, Typeable a) => FromField (WrappedEnumInt a) where
+  fromField f bs =
+    fromField @Int f bs
+      >>= \n -> maybe (returnError ConversionFailed f ("Invalid enum int: " <> show n)) (pure . WrappedEnumInt) (safeToEnum n)
+
+
+instance Enum a => HI.EncodeValue (WrappedEnumInt a) where
+  encodeValue = contramap (\(WrappedEnumInt a) -> fromEnum a) HI.encodeValue
+
+
+instance (Bounded a, Enum a) => HI.DecodeValue (WrappedEnumInt a) where
+  decodeValue = WrappedEnumInt . fromMaybe minBound . safeToEnum <$> HI.decodeValue
 
 
 data BaselineState = BSLearning | BSEstablished

--- a/src/Pkg/EmailTemplates.hs
+++ b/src/Pkg/EmailTemplates.hs
@@ -1042,7 +1042,7 @@ billingNotifEmail subject heading body ctaLabel billingUrl =
 
 
 planUpgradedEmail :: Text -> Text -> Text -> (Text, Html ())
-planUpgradedEmail projectName newPlan billingUrl =
+planUpgradedEmail projectName newPlan =
   billingNotifEmail
     ("[···] Plan upgraded to " <> newPlan <> " - " <> projectName)
     "Plan Upgraded"
@@ -1054,11 +1054,10 @@ planUpgradedEmail projectName newPlan billingUrl =
         " plan. Thank you for your support!"
     )
     "View Billing"
-    billingUrl
 
 
 trialEndingEmail :: Text -> Int -> Text -> (Text, Html ())
-trialEndingEmail projectName daysLeft billingUrl =
+trialEndingEmail projectName daysLeft =
   billingNotifEmail
     ("[···] Your free trial ends in " <> show daysLeft <> " days - " <> projectName)
     (toHtml $ "Your trial ends in " <> show @Text daysLeft <> " days")
@@ -1072,11 +1071,10 @@ trialEndingEmail projectName daysLeft billingUrl =
         p_ "If you'd like to cancel before the trial ends, you can do so from the billing page."
     )
     "Manage Billing"
-    billingUrl
 
 
 planDowngradedEmail :: Text -> Text -> Text -> (Text, Html ())
-planDowngradedEmail projectName reason billingUrl =
+planDowngradedEmail projectName reason =
   billingNotifEmail
     ("[···] Plan downgraded to Free - " <> projectName)
     "Plan Downgraded to Free"
@@ -1090,4 +1088,3 @@ planDowngradedEmail projectName reason billingUrl =
         p_ "On the Free plan, daily event limits apply and additional team members will be deactivated. You can re-subscribe at any time to restore full access."
     )
     "Upgrade Plan"
-    billingUrl

--- a/src/Pkg/EmailTemplates.hs
+++ b/src/Pkg/EmailTemplates.hs
@@ -311,6 +311,15 @@ emailFallbackUrl url = do
   p_ [class_ "sub"] $ toHtml url
 
 
+-- | Standard email footer: divider, optional help links, signoff, fallback URL.
+emailFooter :: Bool -> Text -> Html ()
+emailFooter withHelp url = do
+  emailDivider
+  when withHelp (emailHelpLinks >> br_ [])
+  emailSignoff
+  emailFallbackUrl url
+
+
 emailStatRow :: [(Text, Text, Maybe Text)] -> Html ()
 emailStatRow cols =
   p_ [style_ "margin: 8px 0 20px; font-size: 13px; color: #57606a; line-height: 1.8;"]
@@ -581,10 +590,7 @@ anomalyEndpointEmail userName projectName anomalyUrl endpointRows =
             when (isNothing hostM) $ whenJust ctxM (tr_ . td_ [style_ "padding: 10px 0 2px 0; color: #6b7280; font-size: 13px;"] . toHtml)
             forM_ labels (tr_ . td_ [style_ "padding: 3px 0 3px 18px;"] . span_ [class_ "monoscope-code"] . toHtml)
       emailButton anomalyUrl "Explore the Endpoint"
-      emailHelpLinks
-      br_ []
-      emailSignoff
-      emailFallbackUrl anomalyUrl
+      emailFooter True anomalyUrl
   )
 
 
@@ -613,9 +619,7 @@ issueAssignedEmail userName projectName issueTitleRaw issueUrl errorType errorMe
                 metaCell "Issue:" issueTitle
                 metaCell "Project:" projectName
           emailButton issueUrl "View Issue"
-          emailDivider
-          emailSignoff
-          emailFallbackUrl issueUrl
+          emailFooter False issueUrl
       )
 
 
@@ -982,11 +986,7 @@ monitorAlertEmail projectName monitorTitle monitorUrl currentValue threshold dir
         ]
       whenJust chartUrlM $ chartBlock "Monitor Trend"
       emailButton monitorUrl "View Monitor"
-      emailDivider
-      emailHelpLinks
-      br_ []
-      emailSignoff
-      emailFallbackUrl monitorUrl
+      emailFooter True monitorUrl
   )
 
 
@@ -1002,97 +1002,92 @@ monitorRecoveryEmail projectName monitorTitle monitorUrl =
         b_ $ toHtml projectName
         " project has recovered and is back to normal."
       emailButton monitorUrl "View Monitor"
-      emailDivider
-      emailHelpLinks
-      br_ []
-      emailSignoff
-      emailFallbackUrl monitorUrl
+      emailFooter True monitorUrl
   )
 
 
 freeTierUsageEmail :: Text -> Text -> Int -> Int -> Bool -> (Text, Html ())
 freeTierUsageEmail projectName billingUrl used limit exceeded =
-  let pct = (used * 100) `div` max 1 limit
-   in ( "[···] " <> (if exceeded then "Daily event limit reached" else "Approaching daily event limit") <> " - " <> projectName
-      , emailBody do
-          h1_ $ if exceeded then "Daily Event Limit Reached" else "Approaching Daily Event Limit"
-          p_ do
-            "Your "
-            b_ $ toHtml projectName
-            if exceeded
-              then " project has hit its daily free tier limit. New events are being dropped."
-              else " project is approaching its daily free tier limit."
-          emailStatRow
-            [ ("Events Today", formatWithCommas (fromIntegral used), if exceeded then Just "#cf222e" else Just "#bf8700")
-            , ("Daily Limit", formatWithCommas (fromIntegral limit), Nothing)
-            , ("Usage", show pct <> "%", if exceeded then Just "#cf222e" else Just "#bf8700")
-            ]
-          emailButton billingUrl "Upgrade Plan"
-          emailDivider
-          emailHelpLinks
-          br_ []
-          emailSignoff
-          emailFallbackUrl billingUrl
-      )
+  billingNotifEmail
+    ("[···] " <> (if exceeded then "Daily event limit reached" else "Approaching daily event limit") <> " - " <> projectName)
+    (if exceeded then "Daily Event Limit Reached" else "Approaching Daily Event Limit")
+    ( do
+        p_ do
+          "Your "
+          b_ $ toHtml projectName
+          if exceeded
+            then " project has hit its daily free tier limit. New events are being dropped."
+            else " project is approaching its daily free tier limit."
+        emailStatRow
+          [ ("Events Today", formatWithCommas (fromIntegral used), if exceeded then Just "#cf222e" else Just "#bf8700")
+          , ("Daily Limit", formatWithCommas (fromIntegral limit), Nothing)
+          , ("Usage", show ((used * 100) `div` max 1 limit) <> "%", if exceeded then Just "#cf222e" else Just "#bf8700")
+          ]
+    )
+    "Upgrade Plan"
+    billingUrl
+
+
+-- | Shared skeleton for the plan-change billing emails: h1 heading, body
+-- paragraph(s), CTA button, standard footer (all with @withHelp=True@).
+billingNotifEmail :: Text -> Html () -> Html () -> Text -> Text -> (Text, Html ())
+billingNotifEmail subject heading body ctaLabel billingUrl =
+  ( subject
+  , emailBody do
+      h1_ heading
+      body
+      emailButton billingUrl ctaLabel
+      emailFooter True billingUrl
+  )
 
 
 planUpgradedEmail :: Text -> Text -> Text -> (Text, Html ())
 planUpgradedEmail projectName newPlan billingUrl =
-  ( "[···] Plan upgraded to " <> newPlan <> " - " <> projectName
-  , emailBody do
-      h1_ "Plan Upgraded"
-      p_ do
+  billingNotifEmail
+    ("[···] Plan upgraded to " <> newPlan <> " - " <> projectName)
+    "Plan Upgraded"
+    ( p_ do
         "Your "
         b_ $ toHtml projectName
         " project has been upgraded to the "
         b_ $ toHtml newPlan
         " plan. Thank you for your support!"
-      emailButton billingUrl "View Billing"
-      emailDivider
-      emailHelpLinks
-      br_ []
-      emailSignoff
-      emailFallbackUrl billingUrl
-  )
+    )
+    "View Billing"
+    billingUrl
 
 
 trialEndingEmail :: Text -> Int -> Text -> (Text, Html ())
 trialEndingEmail projectName daysLeft billingUrl =
-  ( "[···] Your free trial ends in " <> show daysLeft <> " days - " <> projectName
-  , emailBody do
-      h1_ $ toHtml $ "Your trial ends in " <> show @Text daysLeft <> " days"
-      p_ do
-        "The 30-day free trial on "
-        b_ $ toHtml projectName
-        " ends in "
-        b_ $ toHtml (show @Text daysLeft)
-        " days. Your subscription will renew automatically and you'll be billed for usage accrued during the trial."
-      p_ "If you'd like to cancel before the trial ends, you can do so from the billing page."
-      emailButton billingUrl "Manage Billing"
-      emailDivider
-      emailHelpLinks
-      br_ []
-      emailSignoff
-      emailFallbackUrl billingUrl
-  )
+  billingNotifEmail
+    ("[···] Your free trial ends in " <> show daysLeft <> " days - " <> projectName)
+    (toHtml $ "Your trial ends in " <> show @Text daysLeft <> " days")
+    ( do
+        p_ do
+          "The 30-day free trial on "
+          b_ $ toHtml projectName
+          " ends in "
+          b_ $ toHtml (show @Text daysLeft)
+          " days. Your subscription will renew automatically and you'll be billed for usage accrued during the trial."
+        p_ "If you'd like to cancel before the trial ends, you can do so from the billing page."
+    )
+    "Manage Billing"
+    billingUrl
 
 
 planDowngradedEmail :: Text -> Text -> Text -> (Text, Html ())
 planDowngradedEmail projectName reason billingUrl =
-  ( "[···] Plan downgraded to Free - " <> projectName
-  , emailBody do
-      h1_ "Plan Downgraded to Free"
-      p_ do
-        "Your "
-        b_ $ toHtml projectName
-        " project has been downgraded to the Free plan because your subscription "
-        toHtml reason
-        "."
-      p_ "On the Free plan, daily event limits apply and additional team members will be deactivated. You can re-subscribe at any time to restore full access."
-      emailButton billingUrl "Upgrade Plan"
-      emailDivider
-      emailHelpLinks
-      br_ []
-      emailSignoff
-      emailFallbackUrl billingUrl
-  )
+  billingNotifEmail
+    ("[···] Plan downgraded to Free - " <> projectName)
+    "Plan Downgraded to Free"
+    ( do
+        p_ do
+          "Your "
+          b_ $ toHtml projectName
+          " project has been downgraded to the Free plan because your subscription "
+          toHtml reason
+          "."
+        p_ "On the Free plan, daily event limits apply and additional team members will be deactivated. You can re-subscribe at any time to restore full access."
+    )
+    "Upgrade Plan"
+    billingUrl

--- a/src/Pkg/Parser/Expr.hs
+++ b/src/Pkg/Parser/Expr.hs
@@ -507,6 +507,13 @@ binTerm pLhs ctor sym = try (ctor <$> pLhs <* space <* void (symbol sym) <* spac
 -- Ordering is significant for 'pTerm' (try-based, longest token first, e.g.
 -- @>=@ before @>@, @!in@ before @in@). The same rows drive 'ToQueryText Expr'
 -- and 'Display Expr' so the constructor->token map lives in one place.
+--
+-- NOTE: 'subBinaryParts'/'valBinaryParts' map each binary 'Expr' constructor to
+-- its row here, and 'Display Expr'/'ToQueryText Expr' fall through to
+-- @error "...unreachable"@ for anything not covered. Because the tables are
+-- decoupled from the constructor definitions, adding a new binary 'Expr'
+-- constructor compiles cleanly but crashes at render until you add its row here
+-- AND its case in those two helpers — GHC's exhaustiveness check won't catch it.
 valBinOps :: [(Values -> Values -> Expr, Text, Text, Text)]
 valBinOps =
   [ (ValEq, "==", " == ", "=")

--- a/src/Pkg/Parser/Expr.hs
+++ b/src/Pkg/Parser/Expr.hs
@@ -992,11 +992,24 @@ scalarFuncToSQL name args
 subBinaryParts :: Expr -> Maybe (Subject, Values, Text, Text)
 subBinaryParts e = do
   (s, v, sym) <- case e of
-    Eq s v -> at s v "=="; NotEq s v -> at s v "!="; GTEq s v -> at s v ">="; LTEq s v -> at s v "<="
-    GT s v -> at s v ">"; LT s v -> at s v "<"; NotIn s v -> at s v "!in"; In s v -> at s v "in"
-    NotHas s v -> at s v "!has"; HasAll s v -> at s v "has_all"; HasAny s v -> at s v "has_any"; Has s v -> at s v "has"
-    NotContains s v -> at s v "!contains"; Contains s v -> at s v "contains"; NotStartsWith s v -> at s v "!startswith"
-    StartsWith s v -> at s v "startswith"; NotEndsWith s v -> at s v "!endswith"; EndsWith s v -> at s v "endswith"
+    Eq s v -> at s v "=="
+    NotEq s v -> at s v "!="
+    GTEq s v -> at s v ">="
+    LTEq s v -> at s v "<="
+    GT s v -> at s v ">"
+    LT s v -> at s v "<"
+    NotIn s v -> at s v "!in"
+    In s v -> at s v "in"
+    NotHas s v -> at s v "!has"
+    HasAll s v -> at s v "has_all"
+    HasAny s v -> at s v "has_any"
+    Has s v -> at s v "has"
+    NotContains s v -> at s v "!contains"
+    Contains s v -> at s v "contains"
+    NotStartsWith s v -> at s v "!startswith"
+    StartsWith s v -> at s v "startswith"
+    NotEndsWith s v -> at s v "!endswith"
+    EndsWith s v -> at s v "endswith"
     _ -> Nothing
   (_, _, qtok, dop) <- find (\(_, sym', _, _) -> sym' == sym) subjectBinOps
   pure (s, v, dop, qtok)
@@ -1007,8 +1020,12 @@ subBinaryParts e = do
 valBinaryParts :: Expr -> Maybe (Values, Values, Text, Text)
 valBinaryParts e = do
   (a, b, sym) <- case e of
-    ValEq a b -> at a b "=="; ValNotEq a b -> at a b "!="; ValGTEq a b -> at a b ">="
-    ValLTEq a b -> at a b "<="; ValGT a b -> at a b ">"; ValLT a b -> at a b "<"
+    ValEq a b -> at a b "=="
+    ValNotEq a b -> at a b "!="
+    ValGTEq a b -> at a b ">="
+    ValLTEq a b -> at a b "<="
+    ValGT a b -> at a b ">"
+    ValLT a b -> at a b "<"
     _ -> Nothing
   (_, _, qtok, dop) <- find (\(_, sym', _, _) -> sym' == sym) valBinOps
   pure (a, b, dop, qtok)

--- a/src/Pkg/Parser/Expr.hs
+++ b/src/Pkg/Parser/Expr.hs
@@ -357,22 +357,30 @@ pScalarFunc = do
 
 -- | pValuesNoFunc: pValues without scalar function parsing (avoids left recursion)
 pValuesNoFunc :: Parser Values
-pValuesNoFunc =
+pValuesNoFunc = pValuesWith pValuesNoFunc []
+
+
+-- | Shared body of pValues / pValuesNoFunc. @self@ ties the recursion for
+-- nested list elements (so the no-func variant stays no-func inside lists);
+-- @extra@ prepends the leading scalar-func alternative for pValues.
+pValuesWith :: Parser Values -> [Parser Values] -> Parser Values
+pValuesWith self extra =
   choice @[]
-    [ Null <$ string "null"
-    , Boolean <$> (True <$ string "true" <|> False <$ string "false" <|> False <$ string "FALSE" <|> True <$ string "TRUE")
-    , Str . toText <$> (char '\"' *> manyTill L.charLiteral (char '\"'))
-    , Str . toText <$> (char '\'' *> manyTill L.charLiteral (char '\''))
-    , List [] <$ string "[]"
-    , List <$> sqParens (pValuesNoFunc `sepBy` (space *> char ',' <* space))
-    , List [] <$ string "()"
-    , List <$> parens (pValuesNoFunc `sepBy` (space *> char ',' <* space))
-    , try pNowFunction
-    , try pAgoFunction
-    , try pDuration
-    , try (Num . toText . show <$> L.signed pass L.float)
-    , Num . toText . show <$> L.signed pass L.decimal
-    ]
+    $ extra
+    <> [ Null <$ string "null"
+       , Boolean <$> (True <$ string "true" <|> False <$ string "false" <|> False <$ string "FALSE" <|> True <$ string "TRUE")
+       , Str . toText <$> (char '\"' *> manyTill L.charLiteral (char '\"'))
+       , Str . toText <$> (char '\'' *> manyTill L.charLiteral (char '\''))
+       , List [] <$ string "[]"
+       , List <$> sqParens (self `sepBy` (space *> char ',' <* space))
+       , List [] <$ string "()"
+       , List <$> parens (self `sepBy` (space *> char ',' <* space))
+       , try pNowFunction
+       , try pAgoFunction
+       , try pDuration
+       , try (Num . toText . show <$> L.signed pass L.float)
+       , Num . toText . show <$> L.signed pass L.decimal
+       ]
 
 
 -- | parse values into our internal AST representation. Int, Str, Num, Bool, List, etc
@@ -417,23 +425,7 @@ pValuesNoFunc =
 -- >>> parse pValues "" "['SELECT','INSERT']"
 -- Right (List [Str "SELECT",Str "INSERT"])
 pValues :: Parser Values
-pValues =
-  choice @[]
-    [ try pScalarFunc -- Must come first to handle coalesce(), iff(), etc.
-    , Null <$ string "null"
-    , Boolean <$> (True <$ string "true" <|> False <$ string "false" <|> False <$ string "FALSE" <|> True <$ string "TRUE")
-    , Str . toText <$> (char '\"' *> manyTill L.charLiteral (char '\"'))
-    , Str . toText <$> (char '\'' *> manyTill L.charLiteral (char '\''))
-    , List [] <$ string "[]"
-    , List <$> sqParens (pValues `sepBy` (space *> char ',' <* space))
-    , List [] <$ string "()"
-    , List <$> parens (pValues `sepBy` (space *> char ',' <* space))
-    , try pNowFunction
-    , try pAgoFunction
-    , try pDuration
-    , try (Num . toText . show <$> L.signed pass L.float)
-    , Num . toText . show <$> L.signed pass L.decimal
-    ]
+pValues = pValuesWith pValues [try pScalarFunc] -- try pScalarFunc must come first to handle coalesce(), iff(), etc.
 
 
 -- | pTerm is the main entry point that desides what tree lines to decend
@@ -497,34 +489,56 @@ pValues =
 pTerm :: Parser Expr
 pTerm =
   (Paren <$> parens pExpr)
-    <|> try (ValEq <$> pValues <* space <* void (symbol "==") <* space <*> pValues)
-    <|> try (ValNotEq <$> pValues <* space <* void (symbol "!=") <* space <*> pValues)
-    <|> try (ValGTEq <$> pValues <* space <* void (symbol ">=") <* space <*> pValues)
-    <|> try (ValLTEq <$> pValues <* space <* void (symbol "<=") <* space <*> pValues)
-    <|> try (ValGT <$> pValues <* space <* void (symbol ">") <* space <*> pValues)
-    <|> try (ValLT <$> pValues <* space <* void (symbol "<") <* space <*> pValues)
-    <|> try (Eq <$> pSubject <* space <* void (symbol "==") <* space <*> pValues)
-    <|> try (NotEq <$> pSubject <* space <* void (symbol "!=") <* space <*> pValues)
-    <|> try (GTEq <$> pSubject <* space <* void (symbol ">=") <* space <*> pValues)
-    <|> try (LTEq <$> pSubject <* space <* void (symbol "<=") <* space <*> pValues)
-    <|> try (GT <$> pSubject <* space <* void (symbol ">") <* space <*> pValues)
-    <|> try (LT <$> pSubject <* space <* void (symbol "<") <* space <*> pValues)
-    <|> try (NotIn <$> pSubject <* space <* void (symbol "!in") <* space <*> pValues)
-    <|> try (In <$> pSubject <* space <* void (symbol "in") <* space <*> pValues)
-    <|> try (NotHas <$> pSubject <* space <* void (symbol "!has") <* space <*> pValues)
-    <|> try (HasAll <$> pSubject <* space <* void (symbol "has_all") <* space <*> pValues)
-    <|> try (HasAny <$> pSubject <* space <* void (symbol "has_any") <* space <*> pValues)
-    <|> try (Has <$> pSubject <* space <* void (symbol "has") <* space <*> pValues)
-    <|> try (NotContains <$> pSubject <* space <* void (symbol "!contains") <* space <*> pValues)
-    <|> try (Contains <$> pSubject <* space <* void (symbol "contains") <* space <*> pValues)
-    <|> try (NotStartsWith <$> pSubject <* space <* void (symbol "!startswith") <* space <*> pValues)
-    <|> try (StartsWith <$> pSubject <* space <* void (symbol "startswith") <* space <*> pValues)
-    <|> try (NotEndsWith <$> pSubject <* space <* void (symbol "!endswith") <* space <*> pValues)
-    <|> try (EndsWith <$> pSubject <* space <* void (symbol "endswith") <* space <*> pValues)
+    <|> asum [binTerm pValues ctor sym | (ctor, sym, _, _) <- valBinOps]
+    <|> asum [binTerm pSubject ctor sym | (ctor, sym, _, _) <- subjectBinOps]
     <|> try (Matches <$> pSubject <* space <* void (symbol "matches") <* space <*> (toText <$> (char '/' *> manyTill L.charLiteral (char '/'))))
     <|> try regexParser
     <|> try (BoolFunc <$> pBoolScalarFunc) -- Standalone boolean functions: isnull(x), isnotnull(x), etc.
     <|> (BoolFunc . ScalarFunc "isnotempty" . pure . Field <$> pSubject) -- Standalone subject = isnotempty check per KQL spec
+
+
+-- | One try-based binary alternative: @lhs OP pValues@.
+binTerm :: Parser a -> (a -> Values -> Expr) -> Text -> Parser Expr
+binTerm pLhs ctor sym = try (ctor <$> pLhs <* space <* void (symbol sym) <* space <*> pValues)
+
+
+-- | The shared binary-operator tables, each row carrying:
+-- (constructor, KQL parse symbol, ToQueryText infix token, Display op-string).
+-- Ordering is significant for 'pTerm' (try-based, longest token first, e.g.
+-- @>=@ before @>@, @!in@ before @in@). The same rows drive 'ToQueryText Expr'
+-- and 'Display Expr' so the constructor->token map lives in one place.
+valBinOps :: [(Values -> Values -> Expr, Text, Text, Text)]
+valBinOps =
+  [ (ValEq, "==", " == ", "=")
+  , (ValNotEq, "!=", " != ", "!=")
+  , (ValGTEq, ">=", " >= ", ">=")
+  , (ValLTEq, "<=", " <= ", "<=")
+  , (ValGT, ">", " > ", ">")
+  , (ValLT, "<", " < ", "<")
+  ]
+
+
+subjectBinOps :: [(Subject -> Values -> Expr, Text, Text, Text)]
+subjectBinOps =
+  [ (Eq, "==", " == ", "=")
+  , (NotEq, "!=", " != ", "!=")
+  , (GTEq, ">=", " >= ", ">=")
+  , (LTEq, "<=", " <= ", "<=")
+  , (GT, ">", " > ", ">")
+  , (LT, "<", " < ", "<")
+  , (NotIn, "!in", " !in ", "NOT IN")
+  , (In, "in", " in ", "IN")
+  , (NotHas, "!has", " !has ", "NOT HAS")
+  , (HasAll, "has_all", " has_all ", "HAS_ALL")
+  , (HasAny, "has_any", " has_any ", "HAS_ANY")
+  , (Has, "has", " has ", "HAS")
+  , (NotContains, "!contains", " !contains ", "NOT CONTAINS")
+  , (Contains, "contains", " contains ", "CONTAINS")
+  , (NotStartsWith, "!startswith", " !startswith ", "NOT STARTSWITH")
+  , (StartsWith, "startswith", " startswith ", "STARTSWITH")
+  , (NotEndsWith, "!endswith", " !endswith ", "NOT ENDSWITH")
+  , (EndsWith, "endswith", " endswith ", "ENDSWITH")
+  ]
 
 
 -- >>> parse regexParser "" "abc=~/abc.*/"
@@ -970,71 +984,63 @@ scalarFuncToSQL name args
 --
 -- >>> display (Matches (Subject "" "email" []) ".*@company\\.com")
 -- "jsonb_path_exists(to_jsonb(email), $$$ ? (@ like_regex \".*@company\\.com\" flag \"i\" )$$::jsonpath)"
+
+-- | Decompose a binary Expr into its operands plus the (display op-string,
+-- toQText infix token) drawn from the shared operator tables, so Display and
+-- ToQueryText reuse a single constructor->token map. The bespoke cases
+-- (Matches/Paren/And/Or/Regex/BoolFunc) are handled directly in the instances.
+subBinaryParts :: Expr -> Maybe (Subject, Values, Text, Text)
+subBinaryParts e = do
+  (s, v, sym) <- case e of
+    Eq s v -> at s v "=="; NotEq s v -> at s v "!="; GTEq s v -> at s v ">="; LTEq s v -> at s v "<="
+    GT s v -> at s v ">"; LT s v -> at s v "<"; NotIn s v -> at s v "!in"; In s v -> at s v "in"
+    NotHas s v -> at s v "!has"; HasAll s v -> at s v "has_all"; HasAny s v -> at s v "has_any"; Has s v -> at s v "has"
+    NotContains s v -> at s v "!contains"; Contains s v -> at s v "contains"; NotStartsWith s v -> at s v "!startswith"
+    StartsWith s v -> at s v "startswith"; NotEndsWith s v -> at s v "!endswith"; EndsWith s v -> at s v "endswith"
+    _ -> Nothing
+  (_, _, qtok, dop) <- find (\(_, sym', _, _) -> sym' == sym) subjectBinOps
+  pure (s, v, dop, qtok)
+  where
+    at s v sym = Just (s, v, sym :: Text)
+
+
+valBinaryParts :: Expr -> Maybe (Values, Values, Text, Text)
+valBinaryParts e = do
+  (a, b, sym) <- case e of
+    ValEq a b -> at a b "=="; ValNotEq a b -> at a b "!="; ValGTEq a b -> at a b ">="
+    ValLTEq a b -> at a b "<="; ValGT a b -> at a b ">"; ValLT a b -> at a b "<"
+    _ -> Nothing
+  (_, _, qtok, dop) <- find (\(_, sym', _, _) -> sym' == sym) valBinOps
+  pure (a, b, dop, qtok)
+  where
+    at a b sym = Just (a, b, sym :: Text)
+
+
 instance Display Expr where
-  displayPrec prec expr@(Eq sub val) = displayExprHelper "=" prec sub val
-  displayPrec prec (NotEq sub val) = displayExprHelper "!=" prec sub val
-  displayPrec prec (GT sub val) = displayExprHelper ">" prec sub val
-  displayPrec prec (LT sub val) = displayExprHelper "<" prec sub val
-  displayPrec prec (GTEq sub val) = displayExprHelper ">=" prec sub val
-  displayPrec prec (LTEq sub val) = displayExprHelper "<=" prec sub val
-  displayPrec prec (In sub val) = displayExprHelper "IN" prec sub val
-  displayPrec prec (NotIn sub val) = displayExprHelper "NOT IN" prec sub val
-  displayPrec prec (Has sub val) = displayExprHelper "HAS" prec sub val
-  displayPrec prec (NotHas sub val) = displayExprHelper "NOT HAS" prec sub val
-  displayPrec prec (HasAny sub val) = displayExprHelper "HAS_ANY" prec sub val
-  displayPrec prec (HasAll sub val) = displayExprHelper "HAS_ALL" prec sub val
-  displayPrec prec (Contains sub val) = displayExprHelper "CONTAINS" prec sub val
-  displayPrec prec (NotContains sub val) = displayExprHelper "NOT CONTAINS" prec sub val
-  displayPrec prec (StartsWith sub val) = displayExprHelper "STARTSWITH" prec sub val
-  displayPrec prec (NotStartsWith sub val) = displayExprHelper "NOT STARTSWITH" prec sub val
-  displayPrec prec (EndsWith sub val) = displayExprHelper "ENDSWITH" prec sub val
-  displayPrec prec (NotEndsWith sub val) = displayExprHelper "NOT ENDSWITH" prec sub val
+  displayPrec prec e
+    | Just (sub, val, op, _) <- subBinaryParts e = displayExprHelper op prec sub val
+    | Just (v1, v2, op, _) <- valBinaryParts e = displayParen (prec > 0) $ displayPrec prec v1 <> " " <> displayBuilder op <> " " <> displayPrec prec v2
   displayPrec prec (Matches sub val) = displayPrec prec $ jsonPathQuery "like_regex" sub (Str val)
   displayPrec prec (Paren u1) = displayParen True $ displayPrec prec u1
   displayPrec prec (And u1 u2) = displayParen (prec > 0) $ displayPrec prec u1 <> " AND " <> displayPrec prec u2
   displayPrec prec (Or u1 u2) = displayParen (prec > 0) $ displayPrec prec u1 <> " OR " <> displayPrec prec u2
   displayPrec prec (Regex sub val) = displayPrec prec $ jsonPathQuery "like_regex" sub (Str val)
-  displayPrec prec (ValEq v1 v2) = displayParen (prec > 0) $ displayPrec prec v1 <> " = " <> displayPrec prec v2
-  displayPrec prec (ValNotEq v1 v2) = displayParen (prec > 0) $ displayPrec prec v1 <> " != " <> displayPrec prec v2
-  displayPrec prec (ValGT v1 v2) = displayParen (prec > 0) $ displayPrec prec v1 <> " > " <> displayPrec prec v2
-  displayPrec prec (ValLT v1 v2) = displayParen (prec > 0) $ displayPrec prec v1 <> " < " <> displayPrec prec v2
-  displayPrec prec (ValGTEq v1 v2) = displayParen (prec > 0) $ displayPrec prec v1 <> " >= " <> displayPrec prec v2
-  displayPrec prec (ValLTEq v1 v2) = displayParen (prec > 0) $ displayPrec prec v1 <> " <= " <> displayPrec prec v2
   displayPrec prec (BoolFunc v) = displayPrec prec v -- Boolean scalar function renders directly to SQL
+  displayPrec _ _ = error "Display Expr: unreachable"
 
 
 -- To be used when generating the text query given an ast
 instance ToQueryText Expr where
-  toQText (Eq sub val) = toQText sub <> " == " <> toQText val
-  toQText (NotEq sub val) = toQText sub <> " != " <> toQText val
-  toQText (GT sub val) = toQText sub <> " > " <> toQText val
-  toQText (LT sub val) = toQText sub <> " < " <> toQText val
-  toQText (GTEq sub val) = toQText sub <> " >= " <> toQText val
-  toQText (LTEq sub val) = toQText sub <> " <= " <> toQText val
-  toQText (In sub val) = toQText sub <> " in " <> toQText val
-  toQText (NotIn sub val) = toQText sub <> " !in " <> toQText val
-  toQText (Has sub val) = toQText sub <> " has " <> toQText val
-  toQText (NotHas sub val) = toQText sub <> " !has " <> toQText val
-  toQText (HasAny sub val) = toQText sub <> " has_any " <> toQText val
-  toQText (HasAll sub val) = toQText sub <> " has_all " <> toQText val
-  toQText (Contains sub val) = toQText sub <> " contains " <> toQText val
-  toQText (NotContains sub val) = toQText sub <> " !contains " <> toQText val
-  toQText (StartsWith sub val) = toQText sub <> " startswith " <> toQText val
-  toQText (NotStartsWith sub val) = toQText sub <> " !startswith " <> toQText val
-  toQText (EndsWith sub val) = toQText sub <> " endswith " <> toQText val
-  toQText (NotEndsWith sub val) = toQText sub <> " !endswith " <> toQText val
+  toQText e
+    | Just (sub, val, _, tok) <- subBinaryParts e = toQText sub <> tok <> toQText val
+    | Just (v1, v2, _, tok) <- valBinaryParts e = toQText v1 <> tok <> toQText v2
   toQText (Matches sub val) = toQText sub <> " matches /" <> val <> "/"
   toQText (Paren expr) = "(" <> toQText expr <> ")"
   toQText (And left right) = toQText left <> " AND " <> toQText right
   toQText (Or left right) = toQText left <> " OR " <> toQText right
   toQText (Regex sub val) = toQText sub <> " =~ " <> toQText (Str val)
-  toQText (ValEq v1 v2) = toQText v1 <> " == " <> toQText v2
-  toQText (ValNotEq v1 v2) = toQText v1 <> " != " <> toQText v2
-  toQText (ValGT v1 v2) = toQText v1 <> " > " <> toQText v2
-  toQText (ValLT v1 v2) = toQText v1 <> " < " <> toQText v2
-  toQText (ValGTEq v1 v2) = toQText v1 <> " >= " <> toQText v2
-  toQText (ValLTEq v1 v2) = toQText v1 <> " <= " <> toQText v2
   toQText (BoolFunc v) = toQText v
+  toQText _ = error "ToQueryText Expr: unreachable"
 
 
 -- Helper function to handle the common display logic

--- a/src/Pkg/Parser/Stats.hs
+++ b/src/Pkg/Parser/Stats.hs
@@ -115,25 +115,21 @@ data ScalarExpr = SVal Values | SAgg AggFunction | SArith ScalarExpr ArithOp Sca
   deriving anyclass (AE.FromJSON, AE.ToJSON)
 
 
-arithOpToSQL :: ArithOp -> Text
-arithOpToSQL = \case Mul -> " * "; Div -> " / "; Add -> " + "; Sub -> " - "
+arithOpText :: ArithOp -> Text
+arithOpText = \case Mul -> " * "; Div -> " / "; Add -> " + "; Sub -> " - "
 
 
 instance Display ScalarExpr where
   displayPrec p (SVal v) = displayPrec p v
   displayPrec _ (SAgg agg) = displayBuilder $ aggToSqlNoAlias agg
   displayPrec _ (SArith l Div r) = displayBuilder $ "COALESCE((" <> display l <> " / NULLIF(" <> display r <> ", 0)), 0)"
-  displayPrec _ (SArith l op r) = displayBuilder $ "(" <> display l <> arithOpToSQL op <> display r <> ")"
-
-
-arithOpToKQL :: ArithOp -> Text
-arithOpToKQL = \case Mul -> " * "; Div -> " / "; Add -> " + "; Sub -> " - "
+  displayPrec _ (SArith l op r) = displayBuilder $ "(" <> display l <> arithOpText op <> display r <> ")"
 
 
 instance ToQueryText ScalarExpr where
   toQText (SVal v) = toQText v
   toQText (SAgg agg) = toQText agg
-  toQText (SArith l op r) = toQText l <> arithOpToKQL op <> toQText r
+  toQText (SArith l op r) = toQText l <> arithOpText op <> toQText r
 
 
 -- | SQL pattern for simple aggregations: fn((subject)::float)

--- a/src/Pkg/PatternMerge.hs
+++ b/src/Pkg/PatternMerge.hs
@@ -118,17 +118,28 @@ wrapTag :: Text -> [Text] -> Text
 wrapTag tag items = unlines $ ("<" <> tag <> ">") : items <> ["</" <> tag <> ">"]
 
 
+-- | Shared judge-prompt scaffolding: dedups items into a numbered list, formats
+-- each pair as index references, and prepends the type-specific system prompt.
+buildJudgePrompt :: Text -> Text -> [(Text, Text)] -> Text
+buildJudgePrompt systemPart itemTag pairs = systemPart <> "\n\n" <> itemsPart <> "\n" <> pairsPart
+  where
+    allItems = ordNub $ concatMap (\(a, b) -> [a, b]) pairs
+    itemIndex = Map.fromList $ zip allItems [0 :: Int ..]
+    itemsPart = wrapTag itemTag $ zipWith (\i t -> "  [" <> show i <> "] " <> t) [0 :: Int ..] allItems
+    pairsPart = wrapTag "pairs" $ zipWith formatPair [0 :: Int ..] pairs
+    formatPair i (a, b) =
+      let aIdx = fromMaybe 0 $ Map.lookup a itemIndex
+          bIdx = fromMaybe 0 $ Map.lookup b itemIndex
+       in "  Pair " <> show i <> ": [" <> show aIdx <> "] vs [" <> show bIdx <> "]"
+
+
 -- | Build an LLM judge prompt for ambiguous endpoint URL pairs.
 -- Deduplicates all paths into a numbered list so the LLM can see the full picture
 -- and cluster endpoints that share centroids, rather than evaluating pairs in isolation.
 buildEndpointJudgePrompt :: [(Text, Text)] -> Text
-buildEndpointJudgePrompt pairs = systemPart <> "\n\n" <> pathsPart <> "\n" <> pairsPart
-  where
-    -- Deduplicate all paths and assign indices
-    allPaths = ordNub $ concatMap (\(a, b) -> [a, b]) pairs
-    pathIndex = Map.fromList $ zip allPaths [0 :: Int ..]
-    systemPart =
-      [text|
+buildEndpointJudgePrompt =
+  buildJudgePrompt
+    [text|
         You are Monoscope's API-route deduplication judge. You decide whether HTTP endpoint URL paths represent the same route (and should be merged into one canonical template) or genuinely distinct routes (and should be kept separate).
 
         Tone: deterministic and structured — your output is parsed as JSON by downstream code.
@@ -163,12 +174,7 @@ buildEndpointJudgePrompt pairs = systemPart <> "\n\n" <> pathsPart <> "\n" <> pa
 
         Example: [{"index": 0, "decision": "MERGE", "canonical": "/api/v1/users/{param}"}, {"index": 1, "decision": "KEEP_SEPARATE"}]
         |]
-    pathsPart = wrapTag "endpoints" $ zipWith (\i p -> "  [" <> show i <> "] " <> p) [0 :: Int ..] allPaths
-    pairsPart = wrapTag "pairs" $ zipWith formatPair [0 :: Int ..] pairs
-    formatPair i (a, b) =
-      let aIdx = fromMaybe 0 $ Map.lookup a pathIndex
-          bIdx = fromMaybe 0 $ Map.lookup b pathIndex
-       in "  Pair " <> show i <> ": [" <> show aIdx <> "] vs [" <> show bIdx <> "]"
+    "endpoints"
 
 
 -- | Token considered a placeholder (excluded from Jaccard comparison).
@@ -258,12 +264,9 @@ mergeByJaccard threshold results = V.fromList $ map (\(dr, _, _) -> dr) $ toList
 -- and Lemur (Chain-of-Thought reasoning). Shows all templates in context with sample logs,
 -- then asks for structured Structure→Semantics→Decision reasoning per pair.
 buildLogClusterJudgePrompt :: [(Text, Text)] -> Text
-buildLogClusterJudgePrompt pairs = systemPart <> "\n\n" <> templatesPart <> "\n" <> pairsPart
-  where
-    allTemplates = ordNub $ concatMap (\(a, b) -> [a, b]) pairs
-    templateIndex = Map.fromList $ zip allTemplates [0 :: Int ..]
-    systemPart =
-      [text|
+buildLogClusterJudgePrompt =
+  buildJudgePrompt
+    [text|
         You are Monoscope's log-pattern deduplication judge. You decide whether two log templates describe the same operational event (MERGE) or distinct events (KEEP_SEPARATE).
 
         Tone: deterministic and structured — your output is parsed as JSON by downstream code.
@@ -298,12 +301,7 @@ buildLogClusterJudgePrompt pairs = systemPart <> "\n\n" <> templatesPart <> "\n"
 
         Example: [{"index": 0, "decision": "MERGE"}, {"index": 1, "decision": "KEEP_SEPARATE"}]
         |]
-    templatesPart = wrapTag "templates" $ zipWith (\i t -> "  [" <> show i <> "] " <> t) [0 :: Int ..] allTemplates
-    pairsPart = wrapTag "pairs" $ zipWith formatPair [0 :: Int ..] pairs
-    formatPair i (a, b) =
-      let aIdx = fromMaybe 0 $ Map.lookup a templateIndex
-          bIdx = fromMaybe 0 $ Map.lookup b templateIndex
-       in "  Pair " <> show i <> ": [" <> show aIdx <> "] vs [" <> show bIdx <> "]"
+    "templates"
 
 
 -- | Shared trivial tokens excluded from meaningful comparison across all pattern types.
@@ -445,12 +443,9 @@ errorCanMerge a b =
 -- | Error-aware CoT judge prompt. Shows all error patterns in a numbered list,
 -- then pairs. Reasoning: Structure (error type match?) -> Semantics (same root cause?) -> Decision.
 buildErrorJudgePrompt :: [(Text, Text)] -> Text
-buildErrorJudgePrompt pairs = systemPart <> "\n\n" <> patternsPart <> "\n" <> pairsPart
-  where
-    allPatterns = ordNub $ concatMap (\(a, b) -> [a, b]) pairs
-    patternIndex = Map.fromList $ zip allPatterns [0 :: Int ..]
-    systemPart =
-      [text|
+buildErrorJudgePrompt =
+  buildJudgePrompt
+    [text|
         You are Monoscope's error-pattern deduplication judge. You decide whether two error patterns describe the same underlying bug (MERGE) or genuinely different failures (KEEP_SEPARATE).
 
         Tone: deterministic and structured — your output is parsed as JSON by downstream code.
@@ -484,9 +479,4 @@ buildErrorJudgePrompt pairs = systemPart <> "\n\n" <> patternsPart <> "\n" <> pa
 
         Example: [{"index": 0, "decision": "MERGE"}, {"index": 1, "decision": "KEEP_SEPARATE"}]
         |]
-    patternsPart = wrapTag "patterns" $ zipWith (\i p -> "  [" <> show i <> "] " <> p) [0 :: Int ..] allPatterns
-    pairsPart = wrapTag "pairs" $ zipWith formatPair [0 :: Int ..] pairs
-    formatPair i (a, b) =
-      let aIdx = fromMaybe 0 $ Map.lookup a patternIndex
-          bIdx = fromMaybe 0 $ Map.lookup b patternIndex
-       in "  Pair " <> show i <> ": [" <> show aIdx <> "] vs [" <> show bIdx <> "]"
+    "patterns"

--- a/src/Pkg/Queue.hs
+++ b/src/Pkg/Queue.hs
@@ -99,6 +99,29 @@ closeSharedKafkaProducer = modifyMVar sharedKafkaProducer $ \case
     pure (Nothing, ())
 
 
+-- | Shared batch-processing span for both ingest paths: wraps the fn invocation
+-- in a withSpan with batch.started/completed/write_failed events and Ok/Error
+-- status. Only the span name and attribute list differ between pubsub and kafka.
+runBatchSpan
+  :: Text
+  -> [(Text, OA.Attribute)]
+  -> ATBackgroundCtx (Either Telemetry.WriteFailure ([Text], [Telemetry.PoisonMsg]))
+  -> ATBackgroundCtx (Either Telemetry.WriteFailure ([Text], [Telemetry.PoisonMsg]))
+runBatchSpan spanName attrs run = withSpan spanName attrs \sp -> do
+  addEvent sp "batch.started" []
+  res <- run
+  case res of
+    Right (ids, poison) -> do
+      addEvent sp "batch.completed" [("processed_count", OA.toAttribute (length ids)), ("poison_count", OA.toAttribute (length poison))]
+      setStatus sp Ok
+      pure (Right (ids, poison))
+    Left wf -> do
+      let !summary = Telemetry.writeFailureSummary wf
+      addEvent sp "batch.write_failed" [("write_failure", OA.toAttribute summary)]
+      setStatus sp (Error summary)
+      pure (Left wf)
+
+
 -- pubsubService connects to the pubsub service and listens for  messages,
 -- then it calls the processMessage function to process the messages, and
 -- acknoleges the list message in one request.
@@ -138,26 +161,14 @@ pubsubService appLogger appCtx tp topics fn = checkpoint "pubsubService" do
           tryAny
             ( liftIO
                 $ runBackground appLogger appCtx tp
-                $ withSpan
+                $ runBatchSpan
                   "pubsub.process_batch"
                   [ ("topic", OA.toAttribute topic)
                   , ("message_count", OA.toAttribute (length validMsgs))
                   , ("subscription", OA.toAttribute subscription)
                   , ("ce-type", OA.toAttribute (fromMaybe "" ceType))
                   ]
-                  \sp -> do
-                    addEvent sp "batch.started" []
-                    res <- fn validMsgs (maybeToMonoid firstAttrs)
-                    case res of
-                      Right (ids, poison) -> do
-                        addEvent sp "batch.completed" [("processed_count", OA.toAttribute (length ids)), ("poison_count", OA.toAttribute (length poison))]
-                        setStatus sp Ok
-                        pure (Right (ids, poison))
-                      Left wf -> do
-                        let !summary = Telemetry.writeFailureSummary wf
-                        addEvent sp "batch.write_failed" [("write_failure", OA.toAttribute summary)]
-                        setStatus sp (Error summary)
-                        pure (Left wf)
+                  (fn validMsgs (maybeToMonoid firstAttrs))
             )
             >>= liftIO
             . routeBatchOutcome appLogger appCtx "pubsub-service" topic validMsgs (maybeToMonoid firstAttrs)
@@ -256,26 +267,14 @@ kafkaService appLogger appCtx tp role label kafkaTopics batchSize fn = checkpoin
                       result <- liftIO
                         $ tryAny
                         $ runBackground appLogger appCtx tp
-                        $ withSpan
+                        $ runBatchSpan
                           "kafka.process_batch"
                           [ ("topic", OA.toAttribute topic)
                           , ("message_count", OA.toAttribute (length records))
                           , ("ce-type", OA.toAttribute ceType)
                           , ("client_id", OA.toAttribute clientId)
                           ]
-                        $ \sp -> do
-                          addEvent sp "batch.started" []
-                          res <- fn records attrs
-                          case res of
-                            Right (ids, poison) -> do
-                              addEvent sp "batch.completed" [("processed_count", OA.toAttribute (length ids)), ("poison_count", OA.toAttribute (length poison))]
-                              setStatus sp Ok
-                              pure (Right (ids, poison))
-                            Left wf -> do
-                              let !summary = Telemetry.writeFailureSummary wf
-                              addEvent sp "batch.write_failed" [("write_failure", OA.toAttribute summary)]
-                              setStatus sp (Error summary)
-                              pure (Left wf)
+                          (fn records attrs)
                       -- Empty ack list = no commit (broker redelivers); non-empty
                       -- = durable. Kafka can't partial-ack within a partition so
                       -- processGroup commits all-or-nothing per partition group.

--- a/src/Pkg/Queue.hs
+++ b/src/Pkg/Queue.hs
@@ -264,17 +264,18 @@ kafkaService appLogger appCtx tp role label kafkaTopics batchSize fn = checkpoin
                   runChunk topic records attrs = do
                     let ceType = HM.lookupDefault "" "ce-type" attrs
                     LogBase.localData ["topic" AE..= topic, "ce_type" AE..= ceType, "record_count" AE..= length records] do
-                      result <- liftIO
-                        $ tryAny
-                        $ runBackground appLogger appCtx tp
-                        $ runBatchSpan
-                          "kafka.process_batch"
-                          [ ("topic", OA.toAttribute topic)
-                          , ("message_count", OA.toAttribute (length records))
-                          , ("ce-type", OA.toAttribute ceType)
-                          , ("client_id", OA.toAttribute clientId)
-                          ]
-                          (fn records attrs)
+                      result <-
+                        liftIO
+                          $ tryAny
+                          $ runBackground appLogger appCtx tp
+                          $ runBatchSpan
+                            "kafka.process_batch"
+                            [ ("topic", OA.toAttribute topic)
+                            , ("message_count", OA.toAttribute (length records))
+                            , ("ce-type", OA.toAttribute ceType)
+                            , ("client_id", OA.toAttribute clientId)
+                            ]
+                            (fn records attrs)
                       -- Empty ack list = no commit (broker redelivers); non-empty
                       -- = durable. Kafka can't partial-ack within a partition so
                       -- processGroup commits all-or-nothing per partition group.

--- a/src/ProcessMessage.hs
+++ b/src/ProcessMessage.hs
@@ -551,12 +551,6 @@ convertRequestMessageToSpan rm msgSize (spanId, trId) =
 
 -- Using nestedJsonFromDotNotation from Utils module
 
--- Helper function to merge JSON objects
--- Now using lodashMerge from aeson-extra which properly handles nested objects
-mergeJsonObjects :: AE.Value -> AE.Value -> AE.Value
-mergeJsonObjects = lodashMerge
-
-
 createSpanAttributes :: RequestMessage -> AE.Value
 createSpanAttributes rm =
   let baseAttrs =
@@ -601,7 +595,7 @@ createSpanAttributes rm =
         reqHeaders = extractHeaders "http.request.headers." rm.requestHeaders
         respHeaders = extractHeaders "http.response.headers." rm.responseHeaders
        in
-        reqHeaders `mergeJsonObjects` respHeaders
+        reqHeaders `lodashMerge` respHeaders
 
 
 -- $setup
@@ -917,18 +911,7 @@ commonFormatPatterns =
 -- >>> map valueToFormatStr ["v1"]
 --
 valueToFormatStr :: Text -> Maybe Text
-valueToFormatStr val = checkFormats formatChecks
-  where
-    checkFormats :: [(RE, Text)] -> Maybe Text
-    checkFormats [] = Nothing
-    checkFormats ((regex, format) : rest) =
-      if matched (val ?=~ regex)
-        then Just format
-        else checkFormats rest
-
-    -- Use exact match patterns first, then fallback to common patterns
-    formatChecks :: [(RE, Text)]
-    formatChecks = commonFormatPatterns
+valueToFormatStr val = snd <$> find (\(regex, _) -> matched (val ?=~ regex)) commonFormatPatterns
 
 
 -- | Detect dynamic URL segments and replace them with named parameters.

--- a/src/Utils.hs
+++ b/src/Utils.hs
@@ -1,5 +1,4 @@
 module Utils (
-  eitherStrToText,
   onpointerdown_,
   jsonValueToHtmlTree,
   freeTierDailyMaxEvents,
@@ -14,12 +13,11 @@ module Utils (
   htmxIndicator_,
   htmxIndicatorWith_,
   htmxOverlayIndicator_,
-  lookupVecInt,
-  lookupVecText,
   lookupVecIntByKey,
   lookupVecBoolByKey,
   lookupValueText,
   formatUTC,
+  formatUTCMicros,
   insertIfNotExist,
   getAlertStatusColor,
   lookupVecTextByKey,
@@ -123,13 +121,6 @@ import "base64" Data.ByteString.Base64 qualified as B64
 -- Added only for satisfying the tests
 instance Eq ZonedTime where
   (==) _ _ = True
-
-
--- | eitherStrToText helps to convert Either String a to Either Text a,
--- to allow using both of them via do notation in the same monad.
-eitherStrToText :: Either String a -> Either Text a
-eitherStrToText (Left str) = Left $ toText str
-eitherStrToText (Right a) = Right a
 
 
 escapedQueryPartial :: Text -> Text
@@ -425,14 +416,6 @@ lookupVecBy :: AE.FromJSON a => V.Vector AE.Value -> HM.HashMap Text Int -> Text
 lookupVecBy vec colIdxMap key = HM.lookup key colIdxMap >>= lookupVec vec
 
 
-lookupVecText :: V.Vector AE.Value -> Int -> Maybe Text
-lookupVecText = lookupVec
-
-
-lookupVecInt :: V.Vector AE.Value -> Int -> Int
-lookupVecInt vec idx = fromMaybe 0 (lookupVec vec idx)
-
-
 lookupVecTextByKey :: V.Vector AE.Value -> HM.HashMap Text Int -> Text -> Maybe Text
 lookupVecTextByKey = lookupVecBy
 
@@ -481,6 +464,11 @@ displayTimestamp inputDateString =
 formatUTC :: UTCTime -> Text
 formatUTC utcTime =
   toText $ formatTime defaultTimeLocale "%Y-%m-%dT%H:%M:%S%QZ" utcTime
+
+
+-- | ISO-8601 with fixed 6-digit (microsecond) fractional seconds.
+formatUTCMicros :: UTCTime -> Text
+formatUTCMicros = toText . formatTime defaultTimeLocale "%Y-%m-%dT%H:%M:%S%6QZ"
 
 
 data FreeTierStatus = NotFreeTier | FreeTierOk | FreeTierWarning Int Int | FreeTierExceeded Int Int
@@ -546,11 +534,7 @@ serviceColors =
 
 
 getServiceColors :: V.Vector Text -> HashMap Text Text
-getServiceColors = V.foldl' assign HM.empty
-  where
-    assign colors service =
-      let colorIdx = fromIntegral (xxHash (encodeUtf8 service)) `mod` V.length serviceColors
-       in HM.insert service (serviceColors V.! colorIdx) colors
+getServiceColors = V.foldl' (\m s -> HM.insert s (serviceFillColor s) m) HM.empty
 
 
 -- | Theme colors (hex) for ECharts - matches colorMapping.ts THEME_COLORS

--- a/src/Utils.hs
+++ b/src/Utils.hs
@@ -1620,14 +1620,12 @@ calculateCycleStartDate start current =
    in UTCTime cycleStartDay (timeOfDayToTime timeOfDay)
 
 
--- | Replace NUL bytes in a 'Text' with the Unicode replacement char (U+FFFD).
--- Postgres' @jsonb@ rejects NUL in text contexts (SQLSTATE @22P05@); span
--- attributes occasionally carry one (k8s events, base64-flagged fields).
---
--- The 'hasNul' guard makes the common case (no NUL) a single linear scan with
--- no allocation.
+-- | Strip NUL bytes from a 'Text'. Postgres' @jsonb@ rejects NUL in text
+-- contexts (SQLSTATE @22P05@); span attributes occasionally carry one (k8s
+-- events, base64-flagged fields). The guard makes the common case (no NUL) a
+-- single linear scan with no allocation.
 scrubNulText :: T.Text -> T.Text
-scrubNulText t = if T.any (== '\NUL') t then T.replace "\NUL" "\xFFFD" t else t
+scrubNulText t = if T.any (== '\NUL') t then T.filter (/= '\NUL') t else t
 
 
 -- | Recursive 'scrubNulText' over an 'AE.Value' — strings, array elements,

--- a/src/Web/ApiHandlers.hs
+++ b/src/Web/ApiHandlers.hs
@@ -100,7 +100,6 @@ import Data.Generics.Labels ()
 import Data.List qualified as List
 import Data.Map.Strict qualified as Map
 import Data.OpenApi (ToSchema (..))
-import Data.Set qualified as S
 import Data.Text qualified as T
 import Data.Time (UTCTime, addUTCTime, nominalDay, zonedTimeToUTC)
 import Data.UUID qualified as UUID
@@ -142,18 +141,30 @@ notFoundOr :: Text -> Maybe a -> ATBaseCtx a
 notFoundOr msg = maybe (throwError err404{errBody = encodeUtf8 msg}) pure
 
 
--- | Dispatch a 'BulkAction' against a table of named operations. Each op returns
--- the count of rows affected; when @0@, every id is reported as "not applied".
--- Ops that cannot report a count can @pure (length ba.ids)@ to mark all as succeeded.
-bulkExec :: BulkAction a -> [(Text, ATBaseCtx Int64)] -> ATBaseCtx (BulkResult a)
+-- | Result an op reports back to 'bulkExec': either an affected-row count
+-- (all-or-nothing across @ba.ids@) or the explicit list of succeeded ids
+-- (the complement of @ba.ids@ is reported as "not applied").
+data BulkOpResult a = BulkCount Int64 | BulkSucceeded [a]
+
+
+-- | Lift a count-returning op into a 'BulkOpResult'.
+count :: Functor f => f Int64 -> f (BulkOpResult a)
+count = fmap BulkCount
+
+
+-- | Dispatch a 'BulkAction' against a table of named operations. A 'BulkCount'
+-- op marks every id succeeded when the count is @>0@, else all "not applied";
+-- a 'BulkSucceeded' op reports per-id partial success.
+-- Ops that cannot report a count can @pure (BulkCount (length ba.ids))@.
+bulkExec :: Eq a => BulkAction a -> [(Text, ATBaseCtx (BulkOpResult a))] -> ATBaseCtx (BulkResult a)
 bulkExec ba ops = do
-  n <- case List.lookup (T.toLower ba.action) ops of
+  r <- case List.lookup (T.toLower ba.action) ops of
     Just op -> op
     Nothing -> throwError err400{errBody = encodeUtf8 $ "Unknown bulk action: " <> ba.action}
-  pure
-    $ if n > 0
-      then BulkResult{succeeded = ba.ids, failed = []}
-      else BulkResult{succeeded = [], failed = [BulkFailure{id = i, error = "not applied"} | i <- ba.ids]}
+  let mkResult ok = BulkResult{succeeded = ok, failed = [BulkFailure{id = i, error = "not applied"} | i <- ba.ids, i `notElem` ok]}
+  pure $ case r of
+    BulkCount n -> if n > 0 then mkResult ba.ids else mkResult []
+    BulkSucceeded ok -> mkResult ok
 
 
 -- | Paginated list helper: normalises page/per_page with caps and constructs
@@ -341,10 +352,7 @@ apiMonitorPatch pid mid patch = do
 
 
 apiMonitorDelete :: Projects.ProjectId -> Monitors.QueryMonitorId -> ATBaseCtx NoContent
-apiMonitorDelete pid mid = do
-  _ <- apiMonitorGet pid mid -- ensures monitor belongs to project
-  _ <- Monitors.monitorSoftDeleteByIds [mid]
-  pure NoContent
+apiMonitorDelete pid mid = withRefetchNoContent (apiMonitorGet pid mid) (Monitors.monitorSoftDeleteByIds [mid])
 
 
 -- | Verify a resource belongs to the project via @fetch@, run a mutation,
@@ -352,6 +360,12 @@ apiMonitorDelete pid mid = do
 -- style lifecycle endpoints.
 withRefetch :: Monad m => m a -> m b -> m a
 withRefetch fetch mutate = fetch *> mutate *> fetch
+
+
+-- | @fetch@ (ownership/validation) then @mutate@, returning 'NoContent'. The
+-- delete/unstar/remove lifecycle counterpart of 'withRefetch'.
+withRefetchNoContent :: Applicative m => m a -> m b -> m NoContent
+withRefetchNoContent fetch mutate = fetch *> mutate $> NoContent
 
 
 apiMonitorToggleActive :: Projects.ProjectId -> Monitors.QueryMonitorId -> ATBaseCtx Monitors.QueryMonitor
@@ -374,12 +388,12 @@ apiMonitorBulk :: Projects.ProjectId -> BulkAction UUID.UUID -> ATBaseCtx (BulkR
 apiMonitorBulk _pid ba =
   bulkExec
     ba
-    [ ("delete", Monitors.monitorSoftDeleteByIds qIds)
-    , ("activate", Monitors.monitorReactivateByIds qIds)
-    , ("deactivate", Monitors.monitorDeactivateByIds qIds)
-    , ("mute", Monitors.monitorMuteByIds ba.durationMinutes qIds)
-    , ("unmute", Monitors.monitorUnmuteByIds qIds)
-    , ("resolve", Monitors.monitorResolveByIds qIds)
+    [ ("delete", count $ Monitors.monitorSoftDeleteByIds qIds)
+    , ("activate", count $ Monitors.monitorReactivateByIds qIds)
+    , ("deactivate", count $ Monitors.monitorDeactivateByIds qIds)
+    , ("mute", count $ Monitors.monitorMuteByIds ba.durationMinutes qIds)
+    , ("unmute", count $ Monitors.monitorUnmuteByIds qIds)
+    , ("resolve", count $ Monitors.monitorResolveByIds qIds)
     ]
   where
     qIds = Monitors.QueryMonitorId <$> ba.ids
@@ -489,10 +503,7 @@ apiDashboardPatch pid did patch = do
 
 
 apiDashboardDelete :: Projects.ProjectId -> Dashboards.DashboardId -> ATBaseCtx NoContent
-apiDashboardDelete pid did = do
-  _ <- apiDashboardGet pid did
-  _ <- Dashboards.deleteDashboard did
-  pure NoContent
+apiDashboardDelete pid did = withRefetchNoContent (apiDashboardGet pid did) (Dashboards.deleteDashboard did)
 
 
 apiDashboardDuplicate :: Projects.ProjectId -> Dashboards.DashboardId -> ATBaseCtx DashboardFull
@@ -511,10 +522,7 @@ apiDashboardStar pid did =
 
 
 apiDashboardUnstar :: Projects.ProjectId -> Dashboards.DashboardId -> ATBaseCtx NoContent
-apiDashboardUnstar pid did = do
-  _ <- apiDashboardGet pid did
-  _ <- Dashboards.updateStarredSince did Nothing
-  pure NoContent
+apiDashboardUnstar pid did = withRefetchNoContent (apiDashboardGet pid did) (Dashboards.updateStarredSince did Nothing)
 
 
 apiDashboardYaml :: Projects.ProjectId -> Dashboards.DashboardId -> ATBaseCtx DashboardYAMLDoc
@@ -615,10 +623,7 @@ apiKeyDeactivate pid kid = do
 
 
 apiKeyDelete :: Projects.ProjectId -> ProjectApiKeys.ProjectApiKeyId -> ATBaseCtx NoContent
-apiKeyDelete pid kid = do
-  _ <- apiKeyGet pid kid
-  _ <- ProjectApiKeys.revokeApiKey kid
-  pure NoContent
+apiKeyDelete pid kid = withRefetchNoContent (apiKeyGet pid kid) (ProjectApiKeys.revokeApiKey kid)
 
 
 apiEventsQuery :: Projects.ProjectId -> EventsQuery -> ATBaseCtx Log.LogResult
@@ -628,7 +633,7 @@ apiEventsQuery pid q = Log.queryEvents pid q.query q.since q.from q.to q.source 
 -- | Bulk action: currently supports "delete".
 apiDashboardBulk :: Projects.ProjectId -> BulkAction UUID.UUID -> ATBaseCtx (BulkResult UUID.UUID)
 apiDashboardBulk pid ba =
-  bulkExec ba [("delete", Dashboards.deleteDashboardsByIds pid (V.fromList $ UUIDId <$> ba.ids))]
+  bulkExec ba [("delete", count $ Dashboards.deleteDashboardsByIds pid (V.fromList $ UUIDId <$> ba.ids))]
 
 
 -- | Payload for POST /share. event_type defaults to "request" (log/span also accepted).
@@ -795,18 +800,14 @@ apiLogPatternAck pid lpid = do
 
 
 apiLogPatternsBulk :: Projects.ProjectId -> BulkAction Int64 -> ATBaseCtx (BulkResult Int64)
-apiLogPatternsBulk pid ba = do
-  st <- case T.toLower ba.action of
-    "acknowledge" -> pure LogPatterns.LPSAcknowledged
-    "ignore" -> pure LogPatterns.LPSIgnored
-    _ -> throwError err400{errBody = encodeUtf8 $ "Unknown bulk action: " <> ba.action}
-  updated <- LogPatterns.setLogPatternStatesByIds pid Nothing (V.fromList ba.ids) st
-  let updatedSet = S.fromList updated
-  pure
-    BulkResult
-      { succeeded = updated
-      , failed = [BulkFailure{id = i, error = "not applied"} | i <- ba.ids, not (S.member i updatedSet)]
-      }
+apiLogPatternsBulk pid ba =
+  bulkExec
+    ba
+    [ ("acknowledge", setState LogPatterns.LPSAcknowledged)
+    , ("ignore", setState LogPatterns.LPSIgnored)
+    ]
+  where
+    setState st = BulkSucceeded <$> LogPatterns.setLogPatternStatesByIds pid Nothing (V.fromList ba.ids) st
 
 
 issueToSummary :: Issues.Issue -> IssueApiSummary
@@ -938,10 +939,10 @@ apiIssueUnarchive pid iid = issueMutate pid iid $ \ids -> Issues.setArchiveState
 apiIssuesBulk :: Projects.ProjectId -> BulkAction Issues.IssueId -> ATBaseCtx (BulkResult Issues.IssueId)
 apiIssuesBulk pid ba = do
   now <- Time.currentTime
-  let ack = Issues.setAckState pid ba.ids (Just now) Nothing
-      unack = Issues.setAckState pid ba.ids Nothing Nothing
-      archive = Issues.setArchiveState pid ba.ids (Just now)
-      unarchive = Issues.setArchiveState pid ba.ids Nothing
+  let ack = count $ Issues.setAckState pid ba.ids (Just now) Nothing
+      unack = count $ Issues.setAckState pid ba.ids Nothing Nothing
+      archive = count $ Issues.setArchiveState pid ba.ids (Just now)
+      unarchive = count $ Issues.setArchiveState pid ba.ids Nothing
   bulkExec
     ba
     [ ("acknowledge", ack)

--- a/src/Web/MCP.hs
+++ b/src/Web/MCP.hs
@@ -48,8 +48,8 @@ import Relude
 import Servant qualified
 import System.Config (AuthContext (..), EnvConfig (..))
 import System.Types (ATBaseCtx)
-import Utils (toUriStr)
 import UnliftIO qualified
+import Utils (toUriStr)
 import Web.ApiHandlers qualified as ApiH
 
 
@@ -390,11 +390,11 @@ toolsListJson reg = AE.object ["tools" AE..= map descriptor (Map.elems reg)]
 -- | MCP tool-result envelope: text content + isError, with optional structuredContent.
 toolResult :: Bool -> Text -> Maybe AE.Value -> AE.Value
 toolResult isErr txt structured =
-  AE.object $
-    [ "content" AE..= ([textContent txt] :: [AE.Value])
-    , "isError" AE..= isErr
-    ]
-      <> maybe [] (\v -> ["structuredContent" AE..= v]) structured
+  AE.object
+    $ [ "content" AE..= ([textContent txt] :: [AE.Value])
+      , "isError" AE..= isErr
+      ]
+    <> maybe [] (\v -> ["structuredContent" AE..= v]) structured
 
 
 toolError :: Text -> AE.Value

--- a/src/Web/MCP.hs
+++ b/src/Web/MCP.hs
@@ -48,6 +48,7 @@ import Relude
 import Servant qualified
 import System.Config (AuthContext (..), EnvConfig (..))
 import System.Types (ATBaseCtx)
+import Utils (toUriStr)
 import UnliftIO qualified
 import Web.ApiHandlers qualified as ApiH
 
@@ -386,21 +387,22 @@ toolsListJson reg = AE.object ["tools" AE..= map descriptor (Map.elems reg)]
         ]
 
 
-toolError :: Text -> AE.Value
-toolError msg =
-  AE.object
-    [ "content" AE..= ([textContent msg] :: [AE.Value])
-    , "isError" AE..= True
+-- | MCP tool-result envelope: text content + isError, with optional structuredContent.
+toolResult :: Bool -> Text -> Maybe AE.Value -> AE.Value
+toolResult isErr txt structured =
+  AE.object $
+    [ "content" AE..= ([textContent txt] :: [AE.Value])
+    , "isError" AE..= isErr
     ]
+      <> maybe [] (\v -> ["structuredContent" AE..= v]) structured
+
+
+toolError :: Text -> AE.Value
+toolError msg = toolResult True msg Nothing
 
 
 okResult :: AE.Value -> AE.Value
-okResult v =
-  AE.object
-    [ "content" AE..= ([textContent (renderJson v)] :: [AE.Value])
-    , "isError" AE..= False
-    , "structuredContent" AE..= v
-    ]
+okResult v = toolResult False (renderJson v) (Just v)
 
 
 textContent :: Text -> AE.Value
@@ -448,11 +450,7 @@ callOpenApi app b args = do
       bodyTxt = truncateText maxToolBodyBytes (decodeUtf8 bodyLBS)
       isErr = code >= 400
       structured = AE.decode bodyLBS :: Maybe AE.Value
-      base =
-        [ "content" AE..= ([textContent bodyTxt] :: [AE.Value])
-        , "isError" AE..= isErr
-        ]
-  pure $ AE.object $ base <> maybe [] (\v -> ["structuredContent" AE..= v]) structured
+  pure $ toolResult isErr bodyTxt structured
 
 
 -- | Truncate text to @n@ bytes (UTF-8) and append a marker. Cheap byte cap;
@@ -468,11 +466,11 @@ splitArgs :: OpenApiBinding -> AE.Object -> (Text, Text, AE.Value)
 splitArgs b args =
   let look k = KM.lookup (AK.fromText k) args
       pathStr = foldl' substPath b.path b.pathParams
-      substPath acc k = maybe acc (\v -> T.replace ("{" <> k <> "}") (urlEncodeText (jsonToText v)) acc) (look k)
+      substPath acc k = maybe acc (\v -> T.replace ("{" <> k <> "}") (toUriStr (jsonToText v)) acc) (look k)
       qs =
         T.intercalate
           "&"
-          [ k <> "=" <> urlEncodeText (jsonToText v)
+          [ k <> "=" <> toUriStr (jsonToText v)
           | k <- b.queryParams
           , Just v <- [look k]
           , v /= AE.Null
@@ -487,10 +485,6 @@ jsonToText AE.Null = ""
 jsonToText (AE.Bool True) = "true"
 jsonToText (AE.Bool False) = "false"
 jsonToText v = decodeUtf8 (AE.encode v)
-
-
-urlEncodeText :: Text -> Text
-urlEncodeText = decodeUtf8 . H.urlEncode True . encodeUtf8
 
 
 -- =============================================================================

--- a/src/Web/Routes.hs
+++ b/src/Web/Routes.hs
@@ -856,10 +856,10 @@ logExplorerServer pid =
 anomaliesServer :: Projects.ProjectId -> Servant.ServerT AnomaliesRoutes ATAuthCtx
 anomaliesServer pid =
   AnomaliesRoutes'
-    { acknowlegeGet = AnomalyList.acknowledgeAnomalyGetH pid
-    , unAcknowlegeGet = AnomalyList.unAcknowledgeAnomalyGetH pid
-    , archiveGet = AnomalyList.archiveAnomalyGetH pid
-    , unarchiveGet = AnomalyList.unArchiveAnomalyGetH pid
+    { acknowlegeGet = AnomalyList.acknowledgeAnomalyGetH pid True
+    , unAcknowlegeGet = \aid -> AnomalyList.acknowledgeAnomalyGetH pid False aid Nothing
+    , archiveGet = AnomalyList.archiveAnomalyGetH pid True
+    , unarchiveGet = AnomalyList.archiveAnomalyGetH pid False
     , bulkActionsPost = AnomalyList.anomalyBulkActionsPostH pid
     , listGet = AnomalyList.anomalyListGetH pid
     , anomalyGet = AnomalyList.anomalyDetailGetH pid


### PR DESCRIPTION
## Summary

Behavior-preserving consolidation across **33 modules**: removes duplicate functions, single-use wrappers, and hand-written instances in favour of shared helpers, library primitives, and deriving. Net **~ -570 LOC** (+899 / -1469 on a +906-LOC-opportunity audit; the rest were skipped as cross-module/behavior-changing).

This was driven by a codebase-wide audit (79 candidate opportunities, adversarially verified) and applied in three phases: low-risk mechanical → duplicate-function/SQL/render merges → structural (OTLP request unification, golden-cache helper).

## Highlights

- **OTLP** (`OtlpServer.hs`): unify `processTraceRequest`/`processLogsRequest` via `processSignalRequest`; collapse the three `*ServiceRpcHandler` into one `mkOtlpRpcHandler`; reuse `getValidTimestamp`; generalize the span/log attribute extractors.
- **AI** (`Pkg/AI.hs`): merge `runAgenticLoop` into `runAgenticLoopRaw`; collapse `runKqlAndFormat` into `runKqlWithRawData`; share the LLM judge-prompt builder (`PatternMerge.hs`).
- **Telemetry**: parameterize the otel-span lookup queries (`selectOtelSpans`); derive `AggregationTemporality` via `WrappedEnumInt`; reuse `atMapText`/`atMapInt`.
- **KQL parser** (`Parser/Expr.hs`): one shared binary-operator table drives `pTerm`, `Display`, and `ToQueryText` — decode is keyed by parse-symbol (not list position) so reordering for parser precedence stays safe.
- **Email/bots**: shared email footer + `billingNotifEmail` skeleton; shared report header; merged dashboard Block Kit builder.
- **Misc**: merge `monitor*ByIds` timestamp helpers, `getDashboardsFor*` queries, LemonSqueezy fetch helpers; inline single-use shims (`mergeJsonObjects`, `eitherStrToText`, `lookupVec*`); dedupe the ISO-8601 formatter and Slack channel fetch; tidy MCP/CLI/Web handler envelopes; remove dead CLI/Utils helpers.

## Correctness notes

- `atMapInt` uses `toBoundedInteger` (out-of-range/non-integral → `Nothing`) to preserve prior status-code semantics rather than `round`.
- `runAgenticQuery` parses the final text only (no `tool_calls` injection), so MCP / bot / log-explorer responses are unchanged; the tool-data-reuse path stays on `runAgenticChatWithHistory` → `AgenticChatResult` (used by Anomalies).

## Out of scope (deliberately)

- No typed-newtype handlers flattened to `Html ()`.
- No new Postgres dual-write complexity (TimeFusion is the end-state store).

## Verification

- Library compiles: **119 modules**, no warnings-as-errors.
- Doctests: **668 examples, 0 failures**.
- Integration suite green; the `Pages.Bots.Agentic` golden specs (which caught an early `tool_calls` regression, since fixed) pass **11/0**.
- Pre-existing `Pages.GitSync` "Real API" e2e tests require `GH_TEST_PAT/OWNER/REPO` and are unaffected by this change.