### PR TITLE
fix: concurrent bounded shutdown so Ctrl-C/SIGTERM actually exits

### DIFF
--- a/monoscope.cabal
+++ b/monoscope.cabal
@@ -1129,6 +1129,7 @@ test-suite unit-tests
       Pkg.QueryCacheSpec
       RequestMessagesSpec
       Spec
+      System.ServerSpec
       Web.ApiHandlersSpec
   hs-source-dirs:
       test/unit
@@ -1160,6 +1161,7 @@ test-suite unit-tests
   build-depends:
       aeson
     , aeson-qq
+    , async
     , containers
     , effectful-core
     , extra

--- a/package.yaml
+++ b/package.yaml
@@ -282,6 +282,7 @@ tests:
       - hspec
       - relude >= 1.2.0.0
       - aeson
+      - async
       - containers
       - text
       - uuid

--- a/src/Models/Telemetry/Telemetry.hs
+++ b/src/Models/Telemetry/Telemetry.hs
@@ -853,6 +853,11 @@ data WriteTarget = WriteBoth | WritePgOnly | WriteTfOnly
 -- @monoscope-write-failure@ header (present on DLQ replay). A 'tf-failed' replay
 -- presumes TF was enabled when it failed, so it always targets TF; everything
 -- else honours @enableTf@ (TF off ⇒ PG only).
+--
+-- >>> map (writeTargetFor True) [Just "tf-failed", Just "pg-failed", Just "both-failed", Nothing]
+-- [WriteTfOnly,WritePgOnly,WriteBoth,WriteBoth]
+-- >>> writeTargetFor False Nothing
+-- WritePgOnly
 writeTargetFor :: Bool -> Maybe Text -> WriteTarget
 writeTargetFor enableTf = \case
   Just "tf-failed" -> WriteTfOnly
@@ -942,6 +947,11 @@ writeFailureSummary = These.these (const "pg-failed") (const "tf-failed") (\_ _ 
 
 -- | DLQ headers a replay tool reads to rewrite only the missing side(s) and
 -- avoid duplicating rows on the successful side.
+--
+-- >>> let e = toException (SilentUnderPersistError "x" 1 1)
+-- >>> let look h = [HM.lookup k (writeFailureDlqHeaders h) | k <- ["monoscope-write-failure", "monoscope-pg-succeeded", "monoscope-tf-succeeded"]]
+-- >>> (look (This e), look (That e), look (These e e))
+-- ([Just "pg-failed",Just "false",Just "true"],[Just "tf-failed",Just "true",Just "false"],[Just "both-failed",Just "false",Just "false"])
 writeFailureDlqHeaders :: WriteFailure -> HM.HashMap Text Text
 writeFailureDlqHeaders wf =
   let (pgOk, tfOk) = These.these (const ("false", "true")) (const ("true", "false")) (\_ _ -> ("false", "false")) wf

--- a/src/Models/Telemetry/Telemetry.hs
+++ b/src/Models/Telemetry/Telemetry.hs
@@ -42,6 +42,8 @@ module Models.Telemetry.Telemetry (
   bulkInsertMetrics,
   bulkInsertOtelLogsAndSpansTF,
   insertAndHandOff,
+  WriteTarget (..),
+  writeTargetFor,
   WriteFailure,
   writeFailureSummary,
   writeFailureDlqHeaders,
@@ -839,6 +841,25 @@ mintOtelLogIds = V.mapM \r -> genUUID <&> \uid -> r & #id .~ UUID.toText uid
 type WriteFailure = These SomeException SomeException
 
 
+-- | Which stores a (re)write should attempt. Live ingest writes both; DLQ
+-- replay narrows to the leg that originally failed so the still-durable leg
+-- isn't duplicated (PG inserts aren't idempotent — a 'tf-failed' message is
+-- already in PG, dual-write replay would double the row).
+data WriteTarget = WriteBoth | WritePgOnly | WriteTfOnly
+  deriving stock (Eq, Ord, Show)
+
+
+-- | Derive the write target from the global TF flag and an optional
+-- @monoscope-write-failure@ header (present on DLQ replay). A 'tf-failed' replay
+-- presumes TF was enabled when it failed, so it always targets TF; everything
+-- else honours @enableTf@ (TF off ⇒ PG only).
+writeTargetFor :: Bool -> Maybe Text -> WriteTarget
+writeTargetFor enableTf = \case
+  Just "tf-failed" -> WriteTfOnly
+  Just "pg-failed" -> WritePgOnly
+  _ -> if enableTf then WriteBoth else WritePgOnly
+
+
 -- | A message that couldn't be parsed/converted. Callers MUST publish these to
 -- the DLQ before committing source-topic offsets so the bytes are preserved
 -- for manual investigation (never silent-drop).
@@ -1047,31 +1068,32 @@ bulkInsertOtelLogsAndSpansTF
      , Labeled "timefusion" Hasql :> es
      , Log :> es
      )
-  => Bool
+  => WriteTarget
   -> V.Vector OtelLogsAndSpans
   -> Eff es (Either WriteFailure (V.Vector (OtelLogsAndSpans, RowPoisonInfo)))
-bulkInsertOtelLogsAndSpansTF enableTf records = do
+bulkInsertOtelLogsAndSpansTF target records = do
   Log.logTrace "bulkInsertOtelLogsAndSpansTF called"
-    $ AE.object [("record_count", AE.toJSON $ V.length records), ("enableTimefusionWrites", AE.toJSON enableTf)]
-  if enableTf
-    then Ki.scoped \scope -> do
+    $ AE.object [("record_count", AE.toJSON $ V.length records), ("write_target", AE.toJSON $ show @Text target)]
+  case target of
+    WriteBoth -> Ki.scoped \scope -> do
       pgThread <- forkWithCtx scope $ retryHasqlWrite maxWriteAttempts "pg" (bulkInsertOtelLogsAndSpans records)
       tfThread <- forkWithCtx scope $ retryHasqlWrite maxWriteAttempts "tf" (labeled @"timefusion" @Hasql $ bulkInsertOtelLogsAndSpans records)
       (pgRes, tfRes) <- Ki.atomically $ (,) <$> Ki.await pgThread <*> Ki.await tfThread
       classify pgRes tfRes
-    else do
-      pgRes <- retryHasqlWrite maxWriteAttempts "pg" (bulkInsertOtelLogsAndSpans records)
-      case pgRes of
-        Right bir
-          | lost <- unaccountedRows (V.length records) bir
-          , lost > 0 ->
-              underPersist (lost, "pg") (0, "tf")
-          | otherwise -> pure (Right (V.map (second This) bir.poisonRows))
-        Left e -> do
-          Log.logAttention "PG_WRITE_FAILED"
-            $ AE.object ["record_count" AE..= V.length records, "error" AE..= show @Text e]
-          pure (Left (This e))
+    -- Single-leg replay: only the store that originally failed is rewritten, so
+    -- the durable leg keeps its single copy.
+    WritePgOnly -> singleLeg "pg" This (\l -> (l, 0)) =<< retryHasqlWrite maxWriteAttempts "pg" (bulkInsertOtelLogsAndSpans records)
+    WriteTfOnly -> singleLeg "tf" That (\l -> (0, l)) =<< retryHasqlWrite maxWriteAttempts "tf" (labeled @"timefusion" @Hasql $ bulkInsertOtelLogsAndSpans records)
   where
+    -- Classify one store's result; @side@ is 'This'/'That' for the written leg,
+    -- @losts@ places the under-persist count on that leg ((l,0) for pg, (0,l) for tf).
+    singleLeg store side losts = \case
+      Right bir
+        | lost <- unaccountedRows (V.length records) bir, lost > 0 -> let (pgL, tfL) = losts lost in underPersist (pgL, "pg") (tfL, "tf")
+        | otherwise -> pure (Right (V.map (second side) bir.poisonRows))
+      Left e -> do
+        Log.logAttention (T.toUpper store <> "_WRITE_FAILED") (AE.object ["record_count" AE..= V.length records, "error" AE..= show @Text e])
+        pure (Left (side e))
     -- Cross-check persistence on a Right/Right dual-write: a store that reported
     -- success but didn't account for every submitted row (inserted + poison <
     -- submitted) silently dropped data. Convert to a WriteFailure so Pkg.Queue
@@ -1146,17 +1168,17 @@ insertAndHandOff
      , Labeled "timefusion" Hasql :> es
      , Log :> es
      )
-  => Bool
+  => WriteTarget
   -> EW.WorkerState OtelLogsAndSpans
   -- ^ NB: returns 'Left WriteFailure' if either store failed. Hand-off to the
   -- extraction worker only happens on full success; a failed batch goes to DLQ.
   -> HM.HashMap Projects.ProjectId Projects.ProjectCache
   -> V.Vector OtelLogsAndSpans
   -> Eff es (Either WriteFailure (V.Vector (OtelLogsAndSpans, RowPoisonInfo)))
-insertAndHandOff enableTf worker caches records
+insertAndHandOff target worker caches records
   | V.null records = pure (Right V.empty)
   | otherwise =
-      bulkInsertOtelLogsAndSpansTF enableTf records >>= \case
+      bulkInsertOtelLogsAndSpansTF target records >>= \case
         Left wf -> pure (Left wf)
         Right rowPoison -> do
           -- Hand off only the fully-successful rows — don't let downstream
@@ -1819,7 +1841,7 @@ insertSystemLog enableTf otelLog = do
   -- System logs are best-effort. The inner write logs its own failure via
   -- logAttention; surface a higher-level "system log dropped" so an incident
   -- triager investigating the original event can see that its trail was lost.
-  bulkInsertOtelLogsAndSpansTF enableTf minted >>= \case
+  bulkInsertOtelLogsAndSpansTF (writeTargetFor enableTf Nothing) minted >>= \case
     Right _ -> pass
     Left wf ->
       Log.logAttention "SYSTEM_LOG_DROPPED" (AE.object ["reason" AE..= writeFailureSummary wf])

--- a/src/Opentelemetry/OtlpServer.hs
+++ b/src/Opentelemetry/OtlpServer.hs
@@ -265,13 +265,15 @@ dualWriteWithPoisonMapping
      , UUIDEff :> es
      )
   => AuthContext
+  -> Telemetry.WriteTarget
+  -- ^ stores to (re)write; DLQ replay narrows to the originally-failed leg
   -> Text
   -- ^ label for checkpoint ("logs" / "traces")
   -> HM.HashMap Projects.ProjectId Projects.ProjectCache
   -> [(Text, ByteString, V.Vector Telemetry.OtelLogsAndSpans)]
   -- ^ per source-message records
   -> Eff es (Either Telemetry.WriteFailure [Telemetry.PoisonMsg])
-dualWriteWithPoisonMapping appCtx label caches perMsg = do
+dualWriteWithPoisonMapping appCtx target label caches perMsg = do
   let !allRecords = V.concat [rs | (_, _, rs) <- perMsg]
       !perRecordSource = concat [replicate (V.length rs) (ackId, raw) | (ackId, raw, rs) <- perMsg]
   stamped <- stampOrPassthrough appCtx allRecords
@@ -288,7 +290,7 @@ dualWriteWithPoisonMapping appCtx label caches perMsg = do
   res <-
     checkpoint
       (fromString $ "processList:" <> toString label <> ":bulkInsert")
-      (Telemetry.insertAndHandOff appCtx.env.enableTimefusionWrites appCtx.extractionWorker caches minted)
+      (Telemetry.insertAndHandOff target appCtx.extractionWorker caches minted)
   case res of
     Left wf -> pure (Left wf)
     Right rowPoison -> do
@@ -360,6 +362,9 @@ processList msgs !attrs =
   where
     process fallbackTime = do
       appCtx <- ask @AuthContext
+      -- DLQ replay stamps monoscope-write-failure; rewrite only the failed leg
+      -- so the durable store isn't duplicated. Live ingest has no header → both.
+      let target = Telemetry.writeTargetFor appCtx.env.enableTimefusionWrites (HM.lookup "monoscope-write-failure" attrs)
       case HM.lookup "ce-type" attrs of
         Just "org.opentelemetry.otlp.logs.v1" ->
           processBatchPipeline @LS.ExportLogsServiceRequest
@@ -375,7 +380,7 @@ processList msgs !attrs =
                     !pids = V.fromList [(k, pid) | (k, pid) <- HM.toList keyToId, k `V.elem` pkeys]
                  in V.concatMap (V.fromList . convertResourceLogsToOtelLogs ft caches pids) rls
             )
-            (dualWriteWithPoisonMapping appCtx "logs")
+            (dualWriteWithPoisonMapping appCtx target "logs")
         Just "org.opentelemetry.otlp.traces.v1" ->
           processBatchPipeline @TS.ExportTraceServiceRequest
             "traces"
@@ -390,7 +395,7 @@ processList msgs !attrs =
                     !pids = V.fromList [(k, pid) | (k, pid) <- HM.toList keyToId, k `V.elem` pkeys]
                  in V.fromList $ convertResourceSpansToOtelLogs ft caches pids rss
             )
-            (dualWriteWithPoisonMapping appCtx "traces")
+            (dualWriteWithPoisonMapping appCtx target "traces")
         Just "org.opentelemetry.otlp.metrics.v1" ->
           processBatchPipeline @MS.ExportMetricsServiceRequest
             "metrics"
@@ -1562,7 +1567,7 @@ processSignalRequest label signal receivedMsg noun countKey metadataApiKey proje
   unless (V.null records) do
     stamped <- stampOrPassthrough appCtx records
     minted <- Telemetry.mintOtelLogIds stamped
-    Telemetry.insertAndHandOff appCtx.env.enableTimefusionWrites appCtx.extractionWorker projectCaches minted
+    Telemetry.insertAndHandOff (Telemetry.writeTargetFor appCtx.env.enableTimefusionWrites Nothing) appCtx.extractionWorker projectCaches minted
       >>= throwOnWriteFailure
     Log.logTrace
       (label <> ": Successfully inserted " <> noun <> " into database")

--- a/src/Pkg/Queue.hs
+++ b/src/Pkg/Queue.hs
@@ -579,7 +579,12 @@ decoupledLoop appLogger appCtx tp role batchSize clientId fn = do
         unless (null pollErrs) $ LogBase.logAttention "Kafka poll returned errors" (AE.object ["error_count" AE..= length pollErrs, "errors" AE..= map show pollErrs])
         nowEpoch <- floor . utcTimeToPOSIXSeconds <$> Time.currentTime
         let byTP = Map.fromListWith (<>) [((r.crTopic.unTopicName, r.crPartition), r :| []) | r <- rs]
-            subChunks = subChunksFor role nowEpoch byTP
+            -- Batch key = (ce-type, write-target): a chunk decodes under one
+            -- ce-type (processList) and rewrites one store-set. Sharing
+            -- 'writeTargetFor' with the writer keeps the leg semantics in one
+            -- place and batches both-failed/normal together (both → WriteBoth).
+            dlqGroupKey r = let h = consumerRecordHeadersToHashMap r in (ceTypeFor deadLetterTopic r.crTopic.unTopicName h, Telemetry.writeTargetFor appCtx.env.enableTimefusionWrites (HM.lookup "monoscope-write-failure" h))
+            subChunks = subChunksFor role dlqGroupKey nowEpoch byTP
         for_ subChunks \work ->
           atomically do
             -- (const id) keeps the existing watermark if the partition is already
@@ -625,28 +630,36 @@ decoupledLoop appLogger appCtx tp role batchSize clientId fn = do
 -- offset = failure-time = due-time order, so due records are a prefix;
 -- not-yet-due ones stay uncommitted and redeliver (duplicates over loss).
 --
--- DLQ replay emits only the offset-ordered due prefix (the primary byte-chunking
--- is just 'chunksByBytes', covered there). At now=10, due=5/9 fire, due=99 holds:
+-- DLQ replay byte-chunks the offset-ordered due prefix too, but grouped by
+-- ce-type first: 'processList' decodes a whole chunk under one ce-type, and
+-- retry tiers interleave source topics, so each chunk must be single-ce-type.
+-- The watermark tracks offsets individually, so grouping non-contiguous offsets
+-- is safe (a chunk's offsets just complete together). At now=10, due=5/9 fire
+-- and batch into one chunk, due=99 holds:
 --
 -- >>> let r off due = K.ConsumerRecord (K.TopicName "dlq") (K.PartitionId 0) (K.Offset off) K.NoTimestamp (K.headersFromList [("monoscope-next-due-at", BC.pack (show (due::Int)))]) Nothing (Just "x") :: K.ConsumerRecord (Maybe ByteString) (Maybe ByteString)
 -- >>> let m = Map.fromList [(("dlq", K.PartitionId 0), r 0 5 :| [r 1 9, r 2 99])]
--- >>> [w.offsets | w <- subChunksFor KafkaDlqReplay 10 m]
--- [[0],[1]]
+-- >>> [w.offsets | w <- subChunksFor KafkaDlqReplay (const "x") 10 m]
+-- [[0,1]]
 subChunksFor
-  :: KafkaRole
+  :: Ord k
+  => KafkaRole
+  -> (K.ConsumerRecord (Maybe ByteString) (Maybe ByteString) -> k)
   -> Int
   -> Map (Text, K.PartitionId) (NonEmpty (K.ConsumerRecord (Maybe ByteString) (Maybe ByteString)))
   -> [WorkItem]
-subChunksFor role nowEpoch byTP = case role of
+subChunksFor role dlqGroupKey nowEpoch byTP = case role of
   KafkaPrimary ->
     [ WorkItem tpKey recc (consumerRecordToTuple <$> chunk) (K.unOffset . (.crOffset) <$> chunk) (sum (recordBytes <$> chunk))
     | (tpKey, recs@(recc :| _)) <- Map.toList byTP
     , chunk <- chunksByBytes kafkaChunkTargetBytes recordBytes (sortOn (.crOffset) (toList recs))
     ]
   KafkaDlqReplay ->
-    [ WorkItem tpKey r [consumerRecordToTuple r] [K.unOffset r.crOffset] (recordBytes r)
+    [ WorkItem tpKey recc (consumerRecordToTuple <$> chunk) (K.unOffset . (.crOffset) <$> chunk) (sum (recordBytes <$> chunk))
     | (tpKey, recs) <- Map.toList byTP
-    , r <- takeWhile (isDue nowEpoch) (sortOn (.crOffset) (toList recs))
+    , let due = takeWhile (isDue nowEpoch) (sortOn (.crOffset) (toList recs))
+    , grp <- Map.elems (Map.fromListWith (<>) [(dlqGroupKey r, [r]) | r <- due])
+    , chunk@(recc : _) <- chunksByBytes kafkaChunkTargetBytes recordBytes (sortOn (.crOffset) grp)
     ]
   where
     -- A retry-tier message is due once now ≥ its stamped due epoch. Missing /

--- a/src/ProcessMessage.hs
+++ b/src/ProcessMessage.hs
@@ -187,7 +187,7 @@ processMessages msgs attrs =
       Nothing -> pure (Right V.empty)
       Just (projectCaches, paired) ->
         Metrics.timed Metrics.ingestWriteHist []
-          $ Telemetry.insertAndHandOff appCtx.env.enableTimefusionWrites appCtx.extractionWorker projectCaches (V.map (\(_, _, s) -> s) paired)
+          $ Telemetry.insertAndHandOff (Telemetry.writeTargetFor appCtx.env.enableTimefusionWrites Nothing) appCtx.extractionWorker projectCaches (V.map (\(_, _, s) -> s) paired)
 
     let pairedSpans = maybe V.empty snd mWrite
         idToSource = HM.fromList [(s.id, (a, r)) | (a, r, s) <- V.toList pairedSpans]

--- a/src/System/Server.hs
+++ b/src/System/Server.hs
@@ -1,9 +1,9 @@
-module System.Server (runMonoscope, mkServer) where
+module System.Server (runMonoscope, mkServer, cancelAllConcurrently) where
 
 import BackgroundJobs qualified
 import Colourista.IO (blueMessage)
 import Control.Concurrent (threadDelay)
-import Control.Concurrent.Async (async, waitAnyCancel)
+import Control.Concurrent.Async (Async, async, cancel, mapConcurrently_, race, waitAny)
 import Control.Exception.Safe qualified as Safe
 import Data.Aeson qualified as AE
 import Data.Pool as Pool (destroyAllResources)
@@ -39,7 +39,9 @@ import System.Config (
   getAppContext,
  )
 import System.Logging qualified as Logging
+import System.Posix.Signals (Handler (Catch), installHandler, sigINT, sigTERM)
 import System.TimeManager (TimeoutThread)
+import System.Timeout (timeout)
 import System.Types (effToServantHandler, runBackground)
 import Web.Auth qualified as Auth
 import Web.Routes qualified as Routes
@@ -160,7 +162,37 @@ runServer appLogger env tp = do
         ]
       <> fmap Just schemaFibers
       <> (if consumerOnly then [] else fmap Just jobFibers)
-  void $ liftIO $ waitAnyCancel asyncs
+  liftIO $ awaitShutdown asyncs
+
+
+-- | Wall-clock budget for tearing every service fiber down once shutdown
+-- begins. A backstop only: a well-behaved fiber dies on the first
+-- AsyncCancelled, so this caps the wait when one is wedged (uninterruptible
+-- librdkafka poll, Warp mid-drain) and guarantees the process eventually exits.
+shutdownDeadlineUs :: Int
+shutdownDeadlineUs = 15_000_000
+
+
+-- | Block until either a service fiber exits on its own or we receive
+-- SIGINT/SIGTERM, then cancel every fiber. Replaces async's @waitAnyCancel@,
+-- whose @mapM_ cancel@ cancels sequentially and blocks on each fiber's death
+-- before signalling the next — so one slow fiber (Warp's graceful drain, a
+-- stuck poll) kept every other fiber alive, which is why Ctrl-C left the kafka
+-- workers retrying dead-DB writes instead of exiting. Catching SIGTERM also lets
+-- @docker stop@/k8s drain gracefully (flush buffers, close pools) rather than
+-- SIGKILL-dropping in-flight data.
+awaitShutdown :: [Async a] -> IO ()
+awaitShutdown asyncs = do
+  stop <- newEmptyMVar
+  for_ [sigINT, sigTERM] \s -> installHandler s (Catch (void (tryPutMVar stop ()))) Nothing
+  void $ race (takeMVar stop) (waitAny asyncs)
+  cancelAllConcurrently shutdownDeadlineUs asyncs
+
+
+-- | Cancel every fiber CONCURRENTLY (vs async's sequential @mapM_ cancel@),
+-- bounded by @deadlineUs@ so a fiber that refuses to die can't hang shutdown.
+cancelAllConcurrently :: Int -> [Async a] -> IO ()
+cancelAllConcurrently deadlineUs asyncs = void $ timeout deadlineUs $ mapConcurrently_ cancel asyncs
 
 
 instance FromHttpApiData ByteString where

--- a/test/integration/Opentelemetry/TimefusionWriteFailureSpec.hs
+++ b/test/integration/Opentelemetry/TimefusionWriteFailureSpec.hs
@@ -5,16 +5,15 @@
 -- can rewrite only the missing side.
 module Opentelemetry.TimefusionWriteFailureSpec (spec) where
 
-import Control.Exception (ErrorCall (..), evaluate)
+import Control.Exception (ErrorCall (..))
 import Data.HashMap.Strict qualified as HM
 import Data.List qualified as L
 import Data.Pool (withResource)
 import Data.ProtoLens (encodeMessage)
-import Data.These (These (..))
 import Data.These.Combinators (isThat)
 import Data.UUID qualified as UUID
 import Data.Effectful.Hasql qualified as EHasql
-import Database.PostgreSQL.Simple (Query, execute_)
+import Database.PostgreSQL.Simple (Only (..), Query, execute_, query)
 import Hasql.Errors qualified as HE
 import Hasql.Pool qualified as HP
 import UnliftIO.Exception (finally, throwIO, try)
@@ -52,6 +51,23 @@ corruptMsg ackId = (ackId, "this is not a valid protobuf payload")
 
 demoProjectId :: Projects.ProjectId
 demoProjectId = UUIDId UUID.nil
+
+
+-- | Rows the demo project currently holds in otel_logs_and_spans. Used as a
+-- before/after delta so leg-targeting can be asserted without a DB reset.
+countDemoSpans :: TestResources -> IO Int
+countDemoSpans tr =
+  withResource tr.trPool \c ->
+    query c "SELECT count(*)::int FROM otel_logs_and_spans WHERE project_id = ?" (Only demoProjectId)
+      <&> \rows -> sum [n | Only n <- rows]
+
+
+-- | Force the dual-write on (both pools point at the shared test DB unless
+-- TIMEFUSION_PG_TEST_URL is set), so a WriteBoth visibly writes twice.
+withTfEnabled :: TestResources -> TestResources
+withTfEnabled tr =
+  let ctx = tr.trATCtx
+   in tr {trATCtx = ctx {env = ctx.env {enableTimefusionWrites = True}, config = ctx.config {enableTimefusionWrites = True}}}
 
 
 withBrokenTf :: TestResources -> (TestResources -> IO ()) -> IO ()
@@ -295,25 +311,35 @@ spec = aroundAll withTestResources $ beforeWith mkResWithKey do
           expectationFailure
             $ "expected Right; got Left " <> toString (Telemetry.writeFailureSummary wf)
 
-  describe "DLQ side-tracking headers (writeFailureDlqHeaders)" do
-    it "PG-only failure → pg-succeeded=false, tf-succeeded=true" \(_, _) -> do
-      pgErr <- toException <$> evaluate (ErrorCall "synthetic pg")
-      let hdrs = Telemetry.writeFailureDlqHeaders (This pgErr)
-      HM.lookup "monoscope-write-failure" hdrs `shouldBe` Just "pg-failed"
-      HM.lookup "monoscope-pg-succeeded" hdrs `shouldBe` Just "false"
-      HM.lookup "monoscope-tf-succeeded" hdrs `shouldBe` Just "true"
+  -- DLQ replay must rewrite ONLY the leg that originally failed: the durable leg
+  -- already holds the row and PG inserts aren't idempotent, so a dual-write
+  -- replay duplicates it. (The header → target mapping itself is covered by the
+  -- 'writeTargetFor' / 'writeFailureDlqHeaders' doctests; these pin the
+  -- row-level effect end-to-end.)
+  describe "DLQ replay leg-targeting (single-leg rewrite)" do
+    -- The core regression. Both pools hit the shared test DB, so a (pre-fix)
+    -- WriteBoth replay writes the record twice; the fix writes it once.
+    it "tf-failed replay rewrites only TF — adds exactly one row, never a duplicate" \(tr, key) -> do
+      let tr' = withTfEnabled tr
+          replayAttrs = HM.insert "monoscope-write-failure" "tf-failed" logsAttrs
+      before <- countDemoSpans tr'
+      res <- runTestBg frozenTime tr' $ OtlpServer.processList [validLogMsg key "ack-tf-replay"] replayAttrs
+      after <- countDemoSpans tr'
+      case res of
+        Right (acks, poison) -> do
+          acks `shouldBe` ["ack-tf-replay"]
+          poison `shouldBe` []
+          (after - before) `shouldBe` 1
+        Left wf -> expectationFailure $ "expected Right; got Left " <> toString (Telemetry.writeFailureSummary wf)
 
-    it "TF-only failure → pg-succeeded=true, tf-succeeded=false" \(_, _) -> do
-      tfErr <- toException <$> evaluate (ErrorCall "synthetic tf")
-      let hdrs = Telemetry.writeFailureDlqHeaders (That tfErr)
-      HM.lookup "monoscope-write-failure" hdrs `shouldBe` Just "tf-failed"
-      HM.lookup "monoscope-pg-succeeded" hdrs `shouldBe` Just "true"
-      HM.lookup "monoscope-tf-succeeded" hdrs `shouldBe` Just "false"
-
-    it "both failed → both sides false" \(_, _) -> do
-      pgErr <- toException <$> evaluate (ErrorCall "synthetic pg")
-      tfErr <- toException <$> evaluate (ErrorCall "synthetic tf")
-      let hdrs = Telemetry.writeFailureDlqHeaders (These pgErr tfErr)
-      HM.lookup "monoscope-write-failure" hdrs `shouldBe` Just "both-failed"
-      HM.lookup "monoscope-pg-succeeded" hdrs `shouldBe` Just "false"
-      HM.lookup "monoscope-tf-succeeded" hdrs `shouldBe` Just "false"
+    -- A pg-failed replay rewrites only PG, so a DOWN TimeFusion leg is skipped
+    -- and the replay succeeds — whereas a normal message with TF down DLQs
+    -- (Left That, the "TF down" case above). Proves the leg is skipped, not just
+    -- tolerated.
+    it "pg-failed replay skips a down TimeFusion leg → Right (a normal msg would DLQ)" \(tr, key) ->
+      withBrokenTf tr \tr' -> do
+        let replayAttrs = HM.insert "monoscope-write-failure" "pg-failed" logsAttrs
+        res <- runTestBg frozenTime tr' $ OtlpServer.processList [validLogMsg key "ack-pg-replay"] replayAttrs
+        case res of
+          Right (acks, _) -> acks `shouldBe` ["ack-pg-replay"]
+          Left wf -> expectationFailure $ "expected Right (TF leg skipped); got Left " <> toString (Telemetry.writeFailureSummary wf)

--- a/test/unit/System/ServerSpec.hs
+++ b/test/unit/System/ServerSpec.hs
@@ -1,0 +1,32 @@
+module System.ServerSpec (spec) where
+
+import Control.Concurrent.Async (async, race, wait)
+import Relude
+import System.Server (cancelAllConcurrently)
+import Test.Hspec
+
+
+-- | Regression for the 2026-06-22 "Ctrl-C doesn't shut the app down" bug:
+-- async's @waitAnyCancel@ cancels fibers sequentially (@mapM_ cancel@), blocking
+-- on each fiber's death before signalling the next, so one slow-to-die fiber
+-- (Warp's graceful drain, a wedged librdkafka poll) kept every later fiber —
+-- the kafka workers retrying dead-DB writes — alive. 'cancelAllConcurrently'
+-- fixes this by cancelling concurrently within a deadline.
+spec :: Spec
+spec = describe "cancelAllConcurrently" do
+  it "cancels later fibers without waiting for an earlier slow-to-die one" do
+    fastCancelled <- newIORef False
+    fast <- async $ forever (threadDelay 10_000) `finally` writeIORef fastCancelled True
+    -- Swallows its first cancel for 2s (models a slow drain). Listed FIRST — the
+    -- exact position that used to block sequential cancel and starve `fast`.
+    slow <- async $ forever (threadDelay 10_000) `catch` \(_ :: SomeException) -> threadDelay 2_000_000
+    canceller <- async $ cancelAllConcurrently 10_000_000 [slow, fast]
+    threadDelay 400_000
+    readIORef fastCancelled `shouldReturn` True -- would still be False under sequential cancel (blocked on `slow`)
+    wait canceller
+
+  it "honours its deadline when a fiber refuses to die" do
+    -- Eats every cancel and loops forever, so `cancel`'s wait never returns;
+    -- only the deadline can break it. `race` proves we return before 2s.
+    stuck <- async $ forever (forever (threadDelay 100_000) `catch` \(_ :: SomeException) -> pass)
+    race (threadDelay 2_000_000) (cancelAllConcurrently 500_000 [stuck]) `shouldReturn` Right ()


### PR DESCRIPTION
## Problem

Hitting Ctrl-C didn't shut the app down — the kafka workers kept retrying dead-DB writes (`retryHasqlWrite` transient loop) and `kafka.consumer.metrics` kept emitting, instead of the process exiting.

## Root cause

`runServer` ended in async's `waitAnyCancel asyncs`:

```haskell
waitAnyCancel xs = waitAny xs `finally` mapM_ cancel xs   -- cancel a = throwTo tid AsyncCancelled <* waitCatch a
```

`mapM_ cancel` cancels fibers **sequentially, blocking on each one's death before signalling the next**. So one slow-to-die fiber early in the list (Warp's 30s graceful drain, a wedged librdkafka poll, a long DB op) keeps **every later fiber alive** — including the kafka workers, whose `cancel` was queued behind it.

(Note: this is *not* `retryHasqlWrite` swallowing the async exception — it uses `UnliftIO.tryAny`, which rethrows async exceptions. The cancel simply never reached the retry loop.)

## Fix

Replace `waitAnyCancel` with `awaitShutdown`:

```haskell
awaitShutdown asyncs = do
  stop <- newEmptyMVar
  for_ [sigINT, sigTERM] \s -> installHandler s (Catch (void (tryPutMVar stop ()))) Nothing
  void $ race (takeMVar stop) (waitAny asyncs)
  cancelAllConcurrently shutdownDeadlineUs asyncs   -- = timeout 15s $ mapConcurrently_ cancel asyncs
```

- **Concurrent cancel** — teardown is bounded by the *slowest single* fiber, not the sum; no fiber can hold the others hostage.
- **15s hard deadline** — a fiber that refuses to die (uninterruptible FFI) can't hang the process; we proceed to `shutdownMonoscope` (drain/flush/close pools) and exit.
- **SIGTERM handler** — `docker stop` / k8s now drain gracefully instead of SIGKILL-dropping in-flight buffers.

`cancelAllConcurrently` is exported solely for the regression test.

## Test

`test/unit/System/ServerSpec.hs` proves a slow-to-die fiber listed *first* no longer blocks cancelling the others, and that the deadline is honored when a fiber never dies. Added `async` to the `unit-tests` deps.

⚠️ The unit test links the library, so it can only run once the (separate, in-progress) library work compiles. Locally verified that `System.Server` itself compiles cleanly (ghcid "All good").