### PR TITLE
fix: align kafka consumer fetch ceiling to 64 MiB broker max

### DIFF
--- a/src/Pkg/Queue.hs
+++ b/src/Pkg/Queue.hs
@@ -470,14 +470,11 @@ kafkaService appLogger appCtx tp role label kafkaTopics batchSize fn = checkpoin
         -- round-trip cost). 250ms stays well under session/poll timeouts.
         <> K.extraProp "fetch.min.bytes" "65536"
         <> K.extraProp "fetch.wait.max.ms" "250"
-        -- Consumer fetch ceiling MUST match the producer/broker 64 MiB max.message.bytes.
-        -- librdkafka defaults max.partition.fetch.bytes to 1 MiB and fetch.max.bytes to
-        -- 50 MiB — both below the 64 MiB a DLQ re-publish can reach — so an oversized-but-
-        -- valid record (esp. header-restamped DLQ messages) is accepted and stored by the
-        -- broker yet MSG_SIZE_TOO_LARGE wedges the partition on consume, re-seeking forever.
-        <> K.extraProp "max.partition.fetch.bytes" "67108864"
-        <> K.extraProp "fetch.max.bytes" "67108864"
-        <> K.extraProp "receive.message.max.bytes" "104857600"
+        -- Fetch ceiling must match broker 64 MiB max.message.bytes, else an oversized-but-valid
+        -- record (e.g. a header-restamped DLQ re-publish) wedges the partition with MSG_SIZE_TOO_LARGE.
+        <> K.extraProp "max.partition.fetch.bytes" "67108864" -- 64 MiB (librdkafka default 1 MiB)
+        <> K.extraProp "fetch.max.bytes" "67108864" -- 64 MiB total per fetch (default 50 MiB)
+        <> K.extraProp "receive.message.max.bytes" "104857600" -- 100 MiB socket buffer (> fetch.max.bytes)
         <> K.extraProp "partition.assignment.strategy" "cooperative-sticky"
         <> K.extraProp "group.instance.id" clientId
         <> K.logLevel K.KafkaLogInfo

--- a/src/Pkg/Queue.hs
+++ b/src/Pkg/Queue.hs
@@ -470,6 +470,14 @@ kafkaService appLogger appCtx tp role label kafkaTopics batchSize fn = checkpoin
         -- round-trip cost). 250ms stays well under session/poll timeouts.
         <> K.extraProp "fetch.min.bytes" "65536"
         <> K.extraProp "fetch.wait.max.ms" "250"
+        -- Consumer fetch ceiling MUST match the producer/broker 64 MiB max.message.bytes.
+        -- librdkafka defaults max.partition.fetch.bytes to 1 MiB and fetch.max.bytes to
+        -- 50 MiB — both below the 64 MiB a DLQ re-publish can reach — so an oversized-but-
+        -- valid record (esp. header-restamped DLQ messages) is accepted and stored by the
+        -- broker yet MSG_SIZE_TOO_LARGE wedges the partition on consume, re-seeking forever.
+        <> K.extraProp "max.partition.fetch.bytes" "67108864"
+        <> K.extraProp "fetch.max.bytes" "67108864"
+        <> K.extraProp "receive.message.max.bytes" "104857600"
         <> K.extraProp "partition.assignment.strategy" "cooperative-sticky"
         <> K.extraProp "group.instance.id" clientId
         <> K.logLevel K.KafkaLogInfo

--- a/test/unit/System/ServerSpec.hs
+++ b/test/unit/System/ServerSpec.hs
@@ -1,6 +1,8 @@
 module System.ServerSpec (spec) where
 
+import Control.Concurrent (threadDelay)
 import Control.Concurrent.Async (async, race, wait)
+import Control.Exception (catch, finally)
 import Relude
 import System.Server (cancelAllConcurrently)
 import Test.Hspec


### PR DESCRIPTION
## What

Raise consumer-side fetch ceilings in `consumerProps` (`src/Pkg/Queue.hs`) to match the producer/broker 64 MiB `max.message.bytes`:

| prop | value |
|---|---|
| `max.partition.fetch.bytes` | 64 MiB |
| `fetch.max.bytes` | 64 MiB |
| `receive.message.max.bytes` | 100 MiB |

Applies to both the primary ingest group and the `_dlq` replay group.

## Why

librdkafka defaults `max.partition.fetch.bytes` to 1 MiB and `fetch.max.bytes` to 50 MiB — both below the 64 MiB a DLQ re-publish can reach. An oversized-but-valid record (esp. header-restamped DLQ messages) is accepted and stored by the broker, yet trips `MSG_SIZE_TOO_LARGE` on consume, wedging the partition in a re-seek loop.

Observed live: DLQ replay group `mono-dlq-46b7bc` holding ~243 MiB in-flight with **0 committed partitions**.

## Risk

Config-only. `receive.message.max.bytes` (100 MiB) ≥ `fetch.max.bytes` (64 MiB) + overhead, so librdkafka accepts the config. `fetch.max.bytes` caps total in-flight per fetch regardless of partition count.

## Deploy sequencing

Land this **first**, confirm the DLQ group starts committing (`committed_partitions` > 0, `inflight_bytes` dropping), **then** consider any DLQ prune. This fixes oversized-but-valid records only — genuine poison (wire-type 6/7, truncated protobuf) still needs the manual prune path.