### PR TITLE
fix(queue): self-heal DLQ commit-starvation via reseek on no-ack

### DIFF
--- a/monoscope.cabal
+++ b/monoscope.cabal
@@ -1162,6 +1162,7 @@ test-suite unit-tests
       aeson
     , aeson-qq
     , async
+    , base
     , containers
     , effectful-core
     , extra

--- a/src/Pkg/Queue.hs
+++ b/src/Pkg/Queue.hs
@@ -18,6 +18,7 @@ module Pkg.Queue (
   retryDestination,
 ) where
 
+import Control.Concurrent.STM (swapTVar)
 import Control.Concurrent.STM.TBQueue (TBQueue, newTBQueueIO, readTBQueue, writeTBQueue)
 import Control.Exception.Annotated (checkpoint)
 import Control.Lens ((^?), _Just)
@@ -516,6 +517,9 @@ decoupledLoop appLogger appCtx tp role batchSize clientId fn = do
   committedVar <- newTVarIO (Map.empty :: Map (Text, K.PartitionId) Int64)
   inflightVar <- newTVarIO (0 :: Int)
   pausedVar <- newTVarIO False
+  -- Partitions a worker couldn't ack (transient failure): the poll thread reseeks
+  -- each back to the recorded base so its un-acked chunk is redelivered+retried.
+  reseekVar <- newTVarIO (Map.empty :: Map (Text, K.PartitionId) Int64)
   let assigned = KE.assignment <&> \m -> [(t, p) | (t, ps) <- Map.toList m, p <- ps]
       worker = forever do
         w <- atomically (readTBQueue workQ)
@@ -532,7 +536,14 @@ decoupledLoop appLogger appCtx tp role batchSize clientId fn = do
               (fn w.payloads attrs)
         acks <- routeBatchOutcome appCtx "kafka-service" topic w.payloads attrs result
         atomically do
-          unless (null acks) $ modifyTVar' trackerVar (Map.adjust (completeOffsets w.offsets) w.tpKey)
+          -- No-ack (transient write/DLQ failure → routeBatchOutcome []): the chunk's
+          -- offsets won't advance the commit base, yet the poll position has already
+          -- moved past them and librdkafka won't redeliver uncommitted offsets
+          -- in-session — so base pins forever (the 2026-06-25 DLQ commit-starvation
+          -- wedge). Record the lowest un-acked offset for the poll thread to reseek.
+          if null acks
+            then modifyTVar' reseekVar (Map.insertWith min w.tpKey (minimum w.offsets))
+            else modifyTVar' trackerVar (Map.adjust (completeOffsets w.offsets) w.tpKey)
           modifyTVar' inflightVar (subtract w.bytes)
       committer = forever do
         threadDelay 1_000_000
@@ -571,6 +582,17 @@ decoupledLoop appLogger appCtx tp role batchSize clientId fn = do
           $ LogBase.logInfo "kafka.consumer.metrics"
           $ AE.object ["client_id" AE..= clientId, "committed_partitions" AE..= length commits, "tracked_partitions" AE..= tracked, "inflight_bytes" AE..= inflight]
       pollOnce = do
+        -- Self-heal commit-starvation: redeliver chunks workers couldn't ack by
+        -- seeking each partition back to its recorded base, and reset that
+        -- partition's tracker (base ← reseek offset, ahead cleared) so the
+        -- re-fetched offsets re-fill cleanly. Seeking backward only — never past
+        -- the committed base — so this never skips (loss); worst case redelivers
+        -- already-processed offsets (idempotent downstream).
+        reseeks <- atomically $ swapTVar reseekVar Map.empty
+        unless (Map.null reseeks) do
+          KE.seekPartitions [K.TopicPartition (K.TopicName t) p (K.PartitionOffset o) | ((t, p), o) <- Map.toList reseeks] (K.Timeout 5000)
+          atomically $ modifyTVar' trackerVar \tk -> foldl' (\m (k, o) -> Map.insert k (PartProgress o mempty) m) tk (Map.toList reseeks)
+          LogBase.logInfo "kafka.consumer.reseek" $ AE.object ["client_id" AE..= clientId, "partitions" AE..= Map.size reseeks]
         (inflight, paused) <- atomically $ (,) <$> readTVar inflightVar <*> readTVar pausedVar
         when (inflight >= highWaterBytes && not paused) do
           ps <- assigned

--- a/src/Pkg/Queue.hs
+++ b/src/Pkg/Queue.hs
@@ -558,6 +558,10 @@ decoupledLoop appLogger appCtx tp role batchSize clientId fn = do
             let live = S.fromList [(t.unTopicName, p) | (t, p) <- asg]
             modifyTVar' trackerVar (Map.filterWithKey \k _ -> S.member k live)
             modifyTVar' committedVar (Map.filterWithKey \k _ -> S.member k live)
+            -- Drop reseeks for revoked partitions too, else the poll thread would
+            -- seek a partition this consumer no longer owns and re-seed a stale
+            -- tracker entry that the prune above can never reach again.
+            modifyTVar' reseekVar (Map.filterWithKey \k _ -> S.member k live)
           (cs,,) . Map.size <$> readTVar trackerVar <*> readTVar inflightVar
         -- Flush-before-commit durability gate: drain the shared producer
         -- (KafkaProducer enqueues are async — linger.ms/batching) so every DLQ
@@ -591,7 +595,7 @@ decoupledLoop appLogger appCtx tp role batchSize clientId fn = do
         reseeks <- atomically $ swapTVar reseekVar Map.empty
         unless (Map.null reseeks) do
           KE.seekPartitions [K.TopicPartition (K.TopicName t) p (K.PartitionOffset o) | ((t, p), o) <- Map.toList reseeks] (K.Timeout 5000)
-          atomically $ modifyTVar' trackerVar \tk -> foldl' (\m (k, o) -> Map.insert k (PartProgress o mempty) m) tk (Map.toList reseeks)
+          atomically $ modifyTVar' trackerVar \tk -> Map.map (`PartProgress` mempty) reseeks <> tk -- left-biased: reseek bases override
           LogBase.logInfo "kafka.consumer.reseek" $ AE.object ["client_id" AE..= clientId, "partitions" AE..= Map.size reseeks]
         (inflight, paused) <- atomically $ (,) <$> readTVar inflightVar <*> readTVar pausedVar
         when (inflight >= highWaterBytes && not paused) do

--- a/test/integration/Pkg/KafkaConsumerSpec.hs
+++ b/test/integration/Pkg/KafkaConsumerSpec.hs
@@ -19,6 +19,7 @@ import Test.Hspec
 import UnliftIO.Async (race_)
 import UnliftIO.Concurrent (threadDelay)
 
+
 -- | An in-memory Kafka shared by the producer and consumer interpreters: each
 -- topic is an append-only log (offset = index). The mock producer enqueues to a
 -- @pending@ buffer (modelling librdkafka's async send queue) and only
@@ -29,12 +30,14 @@ import UnliftIO.Concurrent (threadDelay)
 data Broker = Broker
   { logs :: Map Text [K.ConsumerRecord (Maybe ByteString) (Maybe ByteString)]
   , pending :: [(Text, Maybe ByteString, K.Headers)] -- produced, awaiting FlushProducer
-  , cursor :: Map Text Int -- next index the consumer reads per topic
+  , cursor :: Map (Text, Int) Int -- next index the consumer reads per (topic, partition)
   , committed :: Map (Text, Int) Int64
   }
 
+
 emptyBroker :: Broker
 emptyBroker = Broker mempty mempty mempty mempty
+
 
 -- Append a record to a topic's log, assigning the next sequential offset.
 appendRecord :: Text -> Maybe ByteString -> K.Headers -> Broker -> Broker
@@ -42,20 +45,22 @@ appendRecord topic val hdrs b =
   let existing = Map.findWithDefault [] topic b.logs
       off = fromIntegral (length existing)
       cr = K.ConsumerRecord (K.TopicName topic) (K.PartitionId 0) (K.Offset off) K.NoTimestamp hdrs Nothing val
-   in b {logs = Map.insert topic (existing <> [cr]) b.logs}
+   in b{logs = Map.insert topic (existing <> [cr]) b.logs}
 
-runMockProducer :: (IOE :> es) => TVar Broker -> Eff (KafkaProducer ': es) a -> Eff es a
+
+runMockProducer :: IOE :> es => TVar Broker -> Eff (KafkaProducer ': es) a -> Eff es a
 runMockProducer bVar = interpret \_ -> \case
-  ProduceMessage KP.ProducerRecord {KP.prTopic = topic, KP.prValue = val, KP.prHeaders = hdrs} ->
-    atomically $ modifyTVar' bVar \b -> b {pending = b.pending <> [(topic.unTopicName, val, hdrs)]}
+  ProduceMessage KP.ProducerRecord{KP.prTopic = topic, KP.prValue = val, KP.prHeaders = hdrs} ->
+    atomically $ modifyTVar' bVar \b -> b{pending = b.pending <> [(topic.unTopicName, val, hdrs)]}
   -- Flush makes every buffered record durable on its topic log (offset order).
   FlushProducer ->
-    atomically $ modifyTVar' bVar \b -> (foldl' (\acc (t, v, h) -> appendRecord t v h acc) b b.pending) {pending = []}
+    atomically $ modifyTVar' bVar \b -> (foldl' (\acc (t, v, h) -> appendRecord t v h acc) b b.pending){pending = []}
   _ -> error "runMockProducer: unexpected producer op"
+
 
 -- The consumer reads from the subscribed @topics@, advancing each topic's cursor
 -- (offset order), and commit records the high-water offset per (topic, 0).
-runMockConsumer :: (IOE :> es) => [Text] -> TVar Broker -> Eff (KafkaConsumer ': es) a -> Eff es a
+runMockConsumer :: IOE :> es => [Text] -> TVar Broker -> Eff (KafkaConsumer ': es) a -> Eff es a
 runMockConsumer topics bVar = interpret \_ -> \case
   PollMessageBatch _ (K.BatchSize n) -> do
     batch <- atomically do
@@ -63,19 +68,19 @@ runMockConsumer topics bVar = interpret \_ -> \case
       let pull (acc, st) topic
             | length acc >= n = (acc, st)
             | otherwise =
-                let c = Map.findWithDefault 0 topic st
+                let c = Map.findWithDefault 0 (topic, 0) st -- records are all partition 0 (appendRecord)
                     taken = take (n - length acc) (drop c (Map.findWithDefault [] topic b.logs))
-                 in (acc <> taken, Map.insert topic (c + length taken) st)
+                 in (acc <> taken, Map.insert (topic, 0) (c + length taken) st)
           (recs, cursor') = foldl' pull ([], b.cursor) topics
-      writeTVar bVar b {cursor = cursor'}
+      writeTVar bVar b{cursor = cursor'}
       pure recs
     when (null batch) (threadDelay 20_000) -- don't busy-spin once drained
     pure (map Right batch)
-  CommitPartitionsOffsets _ tps -> atomically $ modifyTVar' bVar \b -> b {committed = foldl' recordTp b.committed tps}
+  CommitPartitionsOffsets _ tps -> atomically $ modifyTVar' bVar \b -> b{committed = foldl' recordTp b.committed tps}
   -- Seek rewinds the per-topic read cursor so the offsets from the target are
   -- re-delivered on the next poll — models librdkafka redelivering uncommitted
   -- offsets only after a seek (never mid-session otherwise).
-  SeekPartitions tps _ -> atomically $ modifyTVar' bVar \b -> b {cursor = foldl' seekCursor b.cursor tps}
+  SeekPartitions tps _ -> atomically $ modifyTVar' bVar \b -> b{cursor = foldl' seekCursor b.cursor tps}
   PausePartitions _ -> pass
   ResumePartitions _ -> pass
   Assignment -> pure $ Map.fromList [(K.TopicName t, [K.PartitionId 0]) | t <- topics]
@@ -83,8 +88,9 @@ runMockConsumer topics bVar = interpret \_ -> \case
   where
     recordTp m (K.TopicPartition (K.TopicName t) (K.PartitionId p) (K.PartitionOffset o)) = Map.insertWith max (t, p) o m
     recordTp m _ = m
-    seekCursor c (K.TopicPartition (K.TopicName t) _ (K.PartitionOffset o)) = Map.insert t (fromIntegral o) c
+    seekCursor c (K.TopicPartition (K.TopicName t) (K.PartitionId p) (K.PartitionOffset o)) = Map.insert (t, fromIntegral p) (fromIntegral o) c
     seekCursor c _ = c
+
 
 -- Run decoupledLoop against the in-memory broker until `done` fires, with a hard
 -- timeout backstop. Returns the final broker state.
@@ -107,9 +113,11 @@ drive tr bVar topics role fn done = do
   void $ timeout 15_000_000 $ race_ loop (atomically done)
   readTVarIO bVar
 
+
 seedTopic :: TVar Broker -> Text -> [Int64] -> IO ()
 seedTopic bVar topic offs =
   atomically $ modifyTVar' bVar \b -> foldl' (\acc o -> appendRecord topic (Just (encodeUtf8 (show o))) (K.headersFromList []) acc) b offs
+
 
 spec :: Spec
 spec = aroundAll withTestResources $ describe "Kafka decoupledLoop (in-memory broker)" do
@@ -127,7 +135,6 @@ spec = aroundAll withTestResources $ describe "Kafka decoupledLoop (in-memory br
     received <- readTVarIO receivedVar
     sort received `shouldBe` sort (map (encodeUtf8 . show) [0 .. 4 :: Int64]) -- each record processed once
     Map.lookup ("otlp_logs", 0) b.committed `shouldBe` Just 5 -- watermark = max offset + 1
-
   it "flushes DLQ publishes durable before committing the source offset (no commit-before-send loss window)" \tr -> do
     bVar <- newTVarIO emptyBroker
     seedTopic bVar "otlp_logs" [0 .. 4]
@@ -170,3 +177,7 @@ spec = aroundAll withTestResources $ describe "Kafka decoupledLoop (in-memory br
         s <- readTVar bVar
         check (Map.lookup ("otlp_logs", 0) s.committed == Just 5)
     Map.lookup ("otlp_logs", 0) b.committed `shouldBe` Just 5 -- reseek redelivered the chunk → watermark recovered
+    -- Prove the retry actually fired (≥2 calls): without it the watermark would be
+    -- unreachable. Guards against the no-ack branch being silently removed (which
+    -- would ack on the first call and pass the assertion above trivially).
+    readTVarIO attemptVar >>= (`shouldSatisfy` (>= 2))

--- a/test/integration/Pkg/KafkaConsumerSpec.hs
+++ b/test/integration/Pkg/KafkaConsumerSpec.hs
@@ -1,6 +1,6 @@
 module Pkg.KafkaConsumerSpec (spec) where
 
-import Control.Concurrent.STM (check)
+import Control.Concurrent.STM (check, stateTVar)
 import Data.Map.Strict qualified as Map
 import Effectful (Eff, IOE, (:>))
 import Effectful.Dispatch.Dynamic (interpret)
@@ -72,6 +72,10 @@ runMockConsumer topics bVar = interpret \_ -> \case
     when (null batch) (threadDelay 20_000) -- don't busy-spin once drained
     pure (map Right batch)
   CommitPartitionsOffsets _ tps -> atomically $ modifyTVar' bVar \b -> b {committed = foldl' recordTp b.committed tps}
+  -- Seek rewinds the per-topic read cursor so the offsets from the target are
+  -- re-delivered on the next poll — models librdkafka redelivering uncommitted
+  -- offsets only after a seek (never mid-session otherwise).
+  SeekPartitions tps _ -> atomically $ modifyTVar' bVar \b -> b {cursor = foldl' seekCursor b.cursor tps}
   PausePartitions _ -> pass
   ResumePartitions _ -> pass
   Assignment -> pure $ Map.fromList [(K.TopicName t, [K.PartitionId 0]) | t <- topics]
@@ -79,6 +83,8 @@ runMockConsumer topics bVar = interpret \_ -> \case
   where
     recordTp m (K.TopicPartition (K.TopicName t) (K.PartitionId p) (K.PartitionOffset o)) = Map.insertWith max (t, p) o m
     recordTp m _ = m
+    seekCursor c (K.TopicPartition (K.TopicName t) _ (K.PartitionOffset o)) = Map.insert t (fromIntegral o) c
+    seekCursor c _ = c
 
 -- Run decoupledLoop against the in-memory broker until `done` fires, with a hard
 -- timeout backstop. Returns the final broker state.
@@ -143,3 +149,24 @@ spec = aroundAll withTestResources $ describe "Kafka decoupledLoop (in-memory br
     let hdrs = foldMap (K.headersToList . (.crHeaders)) (take 1 dlq)
     (snd <$> find ((== "monoscope-attempt-count") . fst) hdrs) `shouldBe` Just "1"
     Map.lookup ("otlp_logs", 0) b.committed `shouldBe` Just 5 -- DLQ accepted → offsets advanced
+
+  -- Regression guard for the 2026-06-25 DLQ commit-starvation wedge: a chunk that
+  -- returns no acks (transient write failure → routeBatchOutcome []) pins the
+  -- commit base while the poll cursor advances past it. librdkafka never
+  -- redelivers uncommitted offsets in-session, so without a self-heal the base
+  -- pins forever (the whole 7.6M-lag stall). The fix seeks the partition back to
+  -- the un-acked base so it is re-fetched and retried once the failure clears.
+  it "reseeks and recommits a chunk whose first processing returned no acks (commit-starvation self-heal)" \tr -> do
+    bVar <- newTVarIO emptyBroker
+    seedTopic bVar "otlp_logs" [0 .. 4]
+    attemptVar <- newTVarIO (0 :: Int)
+    -- First processing of the chunk no-acks (models a transient TF outage);
+    -- once healed, the redelivered chunk acks and the base advances.
+    let testFn tuples _ = do
+          n <- atomically $ stateTVar attemptVar \k -> (k, k + 1)
+          pure $ Right $ if n == 0 then ([], []) else (map fst tuples, [])
+    b <-
+      drive tr bVar ["otlp_logs"] Queue.KafkaPrimary testFn $ do
+        s <- readTVar bVar
+        check (Map.lookup ("otlp_logs", 0) s.committed == Just 5)
+    Map.lookup ("otlp_logs", 0) b.committed `shouldBe` Just 5 -- reseek redelivered the chunk → watermark recovered


### PR DESCRIPTION
## Problem

A consumer chunk that returns no acks (transient write/DLQ-publish failure → `routeBatchOutcome []`) does **not** advance the commit base, but the poll position has already moved past it. librdkafka never redelivers uncommitted offsets in-session, so the base pins forever while the consumer forward-processes to log-end and goes idle.

This is the **2026-06-25 `apitoolkit_eu_dlq` wedge**: group Stable, but committed offsets on the big partitions frozen (~7.6M lag). Data is durable (forward-written to TimeFusion) — only the offset commit is stuck — so restarts give a brief burst then re-freeze at the next no-ack chunk.

## Fix

`decoupledLoop` now self-heals commit-starvation:
- On no-ack, the worker records the chunk's lowest offset in `reseekVar`.
- The poll thread (which owns all Kafka ops) `seekPartitions` each such partition **backward** to that offset and resets its tracker (`PartProgress o mempty`) so the un-acked chunk is redelivered and retried once the transient failure clears.

Seeks **backward only** (never past the committed base) → can never skip/lose. Worst case redelivers already-processed offsets, which is idempotent downstream.

## Test

Regression test in `KafkaConsumerSpec` ("commit-starvation self-heal"): a chunk that no-acks on first processing then acks. Without the fix the base pins and the watermark never recovers (drive times out); with it the reseek redelivers and the commit advances. Adds `SeekPartitions` to the in-memory broker mock.

> ⚠️ **Not validated locally** — the integration harness couldn't run on the author's machine: tmp-postgres lacks `timescaledb_toolkit` (can't build it; CLT too outdated), and an external timescaledb-ha DB deadlocks even the pre-existing baseline kafka test (`drains a poll batch`). **Relying on CI to run the new test.**

## Follow-up (not in this PR)

Drop `group.instance.id` (dynamic membership) to stop restart-orphaning of partitions — separate concern, changes rebalance behavior, deserves its own PR.