### PR TITLE
fix(ci): add base to unit-tests build-depends (fixes GHC-87110 build break)

### DIFF
--- a/monoscope.cabal
+++ b/monoscope.cabal
@@ -1162,6 +1162,7 @@ test-suite unit-tests
       aeson
     , aeson-qq
     , async
+    , base
     , containers
     , effectful-core
     , extra


### PR DESCRIPTION
## Problem

Every **Build and Test** run has failed — on every PR and the now-merged ones (`#440`, `#442`) — compiling `test/unit/System/ServerSpec.hs` (added in #440):

```
test/unit/System/ServerSpec.hs:3:1: error: [GHC-87110]
    Could not load module 'Control.Concurrent'.
    It is a member of the hidden package 'base-4.21.0.0'.
    Perhaps you need to add 'base' to the build-depends in your .cabal file.
```

`ServerSpec` imports `Control.Concurrent` / `Control.Exception` **directly** from base; every other `test/unit` module goes through `relude`, so the `unit-tests` suite never listed `base`. With `NoImplicitPrelude` those direct imports can't resolve → the suite fails to compile. The error line varied between runs (`Control.Exception` vs `Control.Concurrent`) — just whichever import GHC reached first, **not** a parallel-build flake.

## Fix

Add `base` to the `unit-tests` test-suite `build-depends`. Verified locally: `cabal build unit-tests` now compiles `ServerSpec` and links clean.

## Validation

This PR's own **Build and Test** should go green — the first green in recent history.