### PR TITLE
fix(ingest): deterministic content-derived row id so DLQ replay is idempotent

### DIFF
--- a/monoscope.cabal
+++ b/monoscope.cabal
@@ -1123,6 +1123,7 @@ test-suite unit-tests
       BackgroundJobs.SpikeDetectionSpec
       Data.Effectful.HasqlSpec
       Data.Effectful.NotifySpec
+      Models.Telemetry.DeterministicIdSpec
       Pkg.DrainSpec
       Pkg.Parser.ExprSpec
       Pkg.ParserSpec

--- a/src/Models/Telemetry/Telemetry.hs
+++ b/src/Models/Telemetry/Telemetry.hs
@@ -861,8 +861,9 @@ deterministicOtelId r = UUID.toText $ UUIDv5.generateNamed otelIdNamespace $ L.i
     enc :: AE.ToJSON a => Maybe a -> BS.ByteString
     enc = maybe "" (BSL.toStrict . AE.encode)
     keyParts = case r.context >>= (.span_id) of
-      Just sid | not (T.null sid) ->
-        [enc (Just r.project_id), enc (r.context >>= (.trace_id)), enc (Just sid)]
+      Just sid
+        | not (T.null sid) ->
+            [enc (Just r.project_id), enc (r.context >>= (.trace_id)), enc (Just sid)]
       _ ->
         [ enc (Just r.project_id)
         , enc (unAesonTextMaybe r.body)

--- a/src/Models/Telemetry/Telemetry.hs
+++ b/src/Models/Telemetry/Telemetry.hs
@@ -86,6 +86,7 @@ import Data.Aeson.Key qualified as AEK
 import Data.Aeson.KeyMap qualified as KEM
 import Data.ByteString qualified as BS
 import Data.ByteString.Base16 qualified as B16
+import Data.ByteString.Lazy qualified as BSL
 import Data.Default (Default (..))
 import Data.Effectful.Hasql (Hasql)
 import Data.Effectful.Hasql qualified as Hasql
@@ -104,6 +105,7 @@ import Data.These qualified as These
 import Data.Time (UTCTime)
 import Data.Time.Clock (addUTCTime, utctDay)
 import Data.UUID qualified as UUID
+import Data.UUID.Quasi (uuid)
 import Data.UUID.V5 qualified as UUIDv5
 import Data.Vector qualified as V
 import Data.Vector.Split qualified as VS
@@ -831,7 +833,7 @@ bulkInsertMetrics metrics = checkpoint "bulkInsertMetrics" $ unless (V.null metr
 -- | Fixed namespace for the content-derived (v5) row ids below. Arbitrary but
 -- stable — changing it re-ids every row, so don't.
 otelIdNamespace :: UUID.UUID
-otelIdNamespace = fromMaybe UUID.nil (UUID.fromString "6f1a7c30-9b2d-5e84-8a3f-0c1d2e3f4a5b")
+otelIdNamespace = [uuid|6f1a7c30-9b2d-5e84-8a3f-0c1d2e3f4a5b|]
 
 
 -- | Content-derived UUID (v5) for a row's `id`. Reprocessing a dead-letter
@@ -851,13 +853,13 @@ otelIdNamespace = fromMaybe UUID.nil (UUID.fromString "6f1a7c30-9b2d-5e84-8a3f-0
 -- fields (@observed_timestamp@/@start_time@ → currentTime) which aren't stable
 -- across reprocessing.
 deterministicOtelId :: OtelLogsAndSpans -> Text
-deterministicOtelId r = UUID.toText $ UUIDv5.generateNamed otelIdNamespace $ BS.unpack $ encodeUtf8 $ T.intercalate "\US" keyParts
+deterministicOtelId r = UUID.toText $ UUIDv5.generateNamed otelIdNamespace $ BS.unpack $ BS.intercalate "\US" keyParts
   where
-    enc :: AE.ToJSON a => Maybe a -> Text
-    enc = maybe "" (decodeUtf8 . AE.encode)
+    enc :: AE.ToJSON a => Maybe a -> BS.ByteString
+    enc = maybe "" (BSL.toStrict . AE.encode)
     keyParts = case r.context >>= (.span_id) of
-      Just sid | not (T.null sid) -> [r.project_id, fromMaybe "" (r.context >>= (.trace_id)), sid]
-      _ -> [r.project_id, enc (unAesonTextMaybe r.body), fromMaybe "" r.name, enc r.severity, enc (unAesonTextMaybe r.attributes), enc (unAesonTextMaybe r.resource)]
+      Just sid | not (T.null sid) -> [encodeUtf8 r.project_id, encodeUtf8 $ fromMaybe "" (r.context >>= (.trace_id)), encodeUtf8 sid]
+      _ -> [encodeUtf8 r.project_id, enc (unAesonTextMaybe r.body), encodeUtf8 $ fromMaybe "" r.name, enc r.severity, enc (unAesonTextMaybe r.attributes), enc (unAesonTextMaybe r.resource)]
 
 
 -- | Assign every row a deterministic, content-derived `id` (see

--- a/src/Models/Telemetry/Telemetry.hs
+++ b/src/Models/Telemetry/Telemetry.hs
@@ -833,6 +833,7 @@ bulkInsertMetrics metrics = checkpoint "bulkInsertMetrics" $ unless (V.null metr
 otelIdNamespace :: UUID.UUID
 otelIdNamespace = fromMaybe UUID.nil (UUID.fromString "6f1a7c30-9b2d-5e84-8a3f-0c1d2e3f4a5b")
 
+
 -- | Content-derived UUID (v5) for a row's `id`. Reprocessing a dead-letter
 -- message re-parses the original payload and re-derives the SAME id it would
 -- have had on first ingest, so TF's @(id, timestamp)@ dedup (flush + read-side
@@ -857,6 +858,7 @@ deterministicOtelId r = UUID.toText $ UUIDv5.generateNamed otelIdNamespace $ BS.
     keyParts = case r.context >>= (.span_id) of
       Just sid | not (T.null sid) -> [r.project_id, fromMaybe "" (r.context >>= (.trace_id)), sid]
       _ -> [r.project_id, enc (unAesonTextMaybe r.body), fromMaybe "" r.name, enc r.severity, enc (unAesonTextMaybe r.attributes), enc (unAesonTextMaybe r.resource)]
+
 
 -- | Assign every row a deterministic, content-derived `id` (see
 -- 'deterministicOtelId'). Pure and idempotent: same input record ⇒ same id, so

--- a/src/Models/Telemetry/Telemetry.hs
+++ b/src/Models/Telemetry/Telemetry.hs
@@ -84,11 +84,11 @@ import Control.Lens ((.~))
 import Data.Aeson qualified as AE
 import Data.Aeson.Key qualified as AEK
 import Data.Aeson.KeyMap qualified as KEM
+import Data.ByteString qualified as BS
 import Data.ByteString.Base16 qualified as B16
 import Data.Default (Default (..))
 import Data.Effectful.Hasql (Hasql)
 import Data.Effectful.Hasql qualified as Hasql
-import Data.Effectful.UUID (UUIDEff, genUUID)
 import Data.Generics.Labels ()
 import Data.HashMap.Strict qualified as HM
 import Data.HashSet qualified as HS
@@ -104,6 +104,7 @@ import Data.These qualified as These
 import Data.Time (UTCTime)
 import Data.Time.Clock (addUTCTime, utctDay)
 import Data.UUID qualified as UUID
+import Data.UUID.V5 qualified as UUIDv5
 import Data.Vector qualified as V
 import Data.Vector.Split qualified as VS
 import Database.PostgreSQL.Simple.FromField (Conversion, FromField (..))
@@ -827,12 +828,44 @@ bulkInsertMetrics metrics = checkpoint "bulkInsertMetrics" $ unless (V.null metr
       [HI.sql|(#{pid}, #{mName}, #{mType}, #{mUnit}, #{mDesc}, #{svc})|]
 
 
--- | Mint a fresh UUID for every row's `id` field. Call this once at the ingestion
--- call site BEFORE handing the vector to `bulkInsertOtelLogsAndSpansTF`, so the
--- caller holds a vector whose ids match what lands in the DB (needed by the
--- in-process extraction worker hand-off — see plan notes).
-mintOtelLogIds :: UUIDEff :> es => V.Vector OtelLogsAndSpans -> Eff es (V.Vector OtelLogsAndSpans)
-mintOtelLogIds = V.mapM \r -> genUUID <&> \uid -> r & #id .~ UUID.toText uid
+-- | Fixed namespace for the content-derived (v5) row ids below. Arbitrary but
+-- stable — changing it re-ids every row, so don't.
+otelIdNamespace :: UUID.UUID
+otelIdNamespace = fromMaybe UUID.nil (UUID.fromString "6f1a7c30-9b2d-5e84-8a3f-0c1d2e3f4a5b")
+
+-- | Content-derived UUID (v5) for a row's `id`. Reprocessing a dead-letter
+-- message re-parses the original payload and re-derives the SAME id it would
+-- have had on first ingest, so TF's @(id, timestamp)@ dedup (flush + read-side
+-- row_number) collapses the replay instead of appending a fresh random row —
+-- the source of the 06-19 duplicate pile-up. Random v4 (the old behaviour)
+-- defeated that dedup because every replay produced a new id.
+--
+-- Identity: spans key on the OTel-unique @(project_id, trace_id, span_id)@,
+-- matching TF's "same span id at the same timestamp collapses retries" intent
+-- regardless of attribute drift; logs (no span_id) key on stable content
+-- @(project_id, body, name, severity, attributes, resource)@ so distinct logs
+-- that merely share a timestamp stay separate while true repeats collapse.
+-- Deliberately excludes @timestamp@ (it is the *other* dedup key, so it
+-- distinguishes same-content/different-time events) and the parse-time fallback
+-- fields (@observed_timestamp@/@start_time@ → currentTime) which aren't stable
+-- across reprocessing.
+deterministicOtelId :: OtelLogsAndSpans -> Text
+deterministicOtelId r = UUID.toText $ UUIDv5.generateNamed otelIdNamespace $ BS.unpack $ encodeUtf8 $ T.intercalate "\US" keyParts
+  where
+    enc :: AE.ToJSON a => Maybe a -> Text
+    enc = maybe "" (decodeUtf8 . AE.encode)
+    keyParts = case r.context >>= (.span_id) of
+      Just sid | not (T.null sid) -> [r.project_id, fromMaybe "" (r.context >>= (.trace_id)), sid]
+      _ -> [r.project_id, enc (unAesonTextMaybe r.body), fromMaybe "" r.name, enc r.severity, enc (unAesonTextMaybe r.attributes), enc (unAesonTextMaybe r.resource)]
+
+-- | Assign every row a deterministic, content-derived `id` (see
+-- 'deterministicOtelId'). Pure and idempotent: same input record ⇒ same id, so
+-- the dead-letter replay path lands ids that dedup against the original ingest.
+-- Call once at the ingestion call site BEFORE 'bulkInsertOtelLogsAndSpansTF' so
+-- the caller's vector ids match what lands in the DB (the extraction-worker
+-- hand-off relies on this).
+mintOtelLogIds :: V.Vector OtelLogsAndSpans -> V.Vector OtelLogsAndSpans
+mintOtelLogIds = V.map \r -> r & #id .~ deterministicOtelId r
 
 
 -- | This = PG failed; That = TF failed; These = both. Both stores are mandatory
@@ -1841,13 +1874,13 @@ mkSystemLog (UUIDId pid) eventName sev bodyMsg attrs duration ts =
 
 
 insertSystemLog
-  :: (Concurrent :> es, Hasql :> es, IOE :> es, Ki.StructuredConcurrency :> es, Labeled "timefusion" Hasql :> es, Log :> es, UUIDEff :> es)
+  :: (Concurrent :> es, Hasql :> es, IOE :> es, Ki.StructuredConcurrency :> es, Labeled "timefusion" Hasql :> es, Log :> es)
   => Bool
   -- ^ enableTimefusionWrites
   -> OtelLogsAndSpans
   -> Eff es ()
 insertSystemLog enableTf otelLog = do
-  minted <- mintOtelLogIds (V.singleton otelLog)
+  let minted = mintOtelLogIds (V.singleton otelLog)
   -- System logs are best-effort. The inner write logs its own failure via
   -- logAttention; surface a higher-level "system log dropped" so an incident
   -- triager investigating the original event can see that its trail was lost.

--- a/src/Models/Telemetry/Telemetry.hs
+++ b/src/Models/Telemetry/Telemetry.hs
@@ -93,7 +93,7 @@ import Data.Effectful.Hasql qualified as Hasql
 import Data.Generics.Labels ()
 import Data.HashMap.Strict qualified as HM
 import Data.HashSet qualified as HS
-import Data.List qualified as L (groupBy)
+import Data.List qualified as L (groupBy, intercalate)
 import Data.List.Extra (chunksOf)
 import Data.List.NonEmpty qualified as NE
 import Data.Map qualified as Map
@@ -853,13 +853,24 @@ otelIdNamespace = [uuid|6f1a7c30-9b2d-5e84-8a3f-0c1d2e3f4a5b|]
 -- fields (@observed_timestamp@/@start_time@ → currentTime) which aren't stable
 -- across reprocessing.
 deterministicOtelId :: OtelLogsAndSpans -> Text
-deterministicOtelId r = UUID.toText $ UUIDv5.generateNamed otelIdNamespace $ BS.unpack $ BS.intercalate "\US" keyParts
+deterministicOtelId r = UUID.toText $ UUIDv5.generateNamed otelIdNamespace $ L.intercalate [0x1f] (map BS.unpack keyParts)
   where
+    -- JSON-encode every part (incl. project_id/name) so the 0x1f delimiter can
+    -- never appear inside a part (Aeson escapes it). Raw encodeUtf8 would let two
+    -- distinct records collide on the same key via separator injection.
     enc :: AE.ToJSON a => Maybe a -> BS.ByteString
     enc = maybe "" (BSL.toStrict . AE.encode)
     keyParts = case r.context >>= (.span_id) of
-      Just sid | not (T.null sid) -> [encodeUtf8 r.project_id, encodeUtf8 $ fromMaybe "" (r.context >>= (.trace_id)), encodeUtf8 sid]
-      _ -> [encodeUtf8 r.project_id, enc (unAesonTextMaybe r.body), encodeUtf8 $ fromMaybe "" r.name, enc r.severity, enc (unAesonTextMaybe r.attributes), enc (unAesonTextMaybe r.resource)]
+      Just sid | not (T.null sid) ->
+        [enc (Just r.project_id), enc (r.context >>= (.trace_id)), enc (Just sid)]
+      _ ->
+        [ enc (Just r.project_id)
+        , enc (unAesonTextMaybe r.body)
+        , enc r.name
+        , enc r.severity
+        , enc (unAesonTextMaybe r.attributes)
+        , enc (unAesonTextMaybe r.resource)
+        ]
 
 
 -- | Assign every row a deterministic, content-derived `id` (see

--- a/src/Opentelemetry/OtlpServer.hs
+++ b/src/Opentelemetry/OtlpServer.hs
@@ -261,7 +261,6 @@ dualWriteWithPoisonMapping
      , Labeled "timefusion" Hasql.Hasql :> es
      , Log :> es
      , Time.Time :> es
-     
      )
   => AuthContext
   -> Telemetry.WriteTarget

--- a/src/Opentelemetry/OtlpServer.hs
+++ b/src/Opentelemetry/OtlpServer.hs
@@ -34,7 +34,6 @@ import Data.Cache qualified as Cache
 import Data.CaseInsensitive qualified as CI
 import Data.Char (isDigit)
 import Data.Effectful.Hasql qualified as Hasql
-import Data.Effectful.UUID (UUIDEff)
 import Data.HashMap.Strict qualified as HM
 import Data.HashSet qualified as HS
 import Data.List qualified as L
@@ -262,7 +261,7 @@ dualWriteWithPoisonMapping
      , Labeled "timefusion" Hasql.Hasql :> es
      , Log :> es
      , Time.Time :> es
-     , UUIDEff :> es
+     
      )
   => AuthContext
   -> Telemetry.WriteTarget
@@ -277,7 +276,7 @@ dualWriteWithPoisonMapping appCtx target label caches perMsg = do
   let !allRecords = V.concat [rs | (_, _, rs) <- perMsg]
       !perRecordSource = concat [replicate (V.length rs) (ackId, raw) | (ackId, raw, rs) <- perMsg]
   stamped <- stampOrPassthrough appCtx allRecords
-  minted <- Telemetry.mintOtelLogIds stamped
+  let minted = Telemetry.mintOtelLogIds stamped
   -- Guard the 1:1 ordering invariant explicitly: if either upstream step ever
   -- drops or reorders records, silent zipWith misalignment would associate the
   -- wrong (ackId, raw) with a record. Fail loud at the boundary instead.
@@ -338,7 +337,7 @@ throwOnWriteFailure = \case
 -- both stores; poisonMsgs are decode failures whose raw bytes must be DLQ'd
 -- by Pkg.Queue before committing offsets. On dual-write failure, returns
 -- 'Left WriteFailure'. Never throws on write/decode failure.
-processList :: (Concurrent :> es, DB es, Eff.Reader AuthContext :> es, Ki.StructuredConcurrency :> es, Labeled "timefusion" Hasql.Hasql :> es, Log :> es, Time.Time :> es, Tracing :> es, UUIDEff :> es) => [(Text, ByteString)] -> HM.HashMap Text Text -> Eff es (Either Telemetry.WriteFailure ([Text], [Telemetry.PoisonMsg]))
+processList :: (Concurrent :> es, DB es, Eff.Reader AuthContext :> es, Ki.StructuredConcurrency :> es, Labeled "timefusion" Hasql.Hasql :> es, Log :> es, Time.Time :> es, Tracing :> es) => [(Text, ByteString)] -> HM.HashMap Text Text -> Eff es (Either Telemetry.WriteFailure ([Text], [Telemetry.PoisonMsg]))
 processList [] _ = pure (Right ([], []))
 processList msgs !attrs =
   withSpan_ "otlp.process_list" (batchSpanAttrs (length msgs) attrs)
@@ -1483,7 +1482,7 @@ runServer appLogger appCtx tp = do
 
 
 -- | Process trace request with optional API key from gRPC metadata (extracted for testing)
-processTraceRequest :: (Concurrent :> es, DB es, Eff.Reader AuthContext :> es, Ki.StructuredConcurrency :> es, Labeled "timefusion" Hasql.Hasql :> es, Log :> es, Time.Time :> es, UUIDEff :> es) => Maybe Text -> TS.ExportTraceServiceRequest -> Eff es ()
+processTraceRequest :: (Concurrent :> es, DB es, Eff.Reader AuthContext :> es, Ki.StructuredConcurrency :> es, Labeled "timefusion" Hasql.Hasql :> es, Log :> es, Time.Time :> es) => Maybe Text -> TS.ExportTraceServiceRequest -> Eff es ()
 processTraceRequest metadataApiKey req =
   let !resourceSpans = V.fromList $ req ^. TSF.resourceSpans
    in processSignalRequest "Traces" "traces" "Received trace export request" "spans" "span_count" metadataApiKey (getSpanApiKey resourceSpans) (V.toList $ getSpanAttributeValue "at-project-id" resourceSpans) $ \currentTime projectCaches projectIdsAndKeys ->
@@ -1491,7 +1490,7 @@ processTraceRequest metadataApiKey req =
 
 
 -- | Process logs request with optional API key from gRPC metadata (extracted for testing)
-processLogsRequest :: (Concurrent :> es, DB es, Eff.Reader AuthContext :> es, Ki.StructuredConcurrency :> es, Labeled "timefusion" Hasql.Hasql :> es, Log :> es, Time.Time :> es, UUIDEff :> es) => Maybe Text -> LS.ExportLogsServiceRequest -> Eff es ()
+processLogsRequest :: (Concurrent :> es, DB es, Eff.Reader AuthContext :> es, Ki.StructuredConcurrency :> es, Labeled "timefusion" Hasql.Hasql :> es, Log :> es, Time.Time :> es) => Maybe Text -> LS.ExportLogsServiceRequest -> Eff es ()
 processLogsRequest metadataApiKey req =
   let !resourceLogs = V.fromList $ req ^. PLF.resourceLogs
    in processSignalRequest "Logs" "logs" "Received logs export request" "logs" "log_count" metadataApiKey (getLogApiKey resourceLogs) (V.toList $ getLogAttributeValue "at-project-id" resourceLogs) $ \currentTime projectCaches projectIdsAndKeys ->
@@ -1504,7 +1503,7 @@ processLogsRequest metadataApiKey req =
 -- ("Traces"/"Logs"), @signal@ the checkpoint/span label ("traces"/"logs"), @noun@/@countKey@
 -- the converted/inserted record noun and its log count key ("spans"/"span_count").
 processSignalRequest
-  :: (Concurrent :> es, DB es, Eff.Reader AuthContext :> es, Ki.StructuredConcurrency :> es, Labeled "timefusion" Hasql.Hasql :> es, Log :> es, Time.Time :> es, UUIDEff :> es)
+  :: (Concurrent :> es, DB es, Eff.Reader AuthContext :> es, Ki.StructuredConcurrency :> es, Labeled "timefusion" Hasql.Hasql :> es, Log :> es, Time.Time :> es)
   => Text
   -> Text
   -> Text
@@ -1566,7 +1565,7 @@ processSignalRequest label signal receivedMsg noun countKey metadataApiKey proje
 
   unless (V.null records) do
     stamped <- stampOrPassthrough appCtx records
-    minted <- Telemetry.mintOtelLogIds stamped
+    let minted = Telemetry.mintOtelLogIds stamped
     Telemetry.insertAndHandOff (Telemetry.writeTargetFor appCtx.env.enableTimefusionWrites Nothing) appCtx.extractionWorker projectCaches minted
       >>= throwOnWriteFailure
     Log.logTrace

--- a/test/unit/Models/Telemetry/DeterministicIdSpec.hs
+++ b/test/unit/Models/Telemetry/DeterministicIdSpec.hs
@@ -1,0 +1,67 @@
+module Models.Telemetry.DeterministicIdSpec (spec) where
+
+import Data.Aeson qualified as AE
+import Data.Map.Strict qualified as Map
+import Data.Time (UTCTime (..), fromGregorian, secondsToDiffTime)
+import Data.Vector qualified as V
+import Models.Telemetry.Telemetry (Context (..), OtelLogsAndSpans (..), mintOtelLogIds)
+import Pkg.DeriveUtils (AesonText (..))
+import Relude
+import Test.Hspec
+
+-- Deterministic, content-derived row ids (Telemetry.deterministicOtelId): the
+-- guard against the 06-19 duplicate pile-up — reprocessing a dead-letter message
+-- must re-derive the SAME id so TF's (id, timestamp) dedup collapses it instead
+-- of appending a fresh random row (the old v4 behaviour).
+idOf :: OtelLogsAndSpans -> Text
+idOf r = (V.head (mintOtelLogIds (V.singleton r))).id
+
+t0, t1 :: UTCTime
+t0 = UTCTime (fromGregorian 2026 6 19) (secondsToDiffTime 100)
+t1 = UTCTime (fromGregorian 2026 6 19) (secondsToDiffTime 200)
+
+-- Minimal record; only `id` (always overwritten) and identity-bearing fields matter.
+base :: OtelLogsAndSpans
+base =
+  OtelLogsAndSpans
+    { project_id = "proj-1", id = "", timestamp = t0, observed_timestamp = Nothing, context = Nothing, level = Nothing
+    , severity = Nothing, body = Nothing, attributes = Nothing, resource = Nothing, hashes = Nothing, kind = Nothing
+    , status_code = Nothing, status_message = Nothing, start_time = t0, end_time = Nothing, events = Nothing, links = Nothing
+    , duration = Nothing, name = Nothing, parent_id = Nothing, summary = V.empty, date = t0, errors = Nothing, message_size_bytes = 0
+    }
+
+ctx :: Text -> Text -> Maybe Context
+ctx tr sp = Just (Context (Just tr) (Just sp) Nothing Nothing Nothing)
+
+jsonBody :: Text -> Maybe (AesonText AE.Value)
+jsonBody s = Just (AesonText (AE.String s))
+
+jsonMap :: [(Text, AE.Value)] -> Maybe (AesonText (Map Text AE.Value))
+jsonMap kvs = Just (AesonText (Map.fromList kvs))
+
+spec :: Spec
+spec = describe "deterministic OTel row id" do
+  it "is deterministic: two independently-built identical records get the same id" do
+    idOf base{context = ctx "tr" "sp"} `shouldBe` idOf base{context = ctx "tr" "sp"}
+
+  it "spans key on (project, trace_id, span_id): same span id collapses despite attribute drift" do
+    let a = base{context = ctx "tr" "sp", attributes = jsonMap [("k", AE.Number 1)]}
+        b = base{context = ctx "tr" "sp", attributes = jsonMap [("k", AE.Number 2)]}
+    idOf a `shouldBe` idOf b
+
+  it "different span ids get different ids" do
+    idOf base{context = ctx "tr" "sp1"} `shouldNotBe` idOf base{context = ctx "tr" "sp2"}
+
+  it "excludes timestamp: same identity at a different time keeps the same id (timestamp is the *other* dedup key)" do
+    idOf base{context = ctx "tr" "sp", timestamp = t0} `shouldBe` idOf base{context = ctx "tr" "sp", timestamp = t1}
+
+  it "logs (no span_id) key on content: different body ⇒ different id" do
+    idOf base{body = jsonBody "hello"} `shouldNotBe` idOf base{body = jsonBody "world"}
+
+  it "logs: identical content ⇒ same id" do
+    idOf base{body = jsonBody "hello", name = Just "log.event"} `shouldBe` idOf base{body = jsonBody "hello", name = Just "log.event"}
+
+  it "logs: same body but different resource ⇒ different id (no over-collapse across sources)" do
+    let a = base{body = jsonBody "oom", resource = jsonMap [("host", AE.String "pod-a")]}
+        b = base{body = jsonBody "oom", resource = jsonMap [("host", AE.String "pod-b")]}
+    idOf a `shouldNotBe` idOf b

--- a/test/unit/Models/Telemetry/DeterministicIdSpec.hs
+++ b/test/unit/Models/Telemetry/DeterministicIdSpec.hs
@@ -65,3 +65,9 @@ spec = describe "deterministic OTel row id" do
     let a = base{body = jsonBody "oom", resource = jsonMap [("host", AE.String "pod-a")]}
         b = base{body = jsonBody "oom", resource = jsonMap [("host", AE.String "pod-b")]}
     idOf a `shouldNotBe` idOf b
+
+  -- Parts are joined by a 0x1f delimiter; a raw (unescaped) field containing 0x1f
+  -- could shift the delimiter boundary and collide two distinct records. JSON
+  -- encoding every part escapes 0x1f, keeping boundaries unambiguous.
+  it "separator injection: a field containing the 0x1f delimiter does not collide with a shifted boundary" do
+    idOf base{project_id = "x\x1f", name = Just "y"} `shouldNotBe` idOf base{project_id = "x", name = Just "\x1fy"}


### PR DESCRIPTION
## Problem

`mintOtelLogIds` assigned a fresh **random UUID v4** to every row's `id`. So reprocessing a dead-letter message wrote a brand-new row each time — the root of the 2026-06-19 duplicate pile-up. The just-shipped reseek self-heal (#443) *redelivers* chunks, making reprocessing more frequent, so this matters more now.

TimeFusion already dedups on `(id, timestamp)` — flush-time `dedup_batches`, the today-partition sweep, **and** a read-side `row_number()` rewrite for cross-bucket dupes — but random ids defeated all of it (every replay looked like a new row).

## Fix

Make `id` **content-derived** (deterministic UUID v5), so re-parsing the same payload re-derives the same id and TF collapses the duplicate:

- **Spans** (span_id present): key on the OTel-unique `(project_id, trace_id, span_id)` — matches TF's "same span id at the same timestamp collapses retries" intent, regardless of attribute drift.
- **Logs** (no span_id): key on stable content `(project_id, body, name, severity, attributes, resource)` — so distinct logs that merely share a timestamp stay separate, but a reprocessed identical log collapses.
- **Excludes** `timestamp` (it's the *other* dedup key, so same-content/different-time events stay distinct) and the parse-time fallback fields (`observed_timestamp`/`start_time` → `currentTime`) which aren't stable across reprocessing.

`mintOtelLogIds` becomes pure; `UUIDEff` drops out of the ingest path (`Telemetry.insertSystemLog` + OtlpServer — they used it solely for minting).

## Test

`Models.Telemetry.DeterministicIdSpec` (unit, 7 cases, all green locally): determinism, span-retry collapse despite attribute drift, span/content distinctness, timestamp-exclusion, and **no over-collapse** when only `resource` differs (multi-pod logs stay separate).

## Scope note

This stops **new** duplicates from reprocessing. Pre-existing random-id duplicates (original 06-19 ingest + drain so far) won't retroactively collapse — they'd need a separate dedup/cleanup pass if desired.