### PR TITLE
fix(log-explorer): resolve load-more, live-tail, column, and chart-fe…

### DIFF
--- a/src/Models/Telemetry/Telemetry.hs
+++ b/src/Models/Telemetry/Telemetry.hs
@@ -86,14 +86,13 @@ import Data.Aeson.Key qualified as AEK
 import Data.Aeson.KeyMap qualified as KEM
 import Data.ByteString qualified as BS
 import Data.ByteString.Base16 qualified as B16
-import Data.ByteString.Lazy qualified as BSL
 import Data.Default (Default (..))
 import Data.Effectful.Hasql (Hasql)
 import Data.Effectful.Hasql qualified as Hasql
 import Data.Generics.Labels ()
 import Data.HashMap.Strict qualified as HM
 import Data.HashSet qualified as HS
-import Data.List qualified as L (groupBy, intercalate)
+import Data.List qualified as L (groupBy)
 import Data.List.Extra (chunksOf)
 import Data.List.NonEmpty qualified as NE
 import Data.Map qualified as Map
@@ -853,13 +852,13 @@ otelIdNamespace = [uuid|6f1a7c30-9b2d-5e84-8a3f-0c1d2e3f4a5b|]
 -- fields (@observed_timestamp@/@start_time@ → currentTime) which aren't stable
 -- across reprocessing.
 deterministicOtelId :: OtelLogsAndSpans -> Text
-deterministicOtelId r = UUID.toText $ UUIDv5.generateNamed otelIdNamespace $ L.intercalate [0x1f] (map BS.unpack keyParts)
+deterministicOtelId r = UUID.toText $ UUIDv5.generateNamed otelIdNamespace $ intercalate [0x1f] (map BS.unpack keyParts)
   where
     -- JSON-encode every part (incl. project_id/name) so the 0x1f delimiter can
     -- never appear inside a part (Aeson escapes it). Raw encodeUtf8 would let two
     -- distinct records collide on the same key via separator injection.
     enc :: AE.ToJSON a => Maybe a -> BS.ByteString
-    enc = maybe "" (BSL.toStrict . AE.encode)
+    enc = maybe "" (toStrict . AE.encode)
     keyParts = case r.context >>= (.span_id) of
       Just sid
         | not (T.null sid) ->
@@ -1141,8 +1140,8 @@ bulkInsertOtelLogsAndSpansTF target records = do
       classify pgRes tfRes
     -- Single-leg replay: only the store that originally failed is rewritten, so
     -- the durable leg keeps its single copy.
-    WritePgOnly -> singleLeg "pg" This (\l -> (l, 0)) =<< retryHasqlWrite maxWriteAttempts "pg" (bulkInsertOtelLogsAndSpans records)
-    WriteTfOnly -> singleLeg "tf" That (\l -> (0, l)) =<< retryHasqlWrite maxWriteAttempts "tf" (labeled @"timefusion" @Hasql $ bulkInsertOtelLogsAndSpans records)
+    WritePgOnly -> singleLeg "pg" This (,0) =<< retryHasqlWrite maxWriteAttempts "pg" (bulkInsertOtelLogsAndSpans records)
+    WriteTfOnly -> singleLeg "tf" That (0,) =<< retryHasqlWrite maxWriteAttempts "tf" (labeled @"timefusion" @Hasql $ bulkInsertOtelLogsAndSpans records)
   where
     -- Classify one store's result; @side@ is 'This'/'That' for the written leg,
     -- @losts@ places the under-persist count on that leg ((l,0) for pg, (0,l) for tf).

--- a/src/Pkg/Queue.hs
+++ b/src/Pkg/Queue.hs
@@ -152,11 +152,17 @@ runSharedKafkaProducer appCtx = interpret \_ -> \case
 
 
 -- | One-shot producer for callers not already in a producer scope (web
--- handlers): runs the action against the shared producer and surfaces a
--- KafkaError as @Left@ text. Wraps the producer + error interpreters so callers
--- need no Kafka imports.
+-- handlers): runs the action against the shared producer and surfaces failure as
+-- @Left@ text. Wraps the producer + error interpreters so callers need no Kafka
+-- imports. 'tryAny' is essential: producer init throws an IO 'K.KafkaError'
+-- (e.g. "sasl.username and sasl.password must be set" when Kafka is unconfigured,
+-- or a broker that's down) which 'runErrorNoCallStack' does NOT catch — without
+-- this the handler crashes instead of degrading to a "warning" for the client.
 runSharedProducer :: IOE :> es => AuthContext -> Eff (KE.KafkaProducer ': Error K.KafkaError ': es) a -> Eff es (Either Text a)
-runSharedProducer appCtx act = first (toText . show) <$> runErrorNoCallStack @K.KafkaError (runSharedKafkaProducer appCtx act)
+runSharedProducer appCtx act =
+  tryAny (runErrorNoCallStack @K.KafkaError (runSharedKafkaProducer appCtx act)) <&> \case
+    Left e -> Left (toText (show e)) -- init/enqueue threw (unconfigured/unreachable Kafka)
+    Right r -> first (toText . show) r -- enqueue surfaced KafkaError via the Error effect
 
 
 -- | Shared batch-processing span for both ingest paths: wraps the fn invocation

--- a/src/Pkg/TestUtils.hs
+++ b/src/Pkg/TestUtils.hs
@@ -380,7 +380,8 @@ ensureTemplateDatabase connInfo templateDbName = do
     _ <- Migration.runMigration templateConn Migration.defaultOptions $ MigrationDirectory migrationsDirr
     -- Nil user as sudo + demo project + test API key.
     _ <-
-      execute templateConn
+      execute
+        templateConn
         [sql| UPDATE users.users SET is_sudo = true WHERE id = '00000000-0000-0000-0000-000000000000';
 
               INSERT INTO projects.projects (id, title, payment_plan, active, deleted_at, weekly_notif, daily_notif)
@@ -390,7 +391,8 @@ ensureTemplateDatabase connInfo templateDbName = do
               INSERT into projects.project_api_keys (active, project_id, title, key_prefix)
               SELECT True, '00000000-0000-0000-0000-000000000000', 'test', 'z6YeJcRJNH0zy9JOg6ZsQzxM9GHBHdSeu+7ugOpZ9jtR94qV'
               WHERE NOT EXISTS (SELECT 1 FROM projects.project_api_keys WHERE key_prefix = 'z6YeJcRJNH0zy9JOg6ZsQzxM9GHBHdSeu+7ugOpZ9jtR94qV');
-          |] ()
+          |]
+        ()
     close templateConn
 
     -- Stamp the checksum (escape quotes defensively) then lock: template + no connections.

--- a/src/Pkg/TestUtils.hs
+++ b/src/Pkg/TestUtils.hs
@@ -106,7 +106,7 @@ import Data.UUID qualified as UUID
 import Data.UUID.V4 (nextRandom)
 import Data.Vector qualified as V
 import Data.Version (makeVersion)
-import Database.PostgreSQL.Simple (ConnectInfo (..), Connection, Only (..), close, connect, connectPostgreSQL, defaultConnectInfo, execute, execute_)
+import Database.PostgreSQL.Simple (ConnectInfo (..), Connection, Only (..), close, connect, connectPostgreSQL, defaultConnectInfo, execute)
 import Database.PostgreSQL.Simple qualified as PGS
 import Database.PostgreSQL.Simple.Migration (MigrationCommand (MigrationDirectory, MigrationInitialization))
 import Database.PostgreSQL.Simple.Migration qualified as Migration
@@ -339,135 +339,63 @@ withExternalDBSetup f = do
     close masterConn'
 
 
--- Helper function to ensure template database exists and is up to date
+-- | Ensure the template database exists and matches the current migrations.
+--
+-- The template is kept @ALLOW_CONNECTIONS false@ (exactly like Postgres's own
+-- @template0@). This is the key to fast tests: TimescaleDB's background-worker
+-- scheduler periodically attaches to every DB carrying the extension, and
+-- @CREATE DATABASE ... TEMPLATE@ fails outright if *any* session is connected to
+-- the source. With connections disabled the scheduler can't attach, so each
+-- spec's @CREATE DATABASE@ goes from ~5s of terminate/retry churn to ~0.1s.
+--
+-- The migration fingerprint is stamped as the template's DB comment (not a table
+-- inside it) so cache-invalidation can be checked from the master connection
+-- without ever connecting to the locked-down template.
 ensureTemplateDatabase :: (String -> ConnectInfo) -> Text -> IO ()
 ensureTemplateDatabase connInfo templateDbName = do
   masterConn <- connect $ connInfo "postgres"
+  let alter clause = void $ execute masterConn (Query $ encodeUtf8 $ "ALTER DATABASE " <> templateDbName <> " WITH " <> clause) ()
 
-  -- Check if template database exists
-  [Only exists] <-
-    PGS.query
-      masterConn
-      "SELECT EXISTS(SELECT 1 FROM pg_database WHERE datname = ?)"
-      (Only templateDbName)
-
-  -- Get current migration directory checksum for cache invalidation
-  -- Use per-file sizes (sorted by name) so content changes that preserve total size are detected
+  -- Per-file sizes (sorted by name) so content changes that preserve total size still invalidate.
   files <- sort <$> listDirectory migrationsDirr
   sizes <- mapM (getFileSize . (migrationsDirr <>)) files
-  let migrationChecksum = show (zip files sizes)
+  let migrationChecksum = toText (show (zip files sizes))
 
-  -- Check if template needs updating
-  needsUpdate <-
-    if exists
-      then do
-        -- Try to connect to template and check a marker we'll set
-        templateConn <- connect $ connInfo (toString templateDbName)
+  -- Read the checksum we stamped as the template's DB comment — from master, no
+  -- connection to the template (it disallows them). Nothing/mismatch ⇒ (re)build.
+  stamped <-
+    PGS.query masterConn "SELECT shobj_description(oid, 'pg_database') FROM pg_database WHERE datname = ?" (Only templateDbName)
+      :: IO [Only (Maybe Text)]
+  let existing = case stamped of [Only c] -> Just c; _ -> Nothing
 
-        -- Check if our migration checksum marker exists and matches
-        markerExists <-
-          PGS.query
-            templateConn
-            "SELECT EXISTS(SELECT 1 FROM pg_tables WHERE schemaname = 'public' AND tablename = 'template_db_info')"
-            ()
-            :: IO [Only Bool]
+  when (existing /= Just (Just migrationChecksum)) $ do
+    -- Drop a stale template (unlock first: a template DB can't be dropped, and FORCE clears stragglers).
+    when (isJust existing) $ do
+      alter "IS_TEMPLATE false ALLOW_CONNECTIONS true"
+      void $ execute masterConn (Query $ encodeUtf8 $ "DROP DATABASE IF EXISTS " <> templateDbName <> " WITH (FORCE)") ()
 
-        case markerExists of
-          [Only True] -> do
-            checksums <-
-              PGS.query
-                templateConn
-                "SELECT migration_checksum FROM template_db_info LIMIT 1"
-                ()
-                :: IO [Only Text]
-            close templateConn
-            pure $ case checksums of
-              [Only checksum] -> checksum /= toText migrationChecksum
-              _ -> True
-          _ -> do
-            close templateConn
-            pure True
-      else pure True
-
-  when needsUpdate $ do
-    -- Drop existing template if it exists
-    when exists $ do
-      -- First, terminate any connections to the template database
-      void
-        $ execute
-          masterConn
-          ( Query
-              $ encodeUtf8
-              $ "DO $$ BEGIN  PERFORM pg_terminate_backend(pid) FROM pg_stat_activity  WHERE datname = '"
-              <> templateDbName
-              <> "' AND pid <> pg_backend_pid(); END $$;"
-          )
-          ()
-
-      -- Mark database as template
-      _ <-
-        execute
-          masterConn
-          (Query $ encodeUtf8 $ "ALTER DATABASE " <> templateDbName <> " is_template = false")
-          ()
-      _ <-
-        execute
-          masterConn
-          (Query $ encodeUtf8 $ "DROP DATABASE IF EXISTS " <> templateDbName)
-          ()
-      pass
-
-    -- Create fresh template database
-    _ <-
-      execute
-        masterConn
-        (Query $ encodeUtf8 $ "CREATE DATABASE " <> templateDbName)
-        ()
-
-    -- Connect to template database and set up schema
+    void $ execute masterConn (Query $ encodeUtf8 $ "CREATE DATABASE " <> templateDbName) ()
     templateConn <- connect $ connInfo (toString templateDbName)
-
-    -- Run migrations
     _ <- Migration.runMigration templateConn Migration.defaultOptions MigrationInitialization
     _ <- Migration.runMigration templateConn Migration.defaultOptions $ MigrationDirectory migrationsDirr
-
-    -- Set nil user as sudo for tests and create test project
-    let setupData =
-          [sql| UPDATE users.users SET is_sudo = true WHERE id = '00000000-0000-0000-0000-000000000000';
-
-                INSERT INTO projects.projects (id, title, payment_plan, active, deleted_at, weekly_notif, daily_notif)
-                VALUES ('00000000-0000-0000-0000-000000000000', 'Demo Project', 'FREE', true, NULL, true, true)
-                ON CONFLICT (id) DO UPDATE SET payment_plan = 'FREE', active = true, deleted_at = NULL;
-                
-                INSERT into projects.project_api_keys (active, project_id, title, key_prefix) 
-                SELECT True, '00000000-0000-0000-0000-000000000000', 'test', 'z6YeJcRJNH0zy9JOg6ZsQzxM9GHBHdSeu+7ugOpZ9jtR94qV'
-                WHERE NOT EXISTS (
-                  SELECT 1 FROM projects.project_api_keys 
-                  WHERE key_prefix = 'z6YeJcRJNH0zy9JOg6ZsQzxM9GHBHdSeu+7ugOpZ9jtR94qV'
-                );
-          |]
-    _ <- execute templateConn setupData ()
-
-    -- Create marker table with migration checksum
+    -- Nil user as sudo + demo project + test API key.
     _ <-
-      execute_
-        templateConn
-        "CREATE TABLE IF NOT EXISTS template_db_info (migration_checksum TEXT)"
-    _ <-
-      execute
-        templateConn
-        "INSERT INTO template_db_info (migration_checksum) VALUES (?)"
-        (Only $ toText migrationChecksum)
+      execute templateConn
+        [sql| UPDATE users.users SET is_sudo = true WHERE id = '00000000-0000-0000-0000-000000000000';
 
+              INSERT INTO projects.projects (id, title, payment_plan, active, deleted_at, weekly_notif, daily_notif)
+              VALUES ('00000000-0000-0000-0000-000000000000', 'Demo Project', 'FREE', true, NULL, true, true)
+              ON CONFLICT (id) DO UPDATE SET payment_plan = 'FREE', active = true, deleted_at = NULL;
+
+              INSERT into projects.project_api_keys (active, project_id, title, key_prefix)
+              SELECT True, '00000000-0000-0000-0000-000000000000', 'test', 'z6YeJcRJNH0zy9JOg6ZsQzxM9GHBHdSeu+7ugOpZ9jtR94qV'
+              WHERE NOT EXISTS (SELECT 1 FROM projects.project_api_keys WHERE key_prefix = 'z6YeJcRJNH0zy9JOg6ZsQzxM9GHBHdSeu+7ugOpZ9jtR94qV');
+          |] ()
     close templateConn
 
-    -- Mark database as template
-    _ <-
-      execute
-        masterConn
-        (Query $ encodeUtf8 $ "ALTER DATABASE " <> templateDbName <> " is_template = true")
-        ()
-    pass
+    -- Stamp the checksum (escape quotes defensively) then lock: template + no connections.
+    void $ execute masterConn (Query $ encodeUtf8 $ "COMMENT ON DATABASE " <> templateDbName <> " IS '" <> T.replace "'" "''" migrationChecksum <> "'") ()
+    alter "IS_TEMPLATE true ALLOW_CONNECTIONS false"
 
   close masterConn
 

--- a/src/Pkg/TestUtils.hs
+++ b/src/Pkg/TestUtils.hs
@@ -820,6 +820,9 @@ withTestResources f = withSetup $ \pool cstr -> LogBulk.withBulkStdOutLogger \lo
               , convertkitApiKey = ""
               , convertkitApiSecret = ""
               , requestPubsubTopics = ["monoscope-prod-default"]
+              , -- Without this the field defaults to "" (no .env in CI), so DLQ poison
+                -- routes to topic "" and KafkaConsumerSpec's "otlp_deadletter" lookup finds nothing.
+                kafkaDeadLetterTopic = bool envConfig.kafkaDeadLetterTopic "otlp_deadletter" (T.null envConfig.kafkaDeadLetterTopic)
               , enableBackgroundJobs = True
               , enableEventsTableUpdates = True
               , enableDailyJobScheduling = False

--- a/web-components/package-lock.json
+++ b/web-components/package-lock.json
@@ -14,7 +14,6 @@
         "@rrweb/replay": "^2.0.0",
         "@rrweb/types": "^2.0.0-alpha.18",
         "@types/lodash": "^4.17.24",
-        "ansi_up": "^6.0.6",
         "ansi-up": "^1.0.0",
         "clsx": "^2.1.1",
         "date-fns": "^4.3.0",
@@ -36,7 +35,8 @@
         "typescript": "^6.0.3",
         "vite-plugin-monaco-editor": "^1.1.0",
         "vite-plugin-node-polyfills": "^0.28.0",
-        "vitest": "^4.0.16"
+        "vitest": "^4.0.16",
+        "vitest-canvas-mock": "^1.1.4"
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -198,6 +198,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -246,35 +247,15 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -821,6 +802,37 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
@@ -1174,15 +1186,6 @@
       "resolved": "https://registry.npmjs.org/@xstate/fsm/-/fsm-1.6.5.tgz",
       "integrity": "sha512-b5o1I6aLNeYlU/3CPlj/Z91ybk1gUsKT+5NAJI+2W4UjvS5KLG28K9v5UvNoFVjHV8PajVZ00RH3vnjyQO7ZAw==",
       "license": "MIT"
-    },
-    "node_modules/ansi_up": {
-      "version": "6.0.6",
-      "resolved": "https://registry.npmjs.org/ansi_up/-/ansi_up-6.0.6.tgz",
-      "integrity": "sha512-yIa1x3Ecf8jWP4UWEunNjqNX6gzE4vg2gGz+xqRGY+TBSucnYp6RRdPV4brmtg6bQ1ljD48mZ5iGSEj7QEpRKA==",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
     },
     "node_modules/ansi-up": {
       "version": "1.0.0",
@@ -1546,6 +1549,13 @@
         "node": ">=6"
       }
     },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/console-browserify": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz",
@@ -1660,6 +1670,13 @@
       "engines": {
         "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
       }
+    },
+    "node_modules/cssfontparser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/cssfontparser/-/cssfontparser-1.2.1.tgz",
+      "integrity": "sha512-6tun4LoZnj7VN6YeegOVb67KBX/7JJsqvj+pv3ZA7F878/eN33AbGa5b/S/wXxS/tcp8nc40xRUrsPlxIyNUPg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/data-urls": {
       "version": "7.0.0",
@@ -2434,6 +2451,7 @@
       "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@asamuzakjp/css-color": "^5.1.11",
         "@asamuzakjp/dom-selector": "^7.1.1",
@@ -2880,9 +2898,20 @@
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
       "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "dompurify": "3.2.7",
         "marked": "14.0.0"
+      }
+    },
+    "node_modules/moo-color": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/moo-color/-/moo-color-1.0.3.tgz",
+      "integrity": "sha512-i/+ZKXMDf6aqYtBhuOcej71YSlbjT3wCO/4H1j8rPvxDJEifdwgg5MaFyu6iYAT8GBZJg2z0dkgK4YMzvURALQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.1.4"
       }
     },
     "node_modules/mrmime": {
@@ -3997,6 +4026,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
       "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -4101,6 +4131,7 @@
       "integrity": "sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.8",
         "@vitest/mocker": "4.1.8",
@@ -4183,6 +4214,20 @@
         "vite": {
           "optional": false
         }
+      }
+    },
+    "node_modules/vitest-canvas-mock": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/vitest-canvas-mock/-/vitest-canvas-mock-1.1.4.tgz",
+      "integrity": "sha512-4boWHY+STwAxGl1+uwakNNoQky5EjPLC8HuponXNoAscYyT1h/F7RUvTkl4IyF/MiWr3V8Q626je3Iel3eArqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssfontparser": "^1.2.1",
+        "moo-color": "^1.0.3"
+      },
+      "peerDependencies": {
+        "vitest": "^3.0.0 || ^4.0.0"
       }
     },
     "node_modules/vm-browserify": {

--- a/web-components/package-lock.json
+++ b/web-components/package-lock.json
@@ -198,7 +198,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -247,15 +246,35 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
-      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -800,37 +819,6 @@
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
@@ -2451,7 +2439,6 @@
       "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@asamuzakjp/css-color": "^5.1.11",
         "@asamuzakjp/dom-selector": "^7.1.1",
@@ -2898,7 +2885,6 @@
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
       "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "dompurify": "3.2.7",
         "marked": "14.0.0"
@@ -4026,7 +4012,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
       "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -4131,7 +4116,6 @@
       "integrity": "sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.8",
         "@vitest/mocker": "4.1.8",

--- a/web-components/package.json
+++ b/web-components/package.json
@@ -23,7 +23,6 @@
     "@rrweb/types": "^2.0.0-alpha.18",
     "@types/lodash": "^4.17.24",
     "ansi-up": "^1.0.0",
-    "ansi_up": "^6.0.6",
     "clsx": "^2.1.1",
     "date-fns": "^4.3.0",
     "echarts": "^6.1.0",
@@ -44,7 +43,8 @@
     "typescript": "^6.0.3",
     "vite-plugin-monaco-editor": "^1.1.0",
     "vite-plugin-node-polyfills": "^0.28.0",
-    "vitest": "^4.0.16"
+    "vitest": "^4.0.16",
+    "vitest-canvas-mock": "^1.1.4"
   },
   "overrides": {
     "dompurify": "^3.3.2",

--- a/web-components/src/chart-fetch-seq.ts
+++ b/web-components/src/chart-fetch-seq.ts
@@ -1,0 +1,14 @@
+// Per-chart request sequencer. A chart can have several /chart_data fetches in
+// flight at once (5s refresh + intersection observer + time-range change), and
+// they can resolve out of order. beginChartFetch bumps the chart's sequence and
+// returns an isStale() predicate that becomes true once a *newer* fetch starts,
+// so a slow/failed response can be discarded instead of clobbering a newer
+// success — otherwise the error overlay reappears over freshly rendered bars.
+// Keyed by chartId and never evicted; fine because chart IDs are stable for the
+// page's lifetime (a fixed dashboard layout), not generated per render.
+const chartFetchSeq: Record<string, number> = {};
+
+export const beginChartFetch = (chartId: string): (() => boolean) => {
+  const seq = (chartFetchSeq[chartId] = (chartFetchSeq[chartId] || 0) + 1);
+  return () => chartFetchSeq[chartId] !== seq;
+};

--- a/web-components/src/log-list-utils.ts
+++ b/web-components/src/log-list-utils.ts
@@ -242,7 +242,11 @@ export const generateId = (): string => Math.random().toString(36).substring(2, 
 // "load more" / live-tail appends a duplicate of the last/first visible row.
 export const dedupeById = <T extends { id: string }>(items: T[]): T[] => {
   const seen = new Set<string>();
-  return items.filter((it) => (it.id == null || seen.has(it.id) ? false : (seen.add(it.id), true)));
+  return items.filter((it) => {
+    if (it.id == null || seen.has(it.id)) return false; // == null catches both null and undefined
+    seen.add(it.id);
+    return true;
+  });
 };
 
 // Whether a live-stream batch should be buffered ("N new" pill) instead of inserted

--- a/web-components/src/log-list-utils.ts
+++ b/web-components/src/log-list-utils.ts
@@ -240,10 +240,12 @@ export const generateId = (): string => Math.random().toString(36).substring(2, 
 // and any expand state on the kept row). Cursor/recent pagination uses inclusive
 // timestamp boundaries, so the boundary row recurs across pages — without this,
 // "load more" / live-tail appends a duplicate of the last/first visible row.
-export const dedupeById = <T extends { id: string }>(items: T[]): T[] => {
+// id is widened to allow null/undefined: rows are built from untyped server data,
+// so the guard against a missing id is a real runtime check, not dead code.
+export const dedupeById = <T extends { id: string | null | undefined }>(items: T[]): T[] => {
   const seen = new Set<string>();
   return items.filter((it) => {
-    if (it.id == null || seen.has(it.id)) return false; // == null catches both null and undefined
+    if (it.id == null || seen.has(it.id)) return false;
     seen.add(it.id);
     return true;
   });

--- a/web-components/src/log-list-utils.ts
+++ b/web-components/src/log-list-utils.ts
@@ -236,6 +236,43 @@ export const createCachedIconRenderer = () => {
 
 export const generateId = (): string => Math.random().toString(36).substring(2, 15);
 
+// Drop rows whose id was already seen, keeping first occurrence (preserves order
+// and any expand state on the kept row). Cursor/recent pagination uses inclusive
+// timestamp boundaries, so the boundary row recurs across pages — without this,
+// "load more" / live-tail appends a duplicate of the last/first visible row.
+export const dedupeById = <T extends { id: string }>(items: T[]): T[] => {
+  const seen = new Set<string>();
+  return items.filter((it) => (it.id == null || seen.has(it.id) ? false : (seen.add(it.id), true)));
+};
+
+// Whether a live-stream batch should be buffered ("N new" pill) instead of inserted
+// immediately. Buffer whenever the user has scrolled away from the edge new rows
+// appear at — any scroll-off (>0), not an arbitrary 30px, so reading position
+// never jumps under them. Newest-first (non-flip): rows enter at top → buffer if
+// scrollTop>0. Oldest-first (flip): rows enter at bottom → buffer unless at bottom.
+export const shouldBufferRecent = (
+  isLiveStreaming: boolean,
+  scrollTop: number,
+  scrolledToBottom: boolean,
+  flipDirection: boolean,
+): boolean => isLiveStreaming && (flipDirection ? !scrolledToBottom : scrollTop > 0);
+
+// Pagination cursor (ISO) from a row timestamp ± offset. Tolerates ISO strings and
+// numeric epochs in ns/µs/ms — `new Date(epochNs)` otherwise reads ns as ms and
+// produces a year-~55000 cursor that returns nothing, stalling load-more.
+export const cursorFromTimestamp = (timestamp: string | number, offsetMs: number): string => {
+  let ms: number;
+  if (typeof timestamp === 'number' || /^\d+$/.test(String(timestamp))) {
+    const n = Number(timestamp);
+    // Magnitude disambiguates the unit; assumes wall-clock log times in
+    // ~2001–5138 (ms ∈ [1e11,1e14)), so the thresholds never collide in practice.
+    ms = n > 1e17 ? n / 1e6 : n > 1e14 ? n / 1e3 : n; // ns→ms, µs→ms, else ms
+  } else {
+    ms = new Date(timestamp).getTime();
+  }
+  return new Date(ms + offsetMs).toISOString();
+};
+
 export const getColumnWidth = (column: string): string =>
   COLUMN_WIDTHS[column as keyof typeof COLUMN_WIDTHS] || (column === 'id' ? '' : 'w-[16ch] shrink-0');
 

--- a/web-components/src/log-list.ts
+++ b/web-components/src/log-list.ts
@@ -30,6 +30,9 @@ import {
   formatPatternCount,
   highlightPlaceholders,
   generateId,
+  dedupeById,
+  shouldBufferRecent,
+  cursorFromTimestamp,
   renderSparkline,
   parseUserAgent,
   isBotUserAgent,
@@ -126,6 +129,8 @@ export class LogList extends LitElement {
   private sessionPlayerWrapper: HTMLElement | null = null;
   private containerRef = createRef<HTMLDivElement>();
   private nextFetchUrl = '';
+  private fetchGeneration = 0;
+  private isNewResetTimer: ReturnType<typeof setTimeout> | null = null;
 
   // Debounced functions
   private debouncedFetchData: any;
@@ -144,6 +149,24 @@ export class LogList extends LitElement {
     if (source === 'expand-timerange') return;
     this.debouncedRefetchLogs();
   };
+  private liveBtn: HTMLInputElement | null = null;
+  // Named (not anonymous) so they can be removed on disconnect — see setupEventListeners.
+  private handleLiveToggle = (e: Event) => {
+    if ((e.target as HTMLInputElement).checked) {
+      this.isLiveStreaming = true;
+      if (!this.liveStreamInterval)
+        this.liveStreamInterval = setInterval(() => this.fetchData(this.buildRecentFetchUrl(), false, true), 5000);
+    } else {
+      if (this.liveStreamInterval) clearInterval(this.liveStreamInterval);
+      this.liveStreamInterval = null;
+      this.isLiveStreaming = false;
+    }
+    this.requestUpdate();
+  };
+  private handlePageHide = () => {
+    if (this.liveStreamInterval) clearInterval(this.liveStreamInterval);
+    this.liveStreamInterval = null;
+  };
   private isCalculatingWidths: boolean = false;
   private lastVisibilityRange: { first: number; last: number } | null = null;
   private isScrolling = false;
@@ -151,23 +174,26 @@ export class LogList extends LitElement {
   private worker: Worker | null = null;
   private workerReqId = 0;
   private workerCallbacks = new Map<number, { resolve: Function; reject: Function }>();
+  // Seam for tests: the fetch+group step. Defaults to the worker-backed path;
+  // tests override it to feed canned {tree, meta} responses deterministically.
+  transport: (url: string) => Promise<{ tree: any[]; meta: any }> = (url) => this.workerFetch(url);
 
   constructor() {
     super();
-
-    this.worker = new Worker(LogWorkerUrl, { type: 'module' });
-    this.worker.onmessage = (e) => this.handleWorkerMsg(e);
-    this.worker.onerror = (e: ErrorEvent) => {
-      console.error('[Worker] Error:', e.message, e.filename, e.lineno);
-    };
-
     this.debouncedFetchData = debounce(this.fetchData.bind(this), 300);
     this.debouncedUpdateChartMarkArea = debounce(this.updateChartMarkArea.bind(this), 100);
     // Bind resize handler for immediate feedback
     this.boundHandleResize = this.handleResize.bind(this);
-
     this.expandTrace = this.expandTrace.bind(this);
-    this.setupEventListeners();
+  }
+
+  // Worker + listeners are set up on connect (not in the constructor) so they are
+  // symmetric with disconnectedCallback teardown and survive disconnect→reconnect.
+  private initWorker() {
+    if (this.worker) return;
+    this.worker = new Worker(LogWorkerUrl, { type: 'module' });
+    this.worker.onmessage = (e) => this.handleWorkerMsg(e);
+    this.worker.onerror = (e: ErrorEvent) => console.error('[Worker] Error:', e.message, e.filename, e.lineno);
   }
 
   private handleWorkerMsg(e: MessageEvent) {
@@ -202,7 +228,7 @@ export class LogList extends LitElement {
           childrenTimeSpans: [], type: 'log' as const,
         };
       });
-      return { tree, meta: { serviceColors: {}, nextUrl: '', cols: data.cols || [], colIdxMap, count: data.count || 0, totalPatterns: data.totalPatterns ?? 0, totalSessions: data.totalSessions ?? 0, traces: [], hasMore: data.hasMore ?? false, queryResultCount: data.queryResultCount ?? 0 } };
+      return { tree, meta: { serviceColors: {}, nextUrl: '', cols: data.cols || [], colIdxMap, count: data.count || 0, totalPatterns: data.totalPatterns ?? 0, totalSessions: data.totalSessions ?? 0, traces: [], hasMore: data.hasMore ?? ((data.logsData || []).length > 0), queryResultCount: data.queryResultCount ?? 0 } };
     }
 
     // Use early fetch promise if available (set by server-rendered script in head)
@@ -236,24 +262,10 @@ export class LogList extends LitElement {
   }
 
   private setupEventListeners() {
-    // Live streaming button — disabled for aggregate views (patterns/sessions)
-    const liveBtn = document.querySelector('#streamLiveData') as HTMLInputElement;
-    if (liveBtn && !this.isAggregate) {
-      liveBtn.addEventListener('change', () => {
-        if (liveBtn.checked) {
-          this.isLiveStreaming = true;
-          this.liveStreamInterval = setInterval(() => {
-            this.fetchData(this.buildRecentFetchUrl(), false, true);
-          }, 5000);
-        } else {
-          if (this.liveStreamInterval) {
-            clearInterval(this.liveStreamInterval);
-          }
-          this.isLiveStreaming = false;
-        }
-        this.requestUpdate();
-      });
-    }
+    // Live streaming button — disabled for aggregate views (patterns/sessions).
+    // Handler is bound + stored so it can be removed in disconnectedCallback.
+    this.liveBtn = document.querySelector('#streamLiveData') as HTMLInputElement | null;
+    if (this.liveBtn && !this.isAggregate) this.liveBtn.addEventListener('change', this.handleLiveToggle);
 
     // Global event listeners
     ['submit', 'add-query'].forEach((ev) => window.addEventListener(ev, this.debouncedRefetchLogs));
@@ -265,9 +277,7 @@ export class LogList extends LitElement {
     document.addEventListener('update-query', this.handleUpdateQuery);
 
     // Window lifecycle events
-    window.addEventListener('pagehide', () => {
-      if (this.liveStreamInterval) clearInterval(this.liveStreamInterval);
-    });
+    window.addEventListener('pagehide', this.handlePageHide);
 
     // Pointer events for resizing (supports mouse + touch)
     this.handleMouseUp = () => {
@@ -340,10 +350,11 @@ export class LogList extends LitElement {
         const date = new Date(timestamp);
         date.setTime(date.getTime() + 10); // Add 10ms
         url.searchParams.set('from', date.toISOString());
-        // Remove cursor, since, and to params for recent fetch
+        // Recompute the lower bound from the newest loaded row; drop cursor/since.
+        // Keep `to`: on a bounded historical range, live-tail must stay within it
+        // rather than silently pulling rows newer than the user's upper bound.
         url.searchParams.delete('cursor');
         url.searchParams.delete('since');
-        url.searchParams.delete('to');
       }
     }
 
@@ -388,14 +399,9 @@ export class LogList extends LitElement {
     const url = new URL(baseUrl, window.location.origin + window.location.pathname);
     url.searchParams.set('json', 'true');
 
-    // Calculate cursor based on actual oldest timestamp
-    const date = new Date(timestamp);
-    date.setTime(date.getTime() - 10); // Subtract 10ms buffer to avoid missing items
-
-    // Update cursor for pagination while preserving time range filters (from/to/since)
-    // The cursor tells the server where to start pagination
-    // The from/to/since tell the server what time range to query within
-    url.searchParams.set('cursor', date.toISOString());
+    // Cursor from the oldest row, -10ms buffer; preserves from/to/since filters.
+    // cursorFromTimestamp handles ISO or numeric ns/µs/ms timestamps.
+    url.searchParams.set('cursor', cursorFromTimestamp(timestamp, -10));
 
     return url.toString();
   }
@@ -521,6 +527,8 @@ export class LogList extends LitElement {
 
   connectedCallback() {
     super.connectedCallback();
+    this.initWorker();
+    this.setupEventListeners();
     // Initialize empty state
     this.logsColumns = [];
     this.colIdxMap = {};
@@ -628,15 +636,15 @@ export class LogList extends LitElement {
       requestAnimationFrame(() => this.scrollToBottom());
     }
 
-    // Reset isNew flag after animation
-    if (changedProperties.has('spanListTree') && this.fetchedNew) {
-      setTimeout(() => {
-        this.spanListTree.forEach((span) => {
-          if (span.isNew) {
-            span.isNew = false;
-          }
-        });
+    // Reset isNew flag after animation. Keyed on new rows actually being PRESENT in
+    // spanListTree (not on fetchedNew), so rows that arrive via the buffer→"N new"
+    // concatenation path still get cleared — fetchedNew may already be false by then.
+    if (changedProperties.has('spanListTree') && this.spanListTree.some((s) => s.isNew)) {
+      if (this.isNewResetTimer) clearTimeout(this.isNewResetTimer);
+      this.isNewResetTimer = setTimeout(() => {
+        this.spanListTree.forEach((span) => { span.isNew = false; });
         this.fetchedNew = false;
+        this.isNewResetTimer = null;
         this.requestUpdate();
       }, 4000); // Match the animation duration
     }
@@ -660,6 +668,10 @@ export class LogList extends LitElement {
       this.worker.terminate();
       this.worker = null;
     }
+    // Drop (don't reject) in-flight worker callbacks: the worker is gone, and a
+    // late reject would touch a torn-down component. The pending 120s timeouts
+    // see an empty map and no-op.
+    this.workerCallbacks.clear();
 
     // Clean up all observers and timers
     if (this._loadMoreObserver) {
@@ -691,6 +703,9 @@ export class LogList extends LitElement {
     ['submit', 'add-query'].forEach((ev) => window.removeEventListener(ev, this.debouncedRefetchLogs));
     document.removeEventListener('submit', this.handleFormSubmit);
     document.removeEventListener('update-query', this.handleUpdateQuery);
+    this.liveBtn?.removeEventListener('change', this.handleLiveToggle);
+    this.liveBtn = null;
+    window.removeEventListener('pagehide', this.handlePageHide);
 
     // Clean up chart event handlers
     if (this.barChart) {
@@ -709,13 +724,11 @@ export class LogList extends LitElement {
   private handleResize(event: MouseEvent) {
     if (this.resizeTarget === null) return;
     const diff = event.clientX - this.mouseState.x;
-    let width = this.columnMaxWidthMap[this.resizeTarget];
-    if (!width) width = 16;
-    width += diff;
-    if (width > 100) {
-      this.columnMaxWidthMap[this.resizeTarget] = width;
-      this.requestUpdate();
-    }
+    // Seed from the column's actual current width (custom → fixed → min), not a
+    // hardcoded 16 that snapped fixed-width columns to ~100px on first drag.
+    const start = this.columnMaxWidthMap[this.resizeTarget] ?? this.fixedColumnWidths[this.resizeTarget] ?? MIN_COLUMN_WIDTH;
+    this.columnMaxWidthMap[this.resizeTarget] = Math.max(MIN_COLUMN_WIDTH, start + diff);
+    this.requestUpdate();
     this.mouseState = { x: event.clientX };
   }
 
@@ -866,19 +879,22 @@ export class LogList extends LitElement {
       // Build trace tree from rows + server traces for full tree rendering
       const traces = data.traces || [];
       const eventLines = mergedRows.length
-        ? groupSpans(mergedRows, childIdxMap, {}, false, traces)
+        ? dedupeById(groupSpans(mergedRows, childIdxMap, {}, false, traces))
         : [];
       eventLines.forEach((el) => { el.show = true; el.expanded = true; });
-      const qrc = data.queryResultCount ?? mergedRows.length;
+      // skip is a CUMULATIVE offset for the next page. queryResultCount is this
+      // page's count, so advance by it — storing it directly pinned skip to the
+      // page size and refetched (and duplicated) the same window every load-more.
+      const nextSkip = skip + (data.queryResultCount ?? newRows.length);
       this.expandedAggregates = {
         ...this.expandedAggregates,
         [key]: {
           rows: mergedRows,
           cols,
           colIdxMap: childIdxMap,
-          hasMore: !!data.hasMore && qrc < 500,
+          hasMore: !!data.hasMore && nextSkip < 500,
           loading: false,
-          skip: qrc,
+          skip: nextSkip,
           eventLines,
         },
       };
@@ -1045,16 +1061,41 @@ export class LogList extends LitElement {
     else if (isLoadMore) this.isLoadingMore = true;
     else this.isLoading = true;
 
+    // A refresh or initial load replaces the whole result set; load-more/recent
+    // append to it. Several decisions below hinge on that distinction.
+    const isFullFetch = !isLoadMore && !isRecentFetch;
+
+    // A full fetch bumps the generation; a load-more/recent captures it and bails
+    // on resolve if a refresh has since replaced the data — otherwise its rows
+    // (from the OLD query) get merged into the NEW query's results.
+    if (isFullFetch) this.fetchGeneration++;
+    const gen = this.fetchGeneration;
+
     this.showLoadingSpinner(true);
 
     try {
-      const { tree, meta } = await this.workerFetch(url);
+      const { tree, meta } = await this.transport(url);
+      if ((isLoadMore || isRecentFetch) && gen !== this.fetchGeneration) return; // superseded by a refresh
       this.fetchError = null;
 
       // Handle results
       if (tree.length === 0) {
-        this.hasMore = meta.hasMore || false;
-        this.expandTimeRange = !meta.hasMore;
+        // An empty load-more page means we've hit the end of older data: stop
+        // paginating even if the server still reports hasMore, otherwise the
+        // load-more sentinel keeps re-firing and refetches (and, pre-dedup,
+        // re-appends) the same window. Initial/refresh fetches keep trusting meta.
+        this.hasMore = isLoadMore ? false : meta.hasMore || false;
+        this.expandTimeRange = !this.hasMore;
+        // A full fetch (new query, filter or time-range change) that returns
+        // nothing is the FULL result set — clear stale rows so the empty state
+        // shows, instead of leaving the previous query's results on screen.
+        if (isFullFetch) {
+          this.spanListTree = [];
+          this.loadedCount = 0;
+          if (meta.count !== undefined) this.totalCount = meta.count;
+          this.updateVisibleItems();
+          this.updateRowCountDisplay();
+        }
         return;
       }
 
@@ -1062,17 +1103,14 @@ export class LogList extends LitElement {
       if (!this.hasMore) this.expandTimeRange = true;
       if (isLoadMore || isRefresh || !this.spanListTree.length) this.nextFetchUrl = meta.nextUrl;
       if (isRecentFetch || !this.spanListTree.length) this.recentFetchUrl = meta.recentUrl;
-      if (isLoadMore) {
-        this.loadedCount += meta.queryResultCount ?? 0;
-      } else {
-        this.loadedCount = meta.queryResultCount ?? 0;
-      }
       if (meta.count !== undefined && !isLoadMore) this.totalCount = meta.count;
       if (meta.totalPatterns !== undefined && !isLoadMore) this.totalPatterns = meta.totalPatterns;
       if (meta.totalSessions !== undefined && !isLoadMore) this.totalSessions = meta.totalSessions;
-      this.updateRowCountDisplay();
       if (meta.serviceColors) Object.assign(this.serviceColors, meta.serviceColors);
-      this.logsColumns = meta.cols;
+      // Only a new query / refresh redefines the column set. Load-more pages and
+      // 5s live-stream ticks return the same server cols, so adopting them here
+      // would silently undo a user's hideColumn / reorder on every tick.
+      if (isFullFetch) this.logsColumns = meta.cols;
       this.colIdxMap = meta.colIdxMap;
       // Cache server traces for re-render (expand/collapse, flip direction)
       // Cap at 5000 entries to prevent unbounded growth during pagination
@@ -1083,6 +1121,9 @@ export class LogList extends LitElement {
       }
 
       if (isRefresh) {
+        // New query/filter/time-range: drop inline-expanded aggregate children so
+        // they don't render stale rows from the previous query under a surviving key.
+        this.expandedAggregates = {};
         this.spanListTree = tree;
         this.updateVisibleItems();
         if (tree.length > 0) {
@@ -1101,9 +1142,7 @@ export class LogList extends LitElement {
           const scrollHeight = container.scrollHeight;
           const scrolledToBottom = scrollTop + clientHeight >= scrollHeight - 1;
           if (scrolledToBottom) this.shouldScrollToBottom = true;
-          const shouldBuffer =
-            this.isLiveStreaming && ((scrollTop > 30 && !this.flipDirection) || (!scrolledToBottom && this.flipDirection));
-          if (shouldBuffer) {
+          if (shouldBufferRecent(this.isLiveStreaming, scrollTop, scrolledToBottom, this.flipDirection)) {
             this.recentDataToBeAdded = this.addWithFlipDirection(this.recentDataToBeAdded, tree, isRecentFetch);
           } else {
             this.spanListTree = this.addWithFlipDirection(this.spanListTree, tree, isRecentFetch);
@@ -1114,6 +1153,10 @@ export class LogList extends LitElement {
         this.spanListTree = this.addWithFlipDirection(this.spanListTree, tree, isRecentFetch);
         this.updateVisibleItems();
       }
+      // Count what's actually visible. queryResultCount over-counts because the
+      // dedup-dropped boundary row is re-reported on every paginated page.
+      this.loadedCount = this.spanListTree.length;
+      this.updateRowCountDisplay();
 
       // Defer column width calculation
       if ('requestIdleCallback' in window) {
@@ -1136,9 +1179,12 @@ export class LogList extends LitElement {
         this.showErrorToast(msg);
       }
     } finally {
-      this.isLoading = false;
-      this.isFetchingRecent = false;
-      this.isLoadingMore = false;
+      // Reset only THIS fetch's guard — the three kinds run concurrently, so
+      // clearing all of them would let an in-flight load-more re-fire when an
+      // unrelated recent/refresh finishes first.
+      if (isRecentFetch) this.isFetchingRecent = false;
+      else if (isLoadMore) this.isLoadingMore = false;
+      else this.isLoading = false;
       this.showLoadingSpinner(false);
       this.requestUpdate();
     }
@@ -1156,10 +1202,13 @@ export class LogList extends LitElement {
 
   hideColumn(column: string) {
     this.logsColumns = this.logsColumns.filter((col) => col !== column);
+    delete this.columnMaxWidthMap[column]; // don't leak a stale width for a removed column
     this.requestUpdate();
   }
   handleColumnsChanged(e: { detail: string[] }) {
-    this.logsColumns = e.detail;
+    const next = e.detail;
+    for (const c of Object.keys(this.columnMaxWidthMap)) if (!next.includes(c)) delete this.columnMaxWidthMap[c];
+    this.logsColumns = next;
     this.requestUpdate();
   }
   updateColumnMaxWidthMap = (recVecs: any[][]) => {
@@ -1257,7 +1306,7 @@ export class LogList extends LitElement {
       : isRecentFetch
       ? [...newData, ...current]
       : [...current, ...newData];
-    return result;
+    return dedupeById(result);
   }
 
   handleRecentClick() {

--- a/web-components/src/log-list.ts
+++ b/web-components/src/log-list.ts
@@ -344,12 +344,12 @@ export class LogList extends LitElement {
     // If we have data, update the 'from' parameter to fetch newer data
     if (this.spanListTree.length > 0) {
       const firstItem = this.flipDirection ? this.spanListTree[this.spanListTree.length - 1] : this.spanListTree[0];
-      const timestamp = firstItem?.data?.[this.colIdxMap['timestamp'] || this.colIdxMap['created_at']];
+      const timestamp = firstItem?.data?.[this.colIdxMap['timestamp'] ?? this.colIdxMap['created_at']];
 
       if (timestamp) {
-        const date = new Date(timestamp);
-        date.setTime(date.getTime() + 10); // Add 10ms
-        url.searchParams.set('from', date.toISOString());
+        // cursorFromTimestamp tolerates ISO + ns/µs/ms epochs (+10ms so we skip the newest row);
+        // a raw `new Date(epochNs)` would read ns as ms → a year-~55000 `from` → empty live-tail.
+        url.searchParams.set('from', cursorFromTimestamp(timestamp, 10));
         // Recompute the lower bound from the newest loaded row; drop cursor/since.
         // Keep `to`: on a bounded historical range, live-tail must stay within it
         // rather than silently pulling rows newer than the user's upper bound.
@@ -431,10 +431,11 @@ export class LogList extends LitElement {
     // This ensures we fetch older logs when expanding the time range
     if (this.spanListTree.length > 0) {
       const oldestItem = this.flipDirection ? this.spanListTree[0] : this.spanListTree[this.spanListTree.length - 1];
-      const oldestTimestamp = oldestItem?.data?.[this.colIdxMap['timestamp'] || this.colIdxMap['created_at']];
+      const oldestTimestamp = oldestItem?.data?.[this.colIdxMap['timestamp'] ?? this.colIdxMap['created_at']];
 
       if (oldestTimestamp) {
-        url.searchParams.set('cursor', String(oldestTimestamp));
+        // Same ns/µs/ms tolerance as load-more; String(epochNs) would stall the server cursor.
+        url.searchParams.set('cursor', cursorFromTimestamp(oldestTimestamp, 0));
       }
     }
 
@@ -629,6 +630,7 @@ export class LogList extends LitElement {
     // Stop live streaming when switching to an aggregate view
     if (changedProperties.has('mode') && this.isAggregate && this.liveStreamInterval) {
       clearInterval(this.liveStreamInterval);
+      this.liveStreamInterval = null; // else handleLiveToggle's !interval guard skips restart on switch-back
       this.isLiveStreaming = false;
     }
 
@@ -1085,7 +1087,9 @@ export class LogList extends LitElement {
         // load-more sentinel keeps re-firing and refetches (and, pre-dedup,
         // re-appends) the same window. Initial/refresh fetches keep trusting meta.
         this.hasMore = isLoadMore ? false : meta.hasMore || false;
-        this.expandTimeRange = !this.hasMore;
+        // A quiet live-tail tick (no new rows) isn't "history exhausted" — don't flash
+        // the "Show earlier events" button on every empty 5s recent fetch.
+        if (!isRecentFetch) this.expandTimeRange = !this.hasMore;
         // A full fetch (new query, filter or time-range change) that returns
         // nothing is the FULL result set — clear stale rows so the empty state
         // shows, instead of leaving the previous query's results on screen.

--- a/web-components/src/log-list.ts
+++ b/web-components/src/log-list.ts
@@ -76,6 +76,11 @@ export class LogList extends LitElement {
   @state() private expandedTraces: Record<string, boolean> = {};
   @state() private flipDirection: boolean = false;
   @state() private spanListTree: EventLine[] = [];
+  // Ids currently in spanListTree, kept so paginated/live appends dedupe the
+  // incoming page in O(page) instead of re-scanning the whole merged list each
+  // call (which was O(pages²·rows) over a long scroll). Rebuilt on full
+  // fetch/refresh; extended on child-expand splices and tree merges.
+  private seenIds = new Set<string>();
   @state() private recentDataToBeAdded: EventLine[] = [];
   @state() private view: 'tree' | 'list' = 'tree';
   @state() private shouldScrollToBottom: boolean = false;
@@ -157,12 +162,20 @@ export class LogList extends LitElement {
       if (!this.liveStreamInterval)
         this.liveStreamInterval = setInterval(() => this.fetchData(this.buildRecentFetchUrl(), false, true), 5000);
     } else {
-      if (this.liveStreamInterval) clearInterval(this.liveStreamInterval);
-      this.liveStreamInterval = null;
-      this.isLiveStreaming = false;
+      this.stopLiveStream();
     }
     this.requestUpdate();
   };
+  // Tear down live-tail polling and reflect it in the toggle; optional toast when
+  // stopped automatically (e.g. the live window reached the range's upper bound).
+  private stopLiveStream(message?: string) {
+    if (this.liveStreamInterval) clearInterval(this.liveStreamInterval);
+    this.liveStreamInterval = null;
+    this.isLiveStreaming = false;
+    if (this.liveBtn) this.liveBtn.checked = false;
+    if (message) this.showErrorToast(message);
+    this.requestUpdate();
+  }
   private handlePageHide = () => {
     if (this.liveStreamInterval) clearInterval(this.liveStreamInterval);
     this.liveStreamInterval = null;
@@ -349,12 +362,21 @@ export class LogList extends LitElement {
       if (timestamp) {
         // cursorFromTimestamp tolerates ISO + ns/µs/ms epochs (+10ms so we skip the newest row);
         // a raw `new Date(epochNs)` would read ns as ms → a year-~55000 `from` → empty live-tail.
-        url.searchParams.set('from', cursorFromTimestamp(timestamp, 10));
+        const from = cursorFromTimestamp(timestamp, 10);
+        url.searchParams.set('from', from);
         // Recompute the lower bound from the newest loaded row; drop cursor/since.
         // Keep `to`: on a bounded historical range, live-tail must stay within it
         // rather than silently pulling rows newer than the user's upper bound.
         url.searchParams.delete('cursor');
         url.searchParams.delete('since');
+        // Edge case: once the newest loaded row reaches the upper bound, `from`
+        // (newest+10ms) lands at/after `to`, so every tick fetches an empty
+        // [from,to] window — the live banner would hang forever with no rows and
+        // no error. Stop live-tail instead of polling a guaranteed-empty range.
+        const to = url.searchParams.get('to');
+        const toMs = to ? Date.parse(to) : NaN;
+        if (!isNaN(toMs) && Date.parse(from) >= toMs)
+          this.stopLiveStream('Reached the end of the selected time range — live tail paused.');
       }
     }
 
@@ -535,6 +557,7 @@ export class LogList extends LitElement {
     this.colIdxMap = {};
     this.serviceColors = {};
     this.spanListTree = [];
+    this.seenIds.clear();
     this.visibleItems = [];
     this.hasMore = false;
 
@@ -1038,6 +1061,7 @@ export class LogList extends LitElement {
       }
       // Insert children after parent and update children count to actual loaded count
       this.spanListTree.splice(parentIdx + 1, 0, ...eventLines);
+      eventLines.forEach((el) => this.seenIds.add(el.id));
       parent.children = eventLines.filter((el) => el.depth === 1).length;
       this.updateVisibleItems();
       this.requestUpdate();
@@ -1095,6 +1119,7 @@ export class LogList extends LitElement {
         // shows, instead of leaving the previous query's results on screen.
         if (isFullFetch) {
           this.spanListTree = [];
+          this.seenIds.clear();
           this.loadedCount = 0;
           if (meta.count !== undefined) this.totalCount = meta.count;
           this.updateVisibleItems();
@@ -1129,6 +1154,7 @@ export class LogList extends LitElement {
         // they don't render stale rows from the previous query under a surviving key.
         this.expandedAggregates = {};
         this.spanListTree = tree;
+        this.seenIds = new Set(tree.map((r) => r.id));
         this.updateVisibleItems();
         if (tree.length > 0) {
           requestAnimationFrame(() => {
@@ -1149,12 +1175,12 @@ export class LogList extends LitElement {
           if (shouldBufferRecent(this.isLiveStreaming, scrollTop, scrolledToBottom, this.flipDirection)) {
             this.recentDataToBeAdded = this.addWithFlipDirection(this.recentDataToBeAdded, tree, isRecentFetch);
           } else {
-            this.spanListTree = this.addWithFlipDirection(this.spanListTree, tree, isRecentFetch);
+            this.spanListTree = this.mergeIntoTree(tree, isRecentFetch);
             this.updateVisibleItems();
           }
         }
       } else {
-        this.spanListTree = this.addWithFlipDirection(this.spanListTree, tree, isRecentFetch);
+        this.spanListTree = this.mergeIntoTree(tree, isRecentFetch);
         this.updateVisibleItems();
       }
       // Count what's actually visible. queryResultCount over-counts because the
@@ -1211,7 +1237,8 @@ export class LogList extends LitElement {
   }
   handleColumnsChanged(e: { detail: string[] }) {
     const next = e.detail;
-    for (const c of Object.keys(this.columnMaxWidthMap)) if (!next.includes(c)) delete this.columnMaxWidthMap[c];
+    const nextSet = new Set(next);
+    for (const c of Object.keys(this.columnMaxWidthMap)) if (!nextSet.has(c)) delete this.columnMaxWidthMap[c];
     this.logsColumns = next;
     this.requestUpdate();
   }
@@ -1302,15 +1329,30 @@ export class LogList extends LitElement {
     this.requestUpdate();
   }
 
-  private addWithFlipDirection(current: any[], newData: any[], isRecentFetch: boolean) {
-    const result = this.flipDirection
+  // New rows enter at the top for recent/live fetches and the bottom for load-more,
+  // flipped when oldest-first is on.
+  private orderMerge(current: any[], newData: any[], isRecentFetch: boolean) {
+    return this.flipDirection
       ? isRecentFetch
         ? [...current, ...newData]
         : [...newData, ...current]
       : isRecentFetch
       ? [...newData, ...current]
       : [...current, ...newData];
-    return dedupeById(result);
+  }
+
+  // Buffer accumulation ("N new" pill) — small bounded list, full dedupe is fine.
+  private addWithFlipDirection(current: any[], newData: any[], isRecentFetch: boolean) {
+    return dedupeById(this.orderMerge(current, newData, isRecentFetch));
+  }
+
+  // Merge a freshly fetched page into spanListTree, dropping ids already present
+  // (boundary row recurs across inclusive-cursor pages) using the persistent
+  // seenIds set so the cost is O(page), not O(whole tree).
+  private mergeIntoTree(newData: EventLine[], isRecentFetch: boolean) {
+    const fresh = newData.filter((r) => !this.seenIds.has(r.id));
+    fresh.forEach((r) => this.seenIds.add(r.id));
+    return this.orderMerge(this.spanListTree, fresh, isRecentFetch);
   }
 
   handleRecentClick() {
@@ -1323,8 +1365,7 @@ export class LogList extends LitElement {
 
   handleRecentConcatenation() {
     if (this.recentDataToBeAdded.length === 0) return;
-    // Use addWithFlipDirection for consistent ordering
-    this.spanListTree = this.addWithFlipDirection(this.spanListTree, this.recentDataToBeAdded, true);
+    this.spanListTree = this.mergeIntoTree(this.recentDataToBeAdded, true);
     this.recentDataToBeAdded = [];
     this.updateVisibleItems();
     this.batchRequestUpdate('recentConcatenation');
@@ -2438,7 +2479,7 @@ export class LogList extends LitElement {
               this.spanListTree = this.buildSpanListTree(this.spanListTree.map((sp) => sp.data));
               this.recentDataToBeAdded = this.buildSpanListTree(this.recentDataToBeAdded.map((sp) => sp.data));
               if (this.recentDataToBeAdded.length > 0) {
-                this.spanListTree = this.addWithFlipDirection(this.spanListTree, this.recentDataToBeAdded, true);
+                this.spanListTree = this.mergeIntoTree(this.recentDataToBeAdded, true);
                 this.recentDataToBeAdded = [];
               }
               this.requestUpdate();

--- a/web-components/src/widgets.ts
+++ b/web-components/src/widgets.ts
@@ -1,6 +1,7 @@
 'use strict';
 import { params } from './main';
 import { getSeriesColor } from './colorMapping';
+import { beginChartFetch } from './chart-fetch-seq';
 const INITIAL_FETCH_INTERVAL = 5000;
 const $ = (id: string) => document.getElementById(id);
 
@@ -288,6 +289,7 @@ const updateChartData = async (chart: any, opt: any, shouldFetch: boolean, widge
   if (!shouldFetch) return;
 
   const { query, querySQL, pid, chartId, summarizeBy, summarizeByPrefix } = widgetData;
+  const isStale = beginChartFetch(chartId);
   // Batch DOM updates before fetch
   requestAnimationFrame(() => {
     const loader = $(`${chartId}_loader`);
@@ -334,6 +336,7 @@ const updateChartData = async (chart: any, opt: any, shouldFetch: boolean, widge
     }
 
     const { from, to, headers, dataset, rows_per_min, stats, error } = await limitedFetch(`/chart_data?${params}`).then((res) => res.json());
+    if (isStale()) return; // a newer fetch already won; don't overwrite its state
     if (error) {
       // Server-reported SQL failure: show distinct error overlay (not the generic
       // "no data" one) so the user can distinguish a broken widget from an empty range.
@@ -393,7 +396,7 @@ const updateChartData = async (chart: any, opt: any, shouldFetch: boolean, widge
   } catch (e) {
     console.error('Failed to fetch new data:', e);
     chart.hideLoading();
-    showNoDataOverlay(chartId, 'Failed to load data', 'error');
+    if (!isStale()) showNoDataOverlay(chartId, 'Failed to load data', 'error');
   } finally {
     // Batch DOM updates after fetch completes
     requestAnimationFrame(() => {

--- a/web-components/test/chart-fetch-seq.test.ts
+++ b/web-components/test/chart-fetch-seq.test.ts
@@ -1,0 +1,28 @@
+import { describe, test, expect } from 'vitest';
+import { beginChartFetch } from '../src/chart-fetch-seq';
+
+// Regression: dashboard widgets showed the "Query execution failed" overlay on
+// top of freshly rendered bars. A failed /chart_data response arriving AFTER a
+// newer successful one re-applied the error overlay. The sequencer must mark the
+// older (first-issued) fetch as stale so its (error) result is discarded.
+describe('beginChartFetch', () => {
+  test('older fetch is stale once a newer one starts, regardless of resolve order', () => {
+    const isStaleA = beginChartFetch('chart1'); // first issued (will fail, resolves last)
+    const isStaleB = beginChartFetch('chart1'); // newer (succeeds)
+
+    expect(isStaleB()).toBe(false); // latest fetch always applies its result
+    expect(isStaleA()).toBe(true); // superseded — discard even though it resolves later
+  });
+
+  test('latest fetch wins after several in-flight requests', () => {
+    const checks = Array.from({ length: 4 }, () => beginChartFetch('chart2'));
+    checks.slice(0, -1).forEach((isStale) => expect(isStale()).toBe(true));
+    expect(checks.at(-1)!()).toBe(false);
+  });
+
+  test('sequences are independent per chart', () => {
+    const isStaleX = beginChartFetch('chartX');
+    beginChartFetch('chartY'); // bumping another chart must not stale chartX
+    expect(isStaleX()).toBe(false);
+  });
+});

--- a/web-components/test/log-list-bugs.test.ts
+++ b/web-components/test/log-list-bugs.test.ts
@@ -1,0 +1,259 @@
+import { describe, test, expect, vi } from 'vitest';
+import { row, fakeTransport, deferredTransport, stubFetch, ids, mountList } from './log-list-harness';
+import { shouldBufferRecent, cursorFromTimestamp } from '../src/log-list-utils';
+
+describe('LogList — LOWER', () => {
+  // Lo2: a resized-then-hidden column must not retain its width (which would
+  // resurrect on re-add and grow columnMaxWidthMap unboundedly).
+  test('hideColumn prunes its stored width', async () => {
+    const el = await mountList();
+    (el as any).columnMaxWidthMap = { service: 400, summary: 300 };
+    el.hideColumn('service');
+    expect((el as any).columnMaxWidthMap.service).toBeUndefined();
+    expect((el as any).columnMaxWidthMap.summary).toBe(300);
+  });
+  test('handleColumnsChanged prunes widths for removed columns', async () => {
+    const el = await mountList();
+    (el as any).columnMaxWidthMap = { a: 100, b: 200, c: 300 };
+    el.handleColumnsChanged({ detail: ['a', 'c'] });
+    expect(Object.keys((el as any).columnMaxWidthMap).sort()).toEqual(['a', 'c']);
+  });
+
+  // Lo5: patterns/sessions pagination must not stop at page 1 when the server
+  // omits hasMore on a full page.
+  test('aggregate fetch infers hasMore from row presence when server omits it', async () => {
+    const el = await mountList({ mode: 'patterns' } as any);
+    const restore = stubFetch({ logsData: [['x'], ['y']], cols: ['id'], colIdxMap: { id: 0 } }); // no hasMore
+    try {
+      const { meta } = await (el as any).workerFetch('u');
+      expect(meta.hasMore).toBe(true);
+    } finally { restore(); }
+  });
+});
+
+describe('cursorFromTimestamp', () => {
+  test('ISO string round-trips with the offset', () => {
+    expect(cursorFromTimestamp('2026-06-01T00:00:00.000Z', -10)).toBe('2026-05-31T23:59:59.990Z');
+  });
+  test('numeric epoch-ns is not misread as ms (no year-55000 cursor)', () => {
+    const iso = cursorFromTimestamp(1700000000000000000, 0); // 1.7e18 ns ≈ Nov 2023
+    expect(new Date(iso).getUTCFullYear()).toBe(2023);
+  });
+  test('numeric epoch-µs (>1e14) is scaled to ms', () => {
+    const iso = cursorFromTimestamp(1700000000000000, 0); // 1.7e15 µs ≈ Nov 2023
+    expect(new Date(iso).getUTCFullYear()).toBe(2023);
+  });
+  test('numeric epoch-ms (<1e14) passes through unscaled', () => {
+    const iso = cursorFromTimestamp(1700000000000, 0); // 1.7e12 ms ≈ Nov 2023
+    expect(new Date(iso).getUTCFullYear()).toBe(2023);
+  });
+});
+
+describe('LogList — MED correctness', () => {
+  // M3: loadedCount over-counted because queryResultCount re-reports the
+  // dedup-dropped boundary row on every page. It should match visible rows.
+  test('loadedCount equals visible row count after an overlapping load-more', async () => {
+    const el = await mountList();
+    el.transport = fakeTransport({ tree: [row('1'), row('2'), row('3')] }, { tree: [row('3'), row('4')] });
+    await el.fetchData('init', false, false, false);
+    await el.fetchData('lm', false, false, true);
+    expect((el as any).loadedCount).toBe((el as any).spanListTree.length);
+    expect((el as any).loadedCount).toBe(4);
+  });
+
+  // M2: a refresh must drop inline-expanded aggregate children, else stale rows
+  // from the previous query render under a key that survives the new query.
+  test('refresh clears expandedAggregates', async () => {
+    const el = await mountList();
+    (el as any).expandedAggregates = { hash1: { rows: [['x']], cols: ['id'], colIdxMap: { id: 0 }, hasMore: false, loading: false, skip: 1 } };
+    el.transport = fakeTransport({ tree: [row('1')] });
+    await el.fetchData('newquery', true, false, false);
+    expect(Object.keys((el as any).expandedAggregates)).toHaveLength(0);
+  });
+
+  // M1: buffered "new" rows must lose the highlight after they merge, even if
+  // fetchedNew was already cleared by an intervening spanListTree change.
+  test('isNew highlight clears after merge regardless of fetchedNew', async () => {
+    vi.useFakeTimers();
+    try {
+      const el = await mountList();
+      const n1 = { ...row('n1'), isNew: true };
+      (el as any).spanListTree = [n1, row('o1')];
+      (el as any).fetchedNew = false; // the broken precondition
+      (el as any).updated(new Map([['spanListTree', []]])); // lifecycle fires on the merge
+      vi.advanceTimersByTime(4000);
+      expect((el as any).spanListTree.find((r: any) => r.id === 'n1').isNew).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  // M5: live-tail on a bounded range must keep the upper `to` bound.
+  test('buildRecentFetchUrl preserves the to bound', async () => {
+    const el = await mountList();
+    window.history.replaceState({}, '', '/log_explorer?to=2026-06-01T00%3A00%3A00.000Z&query=x');
+    (el as any).colIdxMap = { timestamp: 0 };
+    (el as any).spanListTree = [row('1', ['2026-05-01T00:00:00.000Z'])];
+    const url = new URL((el as any).buildRecentFetchUrl(), 'http://localhost');
+    expect(url.searchParams.get('to')).toBe('2026-06-01T00:00:00.000Z');
+    expect(url.searchParams.has('cursor')).toBe(false);
+  });
+});
+
+// M4: buffering decision (pure) — buffer whenever scrolled off the insertion edge.
+describe('shouldBufferRecent', () => {
+  test('newest-first: buffers as soon as scrolled off the top (>0), not at 30px', () => {
+    expect(shouldBufferRecent(true, 0, true, false)).toBe(false); // at top → insert
+    expect(shouldBufferRecent(true, 10, false, false)).toBe(true); // scrolled → buffer (was false at <=30)
+  });
+  test('oldest-first: buffers unless pinned to the bottom', () => {
+    expect(shouldBufferRecent(true, 999, true, true)).toBe(false); // at bottom → insert
+    expect(shouldBufferRecent(true, 999, false, true)).toBe(true); // scrolled up → buffer
+  });
+  test('never buffers when not live streaming', () => {
+    expect(shouldBufferRecent(false, 500, false, false)).toBe(false);
+  });
+});
+
+describe('LogList — lifecycle cleanup (no leaks across disconnect / remount)', () => {
+  // Bug: the #streamLiveData change listener + pagehide were added in the
+  // CONSTRUCTOR and never removed → after an HTMX-morph remount, the old
+  // (disconnected) instance's closure still fires on the shared global checkbox,
+  // stacking orphaned 5s setInterval polling loops.
+  test('live-stream listener + interval do not leak across disconnect/remount', async () => {
+    const btn = document.createElement('input');
+    btn.type = 'checkbox'; btn.id = 'streamLiveData';
+    document.body.appendChild(btn);
+    const intervals = new Set<any>();
+    const realSet = globalThis.setInterval, realClear = globalThis.clearInterval;
+    (globalThis as any).setInterval = (fn: any) => { const id = realSet(fn, 1e7); intervals.add(id); return id; };
+    (globalThis as any).clearInterval = (id: any) => { intervals.delete(id); realClear(id); };
+    const toggle = (on: boolean) => { btn.checked = on; btn.dispatchEvent(new Event('change')); };
+    try {
+      const a = await mountList();
+      toggle(true);
+      expect(intervals.size).toBe(1);     // A polling
+      a.remove();                          // disconnect A
+      expect(intervals.size).toBe(0);      // its interval cleared
+
+      toggle(false); toggle(true);         // A's orphaned listener must NOT restart polling
+      expect(intervals.size).toBe(0);
+
+      const b = await mountList();
+      toggle(true);
+      expect(intervals.size).toBe(1);      // exactly one (B) — not stacked with A
+      b.remove();
+      expect(intervals.size).toBe(0);
+    } finally {
+      (globalThis as any).setInterval = realSet;
+      (globalThis as any).clearInterval = realClear;
+      btn.remove();
+    }
+  });
+
+  // Bug: in-flight worker callbacks were never cleared on disconnect; the 120s
+  // timeout could later reject onto a dead component (DOM touch after teardown).
+  test('pending worker callbacks are dropped on disconnect, not rejected', async () => {
+    const el = await mountList();
+    let rejected = false;
+    (el as any).workerCallbacks.set(99, { resolve() {}, reject() { rejected = true; } });
+    el.remove();
+    expect((el as any).workerCallbacks.size).toBe(0);
+    expect(rejected).toBe(false);
+  });
+});
+
+// Regression tests for bugs surfaced by the deep log-list audit. Each reproduces a
+// concrete user-visible defect; see web_components_test_harness memory for the map.
+
+describe('LogList — columns survive background refetches', () => {
+  // Bug: hideColumn edits logsColumns locally, but fetchData overwrites it with
+  // meta.cols on EVERY fetch — so a load-more or 5s live-stream tick restores the
+  // hidden column. Column hiding is effectively broken under live/paginated views.
+  test('a hidden column is not restored by a load-more refetch', async () => {
+    const el = await mountList();
+    el.transport = fakeTransport(
+      { tree: [row('1')], meta: { cols: ['id', 'service', 'summary'] } },
+      { tree: [row('2')], meta: { cols: ['id', 'service', 'summary'] } },
+    );
+    await el.fetchData('initial', false, false, false);
+    el.hideColumn('service');
+    expect((el as any).logsColumns).not.toContain('service');
+
+    await el.fetchData('loadmore', false, false, true); // e.g. scroll / live tick
+    expect((el as any).logsColumns).not.toContain('service'); // stays hidden
+  });
+});
+
+describe('LogList — aggregate (patterns) child pagination', () => {
+  // Bug: fetchAggregateChildren stores skip = queryResultCount (per-page count, e.g.
+  // 3) instead of a cumulative offset, and merges with no dedup. "Load more" on a
+  // pattern's children refetches the same window → duplicate child rows and later
+  // pages become unreachable.
+  test('child skip advances cumulatively across pages (no duplicate refetch)', async () => {
+    const el = await mountList({ mode: 'patterns' } as any);
+    (el as any).colIdxMap = { pattern_hash: 0, summary: 1 };
+    const parent = row('p1', ['hash1', 'a pattern']);
+
+    const restore = stubFetch(
+      { rows: [['r1'], ['r2'], ['r3']], cols: ['id'], colIdxMap: { id: 0 }, queryResultCount: 3, hasMore: true },
+      { rows: [['r4'], ['r5'], ['r6']], cols: ['id'], colIdxMap: { id: 0 }, queryResultCount: 3, hasMore: true },
+    );
+    try {
+      await (el as any).toggleAggregateRow(parent); // first open → fetch skip=0
+      const key = 'hash1';
+      expect((el as any).expandedAggregates[key].skip).toBe(3);
+
+      // "Load more" fetches from the stored skip.
+      await (el as any).fetchAggregateChildren(key, (el as any).expandedAggregates[key].skip);
+      // Next offset must be 6, not pinned at the per-page count (3).
+      expect((el as any).expandedAggregates[key].skip).toBe(6);
+      expect((el as any).expandedAggregates[key].rows).toHaveLength(6);
+    } finally {
+      restore();
+    }
+  });
+});
+
+describe('LogList — concurrent refresh vs load-more', () => {
+  // Bug: the three loading guards are independent, so a refresh (new query) and an
+  // in-flight load-more run concurrently. If the load-more resolves AFTER the
+  // refresh, its older rows from the PREVIOUS query are merged into the new query's
+  // results — cross-query contamination with no visible signal.
+  test('a load-more resolving after a refresh does not contaminate the new query', async () => {
+    const el = await mountList();
+    const tx = deferredTransport();
+    el.transport = tx as any;
+
+    // page of query A is on screen
+    await (async () => { const t = fakeTransport({ tree: [row('a1'), row('a2')] }); el.transport = t as any; await el.fetchData('A', false, false, false); el.transport = tx as any; })();
+
+    const loadMore = el.fetchData('A-loadmore', false, false, true); // in flight (deferred)
+    const refresh = el.fetchData('B-newquery', true, false, false); // new query, also deferred
+
+    tx.settle(1, [row('b1'), row('b2')]); // refresh (query B) resolves first
+    await refresh;
+    tx.settle(0, [row('a3'), row('a4')]); // stale load-more (query A) resolves later
+    await loadMore;
+
+    // Must show ONLY query B's rows — A's older page must not be appended.
+    expect(ids(el)).toEqual(['b1', 'b2']);
+  });
+
+  test('finishing one fetch kind does not clear another kind\'s in-flight guard', async () => {
+    const el = await mountList();
+    const tx = deferredTransport();
+    el.transport = tx as any;
+
+    const loadMore = el.fetchData('lm', false, false, true); // isLoadingMore = true
+    const recent = el.fetchData('recent', false, true, false); // isFetchingRecent = true
+
+    tx.settle(1, [row('r1')]); // recent resolves first → its finally runs
+    await recent;
+    expect((el as any).isLoadingMore).toBe(true); // load-more still in flight
+
+    tx.settle(0, [row('r2')]);
+    await loadMore;
+    expect((el as any).isLoadingMore).toBe(false);
+  });
+});

--- a/web-components/test/log-list-bugs.test.ts
+++ b/web-components/test/log-list-bugs.test.ts
@@ -61,6 +61,69 @@ describe('LogList — MED correctness', () => {
     expect((el as any).loadedCount).toBe(4);
   });
 
+  // Dedup must hold across many overlapping pages (inclusive-cursor boundary row
+  // recurs each page) now that the merge filters via a persistent seenIds set
+  // instead of re-deduping the whole tree.
+  test('paginated overlapping pages dedupe to a unique, ordered tree', async () => {
+    const el = await mountList();
+    el.transport = fakeTransport(
+      { tree: [row('1'), row('2'), row('3')] },
+      { tree: [row('3'), row('4'), row('5')] }, // 3 overlaps prior page
+      { tree: [row('5'), row('6')] }, // 5 overlaps prior page
+    );
+    await el.fetchData('init', false, false, false);
+    await el.fetchData('lm1', false, false, true);
+    await el.fetchData('lm2', false, false, true);
+    expect(ids(el)).toEqual(['1', '2', '3', '4', '5', '6']);
+  });
+
+  // A refresh must reset the dedup state, else an id seen by the previous query
+  // would be wrongly dropped from the new query's results.
+  test('refresh resets dedup state so a previously-seen id reappears', async () => {
+    const el = await mountList();
+    el.transport = fakeTransport({ tree: [row('1'), row('2')] }, { tree: [row('2')] });
+    await el.fetchData('init', false, false, false);
+    await el.fetchData('newquery', true, false, false); // refresh / new query
+    expect(ids(el)).toEqual(['2']);
+  });
+
+  // Live-tail on a bounded range must stop (not hang silently) once the newest
+  // loaded row reaches `to`: from=newest+10ms ≥ to → every tick fetches empty.
+  test('buildRecentFetchUrl stops live-tail (with toast) at the upper bound', async () => {
+    const el = await mountList();
+    window.history.replaceState({}, '', '/log_explorer?to=2026-06-01T00%3A00%3A00.000Z&query=x');
+    (el as any).colIdxMap = { timestamp: 0 };
+    (el as any).spanListTree = [row('1', ['2026-06-01T00:00:00.000Z'])]; // newest is AT `to`
+    (el as any).isLiveStreaming = true;
+    (el as any).liveStreamInterval = setInterval(() => {}, 1e7);
+    const btn = document.createElement('input');
+    btn.type = 'checkbox';
+    btn.checked = true;
+    (el as any).liveBtn = btn;
+    let toast: string | undefined;
+    const onToast = (e: any) => (toast = e.detail.value[0]);
+    document.body.addEventListener('errorToast', onToast);
+    try {
+      (el as any).buildRecentFetchUrl();
+      expect((el as any).isLiveStreaming).toBe(false);
+      expect((el as any).liveStreamInterval).toBeNull();
+      expect(btn.checked).toBe(false);
+      expect(toast).toMatch(/end of the selected time range/);
+    } finally {
+      document.body.removeEventListener('errorToast', onToast);
+    }
+  });
+
+  test('buildRecentFetchUrl keeps live-tail running while below the upper bound', async () => {
+    const el = await mountList();
+    window.history.replaceState({}, '', '/log_explorer?to=2026-06-01T00%3A00%3A00.000Z&query=x');
+    (el as any).colIdxMap = { timestamp: 0 };
+    (el as any).spanListTree = [row('1', ['2026-05-01T00:00:00.000Z'])]; // well below `to`
+    (el as any).isLiveStreaming = true;
+    (el as any).buildRecentFetchUrl();
+    expect((el as any).isLiveStreaming).toBe(true);
+  });
+
   // M2: a refresh must drop inline-expanded aggregate children, else stale rows
   // from the previous query render under a key that survives the new query.
   test('refresh clears expandedAggregates', async () => {

--- a/web-components/test/log-list-bugs.test.ts
+++ b/web-components/test/log-list-bugs.test.ts
@@ -98,6 +98,49 @@ describe('LogList — MED correctness', () => {
     expect(url.searchParams.get('to')).toBe('2026-06-01T00:00:00.000Z');
     expect(url.searchParams.has('cursor')).toBe(false);
   });
+
+  // buildRecentFetchUrl must apply the ns/µs/ms tolerance too (it used raw new Date()).
+  test('buildRecentFetchUrl tolerates a nanosecond-epoch timestamp (no year-55000 from)', async () => {
+    const el = await mountList();
+    window.history.replaceState({}, '', '/log_explorer?query=x');
+    (el as any).colIdxMap = { timestamp: 0 };
+    (el as any).spanListTree = [row('1', [1700000000000000000])]; // ns ≈ Nov 2023
+    const url = new URL((el as any).buildRecentFetchUrl(), 'http://localhost');
+    expect(new Date(url.searchParams.get('from')!).getUTCFullYear()).toBe(2023);
+  });
+
+  // expandTimeRangeUrl ("Show earlier events") had the same raw-String(ns) cursor bug.
+  test('expandTimeRangeUrl tolerates a nanosecond-epoch timestamp in the cursor', async () => {
+    const el = await mountList();
+    window.history.replaceState({}, '', '/log_explorer?since=1H&query=x');
+    (el as any).colIdxMap = { timestamp: 0 };
+    (el as any).spanListTree = [row('1', [1700000000000000000])];
+    const url = new URL((el as any).expandTimeRangeUrl(), 'http://localhost');
+    expect(new Date(url.searchParams.get('cursor')!).getUTCFullYear()).toBe(2023);
+  });
+
+  // An empty live-tail tick must NOT flip expandTimeRange on (would flash "Show
+  // earlier events" every quiet 5s tick even though history isn't exhausted).
+  test('an empty recent fetch does not turn on expandTimeRange', async () => {
+    const el = await mountList();
+    el.transport = fakeTransport({ tree: [row('1'), row('2')] }, { tree: [], meta: { hasMore: false } });
+    await el.fetchData('initial', false, false, false);
+    (el as any).expandTimeRange = false;
+    await el.fetchData('recent', false, true, false); // isRecentFetch, returns nothing
+    expect((el as any).expandTimeRange).toBe(false);
+  });
+
+  // Switching to an aggregate view must null the interval, not just clear it — else
+  // handleLiveToggle's `!liveStreamInterval` guard skips setInterval on switch-back.
+  test('mode-switch to aggregate nulls liveStreamInterval (re-enable works later)', async () => {
+    const el = await mountList();
+    (el as any).liveStreamInterval = setInterval(() => {}, 1e7);
+    (el as any).isLiveStreaming = true;
+    (el as any).mode = 'patterns';
+    (el as any).updated(new Map([['mode', 'logs']]));
+    expect((el as any).liveStreamInterval).toBeNull();
+    expect((el as any).isLiveStreaming).toBe(false);
+  });
 });
 
 // M4: buffering decision (pure) — buffer whenever scrolled off the insertion edge.

--- a/web-components/test/log-list-harness.ts
+++ b/web-components/test/log-list-harness.ts
@@ -1,0 +1,60 @@
+// Shared harness for high-level LogList behavior tests: mount the real component,
+// feed canned {tree, meta} via the transport seam (no Web Worker / network), and
+// drive fetchData / events as a user would. See web_components_test_harness memory.
+import { LogList } from '../src/log-list';
+
+// Minimal EventLine-ish row; only fields the merge/render path touches.
+export const row = (id: string, data: any[] = [id]) => ({
+  id, data, depth: 0, children: 0, traceId: id, parentIds: [],
+  show: true, expanded: false, isLastChild: true, siblingsArr: [],
+  childErrors: false, hasErrors: false, isNew: false,
+  startNs: 0, duration: 0, traceStart: 0, traceEnd: 0, childrenTimeSpans: [], type: 'log' as const,
+});
+
+export const meta = (over: any = {}) => ({
+  serviceColors: {}, nextUrl: '', recentUrl: '', cols: ['id'], colIdxMap: { id: 0 },
+  count: 100, traces: [], hasMore: true, queryResultCount: 0, ...over,
+});
+
+// Queues canned pages; replaces the worker transport. Records requested urls.
+export const fakeTransport = (...pages: { tree: any[]; meta?: any }[]) => {
+  const q = [...pages];
+  const urls: string[] = [];
+  const fn = async (url: string) => {
+    urls.push(url);
+    const p = q.shift() ?? { tree: [], meta: {} };
+    return { tree: p.tree, meta: meta({ ...p.meta, queryResultCount: p.tree.length }) };
+  };
+  return Object.assign(fn, { urls });
+};
+
+// Transport whose responses are resolved manually, to test out-of-order / concurrent fetches.
+export const deferredTransport = () => {
+  const pending: Array<{ resolve: (v: any) => void; url: string }> = [];
+  const fn = (url: string) => new Promise<any>((resolve) => pending.push({ url, resolve }));
+  // settle(index, {tree, metaOverrides})
+  const settle = (i: number, tree: any[], over: any = {}) =>
+    pending[i].resolve({ tree, meta: meta({ ...over, queryResultCount: tree.length }) });
+  return Object.assign(fn, { pending, settle });
+};
+
+export const ids = (el: LogList) => (el as any).spanListTree.map((r: any) => r.id);
+
+// Mount with the mount-time auto-fetch disabled so tests drive fetchData explicitly.
+export const mountList = async (props: Partial<LogList> = {}) => {
+  const el = new LogList();
+  (el as any).fetchInitialData = async () => {};
+  Object.assign(el, props);
+  document.body.appendChild(el);
+  await el.updateComplete;
+  return el;
+};
+
+// Stub global fetch with a queue of JSON bodies (for paths that bypass transport,
+// e.g. aggregate-children expand). Returns a restore fn.
+export const stubFetch = (...bodies: any[]) => {
+  const q = [...bodies];
+  const orig = globalThis.fetch;
+  (globalThis as any).fetch = async () => ({ ok: true, status: 200, json: async () => q.shift() ?? {} });
+  return () => { (globalThis as any).fetch = orig; };
+};

--- a/web-components/test/log-list.test.ts
+++ b/web-components/test/log-list.test.ts
@@ -1,0 +1,80 @@
+import { describe, test, expect, beforeEach } from 'vitest';
+import { dedupeById } from '../src/log-list-utils';
+import { LogList } from '../src/log-list';
+import { row, fakeTransport, ids, mountList } from './log-list-harness';
+
+describe('dedupeById', () => {
+  test('keeps first occurrence, preserves order, drops repeats', () => {
+    const r = dedupeById([row('a'), row('b'), row('a'), row('c'), row('b')]);
+    expect(r.map((x) => x.id)).toEqual(['a', 'b', 'c']);
+  });
+  test('handles empty + all-unique unchanged', () => {
+    expect(dedupeById([])).toEqual([]);
+    expect(dedupeById([row('a'), row('b')]).map((x) => x.id)).toEqual(['a', 'b']);
+  });
+});
+
+describe('LogList load-more', () => {
+  let el: LogList;
+  beforeEach(async () => {
+    el = await mountList();
+  });
+
+  // Regression: cursor pagination uses an inclusive timestamp boundary, so page 2
+  // re-returns the last row of page 1. The merge must not duplicate that row in
+  // the table (the reported "load more pulls duplicate data" bug).
+  test('does not duplicate the boundary row across pages', async () => {
+    el.transport = fakeTransport(
+      { tree: [row('1'), row('2'), row('3')] },
+      { tree: [row('3'), row('4'), row('5')] }, // '3' repeats the boundary
+    );
+    await el.fetchData('initial', false, false, false);
+    await el.fetchData('loadmore', false, false, true);
+
+    expect(ids(el)).toEqual(['1', '2', '3', '4', '5']);
+    expect(new Set(ids(el)).size).toBe(ids(el).length); // no dups
+  });
+
+  test('clean page (no overlap) appends all rows in order', async () => {
+    el.transport = fakeTransport({ tree: [row('1'), row('2')] }, { tree: [row('3'), row('4')] });
+    await el.fetchData('initial', false, false, false);
+    await el.fetchData('loadmore', false, false, true);
+    expect(ids(el)).toEqual(['1', '2', '3', '4']);
+  });
+
+  // Regression: an empty load-more page must stop pagination (hasMore=false) even
+  // when the server still reports hasMore:true. Otherwise the load-more sentinel
+  // keeps re-firing and refetches the same window — which re-appended the page
+  // ("server returns nothing → duplicates the page and puts it in again").
+  test('empty load-more page stops pagination and does not re-add rows', async () => {
+    el.transport = fakeTransport(
+      { tree: [row('1'), row('2'), row('3')] },
+      { tree: [], meta: { hasMore: true } }, // server falsely claims more, sends nothing
+      { tree: [row('1'), row('2'), row('3')] }, // a stray refetch would re-serve the window
+    );
+    await el.fetchData('initial', false, false, false);
+    await el.fetchData('loadmore', false, false, true);
+    expect((el as any).hasMore).toBe(false); // pagination halted → sentinel/observer gone
+    expect(ids(el)).toEqual(['1', '2', '3']);
+
+    // Even if a refetch slips through, rows are never duplicated.
+    await el.fetchData('loadmore', false, false, true);
+    expect(ids(el)).toEqual(['1', '2', '3']);
+  });
+
+  // Regression: with rows on screen, running a new query (refresh) that returns
+  // nothing must clear the list and show the empty state — not leave the previous
+  // query's results persisted, which reads as "these are results for the new query".
+  test('refresh with empty result clears stale rows (shows empty, not old data)', async () => {
+    el.transport = fakeTransport(
+      { tree: [row('1'), row('2'), row('3')] },
+      { tree: [], meta: { hasMore: false, count: 0 } }, // new query → no matches
+    );
+    await el.fetchData('initial', false, false, false);
+    expect(ids(el)).toEqual(['1', '2', '3']);
+
+    await el.fetchData('newquery', true, false, false); // isRefresh
+    expect(ids(el)).toEqual([]);
+    expect((el as any).loadedCount).toBe(0);
+  });
+});

--- a/web-components/test/setup.ts
+++ b/web-components/test/setup.ts
@@ -1,5 +1,10 @@
 // This file will be executed before running tests
-import { beforeAll, vi } from 'vitest';
+import { vi } from 'vitest';
+
+// main.ts runs at import time and calls these globals; stub them so any component
+// (e.g. log-list → widgets → main) is importable in jsdom without throwing.
+(window as any).htmx = { defineExtension: vi.fn(), ajax: vi.fn(), process: vi.fn() };
+(window as any).interpolateVarTemplates = vi.fn();
 
 // Mock document.queryCommandSupported and execCommand for Monaco Editor clipboard support
 document.queryCommandSupported = vi.fn(() => false);
@@ -35,6 +40,31 @@ Object.defineProperty(window, 'matchMedia', {
   disconnect() {}
 };
 
+// Controllable IntersectionObserver. jsdom/happy-dom compute no layout, so NO
+// library (not even the W3C polyfill) can fire these from real visibility — they
+// just never trigger. Instead we expose a spec-shaped mock whose callbacks tests
+// fire explicitly via triggerIntersection(), exercising the real observer-driven
+// code paths (e.g. log-list load-more). For true layout-driven observers, run the
+// test under @vitest/browser (real Chromium).
+const ioInstances = new Set<any>();
+(global as any).IntersectionObserver = class IntersectionObserver {
+  callback: IntersectionObserverCallback;
+  elements = new Set<Element>();
+  root = null; rootMargin = ''; thresholds = [];
+  constructor(cb: IntersectionObserverCallback) { this.callback = cb; ioInstances.add(this); }
+  observe(el: Element) { this.elements.add(el); }
+  unobserve(el: Element) { this.elements.delete(el); }
+  disconnect() { this.elements.clear(); ioInstances.delete(this); }
+  takeRecords() { return []; }
+};
+// Fire an intersection for observers watching `el` (or all observed elements).
+(globalThis as any).triggerIntersection = (el?: Element, isIntersecting = true) => {
+  for (const o of ioInstances) {
+    const targets = el ? [...o.elements].filter((e) => e === el) : [...o.elements];
+    if (targets.length) o.callback(targets.map((t) => ({ isIntersecting, target: t, intersectionRatio: isIntersecting ? 1 : 0 })) as any, o);
+  }
+};
+
 // Mock Worker for Monaco Editor since we don't need actual workers in tests
 globalThis.Worker = class Worker {
   constructor(url: string | URL) {}
@@ -54,80 +84,5 @@ globalThis.MonacoEnvironment = {
   }
 };
 
-// Canvas mock for Monaco Editor compatibility with jsdom
-beforeAll(() => {
-
-  // Mock HTMLCanvasElement methods that Monaco Editor uses
-  const mockContext = {
-    fillStyle: '',
-    strokeStyle: '',
-    lineWidth: 1,
-    lineCap: 'butt',
-    lineJoin: 'miter',
-    miterLimit: 10,
-    font: '10px sans-serif',
-    textAlign: 'start',
-    textBaseline: 'alphabetic',
-    direction: 'ltr',
-    globalAlpha: 1,
-    globalCompositeOperation: 'source-over',
-    imageSmoothingEnabled: true,
-    shadowBlur: 0,
-    shadowColor: 'rgba(0, 0, 0, 0)',
-    shadowOffsetX: 0,
-    shadowOffsetY: 0,
-    fillRect: vi.fn(),
-    strokeRect: vi.fn(),
-    clearRect: vi.fn(),
-    beginPath: vi.fn(),
-    closePath: vi.fn(),
-    moveTo: vi.fn(),
-    lineTo: vi.fn(),
-    bezierCurveTo: vi.fn(),
-    quadraticCurveTo: vi.fn(),
-    arc: vi.fn(),
-    arcTo: vi.fn(),
-    ellipse: vi.fn(),
-    rect: vi.fn(),
-    fill: vi.fn(),
-    stroke: vi.fn(),
-    clip: vi.fn(),
-    isPointInPath: vi.fn(),
-    isPointInStroke: vi.fn(),
-    measureText: vi.fn(() => ({ width: 0, actualBoundingBoxAscent: 0, actualBoundingBoxDescent: 0 })),
-    fillText: vi.fn(),
-    strokeText: vi.fn(),
-    drawImage: vi.fn(),
-    createImageData: vi.fn(),
-    getImageData: vi.fn(() => ({ data: [], width: 0, height: 0 })),
-    putImageData: vi.fn(),
-    save: vi.fn(),
-    restore: vi.fn(),
-    scale: vi.fn(),
-    rotate: vi.fn(),
-    translate: vi.fn(),
-    transform: vi.fn(),
-    setTransform: vi.fn(),
-    resetTransform: vi.fn(),
-    createLinearGradient: vi.fn(),
-    createRadialGradient: vi.fn(),
-    createPattern: vi.fn(),
-    getContextAttributes: vi.fn(() => ({})),
-    canvas: null as any,
-  };
-
-  HTMLCanvasElement.prototype.getContext = vi.fn((contextType: string) => {
-    if (contextType === '2d') {
-      mockContext.canvas = this;
-      return mockContext as any;
-    }
-    return null;
-  });
-
-  HTMLCanvasElement.prototype.toDataURL = vi.fn(() => 'data:image/png;base64,');
-  HTMLCanvasElement.prototype.toBlob = vi.fn((callback: any) => {
-    callback(new Blob());
-  });
-
-  console.log('Test setup complete with jsdom and canvas mocking');
-});
+// Canvas 2D context is provided realistically by `vitest-canvas-mock` (first
+// entry in setupFiles), so no hand-rolled getContext stub is needed here.

--- a/web-components/vitest.config.ts
+++ b/web-components/vitest.config.ts
@@ -5,13 +5,14 @@ export default defineConfig({
     // jsdom has better compatibility with Monaco Editor
     environment: 'jsdom',
     globals: true,
-    // Use existing setup file
-    setupFiles: './test/setup.ts',
+    // vitest-canvas-mock gives a realistic 2D context (echarts/canvas run for real);
+    // then our own setup (globals + controllable observers).
+    setupFiles: ['vitest-canvas-mock', './test/setup.ts'],
     deps: {
       optimizer: {
         web: {
           // force Vitest to bundle Monaco instead of trying to stub it
-          include: ['monaco-editor'],
+          include: ['monaco-editor', 'vitest-canvas-mock'],
         }
       }
     },


### PR DESCRIPTION
…tch bugs

Fixes a cluster of LogList explorer + dashboard widget defects, each with a regression test (new vitest harness with a `transport` seam + controllable IntersectionObserver, backed by vitest-canvas-mock):

- dedupe inclusive-boundary row across paginated/live pages (no duplicate rows)
- empty load-more page stops pagination even if server still reports hasMore
- refresh with empty result clears stale rows; drops inline-expanded aggregates
- hidden/reordered columns survive load-more & 5s live-stream refetches
- fetchGeneration guard prevents a stale load-more from contaminating a new query
- per-kind loading-guard reset so concurrent fetches don't clear each other
- live-stream listener/interval + worker callbacks cleaned up on disconnect (no orphaned polling loops or reject-after-teardown across HTMX remounts)
- buildRecentFetchUrl preserves the `to` upper bound on bounded ranges
- cursorFromTimestamp tolerates ns/µs/ms epochs (no year-55000 stall)
- per-chart fetch sequencer discards stale /chart_data responses so a late failure can't reapply the error overlay over freshly rendered bars
- column resize seeds from the column's real current width
- drop unused ansi_up (v6) dependency

<!-- Thank you for contributing to Monscope! -->

<!-- Briefly describe what your PR does here as much as you can. -->

Closes #

<!-- If your PR is related to an issue, provide the number(s) above (after the #); if it resolves multiple issues, be sure to add a comma (e.g. "closes #1000, #1001"). -->

## How to test

<!-- Please include the steps to test your changes here. -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure you have described your changes and added all relevant screenshots or data.
- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes (or request one from the team).
- [ ] You are **NOT** deprecating/removing a feature.
