### PR TITLE
fix(log-explorer): page earlier/load-more cursor from the oldest loaded row

### DIFF
--- a/web-components/src/log-list-utils.ts
+++ b/web-components/src/log-list-utils.ts
@@ -286,7 +286,8 @@ export const cursorFromTimestamp = (timestamp: string | number, offsetMs: number
 const rowTimestamp = (rows: EventLine[], colIdxMap: ColIdxMap, by: typeof minBy): string | number | undefined => {
   const ti = colIdxMap['timestamp'] ?? colIdxMap['created_at'];
   if (ti === undefined) return undefined;
-  const best = by(rows.filter(r => r.data[ti] != null), r => tsToMs(r.data[ti]));
+  // minBy/maxBy skip null/undefined/NaN iteratees, so no pre-filter pass needed.
+  const best = by(rows, r => (r.data[ti] != null ? tsToMs(r.data[ti]) : undefined));
   return best?.data[ti];
 };
 export const oldestRowTimestamp = (rows: EventLine[], colIdxMap: ColIdxMap) => rowTimestamp(rows, colIdxMap, minBy);

--- a/web-components/src/log-list-utils.ts
+++ b/web-components/src/log-list-utils.ts
@@ -1,7 +1,7 @@
 import { format, isValid } from 'date-fns';
 import clsx from 'clsx';
 import { html, svg, TemplateResult } from 'lit';
-import { get } from 'lodash';
+import { get, minBy, maxBy } from 'lodash';
 import { ColIdxMap, EventLine } from './types/types';
 import { AnsiUp } from 'ansi-up';
 // Configuration objects
@@ -278,27 +278,19 @@ const tsToMs = (timestamp: string | number): number => {
 
 export const cursorFromTimestamp = (timestamp: string | number, offsetMs: number): string => new Date(tsToMs(timestamp) + offsetMs).toISOString();
 
-// Oldest (minimum) timestamp among loaded rows. spanListTree is the flattened
-// trace tree: child spans (always ≥ their parent's start) are appended after the
-// trace root, so the trailing array element is a newer leaf — NOT the oldest row.
-// Scan for the true min so "earlier"/load-more cursors page strictly before
-// everything already shown instead of re-fetching rows already on screen.
-export const oldestRowTimestamp = (rows: EventLine[], colIdxMap: ColIdxMap): string | number | undefined => {
+// Extremum timestamp among loaded rows. spanListTree is the flattened trace tree:
+// child spans (always ≥ their parent's start) are appended after the trace root
+// and traces sort newest-first, so NEITHER array endpoint is the true min/max.
+// Scan instead, so "earlier"/load-more (oldest) and live-tail (newest) cursors
+// page strictly outside everything already shown.
+const rowTimestamp = (rows: EventLine[], colIdxMap: ColIdxMap, by: typeof minBy): string | number | undefined => {
   const ti = colIdxMap['timestamp'] ?? colIdxMap['created_at'];
   if (ti === undefined) return undefined;
-  let best: string | number | undefined;
-  let bestMs = Infinity;
-  for (const r of rows) {
-    const ts = (r as any)?.data?.[ti];
-    if (ts == null) continue;
-    const ms = tsToMs(ts);
-    if (ms < bestMs) {
-      bestMs = ms;
-      best = ts;
-    }
-  }
-  return best;
+  const best = by(rows.filter(r => r.data[ti] != null), r => tsToMs(r.data[ti]));
+  return best?.data[ti];
 };
+export const oldestRowTimestamp = (rows: EventLine[], colIdxMap: ColIdxMap) => rowTimestamp(rows, colIdxMap, minBy);
+export const newestRowTimestamp = (rows: EventLine[], colIdxMap: ColIdxMap) => rowTimestamp(rows, colIdxMap, maxBy);
 
 export const getColumnWidth = (column: string): string =>
   COLUMN_WIDTHS[column as keyof typeof COLUMN_WIDTHS] || (column === 'id' ? '' : 'w-[16ch] shrink-0');

--- a/web-components/src/log-list-utils.ts
+++ b/web-components/src/log-list-utils.ts
@@ -266,17 +266,38 @@ export const shouldBufferRecent = (
 // Pagination cursor (ISO) from a row timestamp ± offset. Tolerates ISO strings and
 // numeric epochs in ns/µs/ms — `new Date(epochNs)` otherwise reads ns as ms and
 // produces a year-~55000 cursor that returns nothing, stalling load-more.
-export const cursorFromTimestamp = (timestamp: string | number, offsetMs: number): string => {
-  let ms: number;
+// Magnitude disambiguates the unit; assumes wall-clock log times in
+// ~2001–5138 (ms ∈ [1e11,1e14)), so the thresholds never collide in practice.
+const tsToMs = (timestamp: string | number): number => {
   if (typeof timestamp === 'number' || /^\d+$/.test(String(timestamp))) {
     const n = Number(timestamp);
-    // Magnitude disambiguates the unit; assumes wall-clock log times in
-    // ~2001–5138 (ms ∈ [1e11,1e14)), so the thresholds never collide in practice.
-    ms = n > 1e17 ? n / 1e6 : n > 1e14 ? n / 1e3 : n; // ns→ms, µs→ms, else ms
-  } else {
-    ms = new Date(timestamp).getTime();
+    return n > 1e17 ? n / 1e6 : n > 1e14 ? n / 1e3 : n; // ns→ms, µs→ms, else ms
   }
-  return new Date(ms + offsetMs).toISOString();
+  return new Date(timestamp).getTime();
+};
+
+export const cursorFromTimestamp = (timestamp: string | number, offsetMs: number): string => new Date(tsToMs(timestamp) + offsetMs).toISOString();
+
+// Oldest (minimum) timestamp among loaded rows. spanListTree is the flattened
+// trace tree: child spans (always ≥ their parent's start) are appended after the
+// trace root, so the trailing array element is a newer leaf — NOT the oldest row.
+// Scan for the true min so "earlier"/load-more cursors page strictly before
+// everything already shown instead of re-fetching rows already on screen.
+export const oldestRowTimestamp = (rows: EventLine[], colIdxMap: ColIdxMap): string | number | undefined => {
+  const ti = colIdxMap['timestamp'] ?? colIdxMap['created_at'];
+  if (ti === undefined) return undefined;
+  let best: string | number | undefined;
+  let bestMs = Infinity;
+  for (const r of rows) {
+    const ts = (r as any)?.data?.[ti];
+    if (ts == null) continue;
+    const ms = tsToMs(ts);
+    if (ms < bestMs) {
+      bestMs = ms;
+      best = ts;
+    }
+  }
+  return best;
 };
 
 export const getColumnWidth = (column: string): string =>

--- a/web-components/src/log-list-utils.ts
+++ b/web-components/src/log-list-utils.ts
@@ -284,15 +284,15 @@ export const cursorFromTimestamp = (timestamp: string | number, offsetMs: number
 // Scan instead, so "earlier"/load-more (oldest) and live-tail (newest) cursors
 // page strictly outside everything already shown.
 type ArrayExtremum = (arr: EventLine[], iteratee: (r: EventLine) => number | undefined) => EventLine | undefined;
-const rowTimestamp = (rows: EventLine[], colIdxMap: ColIdxMap, by: ArrayExtremum): string | number | undefined => {
+const byRowTs = (by: ArrayExtremum) => (rows: EventLine[], colIdxMap: ColIdxMap): string | number | undefined => {
   const ti = colIdxMap['timestamp'] ?? colIdxMap['created_at'];
   if (ti === undefined) return undefined;
   // minBy/maxBy skip null/undefined/NaN iteratees, so no pre-filter pass needed.
   const best = by(rows, r => (r.data[ti] != null ? tsToMs(r.data[ti]) : undefined));
   return best?.data[ti]; // RAW value, not ms — cursorFromTimestamp re-tolerates the unit
 };
-export const oldestRowTimestamp = (rows: EventLine[], colIdxMap: ColIdxMap): string | number | undefined => rowTimestamp(rows, colIdxMap, minBy);
-export const newestRowTimestamp = (rows: EventLine[], colIdxMap: ColIdxMap): string | number | undefined => rowTimestamp(rows, colIdxMap, maxBy);
+export const oldestRowTimestamp = byRowTs(minBy);
+export const newestRowTimestamp = byRowTs(maxBy);
 
 export const getColumnWidth = (column: string): string =>
   COLUMN_WIDTHS[column as keyof typeof COLUMN_WIDTHS] || (column === 'id' ? '' : 'w-[16ch] shrink-0');

--- a/web-components/src/log-list-utils.ts
+++ b/web-components/src/log-list-utils.ts
@@ -288,10 +288,7 @@ const rowTimestamp = (rows: EventLine[], colIdxMap: ColIdxMap, by: typeof minBy)
   if (ti === undefined) return undefined;
   // minBy/maxBy skip null/undefined/NaN iteratees, so no pre-filter pass needed.
   const best = by(rows, r => (r.data[ti] != null ? tsToMs(r.data[ti]) : undefined));
-  // Returns the RAW cell value (ISO string or ns/µs/ms epoch), NOT milliseconds —
-  // feed it straight to cursorFromTimestamp, which re-tolerates the unit. Don't
-  // treat it as ms (that's the ns→year-55000 trap this scan exists to avoid).
-  return best?.data[ti];
+  return best?.data[ti]; // RAW value, not ms — cursorFromTimestamp re-tolerates the unit
 };
 export const oldestRowTimestamp = (rows: EventLine[], colIdxMap: ColIdxMap): string | number | undefined => rowTimestamp(rows, colIdxMap, minBy);
 export const newestRowTimestamp = (rows: EventLine[], colIdxMap: ColIdxMap): string | number | undefined => rowTimestamp(rows, colIdxMap, maxBy);

--- a/web-components/src/log-list-utils.ts
+++ b/web-components/src/log-list-utils.ts
@@ -283,12 +283,12 @@ export const cursorFromTimestamp = (timestamp: string | number, offsetMs: number
 // and traces sort newest-first, so NEITHER array endpoint is the true min/max.
 // Scan instead, so "earlier"/load-more (oldest) and live-tail (newest) cursors
 // page strictly outside everything already shown.
-const byRowTs = (by: typeof minBy) => (rows: EventLine[], colIdxMap: ColIdxMap): string | number | undefined => {
+const byRowTs = (by: typeof minBy) => (rows: EventLine[], colIdxMap: ColIdxMap): number | undefined => {
   const ti = colIdxMap['timestamp'] ?? colIdxMap['created_at'];
   if (ti === undefined) return undefined;
   // minBy/maxBy skip null/undefined/NaN iteratees, so no pre-filter pass needed.
   const best = by(rows, r => (r.data[ti] != null ? tsToMs(r.data[ti]) : undefined));
-  return best?.data[ti]; // RAW value, not ms — cursorFromTimestamp re-tolerates the unit
+  return best != null ? tsToMs(best.data[ti]) : undefined; // ms
 };
 export const oldestRowTimestamp = byRowTs(minBy);
 export const newestRowTimestamp = byRowTs(maxBy);

--- a/web-components/src/log-list-utils.ts
+++ b/web-components/src/log-list-utils.ts
@@ -283,8 +283,7 @@ export const cursorFromTimestamp = (timestamp: string | number, offsetMs: number
 // and traces sort newest-first, so NEITHER array endpoint is the true min/max.
 // Scan instead, so "earlier"/load-more (oldest) and live-tail (newest) cursors
 // page strictly outside everything already shown.
-type ArrayExtremum = (arr: EventLine[], iteratee: (r: EventLine) => number | undefined) => EventLine | undefined;
-const byRowTs = (by: ArrayExtremum) => (rows: EventLine[], colIdxMap: ColIdxMap): string | number | undefined => {
+const byRowTs = (by: typeof minBy) => (rows: EventLine[], colIdxMap: ColIdxMap): string | number | undefined => {
   const ti = colIdxMap['timestamp'] ?? colIdxMap['created_at'];
   if (ti === undefined) return undefined;
   // minBy/maxBy skip null/undefined/NaN iteratees, so no pre-filter pass needed.

--- a/web-components/src/log-list-utils.ts
+++ b/web-components/src/log-list-utils.ts
@@ -1,7 +1,7 @@
 import { format, isValid } from 'date-fns';
 import clsx from 'clsx';
 import { html, svg, TemplateResult } from 'lit';
-import { get, minBy, maxBy } from 'lodash';
+import { minBy, maxBy } from 'lodash';
 import { ColIdxMap, EventLine } from './types/types';
 import { AnsiUp } from 'ansi-up';
 // Configuration objects
@@ -288,10 +288,13 @@ const rowTimestamp = (rows: EventLine[], colIdxMap: ColIdxMap, by: typeof minBy)
   if (ti === undefined) return undefined;
   // minBy/maxBy skip null/undefined/NaN iteratees, so no pre-filter pass needed.
   const best = by(rows, r => (r.data[ti] != null ? tsToMs(r.data[ti]) : undefined));
+  // Returns the RAW cell value (ISO string or ns/µs/ms epoch), NOT milliseconds —
+  // feed it straight to cursorFromTimestamp, which re-tolerates the unit. Don't
+  // treat it as ms (that's the ns→year-55000 trap this scan exists to avoid).
   return best?.data[ti];
 };
-export const oldestRowTimestamp = (rows: EventLine[], colIdxMap: ColIdxMap) => rowTimestamp(rows, colIdxMap, minBy);
-export const newestRowTimestamp = (rows: EventLine[], colIdxMap: ColIdxMap) => rowTimestamp(rows, colIdxMap, maxBy);
+export const oldestRowTimestamp = (rows: EventLine[], colIdxMap: ColIdxMap): string | number | undefined => rowTimestamp(rows, colIdxMap, minBy);
+export const newestRowTimestamp = (rows: EventLine[], colIdxMap: ColIdxMap): string | number | undefined => rowTimestamp(rows, colIdxMap, maxBy);
 
 export const getColumnWidth = (column: string): string =>
   COLUMN_WIDTHS[column as keyof typeof COLUMN_WIDTHS] || (column === 'id' ? '' : 'w-[16ch] shrink-0');

--- a/web-components/src/log-list-utils.ts
+++ b/web-components/src/log-list-utils.ts
@@ -388,7 +388,7 @@ export const middleTruncatePath = (path: string, maxTailLen: number = 28): [stri
   return [path.slice(0, Math.max(0, path.length - maxTailLen)), path.slice(-maxTailLen)];
 };
 
-export const formatPatternCount = (n: number): string => {
+export const formatLargeCount = (n: number): string => {
   if (n >= 1_000_000) return (n / 1_000_000).toFixed(1) + 'M';
   if (n >= 1_000) return (n / 1_000).toFixed(1) + 'K';
   return String(n);
@@ -414,7 +414,7 @@ export const renderSparkline = (buckets: number[]): TemplateResult => {
   const peak = Math.max(...buckets, 1);
   const n = buckets.length;
   const h = 40, barZone = 32, topPad = h - barZone;
-  const peakLabel = formatPatternCount(peak);
+  const peakLabel = formatLargeCount(peak);
   const labelW = peakLabel.length * 7 + 4;
   const gap = 2, barW = Math.max(2, Math.floor(120 / n) - gap);
   const barsEnd = n * (barW + gap);

--- a/web-components/src/log-list-utils.ts
+++ b/web-components/src/log-list-utils.ts
@@ -283,7 +283,8 @@ export const cursorFromTimestamp = (timestamp: string | number, offsetMs: number
 // and traces sort newest-first, so NEITHER array endpoint is the true min/max.
 // Scan instead, so "earlier"/load-more (oldest) and live-tail (newest) cursors
 // page strictly outside everything already shown.
-const rowTimestamp = (rows: EventLine[], colIdxMap: ColIdxMap, by: typeof minBy): string | number | undefined => {
+type ArrayExtremum = (arr: EventLine[], iteratee: (r: EventLine) => number | undefined) => EventLine | undefined;
+const rowTimestamp = (rows: EventLine[], colIdxMap: ColIdxMap, by: ArrayExtremum): string | number | undefined => {
   const ti = colIdxMap['timestamp'] ?? colIdxMap['created_at'];
   if (ti === undefined) return undefined;
   // minBy/maxBy skip null/undefined/NaN iteratees, so no pre-filter pass needed.

--- a/web-components/src/log-list.ts
+++ b/web-components/src/log-list.ts
@@ -384,6 +384,15 @@ export class LogList extends LitElement {
     return url.toString();
   }
 
+  // Cursor for paging strictly older than everything loaded: the oldest row's
+  // timestamp ± offset (negative skips the inclusive boundary row). Scanned, not
+  // positional — the flattened trace tree appends newer child spans after the
+  // oldest trace's root, so the array endpoints aren't the min. null when empty.
+  private oldestCursor(offsetMs: number): string | null {
+    const ts = oldestRowTimestamp(this.spanListTree, this.colIdxMap);
+    return ts == null ? null : cursorFromTimestamp(ts, offsetMs);
+  }
+
   private buildLoadMoreUrl(): string {
     // Patterns / sessions: increment aggregate_skip based on loaded count
     if (this.isAggregate || this.mode === 'sessions') { // sessions also use aggregate skip for top-level pagination
@@ -399,12 +408,10 @@ export class LogList extends LitElement {
       return this.buildJsonUrl();
     }
 
-    // Oldest loaded row's timestamp — scanned, not positional: the flattened
-    // trace tree appends newer child spans after the oldest trace's root, so the
-    // array endpoints aren't the min. (See oldestRowTimestamp.)
-    const timestamp = oldestRowTimestamp(this.spanListTree, this.colIdxMap);
+    // Cursor from the oldest row, -10ms buffer to skip the inclusive boundary.
+    const cursor = this.oldestCursor(-10);
 
-    if (!timestamp) {
+    if (!cursor) {
       console.warn('[LoadMore] No timestamp found, falling back to nextFetchUrl or buildJsonUrl', {
         flipDirection: this.flipDirection,
         treeLength: this.spanListTree.length,
@@ -417,10 +424,7 @@ export class LogList extends LitElement {
     const baseUrl = this.nextFetchUrl || window.location.href;
     const url = new URL(baseUrl, window.location.origin + window.location.pathname);
     url.searchParams.set('json', 'true');
-
-    // Cursor from the oldest row, -10ms buffer; preserves from/to/since filters.
-    // cursorFromTimestamp handles ISO or numeric ns/µs/ms timestamps.
-    url.searchParams.set('cursor', cursorFromTimestamp(timestamp, -10));
+    url.searchParams.set('cursor', cursor); // preserves from/to/since filters already on the base URL
 
     return url.toString();
   }
@@ -446,16 +450,9 @@ export class LogList extends LitElement {
       url.searchParams.set('since', target);
     }
 
-    // Use the oldest loaded row's timestamp as the cursor so we fetch strictly
-    // older logs when expanding the range (scanned, not positional — see above).
-    if (this.spanListTree.length > 0) {
-      const oldestTimestamp = oldestRowTimestamp(this.spanListTree, this.colIdxMap);
-
-      if (oldestTimestamp) {
-        // Same ns/µs/ms tolerance as load-more; String(epochNs) would stall the server cursor.
-        url.searchParams.set('cursor', cursorFromTimestamp(oldestTimestamp, 0));
-      }
-    }
+    // Cursor from the oldest loaded row so we fetch strictly older logs on expand.
+    const cursor = this.oldestCursor(0);
+    if (cursor) url.searchParams.set('cursor', cursor);
 
     // Ensure json=true and layout=loadmore for the API request
     url.searchParams.set('json', 'true');

--- a/web-components/src/log-list.ts
+++ b/web-components/src/log-list.ts
@@ -32,7 +32,6 @@ import {
   generateId,
   dedupeById,
   shouldBufferRecent,
-  cursorFromTimestamp,
   oldestRowTimestamp,
   newestRowTimestamp,
   renderSparkline,
@@ -357,7 +356,7 @@ export class LogList extends LitElement {
     url.searchParams.set('json', 'true');
 
     // Lower bound = newest loaded row + 10ms (skip it). null when empty.
-    const from = this.newestCursor(10);
+    const from = this.edgeCursor(newestRowTimestamp, 10);
     if (from != null) {
       url.searchParams.set('from', from);
       // Recompute the lower bound from the newest loaded row; drop cursor/since.
@@ -383,11 +382,9 @@ export class LogList extends LitElement {
   // appends child spans after their (older) trace root, so the array endpoints
   // aren't the true min/max. null when empty. oldest → page earlier/load-more;
   // newest → live-tail lower bound.
-  private oldestCursor(offsetMs: number) { return this.edgeCursor(oldestRowTimestamp, offsetMs); }
-  private newestCursor(offsetMs: number) { return this.edgeCursor(newestRowTimestamp, offsetMs); }
   private edgeCursor(by: typeof oldestRowTimestamp, offsetMs: number): string | null {
-    const ts = by(this.spanListTree, this.colIdxMap);
-    return ts == null ? null : cursorFromTimestamp(ts, offsetMs);
+    const ms = by(this.spanListTree, this.colIdxMap);
+    return ms == null ? null : new Date(ms + offsetMs).toISOString();
   }
 
   private buildLoadMoreUrl(): string {
@@ -406,7 +403,7 @@ export class LogList extends LitElement {
     }
 
     // Cursor from the oldest row, -10ms buffer to skip the inclusive boundary.
-    const cursor = this.oldestCursor(-10);
+    const cursor = this.edgeCursor(oldestRowTimestamp, -10);
 
     if (!cursor) {
       console.warn('[LoadMore] No timestamp found, falling back to nextFetchUrl or buildJsonUrl', {
@@ -448,7 +445,7 @@ export class LogList extends LitElement {
     }
 
     // Cursor from the oldest loaded row so we fetch strictly older logs on expand.
-    const cursor = this.oldestCursor(0);
+    const cursor = this.edgeCursor(oldestRowTimestamp, 0);
     if (cursor) url.searchParams.set('cursor', cursor);
 
     // Ensure json=true and layout=loadmore for the API request

--- a/web-components/src/log-list.ts
+++ b/web-components/src/log-list.ts
@@ -27,7 +27,7 @@ import {
   createCachedIconRenderer,
   WEAK_TEXT_STYLES,
   RIGHT_PREFIX_REGEX,
-  formatPatternCount,
+  formatLargeCount,
   highlightPlaceholders,
   generateId,
   dedupeById,
@@ -586,14 +586,14 @@ export class LogList extends LitElement {
     if (!countEl) return;
     let countText: string, suffixText: string;
     if (this.mode === 'patterns') {
-      countText = `${formatPatternCount(this.totalPatterns)} patterns`;
-      suffixText = ` found (based on ${formatPatternCount(this.totalCount)} logs)`;
+      countText = `${formatLargeCount(this.totalPatterns)} patterns`;
+      suffixText = ` found (based on ${formatLargeCount(this.totalCount)} logs)`;
     } else if (this.mode === 'sessions') {
-      countText = `${formatPatternCount(this.totalSessions)} sessions`;
-      suffixText = this.totalCount ? ` (${formatPatternCount(this.totalCount)} events)` : '';
+      countText = `${formatLargeCount(this.totalSessions)} sessions`;
+      suffixText = this.totalCount ? ` (${formatLargeCount(this.totalCount)} events)` : '';
     } else {
-      countText = formatPatternCount(this.loadedCount);
-      suffixText = this.loadedCount < this.totalCount ? ` of ${formatPatternCount(this.totalCount)} rows` : ' rows';
+      countText = formatLargeCount(this.loadedCount);
+      suffixText = this.loadedCount < this.totalCount ? ` of ${formatLargeCount(this.totalCount)} rows` : ' rows';
     }
     countEl.textContent = countText;
     if (suffixEl) suffixEl.textContent = suffixText;
@@ -1808,7 +1808,7 @@ export class LogList extends LitElement {
           : 1;
         const pct = (count / maxCount) * 100;
         return html`<div class="flex items-center gap-1.5 w-full min-w-0" title="${pct.toFixed(1)}% of total${mergedCount > 0 ? ` (${mergedCount} merged)` : ''}">
-          <span class="text-sm tabular-nums text-textStrong w-10 shrink-0 text-right">${formatPatternCount(count)}</span>
+          <span class="text-sm tabular-nums text-textStrong w-10 shrink-0 text-right">${formatLargeCount(count)}</span>
           ${mergedCount > 0 ? html`<span class="text-[10px] tabular-nums text-textWeak shrink-0" title="${mergedCount} similar patterns merged">+${mergedCount}</span>` : ''}
           <div class="w-12 shrink-0 h-2 bg-strokeWeak/40 rounded-sm overflow-hidden">
             <div class="h-full bg-fillBrand-strong rounded-sm" style="width:${pct}%"></div>

--- a/web-components/src/log-list.ts
+++ b/web-components/src/log-list.ts
@@ -5,7 +5,7 @@ import { customElement, state, query, property } from 'lit/decorators.js';
 import { ref, createRef } from 'lit/directives/ref.js';
 import { APTEvent, ChildrenForLatency, ColIdxMap, EventLine, ServerTraceEntry, Trace, TraceDataMap } from './types/types';
 import debounce from 'lodash/debounce';
-import { includes, startsWith, map, forEach, compact, pick, chunk, chain, lt } from 'lodash';
+import { includes, startsWith, map, forEach, compact, chunk, chain, lt } from 'lodash';
 // Import worker as URL instead of worker instance
 import LogWorkerUrl from './log-worker?worker&url';
 import { groupSpans } from './log-worker-functions';
@@ -385,8 +385,8 @@ export class LogList extends LitElement {
   // newest → live-tail lower bound.
   private oldestCursor(offsetMs: number) { return this.edgeCursor(oldestRowTimestamp, offsetMs); }
   private newestCursor(offsetMs: number) { return this.edgeCursor(newestRowTimestamp, offsetMs); }
-  private edgeCursor(pick: (rows: EventLine[], colIdxMap: ColIdxMap) => string | number | undefined, offsetMs: number): string | null {
-    const ts = pick(this.spanListTree, this.colIdxMap);
+  private edgeCursor(by: typeof oldestRowTimestamp, offsetMs: number): string | null {
+    const ts = by(this.spanListTree, this.colIdxMap);
     return ts == null ? null : cursorFromTimestamp(ts, offsetMs);
   }
 
@@ -589,14 +589,14 @@ export class LogList extends LitElement {
     if (!countEl) return;
     let countText: string, suffixText: string;
     if (this.mode === 'patterns') {
-      countText = `${this.formatCount(this.totalPatterns)} patterns`;
-      suffixText = ` found (based on ${this.formatCount(this.totalCount)} logs)`;
+      countText = `${formatPatternCount(this.totalPatterns)} patterns`;
+      suffixText = ` found (based on ${formatPatternCount(this.totalCount)} logs)`;
     } else if (this.mode === 'sessions') {
-      countText = `${this.formatCount(this.totalSessions)} sessions`;
-      suffixText = this.totalCount ? ` (${this.formatCount(this.totalCount)} events)` : '';
+      countText = `${formatPatternCount(this.totalSessions)} sessions`;
+      suffixText = this.totalCount ? ` (${formatPatternCount(this.totalCount)} events)` : '';
     } else {
-      countText = this.formatCount(this.loadedCount);
-      suffixText = this.loadedCount < this.totalCount ? ` of ${this.formatCount(this.totalCount)} rows` : ' rows';
+      countText = formatPatternCount(this.loadedCount);
+      suffixText = this.loadedCount < this.totalCount ? ` of ${formatPatternCount(this.totalCount)} rows` : ' rows';
     }
     countEl.textContent = countText;
     if (suffixEl) suffixEl.textContent = suffixText;
@@ -624,15 +624,6 @@ export class LogList extends LitElement {
       // Remove spinner
       spinner.remove();
     }
-  }
-
-  private formatCount(count: number): string {
-    if (count >= 1000000) {
-      return (count / 1000000).toFixed(1) + 'M';
-    } else if (count >= 1000) {
-      return (count / 1000).toFixed(1) + 'K';
-    }
-    return count.toString();
   }
 
   firstUpdated() {

--- a/web-components/src/log-list.ts
+++ b/web-components/src/log-list.ts
@@ -34,6 +34,7 @@ import {
   shouldBufferRecent,
   cursorFromTimestamp,
   oldestRowTimestamp,
+  newestRowTimestamp,
   renderSparkline,
   parseUserAgent,
   isBotUserAgent,
@@ -357,8 +358,10 @@ export class LogList extends LitElement {
 
     // If we have data, update the 'from' parameter to fetch newer data
     if (this.spanListTree.length > 0) {
-      const firstItem = this.flipDirection ? this.spanListTree[this.spanListTree.length - 1] : this.spanListTree[0];
-      const timestamp = firstItem?.data?.[this.colIdxMap['timestamp'] ?? this.colIdxMap['created_at']];
+      // Newest loaded row — scanned, not positional: a child span of the newest
+      // trace starts later than (and sits after) its root, so spanListTree[0]
+      // isn't the max. (Mirror of oldestRowTimestamp; see newestRowTimestamp.)
+      const timestamp = newestRowTimestamp(this.spanListTree, this.colIdxMap);
 
       if (timestamp) {
         // cursorFromTimestamp tolerates ISO + ns/µs/ms epochs (+10ms so we skip the newest row);

--- a/web-components/src/log-list.ts
+++ b/web-components/src/log-list.ts
@@ -356,43 +356,37 @@ export class LogList extends LitElement {
     const url = new URL(window.location.href);
     url.searchParams.set('json', 'true');
 
-    // If we have data, update the 'from' parameter to fetch newer data
-    if (this.spanListTree.length > 0) {
-      // Newest loaded row — scanned, not positional: a child span of the newest
-      // trace starts later than (and sits after) its root, so spanListTree[0]
-      // isn't the max. (Mirror of oldestRowTimestamp; see newestRowTimestamp.)
-      const timestamp = newestRowTimestamp(this.spanListTree, this.colIdxMap);
-
-      if (timestamp != null) {
-        // cursorFromTimestamp tolerates ISO + ns/µs/ms epochs (+10ms so we skip the newest row);
-        // a raw `new Date(epochNs)` would read ns as ms → a year-~55000 `from` → empty live-tail.
-        const from = cursorFromTimestamp(timestamp, 10);
-        url.searchParams.set('from', from);
-        // Recompute the lower bound from the newest loaded row; drop cursor/since.
-        // Keep `to`: on a bounded historical range, live-tail must stay within it
-        // rather than silently pulling rows newer than the user's upper bound.
-        url.searchParams.delete('cursor');
-        url.searchParams.delete('since');
-        // Edge case: once the newest loaded row reaches the upper bound, `from`
-        // (newest+10ms) lands at/after `to`, so every tick fetches an empty
-        // [from,to] window — the live banner would hang forever with no rows and
-        // no error. Stop live-tail instead of polling a guaranteed-empty range.
-        const to = url.searchParams.get('to');
-        const toMs = to ? Date.parse(to) : NaN;
-        if (!isNaN(toMs) && Date.parse(from) >= toMs)
-          this.stopLiveStream('Reached the end of the selected time range — live tail paused.');
-      }
+    // Lower bound = newest loaded row + 10ms (skip it). null when empty.
+    const from = this.newestCursor(10);
+    if (from != null) {
+      url.searchParams.set('from', from);
+      // Recompute the lower bound from the newest loaded row; drop cursor/since.
+      // Keep `to`: on a bounded historical range, live-tail must stay within it
+      // rather than silently pulling rows newer than the user's upper bound.
+      url.searchParams.delete('cursor');
+      url.searchParams.delete('since');
+      // Edge case: once the newest loaded row reaches the upper bound, `from`
+      // (newest+10ms) lands at/after `to`, so every tick fetches an empty
+      // [from,to] window — the live banner would hang forever with no rows and
+      // no error. Stop live-tail instead of polling a guaranteed-empty range.
+      const to = url.searchParams.get('to');
+      const toMs = to ? Date.parse(to) : NaN;
+      if (!isNaN(toMs) && Date.parse(from) >= toMs)
+        this.stopLiveStream('Reached the end of the selected time range — live tail paused.');
     }
 
     return url.toString();
   }
 
-  // Cursor for paging strictly older than everything loaded: the oldest row's
-  // timestamp ± offset (negative skips the inclusive boundary row). Scanned, not
-  // positional — the flattened trace tree appends newer child spans after the
-  // oldest trace's root, so the array endpoints aren't the min. null when empty.
-  private oldestCursor(offsetMs: number): string | null {
-    const ts = oldestRowTimestamp(this.spanListTree, this.colIdxMap);
+  // Cursor at an extreme of everything loaded, ± offset (offset skips the
+  // inclusive boundary row). Scanned, not positional — the flattened trace tree
+  // appends child spans after their (older) trace root, so the array endpoints
+  // aren't the true min/max. null when empty. oldest → page earlier/load-more;
+  // newest → live-tail lower bound.
+  private oldestCursor(offsetMs: number) { return this.edgeCursor(oldestRowTimestamp, offsetMs); }
+  private newestCursor(offsetMs: number) { return this.edgeCursor(newestRowTimestamp, offsetMs); }
+  private edgeCursor(pick: typeof oldestRowTimestamp, offsetMs: number): string | null {
+    const ts = pick(this.spanListTree, this.colIdxMap);
     return ts == null ? null : cursorFromTimestamp(ts, offsetMs);
   }
 

--- a/web-components/src/log-list.ts
+++ b/web-components/src/log-list.ts
@@ -33,6 +33,7 @@ import {
   dedupeById,
   shouldBufferRecent,
   cursorFromTimestamp,
+  oldestRowTimestamp,
   renderSparkline,
   parseUserAgent,
   isBotUserAgent,
@@ -398,14 +399,10 @@ export class LogList extends LitElement {
       return this.buildJsonUrl();
     }
 
-    // Get the actual oldest item from current data
-    // flipDirection=false (newest first): oldest is at END of array
-    // flipDirection=true (oldest first): oldest is at START of array
-    const lastItem = this.flipDirection ? this.spanListTree[0] : this.spanListTree[this.spanListTree.length - 1];
-
-    // Get timestamp column name (try timestamp first, then created_at)
-    const timestampCol = this.colIdxMap['timestamp'] !== undefined ? 'timestamp' : 'created_at';
-    const timestamp = lastItem?.data?.[this.colIdxMap[timestampCol]];
+    // Oldest loaded row's timestamp — scanned, not positional: the flattened
+    // trace tree appends newer child spans after the oldest trace's root, so the
+    // array endpoints aren't the min. (See oldestRowTimestamp.)
+    const timestamp = oldestRowTimestamp(this.spanListTree, this.colIdxMap);
 
     if (!timestamp) {
       console.warn('[LoadMore] No timestamp found, falling back to nextFetchUrl or buildJsonUrl', {
@@ -449,11 +446,10 @@ export class LogList extends LitElement {
       url.searchParams.set('since', target);
     }
 
-    // Use the timestamp of the oldest log currently in the list as the cursor
-    // This ensures we fetch older logs when expanding the time range
+    // Use the oldest loaded row's timestamp as the cursor so we fetch strictly
+    // older logs when expanding the range (scanned, not positional — see above).
     if (this.spanListTree.length > 0) {
-      const oldestItem = this.flipDirection ? this.spanListTree[0] : this.spanListTree[this.spanListTree.length - 1];
-      const oldestTimestamp = oldestItem?.data?.[this.colIdxMap['timestamp'] ?? this.colIdxMap['created_at']];
+      const oldestTimestamp = oldestRowTimestamp(this.spanListTree, this.colIdxMap);
 
       if (oldestTimestamp) {
         // Same ns/µs/ms tolerance as load-more; String(epochNs) would stall the server cursor.

--- a/web-components/src/log-list.ts
+++ b/web-components/src/log-list.ts
@@ -385,7 +385,7 @@ export class LogList extends LitElement {
   // newest → live-tail lower bound.
   private oldestCursor(offsetMs: number) { return this.edgeCursor(oldestRowTimestamp, offsetMs); }
   private newestCursor(offsetMs: number) { return this.edgeCursor(newestRowTimestamp, offsetMs); }
-  private edgeCursor(pick: typeof oldestRowTimestamp, offsetMs: number): string | null {
+  private edgeCursor(pick: (rows: EventLine[], colIdxMap: ColIdxMap) => string | number | undefined, offsetMs: number): string | null {
     const ts = pick(this.spanListTree, this.colIdxMap);
     return ts == null ? null : cursorFromTimestamp(ts, offsetMs);
   }

--- a/web-components/src/log-list.ts
+++ b/web-components/src/log-list.ts
@@ -363,7 +363,7 @@ export class LogList extends LitElement {
       // isn't the max. (Mirror of oldestRowTimestamp; see newestRowTimestamp.)
       const timestamp = newestRowTimestamp(this.spanListTree, this.colIdxMap);
 
-      if (timestamp) {
+      if (timestamp != null) {
         // cursorFromTimestamp tolerates ISO + ns/µs/ms epochs (+10ms so we skip the newest row);
         // a raw `new Date(epochNs)` would read ns as ms → a year-~55000 `from` → empty live-tail.
         const from = cursorFromTimestamp(timestamp, 10);

--- a/web-components/test/log-list-bugs.test.ts
+++ b/web-components/test/log-list-bugs.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, vi } from 'vitest';
-import { row, fakeTransport, deferredTransport, stubFetch, ids, mountList } from './log-list-harness';
+import { row, serverTransport, logPage, treeFromLogs, COLS, deferredTransport, stubFetch, ids, mountList } from './log-list-harness';
 import { shouldBufferRecent, cursorFromTimestamp } from '../src/log-list-utils';
 
 describe('LogList — LOWER', () => {
@@ -54,7 +54,7 @@ describe('LogList — MED correctness', () => {
   // dedup-dropped boundary row on every page. It should match visible rows.
   test('loadedCount equals visible row count after an overlapping load-more', async () => {
     const el = await mountList();
-    el.transport = fakeTransport({ tree: [row('1'), row('2'), row('3')] }, { tree: [row('3'), row('4')] });
+    el.transport = serverTransport(logPage(['1', '2', '3']), logPage(['3', '4'])); // page 2 re-sends boundary row 3
     await el.fetchData('init', false, false, false);
     await el.fetchData('lm', false, false, true);
     expect((el as any).loadedCount).toBe((el as any).spanListTree.length);
@@ -66,10 +66,10 @@ describe('LogList — MED correctness', () => {
   // instead of re-deduping the whole tree.
   test('paginated overlapping pages dedupe to a unique, ordered tree', async () => {
     const el = await mountList();
-    el.transport = fakeTransport(
-      { tree: [row('1'), row('2'), row('3')] },
-      { tree: [row('3'), row('4'), row('5')] }, // 3 overlaps prior page
-      { tree: [row('5'), row('6')] }, // 5 overlaps prior page
+    el.transport = serverTransport(
+      logPage(['1', '2', '3']),
+      logPage(['3', '4', '5']), // 3 overlaps prior page
+      logPage(['5', '6']), // 5 overlaps prior page
     );
     await el.fetchData('init', false, false, false);
     await el.fetchData('lm1', false, false, true);
@@ -81,7 +81,7 @@ describe('LogList — MED correctness', () => {
   // would be wrongly dropped from the new query's results.
   test('refresh resets dedup state so a previously-seen id reappears', async () => {
     const el = await mountList();
-    el.transport = fakeTransport({ tree: [row('1'), row('2')] }, { tree: [row('2')] });
+    el.transport = serverTransport(logPage(['1', '2']), logPage(['2']));
     await el.fetchData('init', false, false, false);
     await el.fetchData('newquery', true, false, false); // refresh / new query
     expect(ids(el)).toEqual(['2']);
@@ -92,8 +92,8 @@ describe('LogList — MED correctness', () => {
   test('buildRecentFetchUrl stops live-tail (with toast) at the upper bound', async () => {
     const el = await mountList();
     window.history.replaceState({}, '', '/log_explorer?to=2026-06-01T00%3A00%3A00.000Z&query=x');
-    (el as any).colIdxMap = { timestamp: 0 };
-    (el as any).spanListTree = [row('1', ['2026-06-01T00:00:00.000Z'])]; // newest is AT `to`
+    el.transport = serverTransport(logPage([['1', '2026-06-01T00:00:00.000Z']])); // newest loaded row is AT `to`
+    await el.fetchData('/log_explorer?to=2026-06-01T00%3A00%3A00.000Z&query=x&json=true', false, false, false);
     (el as any).isLiveStreaming = true;
     (el as any).liveStreamInterval = setInterval(() => {}, 1e7);
     const btn = document.createElement('input');
@@ -117,8 +117,8 @@ describe('LogList — MED correctness', () => {
   test('buildRecentFetchUrl keeps live-tail running while below the upper bound', async () => {
     const el = await mountList();
     window.history.replaceState({}, '', '/log_explorer?to=2026-06-01T00%3A00%3A00.000Z&query=x');
-    (el as any).colIdxMap = { timestamp: 0 };
-    (el as any).spanListTree = [row('1', ['2026-05-01T00:00:00.000Z'])]; // well below `to`
+    el.transport = serverTransport(logPage([['1', '2026-05-01T00:00:00.000Z']])); // well below `to`
+    await el.fetchData('/log_explorer?to=2026-06-01T00%3A00%3A00.000Z&query=x&json=true', false, false, false);
     (el as any).isLiveStreaming = true;
     (el as any).buildRecentFetchUrl();
     expect((el as any).isLiveStreaming).toBe(true);
@@ -129,7 +129,7 @@ describe('LogList — MED correctness', () => {
   test('refresh clears expandedAggregates', async () => {
     const el = await mountList();
     (el as any).expandedAggregates = { hash1: { rows: [['x']], cols: ['id'], colIdxMap: { id: 0 }, hasMore: false, loading: false, skip: 1 } };
-    el.transport = fakeTransport({ tree: [row('1')] });
+    el.transport = serverTransport(logPage(['1']));
     await el.fetchData('newquery', true, false, false);
     expect(Object.keys((el as any).expandedAggregates)).toHaveLength(0);
   });
@@ -155,8 +155,8 @@ describe('LogList — MED correctness', () => {
   test('buildRecentFetchUrl preserves the to bound', async () => {
     const el = await mountList();
     window.history.replaceState({}, '', '/log_explorer?to=2026-06-01T00%3A00%3A00.000Z&query=x');
-    (el as any).colIdxMap = { timestamp: 0 };
-    (el as any).spanListTree = [row('1', ['2026-05-01T00:00:00.000Z'])];
+    el.transport = serverTransport(logPage([['1', '2026-05-01T00:00:00.000Z']]));
+    await el.fetchData('/log_explorer?to=2026-06-01T00%3A00%3A00.000Z&query=x&json=true', false, false, false);
     const url = new URL((el as any).buildRecentFetchUrl(), 'http://localhost');
     expect(url.searchParams.get('to')).toBe('2026-06-01T00:00:00.000Z');
     expect(url.searchParams.has('cursor')).toBe(false);
@@ -166,8 +166,8 @@ describe('LogList — MED correctness', () => {
   test('buildRecentFetchUrl tolerates a nanosecond-epoch timestamp (no year-55000 from)', async () => {
     const el = await mountList();
     window.history.replaceState({}, '', '/log_explorer?query=x');
-    (el as any).colIdxMap = { timestamp: 0 };
-    (el as any).spanListTree = [row('1', [1700000000000000000])]; // ns ≈ Nov 2023
+    el.transport = serverTransport(logPage([['1', 1700000000000000000]])); // ns ≈ Nov 2023
+    await el.fetchData('/log_explorer?query=x&json=true', false, false, false);
     const url = new URL((el as any).buildRecentFetchUrl(), 'http://localhost');
     expect(new Date(url.searchParams.get('from')!).getUTCFullYear()).toBe(2023);
   });
@@ -176,8 +176,8 @@ describe('LogList — MED correctness', () => {
   test('expandTimeRangeUrl tolerates a nanosecond-epoch timestamp in the cursor', async () => {
     const el = await mountList();
     window.history.replaceState({}, '', '/log_explorer?since=1H&query=x');
-    (el as any).colIdxMap = { timestamp: 0 };
-    (el as any).spanListTree = [row('1', [1700000000000000000])];
+    el.transport = serverTransport(logPage([['1', 1700000000000000000]]));
+    await el.fetchData('/log_explorer?since=1H&query=x&json=true', false, false, false);
     const url = new URL((el as any).expandTimeRangeUrl(), 'http://localhost');
     expect(new Date(url.searchParams.get('cursor')!).getUTCFullYear()).toBe(2023);
   });
@@ -186,7 +186,7 @@ describe('LogList — MED correctness', () => {
   // earlier events" every quiet 5s tick even though history isn't exhausted).
   test('an empty recent fetch does not turn on expandTimeRange', async () => {
     const el = await mountList();
-    el.transport = fakeTransport({ tree: [row('1'), row('2')] }, { tree: [], meta: { hasMore: false } });
+    el.transport = serverTransport(logPage(['1', '2']), logPage([])); // 2nd tick returns nothing
     await el.fetchData('initial', false, false, false);
     (el as any).expandTimeRange = false;
     await el.fetchData('recent', false, true, false); // isRecentFetch, returns nothing
@@ -203,6 +203,60 @@ describe('LogList — MED correctness', () => {
     (el as any).updated(new Map([['mode', 'logs']]));
     expect((el as any).liveStreamInterval).toBeNull();
     expect((el as any).isLiveStreaming).toBe(false);
+  });
+});
+
+// Pagination workflow: the cursor for "earlier"/load-more must page strictly
+// before the OLDEST loaded row. Reported symptom: last visible row was 16:54:45
+// but the triggered request used cursor=16:55:02 (NEWER) → "earlier" re-fetched
+// rows already on screen.
+//
+// Driven end-to-end through the real worker pipeline (serverTransport runs the
+// real groupSpans): a server page returns a trace whose root (16:54:45) is the
+// oldest row but whose child span (16:55:02) is later. flattenSpanTree appends
+// the root FIRST then its child, and traces sort newest-start-first, so the last
+// array element is the newer child leaf — not the oldest row. Deriving the cursor
+// from spanListTree[length-1] therefore picked the child's (newer) timestamp.
+describe('LogList — earlier/load-more pagination cursor (worker pipeline)', () => {
+  const tsRoot = '2026-06-26T16:54:45.000Z'; // oldest row: the trace root (visually last)
+  const tsChild = '2026-06-26T16:55:02.644Z'; // its later child span, flattened AFTER the root
+  // A trace (root + one later child) — the shape logPage can't express. Indexed by COLS.
+  const rootRow = [tsRoot, 'span-root', 'trace-1', '', 'server', 'id-root', 100, 1_750_000_485_000_000_000];
+  const childRow = [tsChild, 'span-child', 'trace-1', 'span-root', 'client', 'id-child', 50, 1_750_000_502_644_000_000];
+  const traces = [{ trace_id: 'trace-1', start_time: 1_750_000_485_000_000_000, duration: 100, trace_start_time: tsRoot, root: 'span-root', children: { 'span-root': ['span-child'] } }];
+  const page = (over: any = {}) => ({ logsData: [rootRow, childRow], colIdxMap: COLS, traces, ...over });
+
+  test('load-more requests cursor older than the oldest row (not the trailing child leaf)', async () => {
+    const el = await mountList();
+    window.history.replaceState({}, '', '/log_explorer?query=x');
+    const t = serverTransport(page({ nextUrl: '/log_explorer?query=x&layout=loadmore', hasMore: true }), page());
+    el.transport = t;
+
+    await el.fetchData('/log_explorer?query=x&json=true', false, false, false);
+
+    // The trap the bug fell into: the flattened tree ends on the newer child, while
+    // the oldest VISIBLE (depth-0) row is the root. The cursor must follow the root.
+    const tree = (el as any).spanListTree;
+    expect(tree[tree.length - 1].data[0]).toBe(tsChild); // last array elem is the newer leaf
+    expect(tree.find((r: any) => r.depth === 0).data[0]).toBe(tsRoot); // oldest visible row
+
+    // Fire the load-more and inspect the request that actually hit the endpoint.
+    await el.fetchData((el as any).buildLoadMoreUrl(), false, false, true);
+    const sent = new URL(t.urls[1], 'http://localhost');
+    expect(sent.searchParams.get('cursor')).toBe(cursorFromTimestamp(tsRoot, -10));
+  });
+
+  test('"Show earlier events" (expandTimeRangeUrl) requests cursor from the oldest row', async () => {
+    const el = await mountList();
+    window.history.replaceState({}, '', '/log_explorer?since=1H&query=x');
+    // hasMore:false → after the initial fetch the component shows "Show earlier events".
+    el.transport = serverTransport(page({ hasMore: false }));
+
+    await el.fetchData('/log_explorer?since=1H&query=x&json=true', false, false, false);
+    expect((el as any).expandTimeRange).toBe(true);
+
+    const url = new URL((el as any).expandTimeRangeUrl(), 'http://localhost');
+    expect(url.searchParams.get('cursor')).toBe(cursorFromTimestamp(tsRoot, 0));
   });
 });
 
@@ -278,10 +332,8 @@ describe('LogList — columns survive background refetches', () => {
   // hidden column. Column hiding is effectively broken under live/paginated views.
   test('a hidden column is not restored by a load-more refetch', async () => {
     const el = await mountList();
-    el.transport = fakeTransport(
-      { tree: [row('1')], meta: { cols: ['id', 'service', 'summary'] } },
-      { tree: [row('2')], meta: { cols: ['id', 'service', 'summary'] } },
-    );
+    const cols = ['id', 'service', 'summary'];
+    el.transport = serverTransport(logPage(['1'], { cols }), logPage(['2'], { cols }));
     await el.fetchData('initial', false, false, false);
     el.hideColumn('service');
     expect((el as any).logsColumns).not.toContain('service');
@@ -328,18 +380,19 @@ describe('LogList — concurrent refresh vs load-more', () => {
   // results — cross-query contamination with no visible signal.
   test('a load-more resolving after a refresh does not contaminate the new query', async () => {
     const el = await mountList();
+    // Query A's first page is on screen (built through the real pipeline)...
+    el.transport = serverTransport(logPage(['a1', 'a2']));
+    await el.fetchData('A', false, false, false);
+
+    // ...then a load-more and a refresh race, both resolving out of order.
     const tx = deferredTransport();
     el.transport = tx as any;
-
-    // page of query A is on screen
-    await (async () => { const t = fakeTransport({ tree: [row('a1'), row('a2')] }); el.transport = t as any; await el.fetchData('A', false, false, false); el.transport = tx as any; })();
-
     const loadMore = el.fetchData('A-loadmore', false, false, true); // in flight (deferred)
     const refresh = el.fetchData('B-newquery', true, false, false); // new query, also deferred
 
-    tx.settle(1, [row('b1'), row('b2')]); // refresh (query B) resolves first
+    tx.settle(1, treeFromLogs(['b1', 'b2'])); // refresh (query B) resolves first
     await refresh;
-    tx.settle(0, [row('a3'), row('a4')]); // stale load-more (query A) resolves later
+    tx.settle(0, treeFromLogs(['a3', 'a4'])); // stale load-more (query A) resolves later
     await loadMore;
 
     // Must show ONLY query B's rows — A's older page must not be appended.
@@ -354,11 +407,11 @@ describe('LogList — concurrent refresh vs load-more', () => {
     const loadMore = el.fetchData('lm', false, false, true); // isLoadingMore = true
     const recent = el.fetchData('recent', false, true, false); // isFetchingRecent = true
 
-    tx.settle(1, [row('r1')]); // recent resolves first → its finally runs
+    tx.settle(1, treeFromLogs(['r1'])); // recent resolves first → its finally runs
     await recent;
     expect((el as any).isLoadingMore).toBe(true); // load-more still in flight
 
-    tx.settle(0, [row('r2')]);
+    tx.settle(0, treeFromLogs(['r2']));
     await loadMore;
     expect((el as any).isLoadingMore).toBe(false);
   });

--- a/web-components/test/log-list-bugs.test.ts
+++ b/web-components/test/log-list-bugs.test.ts
@@ -285,11 +285,10 @@ describe('LogList — earlier/load-more pagination cursor (worker pipeline)', ()
   });
 });
 
-// serverTransport's leading-boolean opts into flipped (oldest-first) grouping so
-// flipped-component tests get a tree order matching what the component renders.
-// Guards the consume-the-flag branch (queue must stay aligned, not off-by-one).
-describe('serverTransport — flipDirection opt-in', () => {
-  test('leading `true` flips grouping to oldest-first; default stays newest-first', async () => {
+// serverTransportFlipped groups oldest-first so flipped-component tests get a tree
+// order matching what the component renders; serverTransport stays newest-first.
+describe('serverTransport flip variants', () => {
+  test('serverTransportFlipped groups oldest-first; serverTransport stays newest-first', async () => {
     const def = await serverTransport(logPage(['1', '2', '3']))('u'); // id 1 = newest
     expect(def.tree.map((r: any) => r.id)).toEqual(['1', '2', '3']);
     const flipped = await serverTransportFlipped(logPage(['1', '2', '3']))('u');

--- a/web-components/test/log-list-bugs.test.ts
+++ b/web-components/test/log-list-bugs.test.ts
@@ -124,6 +124,31 @@ describe('LogList — MED correctness', () => {
     expect((el as any).isLiveStreaming).toBe(true);
   });
 
+  // Symmetric to the load-more cursor bug: the NEWEST timestamp must be a scan, not
+  // spanListTree[0]. The newest trace's child span starts later than its root but is
+  // flattened AFTER it, so positional access undercounts `from` and the to-boundary
+  // stop-check never fires → live-tail polls an empty [from,to] window forever.
+  test('buildRecentFetchUrl stops live-tail using the newest row (later child span), not the trace root', async () => {
+    const el = await mountList();
+    const tRoot = '2026-06-01T00:00:00.000Z';
+    const tChild = '2026-06-01T00:00:05.000Z'; // newer child of the same trace (sits after root in the tree)
+    const to = '2026-06-01T00:00:02.000Z'; // between root+10ms and child+10ms
+    const rootRow = [tRoot, 's-root', 'tr', '', 'server', 'i-root', 100, 1_780_272_000_000_000_000];
+    const childRow = [tChild, 's-child', 'tr', 's-root', 'client', 'i-child', 50, 1_780_272_005_000_000_000];
+    const traces = [{ trace_id: 'tr', start_time: 1_780_272_000_000_000_000, duration: 100, trace_start_time: tRoot, root: 's-root', children: { 's-root': ['s-child'] } }];
+    window.history.replaceState({}, '', `/log_explorer?to=${encodeURIComponent(to)}&query=x`);
+    el.transport = serverTransport({ logsData: [rootRow, childRow], colIdxMap: COLS, traces });
+    await el.fetchData(`/log_explorer?to=${encodeURIComponent(to)}&query=x&json=true`, false, false, false);
+    (el as any).isLiveStreaming = true;
+    (el as any).liveStreamInterval = setInterval(() => {}, 1e7);
+    const btn = document.createElement('input');
+    btn.type = 'checkbox';
+    btn.checked = true;
+    (el as any).liveBtn = btn;
+    (el as any).buildRecentFetchUrl();
+    expect((el as any).isLiveStreaming).toBe(false); // newest=child → from=child+10ms ≥ to → stops
+  });
+
   // M2: a refresh must drop inline-expanded aggregate children, else stale rows
   // from the previous query render under a key that survives the new query.
   test('refresh clears expandedAggregates', async () => {

--- a/web-components/test/log-list-bugs.test.ts
+++ b/web-components/test/log-list-bugs.test.ts
@@ -285,6 +285,18 @@ describe('LogList — earlier/load-more pagination cursor (worker pipeline)', ()
   });
 });
 
+// serverTransport's leading-boolean opts into flipped (oldest-first) grouping so
+// flipped-component tests get a tree order matching what the component renders.
+// Guards the consume-the-flag branch (queue must stay aligned, not off-by-one).
+describe('serverTransport — flipDirection opt-in', () => {
+  test('leading `true` flips grouping to oldest-first; default stays newest-first', async () => {
+    const def = await serverTransport(logPage(['1', '2', '3']))('u'); // id 1 = newest
+    expect(def.tree.map((r: any) => r.id)).toEqual(['1', '2', '3']);
+    const flipped = await serverTransport(true, logPage(['1', '2', '3']))('u');
+    expect(flipped.tree.map((r: any) => r.id)).toEqual(['3', '2', '1']);
+  });
+});
+
 // M4: buffering decision (pure) — buffer whenever scrolled off the insertion edge.
 describe('shouldBufferRecent', () => {
   test('newest-first: buffers as soon as scrolled off the top (>0), not at 30px', () => {

--- a/web-components/test/log-list-bugs.test.ts
+++ b/web-components/test/log-list-bugs.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, vi } from 'vitest';
-import { row, serverTransport, logPage, treeFromLogs, COLS, deferredTransport, stubFetch, ids, mountList } from './log-list-harness';
+import { row, serverTransport, serverTransportFlipped, logPage, treeFromLogs, COLS, deferredTransport, stubFetch, ids, mountList } from './log-list-harness';
 import { shouldBufferRecent, cursorFromTimestamp } from '../src/log-list-utils';
 
 describe('LogList — LOWER', () => {
@@ -292,7 +292,7 @@ describe('serverTransport — flipDirection opt-in', () => {
   test('leading `true` flips grouping to oldest-first; default stays newest-first', async () => {
     const def = await serverTransport(logPage(['1', '2', '3']))('u'); // id 1 = newest
     expect(def.tree.map((r: any) => r.id)).toEqual(['1', '2', '3']);
-    const flipped = await serverTransport(true, logPage(['1', '2', '3']))('u');
+    const flipped = await serverTransportFlipped(logPage(['1', '2', '3']))('u');
     expect(flipped.tree.map((r: any) => r.id)).toEqual(['3', '2', '1']);
   });
 });

--- a/web-components/test/log-list-bugs.test.ts
+++ b/web-components/test/log-list-bugs.test.ts
@@ -133,9 +133,10 @@ describe('LogList — MED correctness', () => {
     const tRoot = '2026-06-01T00:00:00.000Z';
     const tChild = '2026-06-01T00:00:05.000Z'; // newer child of the same trace (sits after root in the tree)
     const to = '2026-06-01T00:00:02.000Z'; // between root+10ms and child+10ms
-    const rootRow = [tRoot, 's-root', 'tr', '', 'server', 'i-root', 100, 1_780_272_000_000_000_000];
-    const childRow = [tChild, 's-child', 'tr', 's-root', 'client', 'i-child', 50, 1_780_272_005_000_000_000];
-    const traces = [{ trace_id: 'tr', start_time: 1_780_272_000_000_000_000, duration: 100, trace_start_time: tRoot, root: 's-root', children: { 's-root': ['s-child'] } }];
+    const rootNs = Date.parse(tRoot) * 1e6;
+    const rootRow = [tRoot, 's-root', 'tr', '', 'server', 'i-root', 100, rootNs];
+    const childRow = [tChild, 's-child', 'tr', 's-root', 'client', 'i-child', 50, Date.parse(tChild) * 1e6];
+    const traces = [{ trace_id: 'tr', start_time: rootNs, duration: 100, trace_start_time: tRoot, root: 's-root', children: { 's-root': ['s-child'] } }];
     window.history.replaceState({}, '', `/log_explorer?to=${encodeURIComponent(to)}&query=x`);
     el.transport = serverTransport({ logsData: [rootRow, childRow], colIdxMap: COLS, traces });
     await el.fetchData(`/log_explorer?to=${encodeURIComponent(to)}&query=x&json=true`, false, false, false);
@@ -246,9 +247,10 @@ describe('LogList — earlier/load-more pagination cursor (worker pipeline)', ()
   const tsRoot = '2026-06-26T16:54:45.000Z'; // oldest row: the trace root (visually last)
   const tsChild = '2026-06-26T16:55:02.644Z'; // its later child span, flattened AFTER the root
   // A trace (root + one later child) — the shape logPage can't express. Indexed by COLS.
-  const rootRow = [tsRoot, 'span-root', 'trace-1', '', 'server', 'id-root', 100, 1_750_000_485_000_000_000];
-  const childRow = [tsChild, 'span-child', 'trace-1', 'span-root', 'client', 'id-child', 50, 1_750_000_502_644_000_000];
-  const traces = [{ trace_id: 'trace-1', start_time: 1_750_000_485_000_000_000, duration: 100, trace_start_time: tsRoot, root: 'span-root', children: { 'span-root': ['span-child'] } }];
+  const rootNs = Date.parse(tsRoot) * 1e6;
+  const rootRow = [tsRoot, 'span-root', 'trace-1', '', 'server', 'id-root', 100, rootNs];
+  const childRow = [tsChild, 'span-child', 'trace-1', 'span-root', 'client', 'id-child', 50, Date.parse(tsChild) * 1e6];
+  const traces = [{ trace_id: 'trace-1', start_time: rootNs, duration: 100, trace_start_time: tsRoot, root: 'span-root', children: { 'span-root': ['span-child'] } }];
   const page = (over: any = {}) => ({ logsData: [rootRow, childRow], colIdxMap: COLS, traces, ...over });
 
   test('load-more requests cursor older than the oldest row (not the trailing child leaf)', async () => {

--- a/web-components/test/log-list-harness.ts
+++ b/web-components/test/log-list-harness.ts
@@ -24,7 +24,8 @@ export const COLS = { timestamp: 0, latency_breakdown: 1, trace_id: 2, parent_id
 // and the SAME id maps to the SAME time across pages — so overlapping-page dedup
 // behaves as it does against the real server.
 const TS_BASE = Date.parse('2024-01-01T00:00:00.000Z'); // stable past anchor
-const idToTs = (id: string) => new Date(TS_BASE - (/^\d+$/.test(id) ? Number(id) : sum([...id].map(c => c.charCodeAt(0)))) * 1000).toISOString();
+// Position-weighted char sum so permutation ids (e.g. 'a2' vs 'b1') don't collide to the same time.
+const idToTs = (id: string) => new Date(TS_BASE - (/^\d+$/.test(id) ? Number(id) : sum([...id].map((c, i) => c.charCodeAt(0) * (i + 1)))) * 1000).toISOString();
 // Fixture-only: numeric input is taken as already-nanoseconds (the server's start_time_ns),
 // strings as ISO → ns. Deliberately NOT tsToMs (which detects unit + converts to ms).
 const startNs = (ts: string | number) => (typeof ts === 'number' ? ts : Date.parse(ts) * 1e6);

--- a/web-components/test/log-list-harness.ts
+++ b/web-components/test/log-list-harness.ts
@@ -1,6 +1,7 @@
 // Shared harness for high-level LogList behavior tests: mount the real component,
 // feed canned {tree, meta} via the transport seam (no Web Worker / network), and
 // drive fetchData / events as a user would. See web_components_test_harness memory.
+import { sum } from 'lodash';
 import { LogList } from '../src/log-list';
 import { groupSpans } from '../src/log-worker-functions';
 
@@ -23,14 +24,17 @@ export const COLS = { timestamp: 0, latency_breakdown: 1, trace_id: 2, parent_id
 // and the SAME id maps to the SAME time across pages — so overlapping-page dedup
 // behaves as it does against the real server.
 const TS_BASE = Date.parse('2024-01-01T00:00:00.000Z'); // stable past anchor
-const idToTs = (id: string) => new Date(TS_BASE - (/^\d+$/.test(id) ? Number(id) : [...id].reduce((a, c) => a + c.charCodeAt(0), 0)) * 1000).toISOString();
+const idToTs = (id: string) => new Date(TS_BASE - (/^\d+$/.test(id) ? Number(id) : sum([...id].map(c => c.charCodeAt(0)))) * 1000).toISOString();
+// Fixture-only: numeric input is taken as already-nanoseconds (the server's start_time_ns),
+// strings as ISO → ns. Deliberately NOT tsToMs (which detects unit + converts to ms).
 const startNs = (ts: string | number) => (typeof ts === 'number' ? ts : Date.parse(ts) * 1e6);
+const tsIso = (ts: string | number) => (typeof ts === 'string' ? ts : new Date(ts / 1e6).toISOString());
 
 // One server-shaped standalone log row (kind='log'). Positional, in COLS order.
 // Internal to the page builders below — tests construct fixtures via logPage.
 const logRow = (id: string, ts: string | number = idToTs(id)): any[] => [ts, id, id, '', 'log', id, 0, startNs(ts)];
 // The trace-adjacency entry the server emits for a standalone log (its own trace).
-const logTrace = (id: string, ts: string | number = idToTs(id)) => ({ trace_id: id, start_time: startNs(ts), duration: 0, trace_start_time: typeof ts === 'string' ? ts : null, root: id, children: {} });
+const logTrace = (id: string, ts: string | number = idToTs(id)) => ({ trace_id: id, start_time: startNs(ts), duration: 0, trace_start_time: tsIso(ts), root: id, children: {} });
 
 type RowSpec = string | [string, string | number]; // id, or [id, explicit-timestamp]
 const norm = (r: RowSpec): [string, string | number] => (Array.isArray(r) ? r : [r, idToTs(r)]);
@@ -67,11 +71,7 @@ export const fakeTransport = (...pages: { tree: any[]; meta?: any }[]) => {
 // and runs the REAL groupSpans to flatten them into the tree. Tests using it
 // exercise the same fetch → group → merge → build-next-url pipeline the browser
 // does, instead of hand-feeding a pre-built tree. Records the urls requested.
-// Groups newest-first by default; pass a leading `true` to match a component
-// with flipDirection set (e.g. `serverTransport(true, page1, page2)`), else its
-// tree order won't match what the component renders.
-export const serverTransport = (...pages: any[]) => {
-  const flipDirection = typeof pages[0] === 'boolean' ? (pages.shift() as boolean) : false;
+const makeServerTransport = (flipDirection: boolean, pages: any[]) => {
   const q = [...pages];
   const urls: string[] = [];
   const fn = async (url: string) => {
@@ -85,12 +85,18 @@ export const serverTransport = (...pages: any[]) => {
       tree,
       meta: meta({
         nextUrl: d.nextUrl ?? '', recentUrl: d.recentUrl ?? '', cols: d.cols ?? Object.keys(colIdxMap),
-        colIdxMap, count: d.count ?? 0, traces, hasMore: d.hasMore ?? n > 0, queryResultCount: n, // worker: empty→false, full→true
+        // Mirrors the worker: empty page → false, full page → true. So a single
+        // full page leaves hasMore=true; pass { hasMore: false } to fire expandTimeRange.
+        colIdxMap, count: d.count ?? 0, traces, hasMore: d.hasMore ?? n > 0, queryResultCount: n,
       }),
     };
   };
   return Object.assign(fn, { urls });
 };
+// Groups newest-first (matches a component with flipDirection unset); use
+// serverTransportFlipped for a flipDirection=true component so the tree order matches.
+export const serverTransport = (...pages: any[]) => makeServerTransport(false, pages);
+export const serverTransportFlipped = (...pages: any[]) => makeServerTransport(true, pages);
 
 // Transport whose responses are resolved manually, to test out-of-order / concurrent fetches.
 export const deferredTransport = () => {

--- a/web-components/test/log-list-harness.ts
+++ b/web-components/test/log-list-harness.ts
@@ -45,7 +45,8 @@ export const logPage = (rows: RowSpec[], over: any = {}) => ({
   logsData: rows.map((r) => logRow(...norm(r))), colIdxMap: COLS, traces: rows.map((r) => logTrace(...norm(r))), ...over,
 });
 // The flattened tree groupSpans produces for those rows — for deferredTransport.settle.
-export const treeFromLogs = (rows: RowSpec[]) => { const p = logPage(rows); return groupSpans(p.logsData, p.colIdxMap as any, {}, false, p.traces); };
+// flipDirection defaults newest-first; pass true to match a component with flipDirection set.
+export const treeFromLogs = (rows: RowSpec[], flipDirection = false) => { const p = logPage(rows); return groupSpans(p.logsData, p.colIdxMap as any, {}, flipDirection, p.traces); };
 
 export const meta = (over: any = {}) => ({
   serviceColors: {}, nextUrl: '', recentUrl: '', cols: ['id'], colIdxMap: { id: 0 },
@@ -69,6 +70,8 @@ export const fakeTransport = (...pages: { tree: any[]; meta?: any }[]) => {
 // and runs the REAL groupSpans to flatten them into the tree. Tests using it
 // exercise the same fetch → group → merge → build-next-url pipeline the browser
 // does, instead of hand-feeding a pre-built tree. Records the urls requested.
+// NOTE: groups newest-first (flipDirection=false); a test that sets
+// el.flipDirection = true needs its own transport, or this gets the order wrong.
 export const serverTransport = (...pages: any[]) => {
   const q = [...pages];
   const urls: string[] = [];

--- a/web-components/test/log-list-harness.ts
+++ b/web-components/test/log-list-harness.ts
@@ -104,7 +104,7 @@ export const serverTransportFlipped = (...pages: any[]) => makeServerTransport(t
 export const deferredTransport = () => {
   const pending: Array<{ resolve: (v: any) => void; url: string }> = [];
   const fn = (url: string) => new Promise<any>((resolve) => pending.push({ url, resolve }));
-  // settle(index, {tree, metaOverrides})
+  // settle(index, tree, metaOverrides?)
   const settle = (i: number, tree: any[], over: any = {}) =>
     pending[i].resolve({ tree, meta: meta({ ...over, queryResultCount: tree.length }) });
   return Object.assign(fn, { pending, settle });

--- a/web-components/test/log-list-harness.ts
+++ b/web-components/test/log-list-harness.ts
@@ -2,14 +2,50 @@
 // feed canned {tree, meta} via the transport seam (no Web Worker / network), and
 // drive fetchData / events as a user would. See web_components_test_harness memory.
 import { LogList } from '../src/log-list';
+import { groupSpans } from '../src/log-worker-functions';
 
 // Minimal EventLine-ish row; only fields the merge/render path touches.
+// Prefer the server-shaped helpers below (logPage / treeFromLogs) for behavior
+// tests — this is for the few lifecycle tests that inject tree state directly.
 export const row = (id: string, data: any[] = [id]) => ({
   id, data, depth: 0, children: 0, traceId: id, parentIds: [],
   show: true, expanded: false, isLastChild: true, siblingsArr: [],
   childErrors: false, hasErrors: false, isNew: false,
   startNs: 0, duration: 0, traceStart: 0, traceEnd: 0, childrenTimeSpans: [], type: 'log' as const,
 });
+
+// ── Server-shaped fixtures ───────────────────────────────────────────────────
+// The columns the server emits (subset groupSpans keys off). Row arrays below are
+// indexed by this map, exactly like the JSON the log_explorer endpoint returns.
+export const COLS = { timestamp: 0, latency_breakdown: 1, trace_id: 2, parent_id: 3, kind: 4, id: 5, duration: 6, start_time_ns: 7 } as const;
+
+// Deterministic per-id timestamp: numeric ids sort newest-first (id "1" newest),
+// and the SAME id maps to the SAME time across pages — so overlapping-page dedup
+// behaves as it does against the real server.
+const TS_BASE = Date.parse('2026-06-26T17:00:00.000Z');
+const idToTs = (id: string) => new Date(TS_BASE - (/^\d+$/.test(id) ? Number(id) : [...id].reduce((a, c) => a + c.charCodeAt(0), 0)) * 1000).toISOString();
+const startNs = (ts: string | number) => (typeof ts === 'number' ? ts : Date.parse(ts) * 1e6);
+
+// One server-shaped standalone log row (kind='log').
+export const logRow = (id: string, ts: string | number = idToTs(id)): any[] => {
+  const r: any[] = [];
+  r[COLS.timestamp] = ts; r[COLS.latency_breakdown] = id; r[COLS.trace_id] = id; r[COLS.parent_id] = '';
+  r[COLS.kind] = 'log'; r[COLS.id] = id; r[COLS.duration] = 0; r[COLS.start_time_ns] = startNs(ts);
+  return r;
+};
+// The trace-adjacency entry the server emits for a standalone log (its own trace).
+const logTrace = (id: string, ts: string | number = idToTs(id)) => ({ trace_id: id, start_time: startNs(ts), duration: 0, trace_start_time: typeof ts === 'string' ? ts : null, root: id, children: {} });
+
+type RowSpec = string | [string, string | number]; // id, or [id, explicit-timestamp]
+const norm = (r: RowSpec): [string, string | number] => (Array.isArray(r) ? r : [r, idToTs(r)]);
+
+// A server JSON page of standalone logs (newest-first). `over` sets meta fields
+// (nextUrl, recentUrl, hasMore, cols, count, …) the way a real response would.
+export const logPage = (rows: RowSpec[], over: any = {}) => ({
+  logsData: rows.map((r) => logRow(...norm(r))), colIdxMap: COLS, traces: rows.map((r) => logTrace(...norm(r))), ...over,
+});
+// The flattened tree groupSpans produces for those rows — for deferredTransport.settle.
+export const treeFromLogs = (rows: RowSpec[]) => { const p = logPage(rows); return groupSpans(p.logsData, p.colIdxMap as any, {}, false, p.traces); };
 
 export const meta = (over: any = {}) => ({
   serviceColors: {}, nextUrl: '', recentUrl: '', cols: ['id'], colIdxMap: { id: 0 },
@@ -24,6 +60,32 @@ export const fakeTransport = (...pages: { tree: any[]; meta?: any }[]) => {
     urls.push(url);
     const p = q.shift() ?? { tree: [], meta: {} };
     return { tree: p.tree, meta: meta({ ...p.meta, queryResultCount: p.tree.length }) };
+  };
+  return Object.assign(fn, { urls });
+};
+
+// A transport that mimics the production Web Worker (log-worker.ts): it takes
+// server-shaped JSON pages (raw logsData arrays + colIdxMap + trace adjacency)
+// and runs the REAL groupSpans to flatten them into the tree. Tests using it
+// exercise the same fetch → group → merge → build-next-url pipeline the browser
+// does, instead of hand-feeding a pre-built tree. Records the urls requested.
+export const serverTransport = (...pages: any[]) => {
+  const q = [...pages];
+  const urls: string[] = [];
+  const fn = async (url: string) => {
+    urls.push(url);
+    const d = q.shift() ?? { logsData: [] };
+    const colIdxMap = d.colIdxMap ?? {};
+    const traces = d.traces ?? [];
+    const n = d.logsData?.length ?? 0;
+    const tree = n ? groupSpans(d.logsData, colIdxMap, {}, false, traces) : [];
+    return {
+      tree,
+      meta: meta({
+        nextUrl: d.nextUrl ?? '', recentUrl: d.recentUrl ?? '', cols: d.cols ?? Object.keys(colIdxMap),
+        colIdxMap, count: d.count ?? 0, traces, hasMore: d.hasMore ?? n > 0, queryResultCount: n, // worker: empty→false, full→true
+      }),
+    };
   };
   return Object.assign(fn, { urls });
 };

--- a/web-components/test/log-list-harness.ts
+++ b/web-components/test/log-list-harness.ts
@@ -22,12 +22,13 @@ export const COLS = { timestamp: 0, latency_breakdown: 1, trace_id: 2, parent_id
 // Deterministic per-id timestamp: numeric ids sort newest-first (id "1" newest),
 // and the SAME id maps to the SAME time across pages — so overlapping-page dedup
 // behaves as it does against the real server.
-const TS_BASE = Date.parse('2026-06-26T17:00:00.000Z');
+const TS_BASE = Date.parse('2024-01-01T00:00:00.000Z'); // stable past anchor
 const idToTs = (id: string) => new Date(TS_BASE - (/^\d+$/.test(id) ? Number(id) : [...id].reduce((a, c) => a + c.charCodeAt(0), 0)) * 1000).toISOString();
 const startNs = (ts: string | number) => (typeof ts === 'number' ? ts : Date.parse(ts) * 1e6);
 
 // One server-shaped standalone log row (kind='log'). Positional, in COLS order.
-export const logRow = (id: string, ts: string | number = idToTs(id)): any[] => [ts, id, id, '', 'log', id, 0, startNs(ts)];
+// Internal to the page builders below — tests construct fixtures via logPage.
+const logRow = (id: string, ts: string | number = idToTs(id)): any[] => [ts, id, id, '', 'log', id, 0, startNs(ts)];
 // The trace-adjacency entry the server emits for a standalone log (its own trace).
 const logTrace = (id: string, ts: string | number = idToTs(id)) => ({ trace_id: id, start_time: startNs(ts), duration: 0, trace_start_time: typeof ts === 'string' ? ts : null, root: id, children: {} });
 
@@ -66,9 +67,11 @@ export const fakeTransport = (...pages: { tree: any[]; meta?: any }[]) => {
 // and runs the REAL groupSpans to flatten them into the tree. Tests using it
 // exercise the same fetch → group → merge → build-next-url pipeline the browser
 // does, instead of hand-feeding a pre-built tree. Records the urls requested.
-// NOTE: groups newest-first (flipDirection=false); a test that sets
-// el.flipDirection = true needs its own transport, or this gets the order wrong.
+// Groups newest-first by default; pass a leading `true` to match a component
+// with flipDirection set (e.g. `serverTransport(true, page1, page2)`), else its
+// tree order won't match what the component renders.
 export const serverTransport = (...pages: any[]) => {
+  const flipDirection = typeof pages[0] === 'boolean' ? (pages.shift() as boolean) : false;
   const q = [...pages];
   const urls: string[] = [];
   const fn = async (url: string) => {
@@ -77,7 +80,7 @@ export const serverTransport = (...pages: any[]) => {
     const colIdxMap = d.colIdxMap ?? {};
     const traces = d.traces ?? [];
     const n = d.logsData?.length ?? 0;
-    const tree = n ? groupSpans(d.logsData, colIdxMap, {}, false, traces) : [];
+    const tree = n ? groupSpans(d.logsData, colIdxMap, {}, flipDirection, traces) : [];
     return {
       tree,
       meta: meta({

--- a/web-components/test/log-list-harness.ts
+++ b/web-components/test/log-list-harness.ts
@@ -1,7 +1,6 @@
 // Shared harness for high-level LogList behavior tests: mount the real component,
 // feed canned {tree, meta} via the transport seam (no Web Worker / network), and
 // drive fetchData / events as a user would. See web_components_test_harness memory.
-import { sum } from 'lodash';
 import { LogList } from '../src/log-list';
 import { groupSpans } from '../src/log-worker-functions';
 
@@ -25,7 +24,7 @@ export const COLS = { timestamp: 0, latency_breakdown: 1, trace_id: 2, parent_id
 // behaves as it does against the real server.
 const TS_BASE = Date.parse('2024-01-01T00:00:00.000Z'); // stable past anchor
 // Position-weighted char sum so permutation ids (e.g. 'a2' vs 'b1') don't collide to the same time.
-const idToTs = (id: string) => new Date(TS_BASE - (/^\d+$/.test(id) ? Number(id) : sum([...id].map((c, i) => c.charCodeAt(0) * (i + 1)))) * 1000).toISOString();
+const idToTs = (id: string) => new Date(TS_BASE - (/^\d+$/.test(id) ? Number(id) : [...id].reduce((a, c, i) => a + c.charCodeAt(0) * (i + 1), 0)) * 1000).toISOString();
 // Fixture-only: numeric input is taken as already-nanoseconds (the server's start_time_ns),
 // strings as ISO → ns. Deliberately NOT tsToMs (which detects unit + converts to ms).
 const startNs = (ts: string | number) => (typeof ts === 'number' ? ts : Date.parse(ts) * 1e6);
@@ -55,7 +54,9 @@ export const meta = (over: any = {}) => ({
   count: 100, traces: [], hasMore: true, queryResultCount: 0, ...over,
 });
 
-// Queues canned pages; replaces the worker transport. Records requested urls.
+// Queues canned pre-built trees; replaces the worker transport. Records requested urls.
+// Injects the tree directly (bypasses groupSpans) — use for lifecycle/state tests only.
+// For behavior tests that depend on grouping/cursor logic, use serverTransport instead.
 export const fakeTransport = (...pages: { tree: any[]; meta?: any }[]) => {
   const q = [...pages];
   const urls: string[] = [];

--- a/web-components/test/log-list-harness.ts
+++ b/web-components/test/log-list-harness.ts
@@ -26,13 +26,8 @@ const TS_BASE = Date.parse('2026-06-26T17:00:00.000Z');
 const idToTs = (id: string) => new Date(TS_BASE - (/^\d+$/.test(id) ? Number(id) : [...id].reduce((a, c) => a + c.charCodeAt(0), 0)) * 1000).toISOString();
 const startNs = (ts: string | number) => (typeof ts === 'number' ? ts : Date.parse(ts) * 1e6);
 
-// One server-shaped standalone log row (kind='log').
-export const logRow = (id: string, ts: string | number = idToTs(id)): any[] => {
-  const r: any[] = [];
-  r[COLS.timestamp] = ts; r[COLS.latency_breakdown] = id; r[COLS.trace_id] = id; r[COLS.parent_id] = '';
-  r[COLS.kind] = 'log'; r[COLS.id] = id; r[COLS.duration] = 0; r[COLS.start_time_ns] = startNs(ts);
-  return r;
-};
+// One server-shaped standalone log row (kind='log'). Positional, in COLS order.
+export const logRow = (id: string, ts: string | number = idToTs(id)): any[] => [ts, id, id, '', 'log', id, 0, startNs(ts)];
 // The trace-adjacency entry the server emits for a standalone log (its own trace).
 const logTrace = (id: string, ts: string | number = idToTs(id)) => ({ trace_id: id, start_time: startNs(ts), duration: 0, trace_start_time: typeof ts === 'string' ? ts : null, root: id, children: {} });
 
@@ -41,9 +36,10 @@ const norm = (r: RowSpec): [string, string | number] => (Array.isArray(r) ? r : 
 
 // A server JSON page of standalone logs (newest-first). `over` sets meta fields
 // (nextUrl, recentUrl, hasMore, cols, count, …) the way a real response would.
-export const logPage = (rows: RowSpec[], over: any = {}) => ({
-  logsData: rows.map((r) => logRow(...norm(r))), colIdxMap: COLS, traces: rows.map((r) => logTrace(...norm(r))), ...over,
-});
+export const logPage = (rows: RowSpec[], over: any = {}) => {
+  const specs = rows.map(norm);
+  return { logsData: specs.map((s) => logRow(...s)), colIdxMap: COLS, traces: specs.map((s) => logTrace(...s)), ...over };
+};
 // The flattened tree groupSpans produces for those rows — for deferredTransport.settle.
 // flipDirection defaults newest-first; pass true to match a component with flipDirection set.
 export const treeFromLogs = (rows: RowSpec[], flipDirection = false) => { const p = logPage(rows); return groupSpans(p.logsData, p.colIdxMap as any, {}, flipDirection, p.traces); };

--- a/web-components/test/log-list-harness.ts
+++ b/web-components/test/log-list-harness.ts
@@ -28,6 +28,7 @@ const idToTs = (id: string) => new Date(TS_BASE - (/^\d+$/.test(id) ? Number(id)
 // Fixture-only: numeric input is taken as already-nanoseconds (the server's start_time_ns),
 // strings as ISO → ns. Deliberately NOT tsToMs (which detects unit + converts to ms).
 const startNs = (ts: string | number) => (typeof ts === 'number' ? ts : Date.parse(ts) * 1e6);
+// numeric input is ns (same convention as startNs); strings pass through as ISO.
 const tsIso = (ts: string | number) => (typeof ts === 'string' ? ts : new Date(ts / 1e6).toISOString());
 
 // One server-shaped standalone log row (kind='log'). Positional, in COLS order.


### PR DESCRIPTION
## Problem

In the log explorer, clicking **Show earlier events** (and load-more) issued a request whose `cursor` was *newer* than the last visible row — e.g. last visible row `16:54:45` but `cursor=16:55:02.644Z`. "Earlier" then re-fetched rows already on screen instead of paging back.

## Root cause

The cursor was taken from `spanListTree[length-1]`. `spanListTree` is the **flattened trace tree** (`flattenSpanTree`): each trace pushes its root first, then DFS-appends its child spans (which always start ≥ their parent), and traces are sorted newest-start-first. So the last array element is a newer **child leaf** of the oldest trace — not the oldest row.

## Fix

- Add `oldestRowTimestamp()` — scans loaded rows for the true minimum timestamp — and use it in both `buildLoadMoreUrl` and `expandTimeRangeUrl`.
- Extract `tsToMs()` (shared with `cursorFromTimestamp`).

## Tests

Rewrote the log-list suite to drive **server-shaped JSON** through the real `fetch → groupSpans → merge → build-next-url` pipeline, via new harness helpers (`serverTransport`, `logPage`, `treeFromLogs`, `COLS`), instead of injecting pre-grouped trees. New regression tests reproduce the cursor bug end-to-end (red→green verified). Full suite: 119/119.

🤖 Generated with [Claude Code](https://claude.com/claude-code)