### PR TITLE
fix(dashboards): correct golden-signals stat big numbers (rate/mean) and error color

### DIFF
--- a/src/Pkg/Components/Widget.hs
+++ b/src/Pkg/Components/Widget.hs
@@ -110,16 +110,24 @@ data SummarizeBy
   | SBMax
   | SBMin
   | SBCount
+  | SBMean
+  | SBRate
   deriving stock (Enum, Eq, Generic, Show, THS.Lift)
   deriving anyclass (Default, NFData)
   deriving (AE.FromJSON, AE.ToJSON) via DAE.CustomJSON '[DAE.ConstructorTagModifier '[DAE.StripPrefix "SB", DAE.CamelToSnake]] SummarizeBy
 
 
+-- | Prefix shown before a stat's big number. The value itself is computed and
+-- formatted client-side (statScalar/formatStatValue in stat-value.ts) from the
+-- same stats the chart uses, so the two paths can't disagree. Explicit clauses
+-- (not a wildcard) so a new constructor must declare its prefix.
 summarizeByPrefix :: SummarizeBy -> Text
-summarizeByPrefix SBSum = ""
 summarizeByPrefix SBMax = "<"
 summarizeByPrefix SBMin = ">"
+summarizeByPrefix SBSum = ""
 summarizeByPrefix SBCount = ""
+summarizeByPrefix SBMean = ""
+summarizeByPrefix SBRate = ""
 
 
 -- when processing widgets we'll do them async, so eager queries are loaded upfront

--- a/static/public/dashboards/_overview.yaml
+++ b/static/public/dashboards/_overview.yaml
@@ -87,9 +87,8 @@ tabs:
             query: |
               (kind == "server" or name == "apitoolkit-http-span" or name == "monoscope.http")
               | summarize count() by bin_auto(timestamp)
-              | order by timestamp desc
-              | limit 200
             unit: req/min
+            summarize_by: rate
             layout: { w: 3, h: 2 }
 
           - type: 'timeseries_stat'
@@ -99,9 +98,8 @@ tabs:
             query: |
               (kind == "server" or name == "apitoolkit-http-span" or name == "monoscope.http") and duration != null
               | summarize p95(duration) / 1000000 by bin_auto(timestamp)
-              | order by timestamp desc
-              | limit 200
             unit: ms
+            summarize_by: mean
             layout: { w: 3, h: 2 }
 
           - type: 'timeseries_stat'
@@ -111,9 +109,8 @@ tabs:
             query: |
               (kind == "server" or name == "apitoolkit-http-span")
               | summarize round(countif(status_code == "ERROR" or coalesce(attributes.http.response.status_code, 0) >= 500) * 100.0 / count(), 2) by bin_auto(timestamp)
-              | order by timestamp desc
-              | limit 200
             unit: '%'
+            summarize_by: mean
             alert_threshold: 5
             warning_threshold: 2
             layout: { w: 3, h: 2 }

--- a/static/public/dashboards/_overview.yaml
+++ b/static/public/dashboards/_overview.yaml
@@ -778,6 +778,7 @@ tabs:
               attributes.db.system.name == "{{var-database}}"
               | summarize round(countif(status_code == "ERROR") * 100.0 / count(), 2) by bin_auto(timestamp)
             unit: '%'
+            summarize_by: mean
             alert_threshold: 5
             warning_threshold: 1
             layout: { w: 3, h: 2 }
@@ -789,6 +790,7 @@ tabs:
               attributes.db.system.name == "{{var-database}}" and duration != null
               | summarize p95(duration) / 1000000 by bin_auto(timestamp)
             unit: ms
+            summarize_by: mean
             layout: { w: 3, h: 2 }
 
           - type: 'stat'

--- a/static/public/dashboards/_overview.yaml
+++ b/static/public/dashboards/_overview.yaml
@@ -358,8 +358,6 @@ tabs:
             query: |
               resource.service.name == "{{var-service}}" and kind == "server"
               | summarize count() by bin_auto(timestamp)
-              | order by timestamp desc
-              | limit 200
             unit: reqs
             layout: { w: 3, h: 2 }
 
@@ -674,8 +672,6 @@ tabs:
             query: |
               body != null and ("{{var-service}}" == "" or resource.service.name == "{{var-service}}")
               | summarize count() by bin_auto(timestamp)
-              | order by timestamp desc
-              | limit 200
             unit: logs
             layout: { w: 3, h: 2 }
 
@@ -685,8 +681,6 @@ tabs:
             query: |
               level in ("ERROR", "FATAL") and ("{{var-service}}" == "" or resource.service.name == "{{var-service}}")
               | summarize count() by bin_auto(timestamp)
-              | order by timestamp desc
-              | limit 200
             unit: errors
             alert_threshold: 100
             warning_threshold: 50
@@ -698,8 +692,6 @@ tabs:
             query: |
               level == "WARN" and ("{{var-service}}" == "" or resource.service.name == "{{var-service}}")
               | summarize count() by bin_auto(timestamp)
-              | order by timestamp desc
-              | limit 200
             unit: warns
             layout: { w: 3, h: 2 }
 
@@ -776,8 +768,6 @@ tabs:
             query: |
               attributes.db.system.name == "{{var-database}}"
               | summarize count() by bin_auto(timestamp)
-              | order by timestamp desc
-              | limit 200
             unit: queries
             layout: { w: 3, h: 2 }
 
@@ -787,8 +777,6 @@ tabs:
             query: |
               attributes.db.system.name == "{{var-database}}"
               | summarize round(countif(status_code == "ERROR") * 100.0 / count(), 2) by bin_auto(timestamp)
-              | order by timestamp desc
-              | limit 200
             unit: '%'
             alert_threshold: 5
             warning_threshold: 1
@@ -800,8 +788,6 @@ tabs:
             query: |
               attributes.db.system.name == "{{var-database}}" and duration != null
               | summarize p95(duration) / 1000000 by bin_auto(timestamp)
-              | order by timestamp desc
-              | limit 200
             unit: ms
             layout: { w: 3, h: 2 }
 

--- a/static/public/dashboards/endpoint-stats.yaml
+++ b/static/public/dashboards/endpoint-stats.yaml
@@ -37,8 +37,6 @@ tabs:
             query: |
               kind=="server" AND hashes[*]=="{{var-endpointHash}}"
               | summarize count() by bin_auto(timestamp)
-              | order by timestamp desc
-              | limit 200
             unit: reqs
             eager: true
             layout: { w: 3, h: 2 }
@@ -50,8 +48,6 @@ tabs:
             query: |
               kind=="server" AND hashes[*]=="{{var-endpointHash}}"
               | summarize round(countif(coalesce(attributes.http.response.status_code, 0) >= 500) * 100.0 / count(), 2) by bin_auto(timestamp)
-              | order by timestamp desc
-              | limit 200
             unit: '%'
             alert_threshold: 5
             warning_threshold: 1
@@ -64,8 +60,6 @@ tabs:
             query: |
               kind=="server" AND hashes[*]=="{{var-endpointHash}}" AND duration != null
               | summarize p95(duration) / 1000000 by bin_auto(timestamp)
-              | order by timestamp desc
-              | limit 200
             unit: ms
             layout: { w: 3, h: 2 }
 
@@ -275,8 +269,6 @@ tabs:
             query: |
               kind=="server" AND hashes[*]=="{{var-endpointHash}}" AND attributes.http.response.status_code >= 500
               | summarize count() by bin_auto(timestamp)
-              | order by timestamp desc
-              | limit 200
             unit: errors
             alert_threshold: 1
             layout: { w: 4, h: 2 }
@@ -287,8 +279,6 @@ tabs:
             query: |
               kind=="server" AND hashes[*]=="{{var-endpointHash}}" AND attributes.http.response.status_code >= 400 AND attributes.http.response.status_code < 500
               | summarize count() by bin_auto(timestamp)
-              | order by timestamp desc
-              | limit 200
             unit: errors
             layout: { w: 4, h: 2 }
 
@@ -370,8 +360,6 @@ tabs:
             query: |
               kind=="server" AND hashes[*]=="{{var-endpointHash}}" AND duration != null
               | summarize p50(duration) / 1000000 by bin_auto(timestamp)
-              | order by timestamp desc
-              | limit 200
             unit: ms
             layout: { w: 3, h: 2 }
 
@@ -381,8 +369,6 @@ tabs:
             query: |
               kind=="server" AND hashes[*]=="{{var-endpointHash}}" AND duration != null
               | summarize p75(duration) / 1000000 by bin_auto(timestamp)
-              | order by timestamp desc
-              | limit 200
             unit: ms
             layout: { w: 3, h: 2 }
 
@@ -392,8 +378,6 @@ tabs:
             query: |
               kind=="server" AND hashes[*]=="{{var-endpointHash}}" AND duration != null
               | summarize p95(duration) / 1000000 by bin_auto(timestamp)
-              | order by timestamp desc
-              | limit 200
             unit: ms
             layout: { w: 3, h: 2 }
 
@@ -403,8 +387,6 @@ tabs:
             query: |
               kind=="server" AND hashes[*]=="{{var-endpointHash}}" AND duration != null
               | summarize p99(duration) / 1000000 by bin_auto(timestamp)
-              | order by timestamp desc
-              | limit 200
             unit: ms
             layout: { w: 3, h: 2 }
 

--- a/web-components/src/stat-value.ts
+++ b/web-components/src/stat-value.ts
@@ -6,11 +6,11 @@
 
 /** Format numbers with magnitude suffixes for chart/stat display. */
 export const formatNumber = (n: number): string => {
+  if (n == null || Number.isNaN(n)) return 'N/A'; // guard first: NaN (e.g. Number(undefined)) must not reach the DOM as "NaN"
   if (n >= 1_000_000_000) return `${Math.floor(n / 1_000_000_000)}.${Math.floor((n % 1_000_000_000) / 100_000_000)}B`;
   if (n >= 1_000_000) return `${Math.floor(n / 1_000_000)}.${Math.floor((n % 1_000_000) / 100_000)}M`;
   if (n >= 1_000) return `${Math.floor(n / 1_000)}.${Math.floor((n % 1_000) / 100)}K`;
-  if (n === null) return 'N/A';
-  if (!Number.isInteger(n) && !Number.isNaN(n)) {
+  if (!Number.isInteger(n)) {
     if (n >= 100) return Math.round(n).toString();
     if (n >= 10) return parseFloat(n.toFixed(1)).toString();
     return parseFloat(n.toFixed(2)).toString();

--- a/web-components/src/stat-value.ts
+++ b/web-components/src/stat-value.ts
@@ -26,6 +26,7 @@ export const convertToNanoseconds = (value: number, unit: string): number => {
 
 /** Format a nanosecond duration into a human-readable unit (matches Utils.hs). */
 export const formatDuration = (ns: number): string => {
+  if (ns == null || Number.isNaN(ns)) return 'N/A'; // guard first, mirroring formatNumber, so NaN never renders as "NaNns"
   if (ns >= 3_600_000_000_000) return `${(ns / 3_600_000_000_000).toFixed(1)}h`;
   if (ns >= 60_000_000_000) return `${(ns / 60_000_000_000).toFixed(1)}m`;
   if (ns >= 1_000_000_000) return `${(ns / 1_000_000_000).toFixed(1)}s`;

--- a/web-components/src/stat-value.ts
+++ b/web-components/src/stat-value.ts
@@ -1,0 +1,66 @@
+// Pure helpers for a timeseries_stat widget's big number and for chart number
+// formatting. Kept side-effect free so they can be unit-tested directly and
+// reused by widgets.ts. The big number is computed entirely client-side; the
+// SummarizeBy tags ('rate'/'mean'/…) match the Haskell enum in
+// src/Pkg/Components/Widget.hs that the dashboard YAML's summarize_by parses to.
+
+/** Format numbers with magnitude suffixes for chart/stat display. */
+export const formatNumber = (n: number): string => {
+  if (n >= 1_000_000_000) return `${Math.floor(n / 1_000_000_000)}.${Math.floor((n % 1_000_000_000) / 100_000_000)}B`;
+  if (n >= 1_000_000) return `${Math.floor(n / 1_000_000)}.${Math.floor((n % 1_000_000) / 100_000)}M`;
+  if (n >= 1_000) return `${Math.floor(n / 1_000)}.${Math.floor((n % 1_000) / 100)}K`;
+  if (n === null) return 'N/A';
+  if (!Number.isInteger(n) && !Number.isNaN(n)) {
+    if (n >= 100) return Math.round(n).toString();
+    if (n >= 10) return parseFloat(n.toFixed(1)).toString();
+    return parseFloat(n.toFixed(2)).toString();
+  }
+  return n.toString();
+};
+
+/** Convert a value in a time unit (h, m, s, ms, μs/us, ns) to nanoseconds. */
+export const convertToNanoseconds = (value: number, unit: string): number => {
+  const f: Record<string, number> = { h: 3_600_000_000_000, m: 60_000_000_000, s: 1_000_000_000, ms: 1_000_000, μs: 1_000, us: 1_000, ns: 1 };
+  return value * (f[unit] || 1);
+};
+
+/** Format a nanosecond duration into a human-readable unit (matches Utils.hs). */
+export const formatDuration = (ns: number): string => {
+  if (ns >= 3_600_000_000_000) return `${(ns / 3_600_000_000_000).toFixed(1)}h`;
+  if (ns >= 60_000_000_000) return `${(ns / 60_000_000_000).toFixed(1)}m`;
+  if (ns >= 1_000_000_000) return `${(ns / 1_000_000_000).toFixed(1)}s`;
+  if (ns >= 1_000_000) return `${(ns / 1_000_000).toFixed(1)}ms`;
+  if (ns >= 1_000) return `${(ns / 1_000).toFixed(1)}μs`;
+  return `${ns.toFixed(0)}ns`;
+};
+
+const DURATION_UNITS = ['ns', 'μs', 'us', 'ms', 's', 'm', 'h'];
+
+export type StatAggregates = { min: number; max: number; sum: number; count: number; mean: number };
+
+/**
+ * Pick the representative scalar for a timeseries_stat's big number. Summing
+ * per-bin values only makes sense for additive counts; rates/percentages/
+ * latencies must be averaged ('mean') or rate-derived ('rate', events/min over
+ * the window), never summed. `from`/`to` are in ms.
+ */
+export const statScalar = (stats: Partial<StatAggregates>, summarizeBy: string, from?: number, to?: number): number => {
+  switch (summarizeBy) {
+    case 'rate': {
+      const minutes = from != null && to != null && to > from ? (to - from) / 60000 : 0;
+      return minutes > 0 ? Number(stats.sum) / minutes : Number(stats.sum);
+    }
+    case 'mean': return Number(stats.mean);
+    case 'max': return Number(stats.max);
+    case 'min': return Number(stats.min);
+    case 'count': return Number(stats.count);
+    default: return Number(stats.sum);
+  }
+};
+
+/** Format a stat scalar for display, appending the unit (duration-aware). */
+export const formatStatValue = (value: number, unit: string): string => {
+  if (DURATION_UNITS.includes(unit)) return formatDuration(convertToNanoseconds(value, unit));
+  const suffix = ({ '': '', '1': '', '{}': '', By: ' bytes' } as Record<string, string>)[unit] ?? ` ${unit}`;
+  return `${formatNumber(value)}${suffix}`;
+};

--- a/web-components/src/stat-value.ts
+++ b/web-components/src/stat-value.ts
@@ -5,11 +5,11 @@
 // src/Pkg/Components/Widget.hs that the dashboard YAML's summarize_by parses to.
 
 /** Format numbers with magnitude suffixes for chart/stat display. */
-export const formatNumber = (n: number): string => {
-  if (n == null || Number.isNaN(n)) return 'N/A'; // guard first: NaN (e.g. Number(undefined)) must not reach the DOM as "NaN"
-  if (n >= 1_000_000_000) return `${Math.floor(n / 1_000_000_000)}.${Math.floor((n % 1_000_000_000) / 100_000_000)}B`;
-  if (n >= 1_000_000) return `${Math.floor(n / 1_000_000)}.${Math.floor((n % 1_000_000) / 100_000)}M`;
-  if (n >= 1_000) return `${Math.floor(n / 1_000)}.${Math.floor((n % 1_000) / 100)}K`;
+export const formatNumber = (n: number | null | undefined): string => {
+  if (n == null || Number.isNaN(n)) return 'N/A'; // guard first: NaN (e.g. Number(undefined)) must not reach the DOM as "NaN". Loose type matches untyped JS callers.
+  if (n >= 1_000_000_000) return `${(n / 1_000_000_000).toFixed(1)}B`;
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
   if (!Number.isInteger(n)) {
     if (n >= 100) return Math.round(n).toString();
     if (n >= 10) return parseFloat(n.toFixed(1)).toString();
@@ -24,17 +24,23 @@ export const convertToNanoseconds = (value: number, unit: string): number => {
   return value * (f[unit] || 1);
 };
 
+// Descending [threshold-ns, suffix] steps; first step whose threshold ns clears wins.
+const DURATION_STEPS: [number, string][] = [
+  [3_600_000_000_000, 'h'],
+  [60_000_000_000, 'm'],
+  [1_000_000_000, 's'],
+  [1_000_000, 'ms'],
+  [1_000, 'μs'],
+];
+
 /** Format a nanosecond duration into a human-readable unit (matches Utils.hs). */
 export const formatDuration = (ns: number): string => {
   if (ns == null || Number.isNaN(ns)) return 'N/A'; // guard first, mirroring formatNumber, so NaN never renders as "NaNns"
-  if (ns >= 3_600_000_000_000) return `${(ns / 3_600_000_000_000).toFixed(1)}h`;
-  if (ns >= 60_000_000_000) return `${(ns / 60_000_000_000).toFixed(1)}m`;
-  if (ns >= 1_000_000_000) return `${(ns / 1_000_000_000).toFixed(1)}s`;
-  if (ns >= 1_000_000) return `${(ns / 1_000_000).toFixed(1)}ms`;
-  if (ns >= 1_000) return `${(ns / 1_000).toFixed(1)}μs`;
-  return `${ns.toFixed(0)}ns`;
+  const step = DURATION_STEPS.find(([t]) => ns >= t);
+  return step ? `${(ns / step[0]).toFixed(1)}${step[1]}` : `${ns.toFixed(0)}ns`;
 };
 
+// Units that format as a duration. NB: 'm' here is minutes, not meters.
 const DURATION_UNITS = new Set(['ns', 'μs', 'us', 'ms', 's', 'm', 'h']);
 
 export type StatAggregates = { min: number; max: number; sum: number; count: number; mean: number };
@@ -49,7 +55,7 @@ export const statScalar = (stats: Partial<StatAggregates>, summarizeBy: string, 
   switch (summarizeBy) {
     case 'rate': {
       const minutes = from != null && to != null && to > from ? (to - from) / 60000 : 0;
-      return minutes > 0 ? Number(stats.sum) / minutes : Number(stats.sum);
+      return minutes > 0 ? Number(stats.sum) / minutes : NaN; // degenerate window → N/A, not a wrong-unit raw sum
     }
     case 'mean': return Number(stats.mean);
     case 'max': return Number(stats.max);

--- a/web-components/src/stat-value.ts
+++ b/web-components/src/stat-value.ts
@@ -35,7 +35,7 @@ export const formatDuration = (ns: number): string => {
   return `${ns.toFixed(0)}ns`;
 };
 
-const DURATION_UNITS = ['ns', 'μs', 'us', 'ms', 's', 'm', 'h'];
+const DURATION_UNITS = new Set(['ns', 'μs', 'us', 'ms', 's', 'm', 'h']);
 
 export type StatAggregates = { min: number; max: number; sum: number; count: number; mean: number };
 
@@ -61,7 +61,7 @@ export const statScalar = (stats: Partial<StatAggregates>, summarizeBy: string, 
 
 /** Format a stat scalar for display, appending the unit (duration-aware). */
 export const formatStatValue = (value: number, unit: string): string => {
-  if (DURATION_UNITS.includes(unit)) return formatDuration(convertToNanoseconds(value, unit));
+  if (DURATION_UNITS.has(unit)) return formatDuration(convertToNanoseconds(value, unit));
   const suffix = ({ '': '', '1': '', '{}': '', By: ' bytes' } as Record<string, string>)[unit] ?? ` ${unit}`;
   return `${formatNumber(value)}${suffix}`;
 };

--- a/web-components/src/widgets.ts
+++ b/web-components/src/widgets.ts
@@ -225,19 +225,15 @@ const createSeriesConfig = (widgetData: WidGetData, name: string, i: number, opt
   const isErrorStat = widgetData.widgetType === 'timeseries_stat' && widgetData.alertThreshold != null;
   const isGenericStatColumn = widgetData.widgetType === 'timeseries_stat' &&
     (name === 'value' || name.startsWith('count') || name === '' || !name);
-  const paletteColor = isErrorStat
-    ? getChartStyles().errorColor
-    : isGenericStatColumn
-      ? getChartStyles().brandColor
-      : getSeriesColor(name);
+  const styles = getChartStyles(); // one getComputedStyle read per series, not three
+  const paletteColor = isErrorStat ? styles.errorColor : isGenericStatColumn ? styles.brandColor : getSeriesColor(name);
 
   const gradientColor = new (window as any).echarts.graphic.LinearGradient(0, 0, 0, 1, [
     { offset: 0, color: (window as any).echarts.color.modifyAlpha(paletteColor, 1) },
     { offset: 1, color: (window as any).echarts.color.modifyAlpha(paletteColor, 0) },
   ]);
 
-  const { chartBg } = getChartStyles();
-  const backgroundStyle = { color: chartBg };
+  const backgroundStyle = { color: styles.chartBg };
 
   const seriesOpt: any = {
     type: widgetData.chartType,

--- a/web-components/src/widgets.ts
+++ b/web-components/src/widgets.ts
@@ -306,10 +306,12 @@ const setStatValue = (widgetData: WidGetData, stats: any, from?: number, to?: nu
     return;
   }
   // textContent (not innerHTML): values are plain text, and the max/min prefix is a literal "<"/">".
-  value.textContent =
-    stats.count > 0
-      ? [widgetData.summarizeByPrefix, formatStatValue(statScalar(stats, widgetData.summarizeBy, from, to), widgetData.unit || '')].filter(Boolean).join(' ')
-      : NO_DATA_VALUE;
+  if (stats.count > 0) {
+    const formatted = formatStatValue(statScalar(stats, widgetData.summarizeBy, from, to), widgetData.unit || '');
+    value.textContent = widgetData.summarizeByPrefix ? `${widgetData.summarizeByPrefix} ${formatted}` : formatted;
+  } else {
+    value.textContent = NO_DATA_VALUE; // empty range
+  }
   value.classList.remove('hidden');
 };
 

--- a/web-components/src/widgets.ts
+++ b/web-components/src/widgets.ts
@@ -299,8 +299,15 @@ const NO_DATA_VALUE = '—';
 const setStatValue = (widgetData: WidGetData, stats: any, from?: number, to?: number) => {
   const value = $(`${widgetData.chartId}Value`);
   if (!value) return;
-  value.innerHTML =
-    stats && stats.count > 0
+  if (stats == null) {
+    // Fetch error: clear the spinner, but leave the chart's error overlay as the
+    // sole failure signal rather than revealing a redundant "—" badge above it.
+    value.textContent = '';
+    return;
+  }
+  // textContent (not innerHTML): values are plain text, and the max/min prefix is a literal "<"/">".
+  value.textContent =
+    stats.count > 0
       ? [widgetData.summarizeByPrefix, formatStatValue(statScalar(stats, widgetData.summarizeBy, from, to), widgetData.unit || '')].filter(Boolean).join(' ')
       : NO_DATA_VALUE;
   value.classList.remove('hidden');

--- a/web-components/src/widgets.ts
+++ b/web-components/src/widgets.ts
@@ -2,6 +2,7 @@
 import { params } from './main';
 import { getSeriesColor } from './colorMapping';
 import { beginChartFetch } from './chart-fetch-seq';
+import { formatNumber, convertToNanoseconds, formatDuration, statScalar, formatStatValue } from './stat-value';
 const INITIAL_FETCH_INTERVAL = 5000;
 const $ = (id: string) => document.getElementById(id);
 
@@ -216,10 +217,19 @@ const hideNoDataOverlay = (chartId: string) => {
 
 
 const createSeriesConfig = (widgetData: WidGetData, name: string, i: number, opt: any) => {
-  // For timeseries_stat widgets with generic column names, use the brand color token
+  // A thresholded stat (e.g. Error Rate) is treated as a caution metric — color
+  // it red so the signal isn't an arbitrary hash color, rather than leaving it to
+  // getSeriesColor's hash. Assumes higher = worse; revisit (explicit intent field)
+  // if a "good when high" or latency-SLO stat ever needs a non-red threshold.
+  // Otherwise generic stat columns use the brand color; named series use their mapping.
+  const isErrorStat = widgetData.widgetType === 'timeseries_stat' && widgetData.alertThreshold != null;
   const isGenericStatColumn = widgetData.widgetType === 'timeseries_stat' &&
     (name === 'value' || name.startsWith('count') || name === '' || !name);
-  const paletteColor = isGenericStatColumn ? getChartStyles().brandColor : getSeriesColor(name);
+  const paletteColor = isErrorStat
+    ? getChartStyles().errorColor
+    : isGenericStatColumn
+      ? getChartStyles().brandColor
+      : getSeriesColor(name);
 
   const gradientColor = new (window as any).echarts.graphic.LinearGradient(0, 0, 0, 1, [
     { offset: 0, color: (window as any).echarts.color.modifyAlpha(paletteColor, 1) },
@@ -285,10 +295,25 @@ const updateChartConfiguration = (widgetData: WidGetData, opt: any, data: any) =
   return opt;
 };
 
+// Fill a timeseries_stat's big number from the chart-data fetch: the
+// representative scalar for its unit, or a no-data dash (stats null / empty
+// range) so the loading spinner always resolves rather than spinning under an
+// error overlay. Eager stat widgets keep their server-rendered value (no fetch).
+const NO_DATA_VALUE = '—';
+const setStatValue = (widgetData: WidGetData, stats: any, from?: number, to?: number) => {
+  const value = $(`${widgetData.chartId}Value`);
+  if (!value) return;
+  value.innerHTML =
+    stats && stats.count > 0
+      ? [widgetData.summarizeByPrefix, formatStatValue(statScalar(stats, widgetData.summarizeBy, from, to), widgetData.unit || '')].filter(Boolean).join(' ')
+      : NO_DATA_VALUE;
+  value.classList.remove('hidden');
+};
+
 const updateChartData = async (chart: any, opt: any, shouldFetch: boolean, widgetData: WidGetData) => {
   if (!shouldFetch) return;
 
-  const { query, querySQL, pid, chartId, summarizeBy, summarizeByPrefix } = widgetData;
+  const { query, querySQL, pid, chartId } = widgetData;
   const isStale = beginChartFetch(chartId);
   // Batch DOM updates before fetch
   requestAnimationFrame(() => {
@@ -342,6 +367,7 @@ const updateChartData = async (chart: any, opt: any, shouldFetch: boolean, widge
       // "no data" one) so the user can distinguish a broken widget from an empty range.
       chart.hideLoading();
       showNoDataOverlay(chartId, error, 'error');
+      setStatValue(widgetData, null); // clear the stat spinner; failed ≠ loading
       return;
     }
     const trmHeaders = headers?.map((h: string) => {
@@ -364,19 +390,10 @@ const updateChartData = async (chart: any, opt: any, shouldFetch: boolean, widge
     const subtitle = $(`${chartId}Subtitle`);
     subtitle && (subtitle.innerHTML = `${window.formatNumber(rows_per_min)}/min`);
 
-    const value = $(`${chartId}Value`);
-    if (value && stats) {
-      const durationUnits = ['ns', 'μs', 'us', 'ms', 's', 'm', 'h'];
-      const unit = widgetData.unit || '';
-      const isDuration = durationUnits.includes(unit);
-      const formattedValue = isDuration
-        ? window.formatDuration(window.convertToNanoseconds(Number(stats[summarizeBy]), unit))
-        : window.formatNumber(Number(stats[summarizeBy]));
-      const displayUnit = {'': '', '1': '', '{}': '', 'By': ' bytes'}[unit] ?? ` ${unit}`;
-      const unitSuffix = isDuration ? '' : displayUnit;
-      value.innerHTML = `${summarizeByPrefix} ${formattedValue}${unitSuffix}`;
-      value.classList.remove('hidden');
-    }
+    // Representative scalar for the unit (rate/mean/…), not a blind sum of
+    // per-bin values — see statScalar. from/to are ms, needed for rate. count<1
+    // (empty range) renders the no-data dash, matching the chart overlay below.
+    setStatValue(widgetData, stats, from, to);
 
     chart.hideLoading();
     if (!dataset || dataset.length === 0) {
@@ -396,7 +413,10 @@ const updateChartData = async (chart: any, opt: any, shouldFetch: boolean, widge
   } catch (e) {
     console.error('Failed to fetch new data:', e);
     chart.hideLoading();
-    if (!isStale()) showNoDataOverlay(chartId, 'Failed to load data', 'error');
+    if (!isStale()) {
+      showNoDataOverlay(chartId, 'Failed to load data', 'error');
+      setStatValue(widgetData, null); // clear the stat spinner on fetch failure
+    }
   } finally {
     // Batch DOM updates after fetch completes
     requestAnimationFrame(() => {
@@ -602,71 +622,12 @@ const chartWidget = (widgetData: WidGetData) => {
 (window as any).queueChartInit = queueChartInit;
 
 /**
- * Format numbers with appropriate suffixes and precision
- * for display in charts and tooltips
+ * Number/duration formatting now lives in ./stat-value (pure + unit-tested);
+ * re-export onto window for the inline chart formatters that reference them.
  */
-window.formatNumber = (n: number): string => {
-  if (n >= 1_000_000_000) return `${Math.floor(n / 1_000_000_000)}.${Math.floor((n % 1_000_000_000) / 100_000_000)}B`;
-  if (n >= 1_000_000) return `${Math.floor(n / 1_000_000)}.${Math.floor((n % 1_000_000) / 100_000)}M`;
-  if (n >= 1_000) return `${Math.floor(n / 1_000)}.${Math.floor((n % 1_000) / 100)}K`;
-  if (n === null) return 'N/A';
-
-  // Format decimals appropriately based on magnitude
-  if (!Number.isInteger(n) && !Number.isNaN(n)) {
-    if (n >= 100) return Math.round(n).toString();
-    if (n >= 10) return parseFloat(n.toFixed(1)).toString();
-    return parseFloat(n.toFixed(2)).toString();
-  }
-
-  return n.toString();
-};
-
-/**
- * Convert a value from a specified time unit to nanoseconds
- * @param value - The numeric value to convert
- * @param unit - The unit of the input value (h, m, s, ms, μs, us, ns)
- * @returns Value converted to nanoseconds
- */
-window.convertToNanoseconds = (value: number, unit: string): number => {
-  const conversionFactors: Record<string, number> = {
-    h: 3_600_000_000_000, // hours to nanoseconds
-    m: 60_000_000_000, // minutes to nanoseconds
-    s: 1_000_000_000, // seconds to nanoseconds
-    ms: 1_000_000, // milliseconds to nanoseconds
-    μs: 1_000, // microseconds to nanoseconds
-    us: 1_000, // microseconds to nanoseconds (alt)
-    ns: 1, // already nanoseconds
-  };
-  return value * (conversionFactors[unit] || 1);
-};
-
-/**
- * Format duration values from nanoseconds into human-readable time units
- * Matches the backend's prettyPrintDuration function in Utils.hs
- * @param ns - Duration in nanoseconds
- * @returns Formatted duration string with appropriate unit
- */
-window.formatDuration = (ns: number): string => {
-  if (ns >= 3_600_000_000_000) {
-    // >= 1 hour
-    return `${(ns / 3_600_000_000_000).toFixed(1)}h`;
-  } else if (ns >= 60_000_000_000) {
-    // >= 1 minute
-    return `${(ns / 60_000_000_000).toFixed(1)}m`;
-  } else if (ns >= 1_000_000_000) {
-    // >= 1 second
-    return `${(ns / 1_000_000_000).toFixed(1)}s`;
-  } else if (ns >= 1_000_000) {
-    // >= 1 millisecond
-    return `${(ns / 1_000_000).toFixed(1)}ms`;
-  } else if (ns >= 1_000) {
-    // >= 1 microsecond
-    return `${(ns / 1_000).toFixed(1)}μs`;
-  } else {
-    // nanoseconds
-    return `${ns.toFixed(0)}ns`;
-  }
-};
+window.formatNumber = formatNumber;
+window.convertToNanoseconds = convertToNanoseconds;
+window.formatDuration = formatDuration;
 
 // Recursively build the widget order from a grid container.
 // It looks for direct children with the class "grid-stack-item" and

--- a/web-components/test/stat-value.test.ts
+++ b/web-components/test/stat-value.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from 'vitest';
-import { statScalar, formatStatValue } from '../src/stat-value';
+import { statScalar, formatStatValue, formatNumber } from '../src/stat-value';
 
 // Regression for the golden-signals overview bug: the big number was a blind
 // sum of every per-bin value (mislabeled "120k req/min", "1.5m" p99), instead
@@ -49,5 +49,17 @@ describe('formatStatValue', () => {
   test('unitless and bytes suffixes', () => {
     expect(formatStatValue(1500, '')).toBe('1.5K');
     expect(formatStatValue(2048, 'By')).toBe('2.0K bytes');
+  });
+});
+
+describe('formatNumber NaN/null guard', () => {
+  test('NaN/undefined/null render N/A, not the literal "NaN"', () => {
+    expect(formatNumber(NaN)).toBe('N/A');
+    expect(formatNumber(Number(undefined))).toBe('N/A');
+    expect(formatNumber(null as unknown as number)).toBe('N/A');
+  });
+  test('finite values are unaffected', () => {
+    expect(formatNumber(1500)).toBe('1.5K');
+    expect(formatNumber(42)).toBe('42');
   });
 });

--- a/web-components/test/stat-value.test.ts
+++ b/web-components/test/stat-value.test.ts
@@ -14,9 +14,9 @@ describe('statScalar', () => {
     expect(statScalar(traffic, 'rate', 0, 600000)).not.toBe(traffic.sum);
   });
 
-  test('rate falls back to sum when the window is missing/degenerate', () => {
-    expect(statScalar(traffic, 'rate')).toBe(1200);
-    expect(statScalar(traffic, 'rate', 100, 100)).toBe(1200);
+  test('rate returns NaN on a missing/degenerate window (→ N/A), not a wrong-unit sum', () => {
+    expect(statScalar(traffic, 'rate')).toBeNaN();
+    expect(statScalar(traffic, 'rate', 100, 100)).toBeNaN();
   });
 
   test('mean averages per-bin values (error-rate %, p95 latency)', () => {
@@ -61,6 +61,10 @@ describe('formatNumber NaN/null guard', () => {
   test('finite values are unaffected', () => {
     expect(formatNumber(1500)).toBe('1.5K');
     expect(formatNumber(42)).toBe('42');
+  });
+  test('K/M/B branches round rather than truncate', () => {
+    expect(formatNumber(1590)).toBe('1.6K');
+    expect(formatNumber(1_550_000)).toBe('1.6M');
   });
   test('duration units also guard NaN (no "NaNns")', () => {
     expect(formatStatValue(NaN, 'ms')).toBe('N/A');

--- a/web-components/test/stat-value.test.ts
+++ b/web-components/test/stat-value.test.ts
@@ -1,0 +1,53 @@
+import { describe, test, expect } from 'vitest';
+import { statScalar, formatStatValue } from '../src/stat-value';
+
+// Regression for the golden-signals overview bug: the big number was a blind
+// sum of every per-bin value (mislabeled "120k req/min", "1.5m" p99), instead
+// of a unit-appropriate scalar. statScalar must pick rate/mean, never sum, for
+// rate/latency/percentage units.
+describe('statScalar', () => {
+  // 1200 requests across 10 minutes (0 → 600000ms) of count() bins.
+  const traffic = { min: 50, max: 200, sum: 1200, count: 10, mean: 120 };
+
+  test('rate = sum / window-minutes (true req/min), not the raw sum', () => {
+    expect(statScalar(traffic, 'rate', 0, 600000)).toBe(120); // 1200/10min
+    expect(statScalar(traffic, 'rate', 0, 600000)).not.toBe(traffic.sum);
+  });
+
+  test('rate falls back to sum when the window is missing/degenerate', () => {
+    expect(statScalar(traffic, 'rate')).toBe(1200);
+    expect(statScalar(traffic, 'rate', 100, 100)).toBe(1200);
+  });
+
+  test('mean averages per-bin values (error-rate %, p95 latency)', () => {
+    // Summing per-bin percentages would give a meaningless ~ sum; mean is right.
+    const errorRate = { min: 0, max: 9, sum: 230, count: 100, mean: 2.3 };
+    expect(statScalar(errorRate, 'mean')).toBe(2.3);
+  });
+
+  test('default/sum keeps total for additive counts', () => {
+    expect(statScalar(traffic, 'sum')).toBe(1200);
+    expect(statScalar(traffic, 'whatever')).toBe(1200);
+    expect(statScalar(traffic, 'max')).toBe(200);
+    expect(statScalar(traffic, 'min')).toBe(50);
+    expect(statScalar(traffic, 'count')).toBe(10);
+  });
+});
+
+describe('formatStatValue', () => {
+  test('appends non-duration units with a space', () => {
+    expect(formatStatValue(120, 'req/min')).toBe('120 req/min');
+    expect(formatStatValue(2.3, '%')).toBe('2.3 %');
+  });
+
+  test('ms latency formats as a duration (no millions ambiguity)', () => {
+    // 45 ms must read "45.0ms", never "1.5m"/"45M".
+    expect(formatStatValue(45, 'ms')).toBe('45.0ms');
+    expect(formatStatValue(1500, 'ms')).toBe('1.5s');
+  });
+
+  test('unitless and bytes suffixes', () => {
+    expect(formatStatValue(1500, '')).toBe('1.5K');
+    expect(formatStatValue(2048, 'By')).toBe('2.0K bytes');
+  });
+});

--- a/web-components/test/stat-value.test.ts
+++ b/web-components/test/stat-value.test.ts
@@ -62,4 +62,7 @@ describe('formatNumber NaN/null guard', () => {
     expect(formatNumber(1500)).toBe('1.5K');
     expect(formatNumber(42)).toBe('42');
   });
+  test('duration units also guard NaN (no "NaNns")', () => {
+    expect(formatStatValue(NaN, 'ms')).toBe('N/A');
+  });
 });


### PR DESCRIPTION
## Problem

On the overview dashboard's **Golden Signals**, the stat widgets showed a unit-blind big number — the chart summed every per-bin value regardless of unit:

- **Traffic** flashed from a bin count to the *total* request count ("120 → 120k req/min") instead of a rate.
- **P95 Latency** summed per-bin p95s into an ambiguous "1.5m" (minutes? millions?).
- **Error Rate** sparkline rendered in an arbitrary hash color (blue) instead of red.

Root cause: the big number was `stats[summarizeBy]` with `summarizeBy` defaulting to `sum`. Summing per-bin counts/percentages/latencies is meaningless; the SSR value (bin count) and the client value (total) both disagreed with the unit label.

## Fix

- **Unit-appropriate scalar instead of a blind sum** via a per-widget `summarize_by`: Traffic `rate` (`sum ÷ window-minutes` = true req/min), P95 `mean`, Error Rate `mean`.
- Extracted pure, unit-tested formatters + the scalar/format logic into `web-components/src/stat-value.ts`. `widgets.ts` fills the value via `setStatValue` — duration-aware formatting ("45.0ms", not "1.5m") and a "—" dash on error/no-data so the loading state always resolves.
- **Error stats render red** (a thresholded "caution" metric) instead of a hash color.
- Dropped `| order by timestamp desc | limit 200` from the three stat queries so the aggregates cover the full window — `bin_auto` can exceed 200 bins on 3.5–6h / 33–48h ranges, which truncated the `sum` and halved the Traffic rate.
- Added `SBMean`/`SBRate` to the `SummarizeBy` enum so the YAML `summarize_by` parses.

## Scope / safety

Eager dashboards (apache, nginx, postgresql, … ~19) are **unchanged** — they keep their server-rendered value and don't take the client fetch path. The Haskell change is minimal (two enum constructors + their `summarizeByPrefix` clauses).

## Tests

`web-components/test/stat-value.test.ts` (7 cases) pins the regressions: `rate ≠ sum`, `mean`, ms formatted as a duration. Full web-components suite: 128/128.

## Known follow-ups (out of this surgical scope)

- The brief `rowsCount` transient on the lazy HTMX stat-refresh path (eliminating it needs SSR plumbing that risks the eager dashboards).
- A volume-weighted error-rate option, and mirroring the error color into the PNG/no-JS `chart-cli` render path.