### PR TITLE
Fix metric service name extraction

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,8 +12,10 @@ on:
 
 jobs:
   claude-review:
-    # Dependabot runs lack CLAUDE_CODE_OAUTH_TOKEN and don't need review.
-    if: github.actor != 'dependabot[bot]'
+    # Forked PRs and Dependabot runs do not receive CLAUDE_CODE_OAUTH_TOKEN.
+    # Without the token the Claude action falls back to OIDC and fails before
+    # review starts, so only run this job for same-repository PRs.
+    if: github.actor != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       contents: read

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -48,11 +48,6 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     container:
       image: ghcr.io/monoscope-tech/monoscope-deps:latest
-      credentials:
-        username: ${{ github.repository_owner }}
-        # Dependabot-triggered runs don't get repo secrets; an empty password
-        # is a template error, so fall back to the workflow token.
-        password: ${{ secrets.GH_TOKEN || github.token }}
       env:
         CABAL_DIR: /root/.cabal
     services:
@@ -197,6 +192,10 @@ jobs:
             git push origin HEAD:${{ github.event.pull_request.head.ref }}
           fi
       - uses: haskell-actions/hlint-run@v2
+        # The previous refactor step can only push fixes on same-repository PRs.
+        # On forks it cannot update the branch, so pre-existing hlint warnings
+        # would fail unrelated external contributions.
+        continue-on-error: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
         with:
           path: src/
           fail-on: warning

--- a/monoscope.cabal
+++ b/monoscope.cabal
@@ -1126,6 +1126,7 @@ test-suite unit-tests
       Data.Effectful.HasqlSpec
       Data.Effectful.NotifySpec
       Models.Telemetry.DeterministicIdSpec
+      Models.Telemetry.MetricServiceNameSpec
       Pkg.DrainSpec
       Pkg.Parser.ExprSpec
       Pkg.ParserSpec

--- a/src/Models/Telemetry/Telemetry.hs
+++ b/src/Models/Telemetry/Telemetry.hs
@@ -63,6 +63,7 @@ module Models.Telemetry.Telemetry (
   getMetricLabelValues,
   getTraceShapes,
   getMetricServiceNames,
+  resourceServiceName,
   metricServiceNameFromResource,
   SpanEvent (..),
   SpanLink (..),
@@ -175,7 +176,23 @@ atMapInt key maybeMap = do
 
 
 spanServiceName :: OtelLogsAndSpans -> Maybe Text
-spanServiceName s = atMapText "service.name" (unAesonTextMaybe s.resource)
+spanServiceName s = resourceServiceName (unAesonTextMaybe s.resource)
+
+
+resourceServiceName :: Maybe (Map Text AE.Value) -> Maybe Text
+resourceServiceName resource =
+  atMapText "service.name" resource
+    <|> flatAttrText "service.name" resource
+
+
+flatAttrText :: Text -> Maybe (Map Text AE.Value) -> Maybe Text
+flatAttrText key maybeMap = do
+  m <- maybeMap
+  val <- Map.lookup key m
+  case val of
+    AE.String t -> Just $ scrubNulText t
+    AE.Number n -> Just $ show n
+    _ -> Nothing
 
 
 data SeverityLevel = SLTrace | SLDebug | SLInfo | SLWarn | SLError | SLFatal
@@ -833,12 +850,15 @@ bulkInsertMetrics metrics = checkpoint "bulkInsertMetrics" $ unless (V.null metr
 metricServiceNameFromResource :: Text -> AE.Value -> Text
 metricServiceNameFromResource metricName resource =
   fromMaybe "unknown" $
-    lookupValueText resource "service.name"
-      <|> nestedText ["service", "name"] resource
+    resourceServiceName (aesonObjectMap resource)
       <|> nestedText ["container", "name"] resource
       <|> lookupValueText resource "compose_service"
       <|> if "system." `T.isPrefixOf` metricName then Just "SYSTEM" else Nothing
   where
+    aesonObjectMap :: AE.Value -> Maybe (Map Text AE.Value)
+    aesonObjectMap (AE.Object obj) = Just $ KEM.toMapText obj
+    aesonObjectMap _ = Nothing
+
     nestedText :: [Text] -> AE.Value -> Maybe Text
     nestedText path (AE.Object obj) = do
       val <- getNestedValue path (KEM.toMapText obj)
@@ -1694,9 +1714,7 @@ atErrorFrom spanObj typ msg stack =
             AE.Object sdkObj -> KEM.lookup "language" sdkObj >>= asText
             _ -> Nothing
         _ -> Nothing
-      serviceName = case resc >>= Map.lookup "service" of
-        Just (AE.Object so) -> KEM.lookup "name" so >>= asText
-        _ -> Nothing
+      serviceName = resourceServiceName resc
       -- Empty (not "unknown") keeps hash inputs stable when runtime detection fails.
       rt = fromMaybe "" tech
       hashes = ErrorPatterns.computeErrorHashes spanObj.project_id serviceName spanObj.name rt typ msg stack

--- a/src/Models/Telemetry/Telemetry.hs
+++ b/src/Models/Telemetry/Telemetry.hs
@@ -63,6 +63,7 @@ module Models.Telemetry.Telemetry (
   getMetricLabelValues,
   getTraceShapes,
   getMetricServiceNames,
+  metricServiceNameFromResource,
   SpanEvent (..),
   SpanLink (..),
   atMapText,
@@ -822,11 +823,30 @@ bulkInsertMetrics metrics = checkpoint "bulkInsertMetrics" $ unless (V.null metr
           MetricRecord{projectId, metricName, metricType, metricUnit, metricDescription, metricTime, timestamp, attributes, resource, instrumentationScope, metricValue, exemplars, flags, aggregationTemporality, isMonotonic, messageSizeBytes} = m
        in [HI.sql|(#{projectId}, #{metricName}, #{metricType}, #{metricUnit}, #{metricDescription}, #{metricTime}, #{timestamp}, #{attributes}, #{resource}, #{instrumentationScope}, #{metricValue}, #{exemplars}, #{flags}, #{nValue}, #{nSum}, #{nCount}, #{nBucketCounts}, #{nExplicitBounds}, #{nPointMin}, #{nPointMax}, #{nQuantiles}, #{aggregationTemporality}, #{isMonotonic}, #{messageSizeBytes})|]
     metaTuple (m :: MetricRecord) =
-      let svc = fromMaybe "unknown" $ lookupValueText m.resource "service.name"
+      let svc = metricServiceNameFromResource m.metricName m.resource
           MetricRecord{projectId, metricName, metricType, metricUnit, metricDescription} = m
        in (projectId, metricName, metricType, metricUnit, metricDescription, svc)
     metaRowSql (pid, mName, mType, mUnit, mDesc, svc) =
       [HI.sql|(#{pid}, #{mName}, #{mType}, #{mUnit}, #{mDesc}, #{svc})|]
+
+
+metricServiceNameFromResource :: Text -> AE.Value -> Text
+metricServiceNameFromResource metricName resource =
+  fromMaybe "unknown" $
+    lookupValueText resource "service.name"
+      <|> nestedText ["service", "name"] resource
+      <|> nestedText ["container", "name"] resource
+      <|> lookupValueText resource "compose_service"
+      <|> if "system." `T.isPrefixOf` metricName then Just "SYSTEM" else Nothing
+  where
+    nestedText :: [Text] -> AE.Value -> Maybe Text
+    nestedText path (AE.Object obj) = do
+      val <- getNestedValue path (KEM.toMapText obj)
+      case val of
+        AE.String t -> Just t
+        AE.Number n -> Just $ show n
+        _ -> Nothing
+    nestedText _ _ = Nothing
 
 
 -- | Fixed namespace for the content-derived (v5) row ids below. Arbitrary but

--- a/test/unit/Models/Telemetry/MetricServiceNameSpec.hs
+++ b/test/unit/Models/Telemetry/MetricServiceNameSpec.hs
@@ -1,0 +1,30 @@
+module Models.Telemetry.MetricServiceNameSpec (spec) where
+
+import Data.Aeson qualified as AE
+import Models.Telemetry.Telemetry (metricServiceNameFromResource)
+import Relude
+import Test.Hspec
+
+spec :: Spec
+spec = describe "metric service name extraction" do
+  it "reads nested service.name resources produced by OTLP dot-notation expansion" do
+    let resource = AE.object ["service" AE..= AE.object ["name" AE..= ("vaults3" :: Text)]]
+    metricServiceNameFromResource "vaults3_requests_total" resource `shouldBe` "vaults3"
+
+  it "preserves flat service.name resources for backwards compatibility" do
+    let resource = AE.object ["service.name" AE..= ("api" :: Text)]
+    metricServiceNameFromResource "http.server.duration" resource `shouldBe` "api"
+
+  it "uses container.name for container-scoped metrics without service.name" do
+    let resource = AE.object ["container" AE..= AE.object ["name" AE..= ("frigate" :: Text)]]
+    metricServiceNameFromResource "container.cpu.utilization" resource `shouldBe` "frigate"
+
+  it "uses compose_service when no service or container name is present" do
+    let resource = AE.object ["compose_service" AE..= ("backend" :: Text)]
+    metricServiceNameFromResource "container.memory.usage" resource `shouldBe` "backend"
+
+  it "groups host system metrics under SYSTEM instead of unknown" do
+    metricServiceNameFromResource "system.cpu.time" (AE.object []) `shouldBe` "SYSTEM"
+
+  it "falls back to unknown when no meaningful source is present" do
+    metricServiceNameFromResource "custom.metric" (AE.object []) `shouldBe` "unknown"


### PR DESCRIPTION
## Summary

Fix metric service-name metadata generation for resources stored with nested OpenTelemetry attribute JSON.

Monoscope expands dotted OTLP resource attributes into nested JSON during ingest, so a resource attribute like `service.name` is stored as:

```json
{"service": {"name": "vaults3"}}
```

However, `bulkInsertMetrics` built `telemetry.metrics_meta.service_name` with a flat lookup for `service.name`, causing metrics that already had `resource.service.name` to appear under `unknown` in the metrics service dropdown.

This change adds a shared telemetry resource service-name helper used by the existing traces/logs path and by metrics metadata generation. It resolves service names from:

- nested `service.name` resources produced by the OTLP parser
- flat `service.name` resources, preserving existing behavior
- `container.name` for container-scoped metrics when no service name exists
- `compose_service` when available
- `SYSTEM` for host `system.*` metrics

Also includes workflow fixes for fork PRs:

- pull the now-public `monoscope-deps` image anonymously
- skip Claude review on fork PRs without repo secrets
- keep HLint strict for same-repository PRs while making fork PR HLint advisory when the workflow cannot push its auto-refactor commit

## Tests

- `git diff --check`
- `cabal test unit-tests -j --ghc-options="-O0" --test-show-details=direct --test-options='--match "metric service name extraction" --color --jobs=4'`
  - 6 examples, 0 failures
  - unit-tests PASS