### PR TITLE
fix(charts): don't advance query-cache watermark on failed delta fetch

### DIFF
--- a/src/Pages/Charts/Charts.hs
+++ b/src/Pages/Charts/Charts.hs
@@ -224,12 +224,20 @@ queryMetricsWithCache authCtx dbSource respDataType pid source queryAST sqlQuery
           let windowSecs = fromIntegral $ QC.slidingWindowSeconds cacheKey.binInterval
           let slidingWindowStart = addUTCTime (negate windowSecs) reqTo
           let trimmed = QC.trimOldData slidingWindowStart merged
-          QC.updateCache cacheKey (slidingWindowStart, reqTo) trimmed originalQuery
+          -- Only advance the watermark when the delta actually succeeded. A failed
+          -- fetch (timeout, TF planning error, dropped conn) is swallowed into an
+          -- empty MetricsData by 'withChartSpan'; advancing cached_to past it would
+          -- orphan the [cachedTo, reqTo] window forever (no later delta revisits it).
+          when (isNothing deltaData.error)
+            $ QC.updateCache cacheKey (slidingWindowStart, reqTo) trimmed originalQuery
           let result = QC.trimToRange trimmed reqFrom reqTo
           refetchUnlessAdequate (slidingWindowStart <= reqFrom) trimmed result
         QC.CacheMiss -> do
           result <- executeQueryWith sqlQueryCfg queryAST
-          QC.updateCache cacheKey (reqFrom, reqTo) result originalQuery
+          -- Don't cache a failed fetch (same reasoning as the partial-hit guard);
+          -- it carries no data, so leave the cache cold and let the next request retry.
+          when (isNothing result.error)
+            $ QC.updateCache cacheKey (reqFrom, reqTo) result originalQuery
           pure result
         QC.CacheBypassed _ -> executeQueryWith sqlQueryCfg queryAST
   where

--- a/test/integration/Pages/QueryCacheSpec.hs
+++ b/test/integration/Pages/QueryCacheSpec.hs
@@ -1,18 +1,23 @@
 module Pages.QueryCacheSpec (spec) where
 
+import Data.Default (def)
 import Data.Pool (withResource)
 import Data.Time (UTCTime, addUTCTime)
+import Data.Time.Clock.POSIX (utcTimeToPOSIXSeconds)
 import Data.Time.Format.ISO8601 (iso8601Show)
 import Data.UUID qualified as UUID
 import Data.Vector qualified as V
 import Database.PostgreSQL.Simple (execute_)
+import Database.PostgreSQL.Simple qualified as PG
 import Database.PostgreSQL.Simple.SqlQQ (sql)
 import Models.Projects.Projects qualified as Projects
 import Pages.Charts.Charts qualified as Charts
 import Pkg.DeriveUtils (UUIDId (..))
+import Pkg.Parser (dateRange, defSqlQueryCfg, parseQueryToAST)
+import Pkg.QueryCache qualified as QC
 import Pkg.TestUtils
 import Relude
-import Test.Hspec (Spec, around, describe, it, shouldBe, shouldSatisfy)
+import Test.Hspec (Spec, around, describe, it, shouldBe, shouldReturn, shouldSatisfy)
 import Text.Read (read)
 
 
@@ -43,6 +48,31 @@ queryMetrics tr query timeFrom timeTo =
 -- Format time offset from baseTime as ISO8601 string
 timeAt :: Int -> Text
 timeAt offsetSeconds = toText $ iso8601Show $ addUTCTime (fromIntegral offsetSeconds) baseTime
+
+
+-- Read the cache watermark (cached_to) for a given key.
+cachedToFor :: TestResources -> QC.CacheKey -> IO (Maybe UTCTime)
+cachedToFor tr key = withResource tr.trPool \conn -> do
+  rows <-
+    PG.query
+      conn
+      [sql|SELECT cached_to FROM query_cache WHERE project_id = ? AND query_hash = ? AND bin_interval = ? AND source = ?|]
+      (key.projectId, key.queryHash, key.binInterval, key.source) ::
+      IO [PG.Only UTCTime]
+  pure $ PG.fromOnly <$> listToMaybe rows
+
+
+-- Seed a non-empty cache entry for query @q@ covering [t0, t1], keyed exactly as
+-- the request over [t0, t2] will build it (source = Nothing). Returns the key.
+seedCache :: TestResources -> Text -> (UTCTime, UTCTime, UTCTime) -> IO QC.CacheKey
+seedCache tr q (t0, t1, t2) = do
+  sections <- either (fail . toString) pure (parseQueryToAST q)
+  let cfg = (defSqlQueryCfg pid baseTime Nothing Nothing){dateRange = (Just t0, Just t2)}
+      key = QC.generateCacheKey pid Nothing sections cfg
+      seedTs = realToFrac (utcTimeToPOSIXSeconds t0) :: Double
+      seed = def{Charts.dataset = V.singleton (V.fromList [Just seedTs, Just 5]), Charts.headers = V.fromList ["timestamp", "count"], Charts.rowsCount = 1}
+  runQueryEffect tr $ QC.updateCache key (t0, t1) seed q
+  pure key
 
 
 -- Compare two MetricsData for equivalence including stats
@@ -148,3 +178,33 @@ spec = around withTestResources do
       result <- queryMetrics tr q (timeAt (-1800)) (timeAt 1800)
       result.error `shouldBe` Just "Column not found"
       V.length result.dataset `shouldBe` 0
+
+  -- Regression: a partial-hit delta fetch that fails (timeout / TF planning
+  -- error / dropped conn) used to still advance `cached_to` to the requested
+  -- `to`, even though no new data was merged. That left a permanent hole
+  -- between the old and new watermark — short ranges rendered near-empty while
+  -- wider ranges (a separate bin_interval cache entry) looked fine. The
+  -- watermark must never advance past data we actually fetched.
+  describe "partial-hit watermark" do
+    it "does not advance cached_to when the delta fetch errors" $ \tr -> do
+      clearAllTestData tr
+      -- Seed covers [t0, t1]; the bad-column query makes the delta over (t1, t2] error.
+      let q = "totally_made_up_column == \"x\" | summarize count(*) by bin_auto(timestamp)"
+          times@(_, t1, _) = (addUTCTime (-1800) baseTime, baseTime, addUTCTime 1800 baseTime)
+      key <- seedCache tr q times
+      result <- runQueryEffect tr $ Charts.queryMetrics Nothing (Just Charts.DTMetric) (Just pid) (Just q) Nothing Nothing (Just (timeAt (-1800))) (Just (timeAt 1800)) Nothing []
+      -- A failed delta serves the (stale) cached rows rather than dropping them...
+      V.length result.dataset `shouldBe` 1
+      -- ...and must NOT advance the watermark, so the gap is retried next refresh.
+      cachedToFor tr key `shouldReturn` Just t1
+
+    -- Counterpart to the guard above: a delta that *succeeds* but legitimately
+    -- returns no rows is not a failure, so the watermark must still advance.
+    it "advances cached_to when a successful delta returns no rows" $ \tr -> do
+      clearAllTestData tr
+      let q = "summarize count(*) by bin_auto(timestamp)"
+          times@(_, _, t2) = (addUTCTime (-1800) baseTime, baseTime, addUTCTime 1800 baseTime)
+      key <- seedCache tr q times
+      -- No telemetry ingested, so the delta over (t1, t2] succeeds with 0 rows.
+      _ <- runQueryEffect tr $ Charts.queryMetrics Nothing (Just Charts.DTMetric) (Just pid) (Just q) Nothing Nothing (Just (timeAt (-1800))) (Just (timeAt 1800)) Nothing []
+      cachedToFor tr key `shouldReturn` Just t2


### PR DESCRIPTION
## Problem

Time-series chart widgets (e.g. "All traces" on the Log Explorer) could render permanent holes — short ranges (1H) showed bars crammed at one edge while wider ranges (3H) looked fine.

Root cause is in `queryMetricsWithCache`'s **partial-hit** path. The cache is keyed by bin interval, so 1H (`30 seconds` bins) and 3H (`1 minutes` bins) are separate entries. When a delta fetch over `[cachedTo, reqTo]` **fails** — statement timeout, TimeFusion planning error, dropped connection — `withChartSpan` swallows it into an empty `MetricsData{error=Just …}`. `mergeTimeseriesData` then no-ops on the empty delta, but `cached_to` was still advanced to the request end. That **orphans the `[cachedTo, reqTo]` window forever**, because every later delta starts from the advanced watermark.

Verified against prod: the demo project's 30s cache had a 92-minute hole (06:20→07:52 UTC) while both Postgres and TimeFusion had continuous data the whole time.

## Fix

Gate `updateCache` on `isNothing deltaData.error` in both the `PartialHit` and `CacheMiss` branches, so the watermark never advances past data actually fetched. On a transient failure the next poll re-fetches `[cachedTo, now]` and backfills the gap (the backfill query is cheap — worst-case 4h/30s-bin delta on the busy demo project runs in ~320ms). A successful-but-empty delta still advances (legitimately no data).

## Tests

`test/integration/Pages/QueryCacheSpec.hs`:
- failed delta does **not** advance `cached_to`, and still **serves the cached rows** (doesn't drop them)
- a **successful-but-empty** delta **does** advance `cached_to`

Full `QueryCache` spec green: `6 examples, 0 failures`.

## Notes

- Deploying this fixes new occurrences and self-heals existing gaps on the next successful poll. To clear an already-corrupted entry immediately: `DELETE FROM query_cache WHERE project_id='…';` (reseeds on next load).