### PR TITLE
fix(charts): don't advance query-cache watermark on failed delta fetch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 tags
+haddocks
 .stack-work
 static/public/reload.trigger
 */.stack-work

--- a/scripts/stream-demo-telemetry.sh
+++ b/scripts/stream-demo-telemetry.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Stream synthetic logs / traces / metrics into a LOCAL monoscope server,
+# routed to the demo project (UUID.nil) which needs no auth.
+#
+# Pointing the CLI at local is just two env vars:
+#   MONOSCOPE_API_URL   -> the CLI derives the OTLP gRPC endpoint from this
+#                          (http://localhost:8080 => http://localhost:4317)
+#   --resource at-project-id:<nil>  -> routes ingestion to the demo project
+#
+# Usage:
+#   scripts/local/stream-demo-telemetry.sh                 # continuous, all kinds
+#   scripts/local/stream-demo-telemetry.sh --kind trace    # only one kind
+#   RATE=5 COUNT=100 scripts/local/stream-demo-telemetry.sh
+#   MONOSCOPE_API_URL=http://localhost:9090 scripts/local/stream-demo-telemetry.sh
+set -euo pipefail
+
+NIL_PROJECT="00000000-0000-0000-0000-000000000000"
+export MONOSCOPE_API_URL="${MONOSCOPE_API_URL:-http://localhost:8080}"
+RATE="${RATE:-1}"
+COUNT_ARG=(); [[ -n "${COUNT:-}" ]] && COUNT_ARG=(--count "$COUNT")
+
+# Prefer an installed `monoscope`; fall back to `cabal run` from the repo.
+if command -v monoscope >/dev/null 2>&1; then
+  CLI=(monoscope)
+else
+  CLI=(cabal run -v0 monoscope --)
+fi
+
+# Kinds to stream: args override the default of all three.
+KINDS=("$@"); [[ ${#KINDS[@]} -eq 0 ]] && KINDS=(--kind trace --kind log --kind metric)
+# Normalize: strip the flag so we can loop over bare kind names.
+kinds=(); for a in "${KINDS[@]}"; do [[ "$a" == --kind ]] || kinds+=("$a"); done
+
+echo "Streaming ${kinds[*]} → ${MONOSCOPE_API_URL} (OTLP :4317), project ${NIL_PROJECT}, ${RATE}/s"
+
+pids=()
+for k in "${kinds[@]}"; do
+  "${CLI[@]}" telemetrygen \
+    --kind "$k" --rate "$RATE" --service "demo-$k" \
+    --resource "at-project-id:${NIL_PROJECT}" \
+    "${COUNT_ARG[@]}" &
+  pids+=($!)
+done
+
+trap 'kill "${pids[@]}" 2>/dev/null || true' INT TERM
+wait

--- a/src/Pages/Charts/Charts.hs
+++ b/src/Pages/Charts/Charts.hs
@@ -224,12 +224,20 @@ queryMetricsWithCache authCtx dbSource respDataType pid source queryAST sqlQuery
           let windowSecs = fromIntegral $ QC.slidingWindowSeconds cacheKey.binInterval
           let slidingWindowStart = addUTCTime (negate windowSecs) reqTo
           let trimmed = QC.trimOldData slidingWindowStart merged
-          QC.updateCache cacheKey (slidingWindowStart, reqTo) trimmed originalQuery
+          -- Only advance the watermark when the delta actually succeeded. A failed
+          -- fetch (timeout, TF planning error, dropped conn) is swallowed into an
+          -- empty MetricsData by 'withChartSpan'; advancing cached_to past it would
+          -- orphan the [cachedTo, reqTo] window forever (no later delta revisits it).
+          when (isNothing deltaData.error)
+            $ QC.updateCache cacheKey (slidingWindowStart, reqTo) trimmed originalQuery
           let result = QC.trimToRange trimmed reqFrom reqTo
           refetchUnlessAdequate (slidingWindowStart <= reqFrom) trimmed result
         QC.CacheMiss -> do
           result <- executeQueryWith sqlQueryCfg queryAST
-          QC.updateCache cacheKey (reqFrom, reqTo) result originalQuery
+          -- Don't cache a failed fetch (same reasoning as the partial-hit guard);
+          -- it carries no data, so leave the cache cold and let the next request retry.
+          when (isNothing result.error)
+            $ QC.updateCache cacheKey (reqFrom, reqTo) result originalQuery
           pure result
         QC.CacheBypassed _ -> executeQueryWith sqlQueryCfg queryAST
   where

--- a/src/Pages/Charts/Charts.hs
+++ b/src/Pages/Charts/Charts.hs
@@ -228,7 +228,7 @@ queryMetricsWithCache authCtx dbSource respDataType pid source queryAST sqlQuery
           -- fetch (timeout, TF planning error, dropped conn) is swallowed into an
           -- empty MetricsData by 'withChartSpan'; advancing cached_to past it would
           -- orphan the [cachedTo, reqTo] window forever (no later delta revisits it).
-          when (isNothing deltaData.error)
+          whenNothing_ deltaData.error
             $ QC.updateCache cacheKey (slidingWindowStart, reqTo) trimmed originalQuery
           let result = QC.trimToRange trimmed reqFrom reqTo
           refetchUnlessAdequate (slidingWindowStart <= reqFrom) trimmed result

--- a/src/Pages/LogExplorer/Log.hs
+++ b/src/Pages/LogExplorer/Log.hs
@@ -756,8 +756,8 @@ extractMissingColumn t = tfMatch <|> pgMatch
 
 apiLogH :: Projects.ProjectId -> Maybe Text -> Maybe Text -> Maybe UTCTime -> Maybe Text -> Maybe Text -> Maybe Text -> Maybe Text -> Maybe Text -> Maybe Text -> Maybe Text -> Maybe Text -> Maybe Text -> Maybe Text -> Maybe Text -> Maybe Text -> Maybe Text -> Maybe Text -> Maybe Text -> Maybe Text -> Maybe Int -> Maybe Text -> Maybe Text -> ATAuthCtx (RespHeaders LogsGet)
 apiLogH pid queryM' cols' cursorM' sinceM fromM toM layoutM sourceM targetSpansM queryLibItemTitle queryLibItemID detailWM targetEventM showTraceM hxRequestM hxBoostedM jsonM vizTypeM alertM skipM pTargetM sortByM = do
-  (sess, project, bw) <- mkPageCtx pid
   let source = fromMaybe "spans" sourceM
+  (sess, project, bw) <- mkPageCtx pid
   let summaryCols = T.splitOn "," (fromMaybe "" cols')
   let queryInput = maybeToMonoid queryM'
   let parseError msg = addTriggerEvent "showParseError" (AE.toJSON msg) >> addErrorToast "Error Parsing Query" (Just msg) $> ([], Just msg)

--- a/test/integration/Pages/QueryCacheSpec.hs
+++ b/test/integration/Pages/QueryCacheSpec.hs
@@ -1,18 +1,23 @@
 module Pages.QueryCacheSpec (spec) where
 
+import Data.Default (def)
 import Data.Pool (withResource)
 import Data.Time (UTCTime, addUTCTime)
+import Data.Time.Clock.POSIX (utcTimeToPOSIXSeconds)
 import Data.Time.Format.ISO8601 (iso8601Show)
 import Data.UUID qualified as UUID
 import Data.Vector qualified as V
 import Database.PostgreSQL.Simple (execute_)
+import Database.PostgreSQL.Simple qualified as PG
 import Database.PostgreSQL.Simple.SqlQQ (sql)
 import Models.Projects.Projects qualified as Projects
 import Pages.Charts.Charts qualified as Charts
 import Pkg.DeriveUtils (UUIDId (..))
+import Pkg.Parser (dateRange, defSqlQueryCfg, parseQueryToAST)
+import Pkg.QueryCache qualified as QC
 import Pkg.TestUtils
 import Relude
-import Test.Hspec (Spec, around, describe, it, shouldBe, shouldSatisfy)
+import Test.Hspec (Spec, around, describe, it, shouldBe, shouldReturn, shouldSatisfy)
 import Text.Read (read)
 
 
@@ -43,6 +48,31 @@ queryMetrics tr query timeFrom timeTo =
 -- Format time offset from baseTime as ISO8601 string
 timeAt :: Int -> Text
 timeAt offsetSeconds = toText $ iso8601Show $ addUTCTime (fromIntegral offsetSeconds) baseTime
+
+
+-- Read the cache watermark (cached_to) for a given key.
+cachedToFor :: TestResources -> QC.CacheKey -> IO (Maybe UTCTime)
+cachedToFor tr key = withResource tr.trPool \conn -> do
+  rows <-
+    PG.query
+      conn
+      [sql|SELECT cached_to FROM query_cache WHERE project_id = ? AND query_hash = ? AND bin_interval = ? AND source = ?|]
+      (key.projectId, key.queryHash, key.binInterval, key.source) ::
+      IO [PG.Only UTCTime]
+  pure $ PG.fromOnly <$> listToMaybe rows
+
+
+-- Seed a non-empty cache entry for query @q@ covering [t0, t1], keyed exactly as
+-- the request over [t0, t2] will build it (source = Nothing). Returns the key.
+seedCache :: TestResources -> Text -> (UTCTime, UTCTime, UTCTime) -> IO QC.CacheKey
+seedCache tr q (t0, t1, t2) = do
+  sections <- either (fail . toString) pure (parseQueryToAST q)
+  let cfg = (defSqlQueryCfg pid baseTime Nothing Nothing){dateRange = (Just t0, Just t2)}
+      key = QC.generateCacheKey pid Nothing sections cfg
+      seedTs = realToFrac (utcTimeToPOSIXSeconds t0) :: Double
+      seed = def{Charts.dataset = V.singleton (V.fromList [Just seedTs, Just 5]), Charts.headers = V.fromList ["timestamp", "count"], Charts.rowsCount = 1}
+  runQueryEffect tr $ QC.updateCache key (t0, t1) seed q
+  pure key
 
 
 -- Compare two MetricsData for equivalence including stats
@@ -148,3 +178,33 @@ spec = around withTestResources do
       result <- queryMetrics tr q (timeAt (-1800)) (timeAt 1800)
       result.error `shouldBe` Just "Column not found"
       V.length result.dataset `shouldBe` 0
+
+  -- Regression: a partial-hit delta fetch that fails (timeout / TF planning
+  -- error / dropped conn) used to still advance `cached_to` to the requested
+  -- `to`, even though no new data was merged. That left a permanent hole
+  -- between the old and new watermark — short ranges rendered near-empty while
+  -- wider ranges (a separate bin_interval cache entry) looked fine. The
+  -- watermark must never advance past data we actually fetched.
+  describe "partial-hit watermark" do
+    it "does not advance cached_to when the delta fetch errors" $ \tr -> do
+      clearAllTestData tr
+      -- Seed covers [t0, t1]; the bad-column query makes the delta over (t1, t2] error.
+      let q = "totally_made_up_column == \"x\" | summarize count(*) by bin_auto(timestamp)"
+          times@(_, t1, _) = (addUTCTime (-1800) baseTime, baseTime, addUTCTime 1800 baseTime)
+      key <- seedCache tr q times
+      result <- runQueryEffect tr $ Charts.queryMetrics Nothing (Just Charts.DTMetric) (Just pid) (Just q) Nothing Nothing (Just (timeAt (-1800))) (Just (timeAt 1800)) Nothing []
+      -- A failed delta serves the (stale) cached rows rather than dropping them...
+      V.length result.dataset `shouldBe` 1
+      -- ...and must NOT advance the watermark, so the gap is retried next refresh.
+      cachedToFor tr key `shouldReturn` Just t1
+
+    -- Counterpart to the guard above: a delta that *succeeds* but legitimately
+    -- returns no rows is not a failure, so the watermark must still advance.
+    it "advances cached_to when a successful delta returns no rows" $ \tr -> do
+      clearAllTestData tr
+      let q = "summarize count(*) by bin_auto(timestamp)"
+          times@(_, _, t2) = (addUTCTime (-1800) baseTime, baseTime, addUTCTime 1800 baseTime)
+      key <- seedCache tr q times
+      -- No telemetry ingested, so the delta over (t1, t2] succeeds with 0 rows.
+      _ <- runQueryEffect tr $ Charts.queryMetrics Nothing (Just Charts.DTMetric) (Just pid) (Just q) Nothing Nothing (Just (timeAt (-1800))) (Just (timeAt 1800)) Nothing []
+      cachedToFor tr key `shouldReturn` Just t2

--- a/test/integration/Pages/QueryCacheSpec.hs
+++ b/test/integration/Pages/QueryCacheSpec.hs
@@ -57,8 +57,8 @@ cachedToFor tr key = withResource tr.trPool \conn -> do
     PG.query
       conn
       [sql|SELECT cached_to FROM query_cache WHERE project_id = ? AND query_hash = ? AND bin_interval = ? AND source = ?|]
-      (key.projectId, key.queryHash, key.binInterval, key.source) ::
-      IO [PG.Only UTCTime]
+      (key.projectId, key.queryHash, key.binInterval, key.source)
+      :: IO [PG.Only UTCTime]
   pure $ PG.fromOnly <$> listToMaybe rows
 
 
@@ -78,10 +78,14 @@ seedCache tr q (t0, t1, t2) = do
 -- Compare two MetricsData for equivalence including stats
 compareResults :: Charts.MetricsData -> Charts.MetricsData -> Bool
 compareResults a b =
-  a.rowsCount == b.rowsCount
-    && V.length a.dataset == V.length b.dataset
-    && V.toList a.headers == V.toList b.headers
-    && V.toList a.dataset == V.toList b.dataset
+  a.rowsCount
+    == b.rowsCount
+    && V.length a.dataset
+    == V.length b.dataset
+    && V.toList a.headers
+    == V.toList b.headers
+    && V.toList a.dataset
+    == V.toList b.dataset
     && compareStats a.stats b.stats
   where
     compareStats Nothing Nothing = True
@@ -197,6 +201,15 @@ spec = around withTestResources do
       V.length result.dataset `shouldBe` 1
       -- ...and must NOT advance the watermark, so the gap is retried next refresh.
       cachedToFor tr key `shouldReturn` Just t1
+
+    it "does not populate cache when a cache-miss fetch errors" $ \tr -> do
+      clearAllTestData tr
+      let q = "totally_made_up_column == \"x\" | summarize count(*) by bin_auto(timestamp)"
+      sections <- either (fail . toString) pure (parseQueryToAST q)
+      let cfg = (defSqlQueryCfg pid baseTime Nothing Nothing){dateRange = (Just (addUTCTime (-1800) baseTime), Just (addUTCTime 1800 baseTime))}
+          key = QC.generateCacheKey pid Nothing sections cfg
+      _ <- runQueryEffect tr $ Charts.queryMetrics Nothing (Just Charts.DTMetric) (Just pid) (Just q) Nothing Nothing (Just (timeAt (-1800))) (Just (timeAt 1800)) Nothing []
+      cachedToFor tr key `shouldReturn` Nothing
 
     -- Counterpart to the guard above: a delta that *succeeds* but legitimately
     -- returns no rows is not a failure, so the watermark must still advance.


### PR DESCRIPTION
Time-series chart widgets could render permanent holes: in the partial-hit path, a delta fetch that failed (timeout / TF planning error / dropped conn, swallowed into an empty MetricsData by withChartSpan) still advanced cached_to to the request end. That orphaned the [cachedTo, reqTo] window forever, since every later delta starts from the advanced watermark — so short ranges rendered near-empty while wider ranges (a separate bin_interval cache entry) looked fine.

Gate updateCache on `isNothing deltaData.error` in both the PartialHit and CacheMiss branches, so the watermark never advances past data we actually fetched. On a transient failure the next poll re-fetches [cachedTo, now] and backfills the gap.

Regression tests in QueryCacheSpec: failed delta doesn't advance cached_to and still serves the cached rows; a successful-but-empty delta still advances.

<!-- Thank you for contributing to Monscope! -->

<!-- Briefly describe what your PR does here as much as you can. -->

Closes #

<!-- If your PR is related to an issue, provide the number(s) above (after the #); if it resolves multiple issues, be sure to add a comma (e.g. "closes #1000, #1001"). -->

## How to test

<!-- Please include the steps to test your changes here. -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure you have described your changes and added all relevant screenshots or data.
- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes (or request one from the team).
- [ ] You are **NOT** deprecating/removing a feature.
