### PR TITLE
refactor: deep-clean sweep across Pages, Models, and Components

### DIFF
--- a/src/BackgroundJobs.hs
+++ b/src/BackgroundJobs.hs
@@ -2784,7 +2784,7 @@ sendReportForProject pid rType = do
                         (liftIO $ fromRight def <$> Charts.fetchMetricsData Charts.DTMetric (parseQ "| summarize count(*) by bin_auto(timestamp), resource___service___name") currentTime (Just startTime) (Just currentTime) ctx Nothing)
                         (liftIO $ fromRight def <$> Charts.fetchMetricsData Charts.DTMetric (parseQ "status_code == \"ERROR\" | summarize count(*) by bin_auto(timestamp), resource___service___name") currentTime (Just startTime) (Just currentTime) ctx Nothing)
                     )
-                    (Issues.selectIssues pid Nothing (Just False) Nothing 100 0 (Just (startTime, currentTime)) Nothing "7d" [] [])
+                    (Issues.selectIssues pid (Just False) Nothing 100 0 (Just (startTime, currentTime)) Nothing "7d" [] [])
                 )
             )
         )
@@ -2794,10 +2794,8 @@ sendReportForProject pid rType = do
         totalEvents = sum $ map (\(_, _, x) -> x) stats
         totalErrorsPrev = sum $ map (\(_, x, _) -> x) statsPrev
         totalEventsPrev = sum $ map (\(_, _, x) -> x) statsPrev
-        errorsChange' = if totalErrorsPrev == 0 then 0.00 else fromIntegral (totalErrors - totalErrorsPrev) / fromIntegral totalErrorsPrev * 100
-        eventsChange' = if totalEventsPrev == 0 then 0.00 else fromIntegral (totalEvents - totalEventsPrev) / fromIntegral totalEventsPrev * 100
-        errorsChange = fromIntegral (round (errorsChange' * 100)) / 100
-        eventsChange = fromIntegral (round (eventsChange' * 100)) / 100
+        errorsChange = RP.pctChange totalErrors totalErrorsPrev
+        eventsChange = RP.pctChange totalEvents totalEventsPrev
         spanStatsDiff = RP.getSpanTypeStats statsBySpanType statsBySpanTypePrev
         endpointPerformance = RP.computeDurationChanges endpointStats endpointStatsPrev
     let rp_json = RP.buildReportJson' totalEvents totalErrors eventsChange errorsChange spanStatsDiff endpointPerformance slowDbQueries chartDataEvents chartDataErrors anomalies'
@@ -3117,8 +3115,8 @@ enhanceIssuesWithLLM pid issueIds = do
                     criticalityResult <- Enhancement.classifyIssueCriticality ctx issue
                     case criticalityResult of
                       Left err -> Log.logAttention "Failed to classify issue criticality" (issueId, err)
-                      Right (isCritical, breakingCount, incrementalCount) -> do
-                        _ <- Enhancement.updateIssueClassification issue.id isCritical breakingCount incrementalCount
+                      Right (isCritical, breakingCount, _incrementalCount) -> do
+                        _ <- Enhancement.updateIssueClassification issue.id isCritical breakingCount
                         Log.logInfo "Successfully enhanced and classified issue" (issueId, isCritical, breakingCount)
 
                     -- Analyze error patterns for root cause and category

--- a/src/CLI/Commands.hs
+++ b/src/CLI/Commands.hs
@@ -767,7 +767,7 @@ data TraceSummary = TraceSummary
 buildSearchParams :: EventsSearchOpts -> [(Text, Text)]
 buildSearchParams opts =
   let q = foldFiltersIntoQuery opts.query opts.service opts.level
-      includeAttributes = maybe False (any (\field -> field == "attributes" || "attributes." `T.isPrefixOf` field) . map T.strip . T.splitOn ",") opts.fields
+      includeAttributes = maybe False (any ((\field -> field == "attributes" || "attributes." `T.isPrefixOf` field) . T.strip) . T.splitOn ",") opts.fields
       sinceParam = case opts.since of
         Just s -> s
         Nothing -> if isJust opts.from || isJust opts.to then "" else "1H"

--- a/src/Data/Effectful/Wreq.hs
+++ b/src/Data/Effectful/Wreq.hs
@@ -109,7 +109,7 @@ runHTTPRecord ref = interpret $ \_ -> \case
     payload mk = renderBody . requestBody <$> mk defaultRequest
     renderBody = \case
       RequestBodyLBS b -> b
-      RequestBodyBS b -> LBS.fromStrict b
+      RequestBodyBS b -> fromStrict b
       _ -> "" -- streaming bodies aren't rendered; no current caller sends them
     record url getBody = liftIO do
       body <- getBody

--- a/src/Data/Effectful/Wreq.hs
+++ b/src/Data/Effectful/Wreq.hs
@@ -13,6 +13,7 @@ module Data.Effectful.Wreq (
   W.header,
   runHTTPWreq,
   runHTTPGolden,
+  runHTTPRecord,
   Options,
   Response,
   W.responseBody,
@@ -29,7 +30,7 @@ import Data.CaseInsensitive qualified as CI
 import Effectful
 import Effectful.Dispatch.Dynamic
 import Effectful.TH
-import Network.HTTP.Client (HttpException (..), HttpExceptionContent (..), createCookieJar, defaultRequest)
+import Network.HTTP.Client (HttpException (..), HttpExceptionContent (..), RequestBody (..), createCookieJar, defaultRequest, requestBody)
 import Network.HTTP.Client.Internal (Response (..), ResponseClose (..))
 import Network.HTTP.Types.Status (Status (..), statusCode, statusMessage)
 import Network.HTTP.Types.Version (http11)
@@ -85,6 +86,35 @@ runHTTPWreq = interpret $ \_ -> \case
   PutWith opts url body -> liftIO $ W.putWith opts url body
   PatchWith opts url body -> liftIO $ W.patchWith opts url body
   DeleteWith opts url -> liftIO $ W.deleteWith opts url
+
+
+-- | Record outgoing requests as @(url, rendered body)@ instead of performing
+-- them, replying with a stub @200 {}@ response. The assertion seam for
+-- end-to-end payload tests — 'runHTTPGolden' can't serve that, because golden
+-- responses are keyed by URL alone, so two different bodies sent to one URL
+-- are indistinguishable there.
+runHTTPRecord :: IOE :> es => IORef [(Text, LBS.ByteString)] -> Eff (HTTP ': es) a -> Eff es a
+runHTTPRecord ref = interpret $ \_ -> \case
+  Get url -> record url (pure "")
+  Post url body -> record url (payload $ W.postPayload body)
+  Put url body -> record url (payload $ W.putPayload body)
+  Patch url body -> record url (payload $ W.patchPayload body)
+  Delete url -> record url (pure "")
+  GetWith _ url -> record url (pure "")
+  PostWith _ url body -> record url (payload $ W.postPayload body)
+  PutWith _ url body -> record url (payload $ W.putPayload body)
+  PatchWith _ url body -> record url (payload $ W.patchPayload body)
+  DeleteWith _ url -> record url (pure "")
+  where
+    payload mk = renderBody . requestBody <$> mk defaultRequest
+    renderBody = \case
+      RequestBodyLBS b -> b
+      RequestBodyBS b -> LBS.fromStrict b
+      _ -> "" -- streaming bodies aren't rendered; no current caller sends them
+    record url getBody = liftIO do
+      body <- getBody
+      modifyIORef' ref ((toText url, body) :)
+      pure $ toWreqResponse $ WreqResponse 200 "OK" "{}" [] "" []
 
 
 runHTTPGolden :: IOE :> es => FilePath -> Eff (HTTP ': es) a -> Eff es a

--- a/src/Models/Apis/Anomalies.hs
+++ b/src/Models/Apis/Anomalies.hs
@@ -3,12 +3,6 @@ module Models.Apis.Anomalies (
   AnomalyActions (..),
   AnomalyTypes (..),
   AnomalyId,
-  IssuesData (..),
-  ATError (..),
-  NewEndpointIssue (..),
-  NewFieldIssue (..),
-  NewShapeIssue (..),
-  NewFormatIssue (..),
   PayloadChange (..),
   ChangeType (..),
   FieldChange (..),
@@ -28,21 +22,17 @@ import Data.Effectful.Hasql qualified as Hasql
 import Data.Text qualified as T
 import Data.Text.Display (Display)
 import Data.Time
-import Data.UUID qualified as UUID
 import Data.Vector qualified as V
 import Database.PostgreSQL.Entity.Types (CamelToSnake, Entity, FieldModifiers, GenericEntity, PrimaryKey, Schema, TableName)
-import Database.PostgreSQL.Simple (FromRow, ToRow)
+import Database.PostgreSQL.Simple (FromRow)
 import Database.PostgreSQL.Simple.FromField (FromField)
 import Database.PostgreSQL.Simple.Newtypes (Aeson (..))
 import Database.PostgreSQL.Simple.ToField (ToField)
-import Deriving.Aeson qualified as DAE
-import Deriving.Aeson.Stock qualified as DAE
 import Effectful (Eff, type (:>))
 import Effectful.Time (Time)
 import Effectful.Time qualified as Time
 import Hasql.Interpolate qualified as HI
 import Models.Apis.Endpoints qualified as Endpoints
-import Models.Apis.ErrorPatterns qualified as ErrorPatterns
 import Models.Projects.Projects qualified as Projects
 import Pkg.DeriveUtils (UUIDId (..), WrappedEnumSC (..))
 import Pkg.SchemaLearning.Catalog qualified as Fields (
@@ -53,7 +43,6 @@ import Pkg.SchemaLearning.Catalog qualified as Fields (
   ShapeId,
  )
 import Relude hiding (id)
-import Servant (FromHttpApiData (..))
 import System.Types (DB)
 
 
@@ -204,18 +193,16 @@ acknowledgeAnomalies uid issueIds
   | V.null issueIds = pure []
   | otherwise = do
       now <- Time.currentTime
-      targetHashes :: [Text] <-
-        Hasql.interp
-          [HI.sql| UPDATE apis.issues SET acknowledged_by=#{uid}, acknowledged_at=#{now}
-                   WHERE id=ANY(#{issueIds}::uuid[]) RETURNING target_hash |]
-      Hasql.interpExecute_
-        [HI.sql| WITH related AS (
-                   SELECT jsonb_array_elements_text(COALESCE(issue_data->'anomaly_hashes','[]'::jsonb)) AS h
-                   FROM apis.issues WHERE id=ANY(#{issueIds}::uuid[])
-                 )
-                 UPDATE apis.anomalies a SET acknowledged_by=#{uid}, acknowledged_at=#{now}
-                 WHERE a.target_hash IN (SELECT h FROM related) |]
-      pure targetHashes
+      Hasql.interp
+        [HI.sql| UPDATE apis.issues SET acknowledged_by=#{uid}, acknowledged_at=#{now}
+                 WHERE id=ANY(#{issueIds}::uuid[]) RETURNING target_hash |]
+        <* Hasql.interpExecute_
+          [HI.sql| WITH related AS (
+                     SELECT jsonb_array_elements_text(COALESCE(issue_data->'anomaly_hashes','[]'::jsonb)) AS h
+                     FROM apis.issues WHERE id=ANY(#{issueIds}::uuid[])
+                   )
+                   UPDATE apis.anomalies a SET acknowledged_by=#{uid}, acknowledged_at=#{now}
+                   WHERE a.target_hash IN (SELECT h FROM related) |]
 
 
 acknowlegeCascade :: (DB es, Time :> es) => Projects.UserId -> V.Vector Text -> Eff es Int64
@@ -224,7 +211,7 @@ acknowlegeCascade uid targets
   | otherwise = do
       now <- Time.currentTime
       let hashes = (<> "%") <$> targets
-      _ <- Hasql.interpExecute [HI.sql| UPDATE apis.issues SET acknowledged_by = #{uid}, acknowledged_at = #{now} WHERE target_hash=ANY(#{hashes}) |]
+      Hasql.interpExecute_ [HI.sql| UPDATE apis.issues SET acknowledged_by = #{uid}, acknowledged_at = #{now} WHERE target_hash=ANY(#{hashes}) |]
       Hasql.interpExecute [HI.sql| UPDATE apis.anomalies SET acknowledged_by = #{uid}, acknowledged_at = #{now} WHERE target_hash LIKE ANY(#{hashes}) |]
 
 
@@ -236,107 +223,29 @@ archiveAnomaliesAndIssues issueIds
   | V.null issueIds = pure 0
   | otherwise = do
       now <- Time.currentTime
-      n <- Hasql.interpExecute [HI.sql| UPDATE apis.issues SET archived_at=#{now} WHERE id=ANY(#{issueIds}::uuid[]) |]
-      Hasql.interpExecute_
-        [HI.sql| WITH related AS (
-                   SELECT jsonb_array_elements_text(COALESCE(issue_data->'anomaly_hashes','[]'::jsonb)) AS h
-                   FROM apis.issues WHERE id=ANY(#{issueIds}::uuid[])
-                 )
-                 UPDATE apis.anomalies a SET archived_at=#{now}
-                 WHERE a.target_hash IN (SELECT h FROM related) |]
-      pure n
+      Hasql.interpExecute [HI.sql| UPDATE apis.issues SET archived_at=#{now} WHERE id=ANY(#{issueIds}::uuid[]) |]
+        <* Hasql.interpExecute_
+          [HI.sql| WITH related AS (
+                     SELECT jsonb_array_elements_text(COALESCE(issue_data->'anomaly_hashes','[]'::jsonb)) AS h
+                     FROM apis.issues WHERE id=ANY(#{issueIds}::uuid[])
+                   )
+                   UPDATE apis.anomalies a SET archived_at=#{now}
+                   WHERE a.target_hash IN (SELECT h FROM related) |]
 
 
 -------------------------------------------------------------------------------------------
 -- New Issues model implementations
 --
 
-data NewShapeIssue = NewShapeIssue
-  { id :: Fields.ShapeId
-  , endpointId :: Endpoints.EndpointId
-  , endpointMethod :: Text
-  , endpointUrlPath :: Text
-  , host :: Text
-  , newUniqueFields :: V.Vector Text
-  , deletedFields :: V.Vector Text
-  , updatedFieldFormats :: V.Vector Text
-  }
-  deriving stock (Generic, Show)
-  deriving anyclass (NFData)
-  deriving (AE.FromJSON, AE.ToJSON) via DAE.Snake NewShapeIssue
-
-
-data NewFieldIssue = NewFieldIssue
-  { id :: Fields.FieldId
-  , endpointId :: Endpoints.EndpointId
-  , endpointMethod :: Text
-  , endpointUrlPath :: Text
-  , host :: Text
-  , key :: Text
-  , keyPath :: Text
-  , fieldCategory :: Fields.FieldCategoryEnum
-  , format :: Text
-  }
-  deriving stock (Generic, Show)
-  deriving anyclass (NFData)
-  deriving (AE.FromJSON, AE.ToJSON) via DAE.Snake NewFieldIssue
-
-
-data NewFormatIssue = NewFormatIssue
-  { id :: Fields.FormatId
-  , endpointId :: Endpoints.EndpointId
-  , endpointMethod :: Text
-  , endpointUrlPath :: Text
-  , host :: Text
-  , fieldKeyPath :: Text
-  , formatType :: Fields.FieldTypes
-  , fieldCategory :: Fields.FieldCategoryEnum
-  , examples :: Maybe (V.Vector Text)
-  }
-  deriving stock (Generic, Show)
-  deriving anyclass (NFData)
-  deriving (AE.FromJSON, AE.ToJSON) via DAE.Snake NewFormatIssue
-
-
-data NewEndpointIssue = NewEndpointIssue
-  { id :: Endpoints.EndpointId
-  , endpointMethod :: Text
-  , endpointUrlPath :: Text
-  , host :: Text
-  }
-  deriving stock (Generic, Show)
-  deriving anyclass (NFData)
-  deriving (AE.FromJSON, AE.ToJSON) via DAE.Snake NewEndpointIssue
-
-
-data IssuesData
-  = IDNewShapeIssue NewShapeIssue
-  | IDNewFieldIssue NewFieldIssue
-  | IDNewFormatIssue NewFormatIssue
-  | IDNewEndpointIssue NewEndpointIssue
-  | IDNewRuntimeExceptionIssue ErrorPatterns.ATError
-  | IDEmpty
-  deriving stock (Generic, Show)
-  deriving anyclass (NFData)
-  deriving (FromField, ToField) via Aeson IssuesData
-  deriving (AE.FromJSON, AE.ToJSON) via DAE.Snake IssuesData
-
-
-instance Default IssuesData where
-  def = IDEmpty
-
-
--- NFData instance for Aeson wrapper (postgresql-simple doesn't provide it)
+-- Orphans: postgresql-simple's Aeson wrapper provides neither.
 instance NFData a => NFData (Aeson a) where
   rnf (Aeson a) = rnf a
 
 
--- Default instance for Aeson wrapper
 instance Default (Aeson [a]) where
   def = Aeson []
 
 
--- Payload change data structures
 data PayloadChange = PayloadChange
   { method :: Maybe Text
   , statusCode :: Maybe Int
@@ -377,38 +286,9 @@ data FieldChangeKind = Modified | Added | Removed
   deriving anyclass (AE.FromJSON, AE.ToJSON, NFData)
 
 
+-- | Derive a service name from the path (@\/api\/v1\/auth\/login@ → @auth-service@), falling back to the host.
 detectService :: Maybe Text -> Maybe Text -> Text
-detectService hostM endpointPathM =
-  let pathSegments = maybe [] (T.splitOn "/" . T.dropWhile (== '/')) endpointPathM
-      -- Try to detect service from common patterns like /api/v1/auth/login -> auth-service
-      serviceFromPath = case pathSegments of
-        ("api" : _ : service : _) -> service <> "-service"
-        (service : _) | service /= "" -> service <> "-service"
-        _ -> ""
-   in if T.null serviceFromPath
-        then fromMaybe "api-service" hostM
-        else serviceFromPath
-
-
-newtype ErrorId = ErrorId {unErrorId :: UUID.UUID}
-  deriving stock (Generic, Show)
-  deriving newtype (AE.FromJSON, AE.ToJSON, Default, Eq, FromField, FromHttpApiData, NFData, Ord, ToField)
-
-
-data ATError = ATError
-  { id :: ErrorId
-  , createdAt :: ZonedTime
-  , updatedAt :: ZonedTime
-  , projectId :: Projects.ProjectId
-  , hash :: Text
-  , errorType :: Text
-  , message :: Text
-  , errorData :: ErrorPatterns.ATError
-  , firstTraceId :: Maybe Text
-  , recentTraceId :: Maybe Text
-  }
-  deriving stock (Generic, Show)
-  deriving anyclass (Default, FromRow, NFData, ToRow)
-  deriving (Entity) via (GenericEntity '[Schema "apis", TableName "error_patterns", PrimaryKey "id", FieldModifiers '[CamelToSnake]] ATError)
-  deriving (FromField, ToField) via Aeson ATError
-  deriving (AE.FromJSON, AE.ToJSON) via DAE.Snake ATError
+detectService hostM endpointPathM = case maybe [] (T.splitOn "/" . T.dropWhile (== '/')) endpointPathM of
+  ("api" : _ : service : _) -> service <> "-service"
+  (service : _) | service /= "" -> service <> "-service"
+  _ -> fromMaybe "api-service" hostM

--- a/src/Models/Apis/Anomalies.hs
+++ b/src/Models/Apis/Anomalies.hs
@@ -211,7 +211,7 @@ acknowlegeCascade uid targets
   | otherwise = do
       now <- Time.currentTime
       let hashes = (<> "%") <$> targets
-      Hasql.interpExecute_ [HI.sql| UPDATE apis.issues SET acknowledged_by = #{uid}, acknowledged_at = #{now} WHERE target_hash=ANY(#{hashes}) |]
+      Hasql.interpExecute_ [HI.sql| UPDATE apis.issues SET acknowledged_by = #{uid}, acknowledged_at = #{now} WHERE target_hash LIKE ANY(#{hashes}) |]
       Hasql.interpExecute [HI.sql| UPDATE apis.anomalies SET acknowledged_by = #{uid}, acknowledged_at = #{now} WHERE target_hash LIKE ANY(#{hashes}) |]
 
 

--- a/src/Models/Apis/Endpoints.hs
+++ b/src/Models/Apis/Endpoints.hs
@@ -275,7 +275,7 @@ endpointRequestStatsByProject useTf pid archived pHostM sortM searchM page perPa
       rows = map mk metas
       ordered = case fromMaybe "" sortM of
         "first_seen" -> sortOn (zonedTimeToUTC . (.createdAt) . fst) rows
-        "last_seen" -> sortOn (Down . zonedTimeToUTC . (.createdAt) . fst) rows
+        "last_seen" -> sortOn (Down . fmap zonedTimeToUTC . (.lastSeen) . snd) rows
         _ -> sortOn (\(m, s) -> (Down s.totalRequests, m.urlPath)) rows
   pure $ V.fromList $ map snd $ take perPage $ drop (page * perPage) ordered
 

--- a/src/Models/Apis/Endpoints.hs
+++ b/src/Models/Apis/Endpoints.hs
@@ -35,6 +35,7 @@ import Data.Aeson qualified as AE
 import Data.Default (Default)
 import Data.Effectful.Hasql (Hasql)
 import Data.Effectful.Hasql qualified as Hasql
+import Data.List qualified as L
 import Data.Map.Strict qualified as Map
 import Data.Time (UTCTime, ZonedTime, addUTCTime, zonedTimeToUTC)
 import Data.Time.Clock.POSIX (utcTimeToPOSIXSeconds)
@@ -178,7 +179,7 @@ periodWindow p now = (addUTCTime (negate $ fromIntegral (n * w)) now, n, w)
 -- | Assemble a dense activity vector of @n@ buckets from sparse (bucketIdx, count)
 -- pairs. Indices outside @[0, n)@ (e.g. a boundary row) are simply dropped.
 denseBuckets :: Int -> [(Int, Int64)] -> V.Vector Int
-denseBuckets n pairs = V.generate n \i -> fromIntegral $ fromMaybe 0 $ Map.lookup i m
+denseBuckets n pairs = V.generate n \i -> fromIntegral $ Map.findWithDefault 0 i m
   where
     m = Map.fromListWith (+) pairs
 
@@ -188,11 +189,14 @@ epochSecs :: UTCTime -> Int64
 epochSecs = floor . utcTimeToPOSIXSeconds
 
 
+-- | Quoted ISO8601 timestamp literal, inlined into the SQL text rather than bound.
+tsLit :: UTCTime -> HI.Sql
+tsLit t = rawSql $ "'" <> toText (iso8601Show t) <> "'"
+
+
 -- | Max @last_seen@ / min @first_seen@ over rows, comparing via UTC (ZonedTime has no Ord).
 pickZoned :: (UTCTime -> UTCTime -> Ordering) -> [Maybe ZonedTime] -> Maybe ZonedTime
-pickZoned cmp zs = case catMaybes zs of
-  [] -> Nothing
-  (x : xs) -> Just $ foldl' (\a b -> if cmp (zonedTimeToUTC a) (zonedTimeToUTC b) == LT then b else a) x xs
+pickZoned cmp = viaNonEmpty (L.maximumBy (cmp `on` zonedTimeToUTC)) . catMaybes
 
 
 -- | @AND outgoing = ?@ when a direction is specified, empty otherwise.
@@ -200,9 +204,13 @@ directionClauseSql :: Maybe Bool -> HI.Sql
 directionClauseSql = maybe [HI.sql| |] (\o -> [HI.sql| AND outgoing = #{o} |])
 
 
-archivedHostClauseSql :: Bool -> HI.Sql
-archivedHostClauseSql True = [HI.sql| AND h.archived_at IS NOT NULL|]
-archivedHostClauseSql False = [HI.sql| AND h.archived_at IS NULL|]
+-- | Row filters shared by 'endpointRequestStatsByProject' and 'countEndpointsForHost'
+-- (optional host, url_path search, archived state) so their paginators stay in sync.
+endpointFiltersSql :: Maybe Text -> Maybe Text -> Bool -> HI.Sql
+endpointFiltersSql pHostM searchM archived =
+  foldMap (\h -> [HI.sql| AND enp.host = #{h}|]) pHostM
+    <> foldMap (\s -> let pat = "%" <> s <> "%" in [HI.sql| AND enp.url_path LIKE #{pat}|]) searchM
+    <> bool [HI.sql| AND h.archived_at IS NULL|] [HI.sql| AND h.archived_at IS NOT NULL|] archived
 
 
 -- FIXME: Include and return a boolean flag to show if fields that have annomalies.
@@ -216,17 +224,13 @@ endpointRequestStatsByProject useTf pid archived pHostM sortM searchM page perPa
   let isOutgoing = requestType == "Outgoing"
       (start, numBuckets, width) = periodWindow period now
       startEpoch = epochSecs start
-      startSql = rawSql $ "'" <> toText (iso8601Show start) <> "'"
-      pHostQuery = foldMap (\h -> [HI.sql| AND enp.host = #{h}|]) pHostM
-      search = foldMap (\s -> let pat = "%" <> s <> "%" in [HI.sql| AND enp.url_path LIKE #{pat}|]) searchM
-      archivedClause = archivedHostClauseSql archived
   metas :: [EndpointMetaRow] <-
     Hasql.interp
       [HI.sql|
         SELECT enp.id, enp.hash, enp.project_id, enp.url_path, enp.method, enp.host, enp.created_at
         FROM apis.endpoints enp
         JOIN apis.hosts h ON (h.project_id = enp.project_id AND h.host = enp.host AND h.outgoing = enp.outgoing)
-        WHERE enp.project_id = #{pid} AND enp.outgoing = #{isOutgoing} ^{pHostQuery} ^{search} ^{archivedClause}|]
+        WHERE enp.project_id = #{pid} AND enp.outgoing = #{isOutgoing} ^{endpointFiltersSql pHostM searchM archived}|]
   -- Endpoint hashes are stamped onto telemetry by the extraction worker. Querying
   -- them avoids evaluating the host JSON fallback for every span in the project.
   let endpointHashes = V.fromList $ map (.endpointHash) metas
@@ -247,7 +251,7 @@ endpointRequestStatsByProject useTf pid archived pHostM sortM searchM page perPa
                 WHERE project_id = #{pid}::text
                   AND attributes___http___request___method IS NOT NULL
                   AND hashes && #{endpointHashes}::text[]
-                  AND timestamp >= ^{startSql}
+                  AND timestamp >= ^{tsLit start}
               )
               SELECT url_path, method, service, bucket_idx, COUNT(*)::bigint AS cnt, MAX(timestamp) AS last_seen
               FROM filtered GROUP BY url_path, method, service, bucket_idx|]
@@ -317,18 +321,15 @@ data StatsMode = ShellOnly | WithStats
 dependenciesAndEventsCount :: (DB es, Labeled "timefusion" Hasql :> es, Time :> es) => StatsMode -> Bool -> Projects.ProjectId -> Maybe Bool -> Text -> Int -> Text -> Text -> Bool -> Eff es [HostEvents]
 dependenciesAndEventsCount statsMode useTf pid outgoingM sortT skip timeF period showArchived = do
   now <- Time.currentTime
-  let intervalDays = if timeF == "14D" then 14 else 1 :: Int
-      windowStart = addUTCTime (negate $ fromIntegral (intervalDays * 86400)) now
-      windowStartSql = rawSql $ "'" <> toText (iso8601Show windowStart) <> "'"
+  let windowStartSql = tsLit $ addUTCTime (bool (-1) (-14) (timeF == "14D") * 86400) now
       (start, numBuckets, width) = periodWindow period now
       startEpoch = epochSecs start
-      directionClause = directionClauseSql outgoingM
-      archivedClause = rawSql if showArchived then "archived_at IS NOT NULL" else "archived_at IS NULL"
   hosts :: [(Text, Bool)] <-
     Hasql.interp
       [HI.sql|
         SELECT host, outgoing FROM apis.hosts
-        WHERE project_id = #{pid} AND host != '' ^{directionClause} AND ^{archivedClause}|]
+        WHERE project_id = #{pid} AND host != '' ^{directionClauseSql outgoingM}
+          AND ^{rawSql $ bool "archived_at IS NULL" "archived_at IS NOT NULL" showArchived}|]
   tels :: [HostTelRow] <- case statsMode of
     ShellOnly -> pure []
     WithStats ->
@@ -405,35 +406,29 @@ unarchiveHosts pid outgoingM hosts =
 
 countEndpointInbox :: DB es => Projects.ProjectId -> Text -> Text -> Eff es Int
 countEndpointInbox pid host requestType =
-  let dirClause = rawSql case requestType of
-        "Outgoing" -> "enp.outgoing = true"
-        _ -> "enp.outgoing = false"
+  let isOutgoing = requestType == "Outgoing"
    in fromMaybe 0
         <$> Hasql.interpOne
           [HI.sql|
             SELECT coalesce(COUNT(*)::BIGINT, 0)
             FROM apis.endpoints enp
             LEFT JOIN apis.issues ann ON (ann.issue_type = 'api_change' AND ann.endpoint_hash = enp.hash)
-            WHERE enp.project_id = #{pid} AND ^{dirClause}
+            WHERE enp.project_id = #{pid} AND enp.outgoing = #{isOutgoing}
               AND ann.id IS NOT NULL AND ann.acknowledged_at IS NULL AND host = #{host} |]
 
 
--- | Count of endpoints under a (project, direction) optionally filtered by
--- host, url_path search, and archived status — mirrors the row filters used by
--- 'endpointRequestStatsByProject' so paginators stay in sync.
+-- | Count of endpoints under a (project, direction), under the same row filters as
+-- 'endpointRequestStatsByProject'.
 countEndpointsForHost :: DB es => Projects.ProjectId -> Bool -> Bool -> Maybe Text -> Maybe Text -> Eff es Int
 countEndpointsForHost pid outgoing archived pHostM searchM =
-  let hostQ = foldMap (\h -> [HI.sql| AND enp.host = #{h}|]) pHostM
-      searchQ = foldMap (\s -> let pat = "%" <> s <> "%" in [HI.sql| AND enp.url_path LIKE #{pat}|]) searchM
-      archivedQ = archivedHostClauseSql archived
-   in fromMaybe 0
-        <$> Hasql.interpOne
-          [HI.sql|
-            SELECT COUNT(*)::bigint
-            FROM apis.endpoints enp
-            JOIN apis.hosts h ON (h.project_id = enp.project_id AND h.host = enp.host AND h.outgoing = enp.outgoing)
-            WHERE enp.project_id = #{pid} AND enp.outgoing = #{outgoing}
-              ^{hostQ} ^{searchQ} ^{archivedQ} |]
+  fromMaybe 0
+    <$> Hasql.interpOne
+      [HI.sql|
+        SELECT COUNT(*)::bigint
+        FROM apis.endpoints enp
+        JOIN apis.hosts h ON (h.project_id = enp.project_id AND h.host = enp.host AND h.outgoing = enp.outgoing)
+        WHERE enp.project_id = #{pid} AND enp.outgoing = #{outgoing}
+          ^{endpointFiltersSql pHostM searchM archived} |]
 
 
 -- | Paginated endpoint list with optional url_path LIKE filter. Returns (rows, total count).
@@ -493,11 +488,7 @@ insertCanonicalEndpoints rows =
            FROM unnest(#{pids}::uuid[], #{tpls}::text[], #{methods}::text[], #{hosts}::text[], #{hashes}::text[]) AS t(p, tp, m, h, eh)
            ON CONFLICT (hash) DO UPDATE SET canonical_hash = EXCLUDED.canonical_hash, canonical_path = EXCLUDED.canonical_path |]
   where
-    pids = [p | (p, _, _, _, _) <- rows]
-    tpls = [t | (_, t, _, _, _) <- rows]
-    methods = [m | (_, _, m, _, _) <- rows]
-    hosts = [h | (_, _, _, h, _) <- rows]
-    hashes = [eh | (_, _, _, _, eh) <- rows]
+    (pids, tpls, methods, hosts, hashes) = L.unzip5 rows
 
 
 -- Endpoint embedding + merge ---------------------------------------------------
@@ -533,7 +524,7 @@ updateEndpointEmbeddings pairs =
 
 getCanonicalEndpoints :: DB es => Projects.ProjectId -> Eff es [(EndpointId, [Float])]
 getCanonicalEndpoints pid =
-  map (\(eid, emb :: V.Vector Float) -> (eid, V.toList emb))
+  map (second (V.toList @Float))
     <$> Hasql.interp
       [HI.sql| SELECT id, embedding FROM apis.endpoints
         WHERE project_id = #{pid} AND canonical_hash IS NULL
@@ -574,9 +565,7 @@ getMergedEndpointPairs pid =
 migrateAndDeleteMergedEndpoints :: DB es => [(Text, Text)] -> Eff es ()
 migrateAndDeleteMergedEndpoints [] = pass
 migrateAndDeleteMergedEndpoints pairs = do
-  let (oldHashes, canonHashes) = unzip pairs
-      oldArr = V.fromList oldHashes
-      canonArr = V.fromList canonHashes
+  let (oldArr, canonArr) = bimap V.fromList V.fromList $ unzip pairs
   -- Remap anomalies (skip if canonical target already exists for same project)
   Hasql.interpExecute_
     [HI.sql|

--- a/src/Models/Apis/ErrorPatterns.hs
+++ b/src/Models/Apis/ErrorPatterns.hs
@@ -380,7 +380,7 @@ bulkCalculateAndUpdateBaselines pid now =
     |]
 
 
--- | Get all error patterns with their current hour counts (for batch spike detection)
+-- | An error pattern joined with its current-hour occurrence count (batch spike detection).
 data ErrorPatternWithCurrentRate = ErrorPatternWithCurrentRate
   { errorId :: ErrorPatternId
   , projectId :: Projects.ProjectId
@@ -406,11 +406,8 @@ data ErrorPatternWithCurrentRate = ErrorPatternWithCurrentRate
 
 getErrorPatternsWithCurrentRates :: DB es => Projects.ProjectId -> UTCTime -> Eff es [ErrorPatternWithCurrentRate]
 getErrorPatternsWithCurrentRates pid now =
-  Hasql.interp q
-  where
-    hourBucket = truncateHour now
-    q =
-      [HI.sql|
+  Hasql.interp
+    [HI.sql|
         SELECT
           e.id, e.project_id, e.error_type, LEFT(e.message, 2000), e.service, e.state,
           e.baseline_state, e.baseline_error_rate_mean, e.baseline_error_rate_stddev,
@@ -419,7 +416,7 @@ getErrorPatternsWithCurrentRates pid now =
         FROM apis.error_patterns e
         LEFT JOIN apis.error_hourly_stats counts
           ON counts.error_id = e.id AND counts.project_id = e.project_id
-          AND counts.hour_bucket = #{hourBucket}
+          AND counts.hour_bucket = #{truncateHour now}
         WHERE e.project_id = #{pid} AND e.state != 'resolved' AND NOT e.is_ignored
       |]
 
@@ -442,7 +439,7 @@ findCanonicalMatch pid service eType msg =
 batchUpsertErrorPatterns :: DB es => Projects.ProjectId -> V.Vector ATError -> UTCTime -> Eff es [(Text, Text)]
 batchUpsertErrorPatterns _pid errors _now | V.null errors = pure []
 batchUpsertErrorPatterns pid errors now =
-  filter (\(_, s) -> s == "new" || s == "regressed")
+  filter ((`elem` ["new", "regressed"]) . snd)
     <$> Hasql.interp
       [HI.sql| INSERT INTO apis.error_patterns (
             project_id, error_type, message, stacktrace, hash, parent_hash, is_framework,
@@ -492,8 +489,8 @@ batchUpsertErrorPatterns pid errors now =
             ELSE 'unchanged' END::text |]
   where
     -- Group by hash: keep last occurrence + sum count (avoids ON CONFLICT duplicate-row error)
-    grouped = HM.elems $ V.foldl' (\m e -> HM.insertWith (\(a, n) (_, k) -> (a, n + k)) e.hash (e, 1 :: Int) m) HM.empty errors
-    (errs, counts) = V.unzip $ V.fromList grouped
+    (errs, counts) =
+      V.unzip $ V.fromList $ HM.elems $ V.foldl' (\m e -> HM.insertWith (\(a, n) (_, k) -> (a, n + k)) e.hash (e, 1 :: Int) m) HM.empty errors
     errorTypes = V.map (.errorType) errs
     messages = V.map (.message) errs
     stacktraces = V.map (.stackTrace) errs
@@ -517,12 +514,11 @@ upsertErrorPatternHourlyStats pid now stats =
   Hasql.interpExecute
     [HI.sql|
           INSERT INTO apis.error_hourly_stats (project_id, error_id, hour_bucket, event_count, user_count)
-          SELECT e.project_id, e.id, #{hourBucket}, u.event_count, u.user_count
+          SELECT e.project_id, e.id, #{truncateHour now}, u.event_count, u.user_count
           FROM (SELECT unnest(#{hashes}::text[]) AS hash, unnest(#{eventCounts}::bigint[]) AS event_count, unnest(#{userCounts}::bigint[]) AS user_count) u
           JOIN apis.error_patterns e ON e.project_id = #{pid} AND e.hash = u.hash
           ON CONFLICT (project_id, error_id, hour_bucket)
           DO UPDATE SET event_count = apis.error_hourly_stats.event_count + EXCLUDED.event_count,
                         user_count = apis.error_hourly_stats.user_count + EXCLUDED.user_count |]
   where
-    hourBucket = truncateHour now
     (hashes, eventCounts, userCounts) = V.unzip3 stats

--- a/src/Models/Apis/Integrations.hs
+++ b/src/Models/Apis/Integrations.hs
@@ -60,12 +60,17 @@ insertAccessToken pid teamId channelId teamName botToken channelName webhookUrl 
                DO UPDATE SET team_id = EXCLUDED.team_id, channel_id = EXCLUDED.channel_id, team_name = EXCLUDED.team_name, bot_token = EXCLUDED.bot_token, channel_name = EXCLUDED.channel_name, webhook_url = EXCLUDED.webhook_url |]
 
 
+-- | Column order must match 'SlackData''s field order — 'HI.DecodeRow' is positional.
+selectSlack :: HI.Sql
+selectSlack = [HI.sql|SELECT project_id, team_id, team_name, bot_token, channel_id, channel_name, webhook_url FROM apis.slack |]
+
+
 getProjectSlackData :: DB es => Projects.ProjectId -> Eff es (Maybe SlackData)
-getProjectSlackData pid = Hasql.interpOne [HI.sql|SELECT project_id, team_id, team_name, bot_token, channel_id, channel_name, webhook_url FROM apis.slack WHERE project_id = #{pid} |]
+getProjectSlackData pid = Hasql.interpOne (selectSlack <> [HI.sql|WHERE project_id = #{pid}|])
 
 
 getSlackDataByTeamId :: DB es => Text -> Eff es (Maybe SlackData)
-getSlackDataByTeamId teamId = Hasql.interpOne [HI.sql|SELECT project_id, team_id, team_name, bot_token, channel_id, channel_name, webhook_url FROM apis.slack WHERE team_id = #{teamId} |]
+getSlackDataByTeamId teamId = Hasql.interpOne (selectSlack <> [HI.sql|WHERE team_id = #{teamId}|])
 
 
 -- | Update the OAuth-time default channel cached on apis.slack.
@@ -102,12 +107,16 @@ insertDiscordData pid guildId =
                DO UPDATE SET guild_id = EXCLUDED.guild_id |]
 
 
+selectDiscord :: HI.Sql
+selectDiscord = [HI.sql|SELECT project_id, guild_id FROM apis.discord |]
+
+
 getDiscordData :: DB es => Text -> Eff es (Maybe DiscordData)
-getDiscordData guildId = Hasql.interpOne [HI.sql|SELECT project_id, guild_id FROM apis.discord WHERE guild_id = #{guildId} |]
+getDiscordData guildId = Hasql.interpOne (selectDiscord <> [HI.sql|WHERE guild_id = #{guildId}|])
 
 
 getDiscordDataByProjectId :: DB es => Projects.ProjectId -> Eff es (Maybe DiscordData)
-getDiscordDataByProjectId pid = Hasql.interpOne [HI.sql|SELECT project_id, guild_id FROM apis.discord WHERE project_id = #{pid} |]
+getDiscordDataByProjectId pid = Hasql.interpOne (selectDiscord <> [HI.sql|WHERE project_id = #{pid}|])
 
 
 -- | Shared (d.title, d.id::text) dashboard lookup; each caller supplies the
@@ -129,7 +138,7 @@ getDashboardsForWhatsapp number =
 
 
 getDashboardsForDiscord :: DB es => Text -> Eff es [(Text, Text)]
-getDashboardsForDiscord guildId = dashboardsByProjectJoin [HI.sql|JOIN apis.discord dd ON d.project_id = dd.project_id where guild_id=#{guildId}|]
+getDashboardsForDiscord guildId = dashboardsByProjectJoin [HI.sql|JOIN apis.discord dd ON d.project_id = dd.project_id WHERE dd.guild_id = #{guildId}|]
 
 
 deleteSlackData :: DB es => Projects.ProjectId -> Eff es Int64

--- a/src/Models/Apis/IssueEnhancement.hs
+++ b/src/Models/Apis/IssueEnhancement.hs
@@ -35,7 +35,6 @@ data IssueEnhancement = IssueEnhancement
   deriving anyclass (AE.FromJSON, AE.ToJSON)
 
 
--- | Enhance a single issue with LLM-generated title and description
 enhanceIssueWithLLM :: ELLM.LLM :> es => AuthContext -> Issues.Issue -> Eff es (Either Text IssueEnhancement)
 enhanceIssueWithLLM authCtx issue = runExceptT do
   enhancedTitle <- ExceptT $ generateEnhancedTitle authCtx issue
@@ -43,101 +42,51 @@ enhanceIssueWithLLM authCtx issue = runExceptT do
   pure IssueEnhancement{issueId = issue.id, enhancedTitle, enhancedDescription, recommendedAction, migrationComplexity}
 
 
--- | Generate an enhanced title using LLM
+-- | Call the small model with a plain-text prompt.
+askLLMRaw :: ELLM.LLM :> es => AuthContext -> Text -> Eff es (Either Text Text)
+askLLMRaw authCtx prompt = AI.callOpenAIAPIEff authCtx.config.openaiSmallModel prompt authCtx.config.openaiApiKey
+
+
+-- | Prompt the small model and unwrap the plain-text completion.
+askLLM :: ELLM.LLM :> es => AuthContext -> Text -> Eff es (Either Text Text)
+askLLM authCtx prompt = (fmap fst . AI.getNormalTupleResponse =<<) <$> askLLMRaw authCtx prompt
+
+
+-- | Completion split into stripped lines, for the strict N-line reply formats.
+askLLMLines :: ELLM.LLM :> es => AuthContext -> Text -> Eff es (Either Text [Text])
+askLLMLines authCtx prompt = fmap (map T.strip . lines . T.strip) <$> askLLMRaw authCtx prompt
+
+
+badFormat :: Either Text a
+badFormat = Left "Invalid response format from LLM"
+
+
 generateEnhancedTitle :: ELLM.LLM :> es => AuthContext -> Issues.Issue -> Eff es (Either Text Text)
-generateEnhancedTitle authCtx issue = runExceptT do
-  r <- ExceptT $ AI.callOpenAIAPIEff authCtx.config.openaiSmallModel (buildTitlePrompt issue) authCtx.config.openaiApiKey
-  (title, _) <- hoistEither $ AI.getNormalTupleReponse r
-  pure $ T.take 200 title
+generateEnhancedTitle authCtx issue = fmap (T.take 200) <$> askLLM authCtx (buildTitlePrompt issue)
 
 
--- | Generate enhanced description with recommended actions
+-- | (description, recommended action, migration complexity) — one per response line.
 generateEnhancedDescription :: ELLM.LLM :> es => AuthContext -> Issues.Issue -> Eff es (Either Text (Text, Text, Text))
-generateEnhancedDescription authCtx issue = runExceptT do
-  r <- ExceptT $ AI.callOpenAIAPIEff authCtx.config.openaiSmallModel (buildDescriptionPrompt issue) authCtx.config.openaiApiKey
-  (response, _) <- hoistEither $ AI.getNormalTupleReponse r
-  let lines' = lines response
-  pure (fromMaybe "" $ viaNonEmpty head lines', fromMaybe Issues.defaultRecommendedAction $ lines' !!? 1, fromMaybe "medium" $ lines' !!? 2)
+generateEnhancedDescription authCtx issue = fmap (triple . lines) <$> askLLM authCtx (buildDescriptionPrompt issue)
+  where
+    triple ls = (fromMaybe "" $ ls !!? 0, fromMaybe Issues.defaultRecommendedAction $ ls !!? 1, fromMaybe "medium" $ ls !!? 2)
 
 
-withIssueData :: AE.FromJSON a => Issues.Issue -> (a -> b) -> b -> b
-withIssueData issue f fallback = case AE.fromJSON (getAeson issue.issueData) of
+withIssueData :: AE.FromJSON a => Issues.Issue -> b -> (a -> b) -> b
+withIssueData issue fallback f = case AE.fromJSON (getAeson issue.issueData) of
   AE.Success d -> f d
   _ -> fallback
 
 
--- | Build prompt for title generation
+-- | Fence the untrusted issue payload so the system prompt can treat it as data.
+issuePrompt :: Text -> Text -> Text
+issuePrompt systemPrompt ctx = systemPrompt <> "\n\n<issue>\n" <> ctx <> "\n</issue>"
+
+
 buildTitlePrompt :: Issues.Issue -> Text
 buildTitlePrompt issue =
-  let baseContext = case issue.issueType of
-        Issues.ApiChange ->
-          withIssueData @Issues.APIChangeData
-            issue
-            ( \d ->
-                let isNewEndpoint = V.null d.newFields && V.null d.deletedFields && V.null d.modifiedFields
-                 in if isNewEndpoint
-                      then
-                        [fmtTrim|Generate a concise title for this newly discovered API endpoint.
-            Endpoint: {d.endpointMethod} {d.endpointPath}
-            Service: {Issues.serviceLabel issue.service}
-            This is a brand new endpoint that was just detected for the first time.|]
-                      else
-                        [fmtTrim|Generate a concise, descriptive title for this API change.
-            Endpoint: {d.endpointMethod} {d.endpointPath}
-            New fields: {V.length d.newFields}
-            Deleted fields: {V.length d.deletedFields}
-            Modified fields: {V.length d.modifiedFields}
-            Service: {Issues.serviceLabel issue.service}|]
-            )
-            "Generate a concise title for this API change."
-        Issues.RuntimeException ->
-          withIssueData @Issues.RuntimeExceptionData
-            issue
-            ( \d ->
-                [fmtTrim|Generate a concise title for this runtime exception.
-            Error type: {d.errorType}
-            Error message: {T.take 100 d.errorMessage}
-            Service: {Issues.serviceLabel issue.service}|]
-            )
-            "Generate a concise title for this runtime exception."
-        Issues.QueryAlert ->
-          withIssueData @Issues.QueryAlertData
-            issue
-            ( \d ->
-                [fmtTrim|Generate a concise title for this query alert.
-            Query: {d.queryName}
-            Threshold: {d.thresholdValue} ({display d.thresholdType})
-            Actual value: {d.actualValue}|]
-            )
-            "Generate a concise title for this query alert."
-        Issues.LogPattern ->
-          withIssueData @Issues.LogPatternData
-            issue
-            ( \d ->
-                [fmtTrim|Generate a concise title for this new log pattern detection.
-            Log pattern: {d.logPattern}
-            Sample message: {fromMaybe "N/A" d.sampleMessage}
-            Log level: {fromMaybe "unknown" d.logLevel}
-            Service: {Issues.serviceLabel d.serviceName}
-            Occurrences: {d.occurrenceCount}|]
-            )
-            ("Generate a concise title for this log pattern. Title: " <> issue.title)
-        Issues.LogPatternRateChange ->
-          withIssueData @Issues.LogPatternRateChangeData
-            issue
-            ( \d ->
-                let dir = display d.changeDirection
-                 in [fmtTrim|Generate a concise title for this log pattern volume {dir}.
-            Log pattern: {d.logPattern}
-            Current rate: {Issues.showRate d.currentRatePerHour}
-            Baseline: {Issues.showRate d.baselineMean}
-            Change: {Issues.showPct d.changePercent}
-            Service: {Issues.serviceLabel d.serviceName}|]
-            )
-            ("Generate a concise title for this log pattern rate change. Title: " <> issue.title)
-
-      systemPrompt =
-        [text|
+  issuePrompt
+    [text|
           You are Monoscope's issue titler. Your job is to write a single short title that summarizes a Monoscope issue (API change, runtime exception, query alert, new log pattern, or log-pattern rate change) for an on-call engineer scanning a list.
 
           Tone: precise, factual, technical. No marketing language, no filler words.
@@ -163,92 +112,57 @@ buildTitlePrompt issue =
           ## Output
           Return only the title text. No quotes, no markdown, no trailing newline beyond the line itself.
           |]
-   in systemPrompt <> "\n\n<issue>\n" <> baseContext <> "\n</issue>"
-
-
--- | Build prompt for description generation
-buildDescriptionPrompt :: Issues.Issue -> Text
-buildDescriptionPrompt issue =
-  let baseContext = case issue.issueType of
-        Issues.ApiChange ->
-          withIssueData @Issues.APIChangeData
-            issue
-            ( \d ->
-                let isNewEndpoint = V.null d.newFields && V.null d.deletedFields && V.null d.modifiedFields
-                 in if isNewEndpoint
-                      then
-                        [fmtTrim|Describe this newly discovered API endpoint.
+    case issue.issueType of
+      Issues.ApiChange ->
+        withIssueData @Issues.APIChangeData issue "Generate a concise title for this API change." \d ->
+          if V.null d.newFields && V.null d.deletedFields && V.null d.modifiedFields
+            then
+              [fmtTrim|Generate a concise title for this newly discovered API endpoint.
             Endpoint: {d.endpointMethod} {d.endpointPath}
             Service: {Issues.serviceLabel issue.service}
-            This endpoint was just detected for the first time. Summarize what it likely does based on its path and method.|]
-                      else
-                        [fmtTrim|Describe this API change and its impact.
+            This is a brand new endpoint that was just detected for the first time.|]
+            else
+              [fmtTrim|Generate a concise, descriptive title for this API change.
             Endpoint: {d.endpointMethod} {d.endpointPath}
-            New fields: {show $ V.toList d.newFields}
-            Deleted fields: {show $ V.toList d.deletedFields}
-            Modified fields: {show $ V.toList d.modifiedFields}
-            Total anomalies grouped: {V.length d.anomalyHashes}
+            New fields: {V.length d.newFields}
+            Deleted fields: {V.length d.deletedFields}
+            Modified fields: {V.length d.modifiedFields}
             Service: {Issues.serviceLabel issue.service}|]
-            )
-            "Describe this API change and its implications."
-        Issues.RuntimeException ->
-          withIssueData @Issues.RuntimeExceptionData
-            issue
-            ( \d ->
-                [fmtTrim|Analyze this runtime exception and provide debugging guidance.
+      Issues.RuntimeException ->
+        withIssueData @Issues.RuntimeExceptionData issue "Generate a concise title for this runtime exception." \d ->
+          [fmtTrim|Generate a concise title for this runtime exception.
             Error type: {d.errorType}
-            Error message: {d.errorMessage}
-            Stack trace: {T.take 500 d.stackTrace}
-            Request context: {fromMaybe "Unknown" d.requestMethod} {fromMaybe "Unknown" d.requestPath}
-            Occurrences: {d.occurrenceCount}|]
-            )
-            "Analyze this runtime exception."
-        Issues.QueryAlert ->
-          withIssueData @Issues.QueryAlertData
-            issue
-            ( \d ->
-                [fmtTrim|Describe this query alert and recommended actions.
+            Error message: {T.take 100 d.errorMessage}
+            Service: {Issues.serviceLabel issue.service}|]
+      Issues.QueryAlert ->
+        withIssueData @Issues.QueryAlertData issue "Generate a concise title for this query alert." \d ->
+          [fmtTrim|Generate a concise title for this query alert.
             Query: {d.queryName}
-            Expression: {d.queryExpression}
             Threshold: {d.thresholdValue} ({display d.thresholdType})
-            Actual value: {d.actualValue}
-            Triggered at: {show d.triggeredAt}|]
-            )
-            "Describe this query alert."
-        Issues.LogPattern ->
-          withIssueData @Issues.LogPatternData
-            issue
-            ( \d ->
-                [fmtTrim|Describe this new log pattern and its implications.
+            Actual value: {d.actualValue}|]
+      Issues.LogPattern ->
+        withIssueData @Issues.LogPatternData issue ("Generate a concise title for this log pattern. Title: " <> issue.title) \d ->
+          [fmtTrim|Generate a concise title for this new log pattern detection.
             Log pattern: {d.logPattern}
             Sample message: {fromMaybe "N/A" d.sampleMessage}
             Log level: {fromMaybe "unknown" d.logLevel}
             Service: {Issues.serviceLabel d.serviceName}
-            Source: {d.sourceField}
-            Occurrences: {d.occurrenceCount}
-            First seen: {show d.firstSeenAt}|]
-            )
-            ("Describe this log pattern issue. Title: " <> issue.title)
-        Issues.LogPatternRateChange ->
-          withIssueData @Issues.LogPatternRateChangeData
-            issue
-            ( \d ->
-                let dir = display d.changeDirection
-                 in [fmtTrim|Describe this log pattern volume {dir} and its implications.
+            Occurrences: {d.occurrenceCount}|]
+      Issues.LogPatternRateChange ->
+        withIssueData @Issues.LogPatternRateChangeData issue ("Generate a concise title for this log pattern rate change. Title: " <> issue.title) \d ->
+          let dir = display d.changeDirection
+           in [fmtTrim|Generate a concise title for this log pattern volume {dir}.
             Log pattern: {d.logPattern}
-            Sample message: {fromMaybe "N/A" d.sampleMessage}
             Current rate: {Issues.showRate d.currentRatePerHour}
-            Baseline mean: {Issues.showRate d.baselineMean}
-            Baseline MAD: {Issues.showRate d.baselineMad}
-            Z-score: {show (round d.zScore :: Int)} standard deviations
+            Baseline: {Issues.showRate d.baselineMean}
             Change: {Issues.showPct d.changePercent}
-            Service: {Issues.serviceLabel d.serviceName}
-            Log level: {fromMaybe "unknown" d.logLevel}|]
-            )
-            ("Describe this log pattern rate change. Title: " <> issue.title)
+            Service: {Issues.serviceLabel d.serviceName}|]
 
-      systemPrompt =
-        [text|
+
+buildDescriptionPrompt :: Issues.Issue -> Text
+buildDescriptionPrompt issue =
+  issuePrompt
+    [text|
           You are Monoscope's issue describer. Your job is to summarize a Monoscope issue (API change, runtime exception, query alert, new log pattern, or log-pattern rate change) into a 3-line briefing for the engineer who will fix or migrate it.
 
           Tone: precise, factual, actionable. No marketing language.
@@ -272,41 +186,77 @@ buildDescriptionPrompt issue =
           high
           </example>
           |]
-   in systemPrompt <> "\n\n<issue>\n" <> baseContext <> "\n</issue>"
+    case issue.issueType of
+      Issues.ApiChange ->
+        withIssueData @Issues.APIChangeData issue "Describe this API change and its implications." \d ->
+          if V.null d.newFields && V.null d.deletedFields && V.null d.modifiedFields
+            then
+              [fmtTrim|Describe this newly discovered API endpoint.
+            Endpoint: {d.endpointMethod} {d.endpointPath}
+            Service: {Issues.serviceLabel issue.service}
+            This endpoint was just detected for the first time. Summarize what it likely does based on its path and method.|]
+            else
+              [fmtTrim|Describe this API change and its impact.
+            Endpoint: {d.endpointMethod} {d.endpointPath}
+            New fields: {show $ V.toList d.newFields}
+            Deleted fields: {show $ V.toList d.deletedFields}
+            Modified fields: {show $ V.toList d.modifiedFields}
+            Total anomalies grouped: {V.length d.anomalyHashes}
+            Service: {Issues.serviceLabel issue.service}|]
+      Issues.RuntimeException ->
+        withIssueData @Issues.RuntimeExceptionData issue "Analyze this runtime exception." \d ->
+          [fmtTrim|Analyze this runtime exception and provide debugging guidance.
+            Error type: {d.errorType}
+            Error message: {d.errorMessage}
+            Stack trace: {T.take 500 d.stackTrace}
+            Request context: {fromMaybe "Unknown" d.requestMethod} {fromMaybe "Unknown" d.requestPath}
+            Occurrences: {d.occurrenceCount}|]
+      Issues.QueryAlert ->
+        withIssueData @Issues.QueryAlertData issue "Describe this query alert." \d ->
+          [fmtTrim|Describe this query alert and recommended actions.
+            Query: {d.queryName}
+            Expression: {d.queryExpression}
+            Threshold: {d.thresholdValue} ({display d.thresholdType})
+            Actual value: {d.actualValue}
+            Triggered at: {show d.triggeredAt}|]
+      Issues.LogPattern ->
+        withIssueData @Issues.LogPatternData issue ("Describe this log pattern issue. Title: " <> issue.title) \d ->
+          [fmtTrim|Describe this new log pattern and its implications.
+            Log pattern: {d.logPattern}
+            Sample message: {fromMaybe "N/A" d.sampleMessage}
+            Log level: {fromMaybe "unknown" d.logLevel}
+            Service: {Issues.serviceLabel d.serviceName}
+            Source: {d.sourceField}
+            Occurrences: {d.occurrenceCount}
+            First seen: {show d.firstSeenAt}|]
+      Issues.LogPatternRateChange ->
+        withIssueData @Issues.LogPatternRateChangeData issue ("Describe this log pattern rate change. Title: " <> issue.title) \d ->
+          let dir = display d.changeDirection
+           in [fmtTrim|Describe this log pattern volume {dir} and its implications.
+            Log pattern: {d.logPattern}
+            Sample message: {fromMaybe "N/A" d.sampleMessage}
+            Current rate: {Issues.showRate d.currentRatePerHour}
+            Baseline mean: {Issues.showRate d.baselineMean}
+            Baseline MAD: {Issues.showRate d.baselineMad}
+            Z-score: {show (round d.zScore :: Int)} standard deviations
+            Change: {Issues.showPct d.changePercent}
+            Service: {Issues.serviceLabel d.serviceName}
+            Log level: {fromMaybe "unknown" d.logLevel}|]
 
 
 -- | Classify issue as critical/safe and count breaking/incremental changes
 classifyIssueCriticality :: ELLM.LLM :> es => AuthContext -> Issues.Issue -> Eff es (Either Text (Bool, Int, Int))
-classifyIssueCriticality authCtx issue = runExceptT do
-  res <- ExceptT $ AI.callOpenAIAPIEff authCtx.config.openaiSmallModel (buildCriticalityPrompt issue) authCtx.config.openaiApiKey
-  case T.strip <$> lines (T.strip res) of
-    (criticalStr : breakingStr : incrementalStr : _) ->
-      pure (T.toLower criticalStr == "critical", fromMaybe 0 $ readMaybe $ toString breakingStr, fromMaybe 0 $ readMaybe $ toString incrementalStr)
-    _ -> hoistEither $ Left "Invalid response format from LLM"
+classifyIssueCriticality authCtx issue = (parse =<<) <$> askLLMLines authCtx (buildCriticalityPrompt issue)
+  where
+    parse (critical : breaking : incremental : _) = Right (T.toLower critical == "critical", count breaking, count incremental)
+    parse _ = badFormat
+    count = fromMaybe 0 . readMaybe . toString
 
 
--- | Build prompt for criticality classification
 buildCriticalityPrompt :: Issues.Issue -> Text
 buildCriticalityPrompt issue =
-  let context = case issue.issueType of
-        Issues.ApiChange ->
-          withIssueData @Issues.APIChangeData
-            issue
-            ( \d ->
-                [fmtTrim|API change detected
-            Endpoint: {d.endpointMethod} {d.endpointPath}
-            New fields: {V.length d.newFields}
-            Deleted fields: {V.length d.deletedFields}
-            Modified fields: {V.length d.modifiedFields}|]
-            )
-            ("API change: " <> issue.title)
-        Issues.RuntimeException -> "Runtime exception: " <> issue.title
-        Issues.QueryAlert -> "Query alert: " <> issue.title
-        Issues.LogPattern -> "Log pattern: " <> issue.title
-        Issues.LogPatternRateChange -> "Log pattern rate change: " <> issue.title
-
-      systemPrompt =
-        [text|
+  issuePrompt
+    [text|
           You are Monoscope's issue-severity classifier. Your job is to decide whether a Monoscope issue (API change, runtime exception, query alert, new log pattern, or log-pattern rate change) is critical or safe, and to count the breaking and incremental sub-changes.
 
           Tone: deterministic and precise — downstream code parses your response.
@@ -342,17 +292,27 @@ buildCriticalityPrompt issue =
           1
           </example>
           |]
-   in systemPrompt <> "\n\n<issue>\n" <> context <> "\n</issue>"
+    case issue.issueType of
+      Issues.ApiChange ->
+        withIssueData @Issues.APIChangeData issue ("API change: " <> issue.title) \d ->
+          [fmtTrim|API change detected
+            Endpoint: {d.endpointMethod} {d.endpointPath}
+            New fields: {V.length d.newFields}
+            Deleted fields: {V.length d.deletedFields}
+            Modified fields: {V.length d.modifiedFields}|]
+      Issues.RuntimeException -> "Runtime exception: " <> issue.title
+      Issues.QueryAlert -> "Query alert: " <> issue.title
+      Issues.LogPattern -> "Log pattern: " <> issue.title
+      Issues.LogPatternRateChange -> "Log pattern rate change: " <> issue.title
 
 
--- | Update issue classification in database
-updateIssueClassification :: DB es => Issues.IssueId -> Bool -> Int -> Int -> Eff es ()
-updateIssueClassification issueId isCritical breakingCount incrementalCount = do
-  let severity
-        | isCritical = Issues.Critical
-        | breakingCount > 0 = Issues.Warning
-        | otherwise = Issues.Info
-  Issues.updateIssueCriticality issueId isCritical severity
+updateIssueClassification :: DB es => Issues.IssueId -> Bool -> Int -> Eff es ()
+updateIssueClassification issueId isCritical breakingCount =
+  Issues.updateIssueCriticality issueId isCritical
+    $ if
+      | isCritical -> Issues.Critical
+      | breakingCount > 0 -> Issues.Warning
+      | otherwise -> Issues.Info
 
 
 -- | Analyze a RuntimeException issue to extract root cause and error category.
@@ -360,23 +320,19 @@ updateIssueClassification issueId isCritical breakingCount incrementalCount = do
 analyzeErrorPattern :: ELLM.LLM :> es => AuthContext -> Issues.Issue -> Eff es (Either Text (Text, Text))
 analyzeErrorPattern authCtx issue
   | issue.issueType /= Issues.RuntimeException = pure $ Left "not a runtime exception"
-  | otherwise = runExceptT do
-      r <- ExceptT $ ELLM.callLLM authCtx.config.openaiSmallModel (buildAnalysisPrompt issue) authCtx.config.openaiApiKey
-      case lines (T.strip r) of
-        (rootCause : category : _) -> pure (T.strip rootCause, T.toLower $ T.strip category)
-        _ -> hoistEither $ Left "Invalid response format from LLM"
+  | otherwise = (parse =<<) <$> askLLMLines authCtx (buildAnalysisPrompt issue)
+  where
+    parse (rootCause : category : _) = Right (rootCause, T.toLower category)
+    parse _ = badFormat
 
 
 buildAnalysisPrompt :: Issues.Issue -> Text
-buildAnalysisPrompt issue =
-  withIssueData @Issues.RuntimeExceptionData
-    issue
-    ( \d ->
-        let errType = d.errorType
-            msg = T.take 300 d.errorMessage
-            stack = T.take 500 d.stackTrace
-            req = fromMaybe "Unknown" d.requestMethod <> " " <> fromMaybe "Unknown" d.requestPath
-         in [text|
+buildAnalysisPrompt issue = withIssueData @Issues.RuntimeExceptionData issue "" \d ->
+  let errType = d.errorType
+      msg = T.take 300 d.errorMessage
+      stack = T.take 500 d.stackTrace
+      req = fromMaybe "Unknown" d.requestMethod <> " " <> fromMaybe "Unknown" d.requestPath
+   in [text|
               You are Monoscope's runtime-error analyzer. Your job is to read a single runtime exception and emit a structured 2-line diagnosis that downstream code parses verbatim.
 
               Tone: technical and concrete. Name the likely root cause, not symptoms.
@@ -407,5 +363,3 @@ buildAnalysisPrompt issue =
               Request: $req
               </error>
               |]
-    )
-    ""

--- a/src/Models/Apis/Issues.hs
+++ b/src/Models/Apis/Issues.hs
@@ -712,7 +712,7 @@ createAPIChangeIssue projectId endpointHash anomalies = do
           if V.any ((== Anomalies.ATEndpoint) . (.anomalyType)) anomalies
             then "New endpoint detected: " <> apiChangeData.endpointMethod <> " " <> apiChangeData.endpointPath <> " on " <> apiChangeData.endpointHost
             else "API structure has changed"
-      , recommendedAction = "Review the API changes and update your integration accordingly."
+      , recommendedAction = defaultRecommendedAction
       , migrationComplexity = if breakingChanges > 5 then "high" else if breakingChanges > 0 then "medium" else "low"
       , issueData = apiChangeData
       , timestamp = Just firstAnomaly.createdAt
@@ -884,7 +884,7 @@ createLogPatternRateChangeIssue projectId lp sr = do
           " · "
           [ svcLabel
           , T.take 40 lp.logPattern
-          , dir <> " " <> showPct changePercentVal <> " (" <> showRate sr.currentRate <> "/hr vs " <> showRate sr.mean <> "/hr)"
+          , dir <> " " <> showPct changePercentVal <> " (" <> showRate sr.currentRate <> " vs " <> showRate sr.mean <> ")"
           ]
   mkIssue
     MkIssueOpts

--- a/src/Models/Apis/Issues.hs
+++ b/src/Models/Apis/Issues.hs
@@ -163,11 +163,12 @@ data IssueType
 
 -- | Hash prefix used in otel_logs_and_spans hashes column
 hashPrefix :: IssueType -> Maybe Text
-hashPrefix LogPattern = Just "pat:"
-hashPrefix LogPatternRateChange = Just "pat:"
-hashPrefix RuntimeException = Just "err:"
-hashPrefix ApiChange = Just "" -- endpoint hash is stored unprefixed on span hashes
-hashPrefix _ = Nothing
+hashPrefix = \case
+  LogPattern -> Just "pat:"
+  LogPatternRateChange -> Just "pat:"
+  RuntimeException -> Just "err:"
+  ApiChange -> Just "" -- endpoint hash is stored unprefixed on span hashes
+  QueryAlert -> Nothing
 
 
 defaultRecommendedAction :: Text
@@ -217,11 +218,10 @@ serviceLabel = fromMaybe "unknown-service"
 
 
 isNewEndpointOnly :: Issue -> Bool
-isNewEndpointOnly issue
-  | issue.issueType /= ApiChange = False
-  | otherwise = case AE.fromJSON (getAeson issue.issueData) of
-      AE.Success (d :: APIChangeData) -> V.null d.newFields && V.null d.deletedFields && V.null d.modifiedFields
-      _ -> False
+isNewEndpointOnly issue =
+  issue.issueType == ApiChange && case AE.fromJSON (getAeson issue.issueData) of
+    AE.Success (d :: APIChangeData) -> V.null d.newFields && V.null d.deletedFields && V.null d.modifiedFields
+    AE.Error _ -> False
 
 
 -- | API Change issue data
@@ -418,10 +418,17 @@ bumpIssueUpdatedAt issueId = do
           WHERE id = #{issueId} |]
 
 
+-- | @AND pfx.col IS [NOT] NULL@ clause, or empty if the filter is unset. Shared
+-- between 'selectIssues' (prefixed, joined query) and 'selectIssuesByFilters'
+-- (unprefixed, single-table query — pass @mempty@ for @pfx@).
+sqlNullFilter :: HI.Sql -> HI.Sql -> Maybe Bool -> HI.Sql
+sqlNullFilter pfx col = foldMap (bool [HI.sql| AND ^{pfx}^{col} IS NULL|] [HI.sql| AND ^{pfx}^{col} IS NOT NULL|])
+
+
 -- | Select issues with filters, returns issues and total count for pagination
 -- period: "24h" = 24 hourly buckets, "7d" = 7 daily buckets (default)
-selectIssues :: (DB es, Time :> es) => Projects.ProjectId -> Maybe IssueType -> Maybe Bool -> Maybe Bool -> Int -> Int -> Maybe (UTCTime, UTCTime) -> Maybe Text -> Text -> [Text] -> [Text] -> Eff es ([IssueL], Int)
-selectIssues pid _typeM isAcknowledged isArchived limit offset timeRangeM sortM period serviceFilters typeFilters = do
+selectIssues :: (DB es, Time :> es) => Projects.ProjectId -> Maybe Bool -> Maybe Bool -> Int -> Int -> Maybe (UTCTime, UTCTime) -> Maybe Text -> Text -> [Text] -> [Text] -> Eff es ([IssueL], Int)
+selectIssues pid isAcknowledged isArchived limit offset timeRangeM sortM period serviceFilters typeFilters = do
   now <- Time.currentTime
   -- period controls bucket granularity: "24h" = hourly, "7d" = daily.
   -- seriesStart/step are bound here (not via SQL NOW()) so charts honour the test clock.
@@ -433,12 +440,11 @@ selectIssues pid _typeM isAcknowledged isArchived limit offset timeRangeM sortM 
       orderBy = rawSql case T.uncons =<< sortM of
         Just (s, c) | s == '-' || s == '+', c `elem` ["created_at", "updated_at", "title"] -> "i." <> c <> bool " ASC" " DESC" (s == '-')
         _ -> "i.critical DESC, i.created_at DESC"
-      nullF pfx col = foldMap (bool [HI.sql| AND ^{pfx}^{col} IS NULL|] [HI.sql| AND ^{pfx}^{col} IS NOT NULL|])
       arrF pfx col xs = if null xs then mempty else [HI.sql| AND ^{pfx}^{col} = ANY(#{xs}::text[])|]
       mkFilters pfx =
         foldMap (\(s, e) -> [HI.sql| AND ^{pfx}created_at >= #{s} AND ^{pfx}created_at <= #{e}|]) timeRangeM
-          <> nullF pfx [HI.sql|acknowledged_at|] isAcknowledged
-          <> nullF pfx [HI.sql|archived_at|] isArchived
+          <> sqlNullFilter pfx [HI.sql|acknowledged_at|] isAcknowledged
+          <> sqlNullFilter pfx [HI.sql|archived_at|] isArchived
           <> bool mempty [HI.sql| AND (^{pfx}severity IS NULL OR ^{pfx}severity != 'low')|] isInbox
           <> arrF pfx [HI.sql|service|] serviceFilters
           <> arrF pfx [HI.sql|issue_type::text|] typeFilters
@@ -597,9 +603,8 @@ setAckState pid iids mTs mUid
 -- within its cooldown window. The detector uses this to suppress re-firing.
 isInCooldown :: DB es => Projects.ProjectId -> Text -> IssueType -> UTCTime -> Eff es Bool
 isInCooldown pid tgt ty now =
-  isJust <$> (Hasql.interpOne q :: DB es => Eff es (Maybe Int64))
-  where
-    q =
+  isJust @Int64
+    <$> Hasql.interpOne
       [HI.sql|
         SELECT 1::bigint FROM apis.issues
         WHERE project_id = #{pid}
@@ -622,12 +627,6 @@ setArchiveState pid iids mTs
           WHERE project_id = #{pid} AND id = ANY(#{iids}::uuid[]) |]
 
 
--- | Archive open @log_pattern@ / @log_pattern_rate_change@ issues whose
--- @updated_at@ is older than @days@. @insertIssue@ bumps @updated_at@ on
--- conflict, so an actively-firing pattern never ages out — only dead signal
--- does. The predicate runs against OLD @updated_at@ before the
--- @set_updated_at@ trigger fires, so the cutoff is evaluated on the
--- pre-archive value.
 -- | Auto-archive open discovery-type issues (log_pattern, log_pattern_rate_change,
 -- api_change) whose @updated_at@ is older than @days@. @insertIssue@ bumps
 -- @updated_at@ on conflict, so an actively-drifting endpoint or firing pattern
@@ -669,22 +668,13 @@ selectIssuesByFilters
   -> Int -- offset
   -> Eff es ([Issue], Int)
 selectIssuesByFilters pid isAck isArch tyM svcM limit offset = do
-  let anyAck = isNothing isAck
-      ackFlag = fromMaybe False isAck
-      anyArch = isNothing isArch
-      archFlag = fromMaybe False isArch
-      anyType = maybe True T.null tyM
-      ty = fromMaybe "" tyM
-      anySvc = maybe True T.null svcM
-      svc = fromMaybe "" svcM
+  let eqF col = foldMap (\v -> if T.null v then mempty else [HI.sql| AND ^{col} = #{v}|])
       whereSql =
-        [HI.sql|
-          WHERE project_id = #{pid}
-            AND (#{anyAck} OR (#{ackFlag} AND acknowledged_at IS NOT NULL) OR (NOT #{ackFlag} AND acknowledged_at IS NULL))
-            AND (#{anyArch} OR (#{archFlag} AND archived_at IS NOT NULL) OR (NOT #{archFlag} AND archived_at IS NULL))
-            AND (#{anyType} OR issue_type::text = #{ty})
-            AND (#{anySvc} OR service = #{svc})
-        |]
+        [HI.sql| WHERE project_id = #{pid}|]
+          <> sqlNullFilter mempty [HI.sql|acknowledged_at|] isAck
+          <> sqlNullFilter mempty [HI.sql|archived_at|] isArch
+          <> eqF [HI.sql|issue_type::text|] tyM
+          <> eqF [HI.sql|service|] svcM
   rows <- Hasql.interp (selectFrom @Issue <> whereSql <> [HI.sql| ORDER BY updated_at DESC LIMIT #{limit} OFFSET #{offset} |])
   total <- fromMaybe 0 <$> Hasql.interpOne ([HI.sql| SELECT COUNT(*)::bigint FROM apis.issues |] <> whereSql)
   pure (rows, total)
@@ -781,7 +771,6 @@ data AIConversation = AIConversation
   deriving anyclass (Default, FromRow, HI.DecodeRow, ToRow)
 
 
--- | AI Chat message
 -- | Author of a stored AI chat message. Encodes to "user"/"assistant"/"system"
 -- (byte-identical to the previous free-text column).
 data ChatRole = ChatUser | ChatAssistant | ChatSystem
@@ -810,11 +799,11 @@ getOrCreateConversation pid convId convType ctx = do
   now <- Time.currentTime
   let ctxJ = Aeson ctx
   result <-
-    Hasql.interp
+    Hasql.interpOne
       [HI.sql| INSERT INTO apis.ai_conversations (project_id, conversation_id, conversation_type, context)
               VALUES (#{pid}, #{convId}, #{convType}, #{ctxJ}) ON CONFLICT (project_id, conversation_id) DO UPDATE SET updated_at = #{now}
               RETURNING id, project_id, conversation_id, conversation_type, context, created_at, updated_at |]
-  maybe (throwError err500{errBody = "getOrCreateConversation: RETURNING clause must return a row"}) pure $ listToMaybe result
+  maybe (throwError err500{errBody = "getOrCreateConversation: RETURNING clause must return a row"}) pure result
 
 
 -- | Insert a new chat message
@@ -851,18 +840,18 @@ discordThreadToConversationId :: Text -> UUIDId "conversation"
 discordThreadToConversationId = textToConversationId
 
 
--- | Try to acquire an advisory lock for chat migration to prevent race conditions.
--- Returns True if lock was acquired, False if already locked (another request is migrating).
--- Uses PostgreSQL advisory locks which are automatically released on connection close.
 chatMigrationLockKey :: UUIDId "conversation" -> Int64
 chatMigrationLockKey convId = fromIntegral @Int @Int64 $ abs $ hash $ show convId.unwrap
 
 
+-- | Try to acquire an advisory lock for chat migration to prevent race conditions.
+-- Returns True if lock was acquired, False if already locked (another request is migrating).
+-- Uses PostgreSQL advisory locks which are automatically released on connection close.
 tryAcquireChatMigrationLock :: DB es => UUIDId "conversation" -> Eff es Bool
 tryAcquireChatMigrationLock convId = do
   let lockKey = chatMigrationLockKey convId
   result :: [Bool] <- Hasql.interp [HI.sql| SELECT pg_try_advisory_lock(#{lockKey}) |]
-  pure $ fromMaybe False $ viaNonEmpty head result
+  pure $ or result
 
 
 -- | Release a chat migration advisory lock so that a failed migration can be retried
@@ -879,7 +868,6 @@ createLogPatternRateChangeIssue projectId lp sr = do
   now <- Time.currentTime
   let changePercentVal = if sr.mean > 1 then min 9999 $ abs ((sr.currentRate / sr.mean) - 1) * 100 else 0
       dir = display sr.direction
-      zonedNow = utcToZonedTime utc now
       lvl = T.toLower $ fromMaybe "" lp.logLevel
       -- Silent drops on unknown/empty services are almost always deploy/pod-restart
       -- noise, not incidents. Demote them so the Inbox filter hides them by default.
@@ -891,20 +879,13 @@ createLogPatternRateChangeIssue projectId lp sr = do
             (Spike, "error") -> Critical
             (Spike, _) -> Warning
             (Drop, _) -> Info
-      patternSnippet = T.take 40 lp.logPattern
       title =
-        svcLabel
-          <> " · "
-          <> patternSnippet
-          <> " · "
-          <> dir
-          <> " "
-          <> showPct changePercentVal
-          <> " ("
-          <> showRate sr.currentRate
-          <> "/hr vs "
-          <> showRate sr.mean
-          <> "/hr)"
+        T.intercalate
+          " · "
+          [ svcLabel
+          , T.take 40 lp.logPattern
+          , dir <> " " <> showPct changePercentVal <> " (" <> showRate sr.currentRate <> "/hr vs " <> showRate sr.mean <> "/hr)"
+          ]
   mkIssue
     MkIssueOpts
       { projectId
@@ -934,7 +915,7 @@ createLogPatternRateChangeIssue projectId lp sr = do
             , changeDirection = sr.direction
             , detectedAt = now
             }
-      , timestamp = Just zonedNow
+      , timestamp = Just $ utcToZonedTime utc now
       }
 
 
@@ -950,24 +931,12 @@ createLogPatternRateChangeIssue projectId lp sr = do
 -- "api: GET /users 500"
 sanitizeLogPatternTitle :: Text -> Maybe Text -> Maybe Text -> Text
 sanitizeLogPatternTitle raw sampleM serviceM =
-  let replacements :: [(Text, Text)]
-      replacements =
-        [ (";neutral⇒", " ")
-        , (";badge-error⇒", " ")
-        , (";badge-warning⇒", " ")
-        , (";badge-info⇒", " ")
-        , (";badge-success⇒", " ")
-        , ("{integer}", "")
-        , ("{uuid}", "")
-        , ("{float}", "")
-        , ("{*}", "")
-        , ("{hex}", "")
-        ]
+  let replacements =
+        [(m, " ") | m <- [";neutral⇒", ";badge-error⇒", ";badge-warning⇒", ";badge-info⇒", ";badge-success⇒"]]
+          <> [(p, "") | p <- ["{integer}", "{uuid}", "{float}", "{*}", "{hex}"]]
       stripped = unwords $ words $ foldl' (\t (a, b) -> T.replace a b t) raw replacements
-      printableRatio txt
-        | T.null txt = 0
-        | otherwise = fromIntegral (T.length (T.filter (\c -> isPrint c && isAscii c) txt)) / fromIntegral (T.length txt) :: Double
-      usable = not (T.null stripped) && printableRatio stripped > 0.7
+      -- printable-ASCII ratio > 0.7, as integer arithmetic
+      usable = not (T.null stripped) && 10 * T.length (T.filter (\c -> isPrint c && isAscii c) stripped) > 7 * T.length stripped
       fallback = case (serviceM, sampleM) of
         (Just svc, Just s) -> svc <> ": " <> T.take 80 s
         (_, Just s) -> s
@@ -979,23 +948,11 @@ sanitizeLogPatternTitle raw sampleM serviceM =
 -- | Create an issue for a new log pattern
 createLogPatternIssue :: (Time :> es, UUIDEff :> es) => Projects.ProjectId -> LogPatterns.LogPattern -> Eff es Issue
 createLogPatternIssue projectId lp = do
-  let logPatternData =
-        LogPatternData
-          { patternHash = lp.patternHash
-          , logPattern = lp.logPattern
-          , sampleMessage = lp.sampleMessage
-          , logLevel = lp.logLevel
-          , serviceName = lp.serviceName
-          , sourceField = lp.sourceField
-          , firstSeenAt = zonedTimeToUTC lp.firstSeenAt
-          , occurrenceCount = lp.occurrenceCount
-          }
-      lvl = T.toLower $ fromMaybe "" lp.logLevel
-      severity = case lvl of
-        "error" -> Critical
-        "warning" -> Warning
-        "warn" -> Warning
-        _ -> Info
+  let lvl = T.toLower $ fromMaybe "" lp.logLevel
+      severity
+        | lvl == "error" = Critical
+        | lvl `elem` ["warning", "warn"] = Warning
+        | otherwise = Info
   mkIssue
     MkIssueOpts
       { projectId
@@ -1009,7 +966,17 @@ createLogPatternIssue projectId lp = do
       , title = "New Log Pattern: " <> sanitizeLogPatternTitle lp.logPattern lp.sampleMessage lp.serviceName
       , recommendedAction = "A new log pattern has been detected. Review to ensure it's expected behavior."
       , migrationComplexity = "n/a"
-      , issueData = logPatternData
+      , issueData =
+          LogPatternData
+            { patternHash = lp.patternHash
+            , logPattern = lp.logPattern
+            , sampleMessage = lp.sampleMessage
+            , logLevel = lp.logLevel
+            , serviceName = lp.serviceName
+            , sourceField = lp.sourceField
+            , firstSeenAt = zonedTimeToUTC lp.firstSeenAt
+            , occurrenceCount = lp.occurrenceCount
+            }
       , timestamp = Just lp.firstSeenAt
       }
 
@@ -1223,13 +1190,20 @@ getLatestReportByType :: DB es => Projects.ProjectId -> Text -> Eff es (Maybe Re
 getLatestReportByType pid rType = Hasql.interpOne [HI.sql| SELECT * FROM apis.reports WHERE project_id = #{pid} AND report_type = #{rType} ORDER BY created_at DESC LIMIT 1 |]
 
 
+-- | Which hash an error issue is keyed on. Framework/transport errors key on the
+-- *parent* (broad) hash so per-route variants collapse into one issue via the
+-- (project_id, target_hash, issue_type) ON CONFLICT index; app errors — and framework
+-- errors with no parent hash — keep their narrow per-route identity.
+frameworkTarget :: Bool -> Maybe Text -> Text -> (Bool, Text)
+frameworkTarget isFw parentHash hsh = maybe (False, hsh) (True,) (parentHash <* guard isFw)
+
+
 createErrorSpikeIssue :: (Time :> es, UUIDEff :> es) => Projects.ProjectId -> ErrorPatterns.ErrorPatternWithCurrentRate -> Double -> Double -> Double -> Eff es Issue
 createErrorSpikeIssue projectId errRate currentRate baselineMean zScore =
   let increasePercent = if baselineMean > 0 then ((currentRate / baselineMean) - 1) * 100 else 0
       -- Inherit classification from the underlying pattern so a spike on a framework
       -- error dedupes against the rolled-up framework issue via the same target_hash.
-      useFramework = errRate.isFramework && isJust errRate.parentHash
-      tgt = if useFramework then fromMaybe errRate.hash errRate.parentHash else errRate.hash
+      (useFramework, tgt) = frameworkTarget errRate.isFramework errRate.parentHash errRate.hash
    in mkErrorIssue
         projectId
         tgt
@@ -1244,17 +1218,11 @@ createErrorSpikeIssue projectId errRate currentRate baselineMean zScore =
         ("Error rate has spiked " <> show (round zScore :: Int) <> " standard deviations above baseline. Current: " <> show (round currentRate :: Int) <> "/hr, Baseline: " <> show (round baselineMean :: Int) <> "/hr. Investigate recent deployments or changes.")
 
 
--- | Create a new issue for an error pattern. Framework/transport errors are keyed on
--- the *parent* (broad) hash so that subsequent per-route variants hit the ON CONFLICT
--- path and do not fragment into many issues. App errors keep per-route identity and
--- store the parent hash for UI rollup.
+-- | Create a new issue for an error pattern. See 'frameworkTarget' for how the
+-- target hash is chosen; the parent hash is always stored for UI rollup.
 createNewErrorIssue :: (Time :> es, UUIDEff :> es) => Projects.ProjectId -> ErrorPatterns.ErrorPattern -> Eff es Issue
 createNewErrorIssue projectId err =
-  -- Framework errors key the issue on parentHash so per-route variants collapse into one
-  -- issue via the (project_id, target_hash, issue_type) ON CONFLICT index. If the broad
-  -- hash is somehow missing we fall back to the narrow hash (behaves like an app error).
-  let useFramework = err.isFramework && isJust err.parentHash
-      tgt = if useFramework then fromMaybe err.hash err.parentHash else err.hash
+  let (useFramework, tgt) = frameworkTarget err.isFramework err.parentHash err.hash
       title =
         (if useFramework then "Framework Error: " else "New Error: ")
           <> err.errorType

--- a/src/Models/Apis/LogPatterns.hs
+++ b/src/Models/Apis/LogPatterns.hs
@@ -41,7 +41,6 @@ module Models.Apis.LogPatterns (
 )
 where
 
-import Control.Lens (view, _1, _2, _3, _4, _5, _6)
 import Data.Aeson qualified as AE
 import Data.Effectful.Hasql qualified as Hasql
 import Data.List (lookup)
@@ -162,9 +161,7 @@ getLogPatternTexts pid sourceField = Hasql.interp [HI.sql| SELECT LEFT(log_patte
 getLogPatternTextsByService :: DB es => Projects.ProjectId -> Text -> Text -> Eff es ([Text], Maybe UTCTime)
 getLogPatternTextsByService pid sourceField svcName = do
   rows :: [(Text, Maybe UTCTime)] <- Hasql.interp [HI.sql| SELECT LEFT(log_pattern, 2000), last_seen_at FROM apis.log_patterns WHERE project_id = #{pid} AND source_field = #{sourceField} AND service_name = #{svcName} AND canonical_id IS NULL ORDER BY last_seen_at DESC NULLS LAST LIMIT 5000|]
-  let texts = map (view _1) rows
-      maxSeen = viaNonEmpty head [t | (_, Just t) <- rows]
-  pure (texts, maxSeen)
+  pure (fst <$> rows, asum (snd <$> rows)) -- ordered DESC NULLS LAST, so the first non-null is the max
 
 
 -- | Get log pattern by unique key (project_id, source_field, pattern_hash)
@@ -249,12 +246,7 @@ updateBaselineBatch pid rows
   | V.null rows = pure 0
   | otherwise = do
       now <- Time.currentTime
-      let srcFields = V.map (view _1) rows
-          hashes = V.map (view _2) rows
-          states = V.map (view _3) rows
-          means = V.map (view _4) rows
-          mads = V.map (view _5) rows
-          samples = V.map (view _6) rows
+      let (srcFields, hashes, states, means, mads, samples) = V.unzip6 rows
       Hasql.interpExecute
         [HI.sql|
               UPDATE apis.log_patterns lp
@@ -272,16 +264,11 @@ updateBaselineBatch pid rows
 -- Pre-merges rows with the same (projectId, sourceField, hash) to avoid
 -- "ON CONFLICT DO UPDATE command cannot affect row a second time".
 upsertLogPatternBatch :: (DB es, Time :> es) => [UpsertPattern] -> Eff es Int64
-upsertLogPatternBatch [] = pure 0
 upsertLogPatternBatch ups = do
   now <- Time.currentTime
-  sum
-    <$> forM
-      (dedup ups)
-      ( \u' -> do
-          let (u :: UpsertPattern) = cap u'
-          Hasql.interpExecute
-            [HI.sql| INSERT INTO apis.log_patterns (project_id, log_pattern, pattern_hash, source_field, service_name, log_level, trace_id, sample_message, occurrence_count, last_seen_at, is_error)
+  fmap sum $ forM (cap <$> dedup ups) \u ->
+    Hasql.interpExecute
+      [HI.sql| INSERT INTO apis.log_patterns (project_id, log_pattern, pattern_hash, source_field, service_name, log_level, trace_id, sample_message, occurrence_count, last_seen_at, is_error)
         VALUES (#{u.projectId}, #{u.logPattern}, #{u.hash}, #{u.sourceField}, #{u.serviceName}, #{u.logLevel}, #{u.traceId}, #{u.sampleMessage}, #{u.eventCount}, #{now}, #{u.isError})
         ON CONFLICT (project_id, source_field, pattern_hash) DO UPDATE SET
           last_seen_at = EXCLUDED.last_seen_at,
@@ -292,12 +279,12 @@ upsertLogPatternBatch ups = do
           trace_id = COALESCE(EXCLUDED.trace_id, apis.log_patterns.trace_id),
           is_error = apis.log_patterns.is_error OR EXCLUDED.is_error
   |]
-      )
   where
     maxTextLen = 32000
-    cap u = u{logPattern = T.take maxTextLen u.logPattern, sampleMessage = T.take maxTextLen <$> u.sampleMessage} :: UpsertPattern
-    dedup = Map.elems . foldl' merge Map.empty
-    merge acc u = Map.insertWith mergeUp (u.projectId, u.sourceField, u.hash) u acc
+    cap :: UpsertPattern -> UpsertPattern
+    cap u = u{logPattern = T.take maxTextLen u.logPattern, sampleMessage = T.take maxTextLen <$> u.sampleMessage}
+    dedup :: [UpsertPattern] -> [UpsertPattern]
+    dedup = Map.elems . Map.fromListWith mergeUp . map (\u -> ((u.projectId, u.sourceField, u.hash), u))
     mergeUp new old = old{eventCount = old.eventCount + new.eventCount, sampleMessage = old.sampleMessage <|> new.sampleMessage, serviceName = old.serviceName <|> new.serviceName, logLevel = old.logLevel <|> new.logLevel, traceId = old.traceId <|> new.traceId, isError = old.isError || new.isError}
 
 
@@ -312,18 +299,13 @@ upsertHourlyStat pid sourceField patHash hourBucket count =
 
 -- | Batch version of upsertHourlyStat using executeMany.
 upsertHourlyStatBatch :: DB es => [(Projects.ProjectId, Text, Text, UTCTime, Int64)] -> Eff es Int64
-upsertHourlyStatBatch [] = pure 0
 upsertHourlyStatBatch rows =
-  sum
-    <$> forM
-      (Map.toList deduped)
-      ( \((pid, sf, ph, hb), ec) ->
-          Hasql.interpExecute
-            [HI.sql| INSERT INTO apis.log_pattern_hourly_stats (project_id, source_field, pattern_hash, hour_bucket, event_count)
+  fmap sum $ forM (Map.toList deduped) \((pid, sf, ph, hb), ec) ->
+    Hasql.interpExecute
+      [HI.sql| INSERT INTO apis.log_pattern_hourly_stats (project_id, source_field, pattern_hash, hour_bucket, event_count)
         VALUES (#{pid}, #{sf}, #{ph}, #{hb}, #{ec})
         ON CONFLICT (project_id, source_field, pattern_hash, hour_bucket)
         DO UPDATE SET event_count = apis.log_pattern_hourly_stats.event_count + EXCLUDED.event_count |]
-      )
   where
     deduped = Map.fromListWith (+) [((pid, sf, ph, truncateHour hb), ec) | (pid, sf, ph, hb, ec) <- rows]
 
@@ -343,10 +325,9 @@ data BatchPatternStats = BatchPatternStats
 
 
 getBatchPatternStats :: DB es => Projects.ProjectId -> UTCTime -> Int -> Eff es [BatchPatternStats]
-getBatchPatternStats pid now hoursBack = Hasql.interp q
-  where
-    q =
-      [HI.sql|
+getBatchPatternStats pid now hoursBack =
+  Hasql.interp
+    [HI.sql|
         WITH hourly_counts AS (
           SELECT source_field, pattern_hash, hour_bucket, event_count FROM apis.log_pattern_hourly_stats
           WHERE project_id = #{pid} AND hour_bucket >= #{now}::timestamptz - INTERVAL '1 hour' * #{hoursBack}
@@ -403,10 +384,8 @@ data LogPatternWithRate = LogPatternWithRate
 -- Scale ceiling: established patterns grow slowly (~weeks); expect <1k per project at steady state.
 getPatternsWithCurrentRates :: DB es => Projects.ProjectId -> UTCTime -> Eff es [LogPatternWithRate]
 getPatternsWithCurrentRates pid now =
-  Hasql.interp q
-  where
-    q =
-      [HI.sql|
+  Hasql.interp
+    [HI.sql|
         SELECT lp.id, lp.project_id, LEFT(lp.log_pattern, 2000), lp.pattern_hash, lp.source_field,
           lp.service_name, lp.log_level, LEFT(lp.sample_message, 2000),
           lp.baseline_state, lp.baseline_volume_hourly_mean, lp.baseline_volume_hourly_mad,

--- a/src/Models/Apis/LogPatterns.hs
+++ b/src/Models/Apis/LogPatterns.hs
@@ -264,6 +264,7 @@ updateBaselineBatch pid rows
 -- Pre-merges rows with the same (projectId, sourceField, hash) to avoid
 -- "ON CONFLICT DO UPDATE command cannot affect row a second time".
 upsertLogPatternBatch :: (DB es, Time :> es) => [UpsertPattern] -> Eff es Int64
+upsertLogPatternBatch [] = pure 0
 upsertLogPatternBatch ups = do
   now <- Time.currentTime
   sum <$> forM (cap <$> dedup ups) \u ->

--- a/src/Models/Apis/LogPatterns.hs
+++ b/src/Models/Apis/LogPatterns.hs
@@ -266,7 +266,7 @@ updateBaselineBatch pid rows
 upsertLogPatternBatch :: (DB es, Time :> es) => [UpsertPattern] -> Eff es Int64
 upsertLogPatternBatch ups = do
   now <- Time.currentTime
-  fmap sum $ forM (cap <$> dedup ups) \u ->
+  sum <$> forM (cap <$> dedup ups) \u ->
     Hasql.interpExecute
       [HI.sql| INSERT INTO apis.log_patterns (project_id, log_pattern, pattern_hash, source_field, service_name, log_level, trace_id, sample_message, occurrence_count, last_seen_at, is_error)
         VALUES (#{u.projectId}, #{u.logPattern}, #{u.hash}, #{u.sourceField}, #{u.serviceName}, #{u.logLevel}, #{u.traceId}, #{u.sampleMessage}, #{u.eventCount}, #{now}, #{u.isError})
@@ -300,7 +300,7 @@ upsertHourlyStat pid sourceField patHash hourBucket count =
 -- | Batch version of upsertHourlyStat using executeMany.
 upsertHourlyStatBatch :: DB es => [(Projects.ProjectId, Text, Text, UTCTime, Int64)] -> Eff es Int64
 upsertHourlyStatBatch rows =
-  fmap sum $ forM (Map.toList deduped) \((pid, sf, ph, hb), ec) ->
+  sum <$> forM (Map.toList deduped) \((pid, sf, ph, hb), ec) ->
     Hasql.interpExecute
       [HI.sql| INSERT INTO apis.log_pattern_hourly_stats (project_id, source_field, pattern_hash, hour_bucket, event_count)
         VALUES (#{pid}, #{sf}, #{ph}, #{hb}, #{ec})

--- a/src/Models/Apis/LogQueries.hs
+++ b/src/Models/Apis/LogQueries.hs
@@ -26,7 +26,6 @@ module Models.Apis.LogQueries (
 where
 
 import Control.Exception.Annotated (checkpoint, try)
-import Control.Lens (view, _5)
 import Data.Aeson qualified as AE
 import Data.Annotation (toAnnotation)
 import Data.Char (isDigit)
@@ -132,16 +131,8 @@ data RequestTypes
 normalizeUrlPath :: SDKTypes -> Int -> Text -> Text -> Text
 -- NOTE: Temporary workaround due to storing complex paths in the urlPath, which should be unaccepted, and messes with our logic
 normalizeUrlPath JsExpress _ "OPTIONS" _ = ""
-normalizeUrlPath _ statusCode _ urlPath = removeQueryParams statusCode urlPath
-
-
--- removeQueryParams ...
--- >>> removeQueryParams 200 "https://monoscope.tech/abc/:bla?q=abc"
---
--- Function to remove the query parameter section from a URL
-removeQueryParams :: Int -> Text -> Text
-removeQueryParams 404 _ = ""
-removeQueryParams _ urlPath = T.takeWhile (/= '?') urlPath
+normalizeUrlPath _ 404 _ _ = ""
+normalizeUrlPath _ _ _ urlPath = T.takeWhile (/= '?') urlPath
 
 
 data ATError = ATError
@@ -167,15 +158,9 @@ data ATError = ATError
   deriving (AE.FromJSON, AE.ToJSON) via DAE.Snake ATError
 
 
-incrementByOneMillisecond :: String -> String
+incrementByOneMillisecond :: Text -> Text
 incrementByOneMillisecond dateStr =
-  case maybeTime of
-    Nothing -> ""
-    Just utcTime ->
-      let newTime = posixSecondsToUTCTime $ utcTimeToPOSIXSeconds utcTime + 0.000001
-       in iso8601Show newTime
-  where
-    maybeTime = parseTimeM True defaultTimeLocale "%Y-%m-%dT%H:%M:%S%QZ" dateStr :: Maybe UTCTime
+  maybe "" (toText . iso8601Show . addUTCTime 0.000001) (parseTimeM True defaultTimeLocale "%Y-%m-%dT%H:%M:%S%QZ" (toString dateStr) :: Maybe UTCTime)
 
 
 -- | Which log-explorer data endpoint a URL targets. 'Data' serves logs/spans;
@@ -183,25 +168,26 @@ incrementByOneMillisecond dateStr =
 -- is derived from the constructor name via 'encodeEnumSC' (snake_case), so it
 -- can't drift from the constructor.
 data LogEndpoint = Data | Sessions | Patterns
-  deriving stock (Bounded, Enum, Eq, Show)
+  deriving stock (Eq, Show)
 
 
 logExplorerUrlPath :: Projects.ProjectId -> LogEndpoint -> Maybe Text -> Maybe Text -> Maybe Text -> Maybe Text -> Maybe Text -> Maybe Text -> Maybe Text -> Maybe Text -> Bool -> Text
 logExplorerUrlPath pid endpoint q cols cursor since fromV toV layout source recent = "/p/" <> pid.toText <> "/log_explorer/" <> toText (encodeEnumSC @"" endpoint) <> "?" <> T.intercalate "&" params
   where
-    recentTo = cursor >>= (\x -> Just (toText . incrementByOneMillisecond . toString $ x))
+    param k v = ((k <> "=") <>) . toQueryParam <$> v
+    unlessRecent v = if recent then Nothing else v
     params =
-      catMaybes
-        [ Just "json=true"
-        , fmap ("query=" <>) (toQueryParam <$> q)
-        , fmap ("cols=" <>) (toQueryParam <$> cols)
-        , if recent then Nothing else fmap ("cursor=" <>) (toQueryParam <$> cursor)
-        , if recent then Nothing else fmap ("since=" <>) (toQueryParam <$> since)
-        , fmap ("from=" <>) (toQueryParam <$> fromV)
-        , if recent then fmap ("to=" <>) (toQueryParam <$> recentTo) else fmap ("to=" <>) (toQueryParam <$> toV)
-        , fmap ("layout=" <>) (toQueryParam <$> layout)
-        , fmap ("source=" <>) (toQueryParam <$> source)
-        ]
+      "json=true"
+        : catMaybes
+          [ param "query" q
+          , param "cols" cols
+          , param "cursor" (unlessRecent cursor)
+          , param "since" (unlessRecent since)
+          , param "from" fromV
+          , param "to" (if recent then incrementByOneMillisecond <$> cursor else toV)
+          , param "layout" layout
+          , param "source" source
+          ]
 
 
 -- | Execute a user-provided SQL query with mandatory project_id filtering.
@@ -224,27 +210,24 @@ executeSecuredQuery useTimefusion pid userQuery limit
       let wrapped = rawSql ("SELECT jsonb_build_array(sub.*) FROM (" <> userQuery <> ") sub") <> [HI.sql| LIMIT #{limit}|]
       resultE <- try @Hasql.HasqlException $ Hasql.withHasqlTimefusion useTimefusion do
         rows :: [AE.Value] <- Hasql.interp wrapped
-        pure $ V.fromList $ mapMaybe jsonArrayToVector rows
+        pure $ jsonArrayRows rows
       pure $ first (\e -> "Query execution failed: " <> toText (displayException e)) resultE
 
 
 -- | Each query path projects a single jsonb-array column per row (via
 -- inlined @jsonb_build_array(...)@); this decodes that wire shape into
--- the positional 'V.Vector AE.Value' callers index into.
-jsonArrayToVector :: AE.Value -> Maybe (V.Vector AE.Value)
-jsonArrayToVector (AE.Array arr) = Just arr
-jsonArrayToVector _ = Nothing
+-- the positional 'V.Vector AE.Value' rows callers index into.
+jsonArrayRows :: [AE.Value] -> V.Vector (V.Vector AE.Value)
+jsonArrayRows =
+  V.fromList . mapMaybe \case
+    AE.Array arr -> Just arr
+    _ -> Nothing
 
 
 -- | Check that query contains a project_id filter with the correct project ID
 -- This validates that the query has been properly prepared with the project_id substituted
 hasProjectIdFilter :: Text -> Projects.ProjectId -> Bool
-hasProjectIdFilter query pid =
-  let pidText = pid.toText
-   in ("project_id='" <> pidText <> "'")
-        `T.isInfixOf` query
-        || ("project_id = '" <> pidText <> "'")
-        `T.isInfixOf` query
+hasProjectIdFilter query pid = any (`T.isInfixOf` query) ["project_id='" <> pid.toText <> "'", "project_id = '" <> pid.toText <> "'"]
 
 
 -- | Dangerous SQL patterns that must not appear in user queries
@@ -277,12 +260,7 @@ dangerousSqlPatterns =
 validateSqlQuery :: Text -> Bool
 validateSqlQuery query =
   let lowerQuery = T.toLower query
-      -- Check for comment-based bypass attempts in original query
-      hasComments = "--" `T.isInfixOf` query || "/*" `T.isInfixOf` query
-   in not hasComments
-        && all (\p -> not $ p `T.isInfixOf` lowerQuery) dangerousSqlPatterns
-        && "select"
-        `T.isInfixOf` lowerQuery
+   in "select" `T.isInfixOf` lowerQuery && not (any (`T.isInfixOf` lowerQuery) dangerousSqlPatterns)
 
 
 selectLogTable :: (DB es, Log :> es, Time.Time :> es, Tracing :> es) => Projects.ProjectId -> [Section] -> Text -> Maybe UTCTime -> (Maybe UTCTime, Maybe UTCTime) -> [Text] -> Maybe Sources -> Maybe Text -> Eff es (Either Text (V.Vector (V.Vector AE.Value), [Text], Int))
@@ -323,26 +301,23 @@ selectLogTable pid queryAST queryText cursorM dateRange projectedColsByUser sour
       $ try @SomeException
       $ checkpoint (toAnnotation ("selectLogTable", q)) do
         rows :: [AE.Value] <- Hasql.interp (rawSql q)
-        pure $ V.fromList $ mapMaybe jsonArrayToVector rows
-  case result of
-    Left e -> pure $ Left $ show e
-    Right logItemsV -> do
-      let limit = fromMaybe defaultQueryLimit queryComponents.takeLimit
-      if queryComponents.hasCountOver
-        then do
-          let dropLast v = V.take (V.length v - 1) v
-              count = fromMaybe 0 $ do
+        pure $ jsonArrayRows rows
+  pure case result of
+    Left e -> Left $ show e
+    Right logItemsV
+      | queryComponents.hasCountOver ->
+          let count = fromMaybe 0 do
                 firstRow <- logItemsV V.!? 0
                 AE.Number n <- firstRow V.!? (V.length firstRow - 1)
                 pure $ round n
-          pure $ Right (V.map dropLast logItemsV, queryComponents.toColNames, count)
-        else do
-          -- No count(*) OVER(): use overflow row to detect hasMore
-          let hasOverflow = V.length logItemsV > limit
+           in Right (V.map (\v -> V.take (V.length v - 1) v) logItemsV, queryComponents.toColNames, count)
+      -- No count(*) OVER(): the overflow row detects hasMore, signalled by
+      -- returning count > rows length.
+      | otherwise ->
+          let limit = fromMaybe defaultQueryLimit queryComponents.takeLimit
+              hasOverflow = V.length logItemsV > limit
               rows = if hasOverflow then V.take limit logItemsV else logItemsV
-              -- Signal hasMore by returning count > rows length
-              count = if hasOverflow then V.length rows + 1 else V.length rows
-          pure $ Right (rows, queryComponents.toColNames, count)
+           in Right (rows, queryComponents.toColNames, V.length rows + bool 0 1 hasOverflow)
 
 
 -- | Return spans that are transitive descendants of @seedSpanIds@ within
@@ -355,32 +330,29 @@ selectLogTable pid queryAST queryText cursorM dateRange projectedColsByUser sour
 -- whereas the bounded scan here is a single pass and the result set is
 -- already capped at 2000 rows so the in-memory walk is negligible.
 selectChildSpansAndLogs :: (DB es, Time.Time :> es) => Projects.ProjectId -> [Text] -> V.Vector Text -> V.Vector Text -> (Maybe UTCTime, Maybe UTCTime) -> V.Vector Text -> Eff es [V.Vector AE.Value]
+-- Skipping the SQL round-trip on an empty seed set matters: 'keepDescendantsOf'
+-- would also return [] but we'd pay for the query first.
+selectChildSpansAndLogs _ _ _ seedSpanIds _ _ | V.null seedSpanIds = pure []
 selectChildSpansAndLogs pid projectedColsByUser traceIds seedSpanIds dateRange excludedSpanIds = do
   now <- Time.currentTime
   let qConfig = defSqlQueryCfg pid now (Just SSpans) Nothing
       (r, colNames) = getProcessedColumns projectedColsByUser qConfig.defaultSelect
-  let traceIdsList = V.toList traceIds
+      traceIdsList = V.toList traceIds
       excludedList = V.toList excludedSpanIds
       dateRangeSql = case dateRange of
         (Nothing, Just b) -> [HI.sql| AND timestamp BETWEEN #{b} AND #{now} |]
         (Just a, Just b) -> let a' = addUTCTime (-30) a; b' = addUTCTime 30 b in [HI.sql| AND timestamp BETWEEN #{a'} AND #{b'} |]
         _ -> mempty
-  -- Skip the SQL round-trip when there's nothing to expand from;
-  -- 'keepDescendantsOf' would also return [] but we'd pay for the query first.
-  if V.null seedSpanIds
-    then pure []
-    else do
-      let inner =
-            rawSql ("SELECT jsonb_build_array(" <> r <> ") FROM otel_logs_and_spans WHERE project_id=")
-              <> [HI.sql|#{pid.toText}::text|]
-              <> dateRangeSql
-              <> [HI.sql| AND context___trace_id=ANY(#{traceIdsList}) AND parent_id IS NOT NULL AND id::text != ALL(#{excludedList}) ORDER BY timestamp DESC LIMIT 2000|]
-      rawRows :: [AE.Value] <- Hasql.interp inner
-      let results = V.fromList $ mapMaybe jsonArrayToVector rawRows
-      -- 'colNames' from getProcessedColumns retains "<expr> as <alias>" entries;
-      -- strip to bare aliases so the index map matches what callers / 'lookupVecTextByKey'
-      -- look up (e.g. "latency_breakdown", "parent_id").
-      pure $ keepDescendantsOf (listToIndexHashMap (listToColNames colNames)) seedSpanIds results
+  rawRows :: [AE.Value] <-
+    Hasql.interp
+      $ rawSql ("SELECT jsonb_build_array(" <> r <> ") FROM otel_logs_and_spans WHERE project_id=")
+      <> [HI.sql|#{pid.toText}::text|]
+      <> dateRangeSql
+      <> [HI.sql| AND context___trace_id=ANY(#{traceIdsList}) AND parent_id IS NOT NULL AND id::text != ALL(#{excludedList}) ORDER BY timestamp DESC LIMIT 2000|]
+  -- 'colNames' from getProcessedColumns retains "<expr> as <alias>" entries;
+  -- strip to bare aliases so the index map matches what callers / 'lookupVecTextByKey'
+  -- look up (e.g. "latency_breakdown", "parent_id").
+  pure $ keepDescendantsOf (listToIndexHashMap (listToColNames colNames)) seedSpanIds $ jsonArrayRows rawRows
 
 
 -- | Keep only rows that are transitive descendants of any @seedSpanIds@
@@ -394,7 +366,7 @@ selectChildSpansAndLogs pid projectedColsByUser traceIds seedSpanIds dateRange e
 -- them (in 'requestVecs') and we only return strict descendants.
 keepDescendantsOf :: HM.HashMap Text Int -> V.Vector Text -> V.Vector (V.Vector AE.Value) -> [V.Vector AE.Value]
 keepDescendantsOf colIdxMap seedSpanIds rows
-  | V.null seedSpanIds || V.null rows = []
+  | V.null rows = []
   | otherwise =
       let sid r = lookupVecTextByKey r colIdxMap "latency_breakdown"
           pid' r = lookupVecTextByKey r colIdxMap "parent_id"
@@ -458,13 +430,12 @@ data SessionRow = SessionRow
   deriving stock (Generic, Show)
 
 
--- | Mirrors the column order of the SELECT in 'fetchSessions'. Decoded
--- directly via hasql to bypass the jsonb wrapper entirely — Postgres'
--- jsonb type still rejects NULL bytes / lone surrogates in TEXT values
--- regardless of which function builds it, so the only safe path for raw
--- OTLP text (user_agent, url_path, ...) is to never round-trip through
--- jsonb at all.
--- | One decoded row of 'fetchSessions'. The trailing @sum*@ fields are the
+-- | One decoded row of 'fetchSessions', mirroring the column order of its
+-- SELECT. Decoded directly via hasql to bypass the jsonb wrapper entirely —
+-- Postgres' jsonb type rejects NULL bytes / lone surrogates in TEXT values
+-- regardless of which function builds it, so the only safe path for raw OTLP
+-- text (user_agent, url_path, ...) is to never round-trip through jsonb.
+-- The trailing @sum*@ fields are the
 -- session-level summary, CROSS JOINed onto every page row so the header
 -- aggregates ride the same single scan (decoded once, from the head row).
 -- (hasql-interpolate decodes a flat column list, so these live in one record
@@ -503,24 +474,50 @@ data RawSessionRow = RawSessionRow
   deriving anyclass (HI.DecodeRow)
 
 
--- | Build a WHERE body always scoped to the project. `QueryComponents.whereClause`
--- carries only user-supplied filters (see `Pkg.Parser.sqlFromQueryComponents`
--- where `project_id` is attached separately via `buildWhere`), so any caller
--- that embeds `whereClause` into its own SQL must prepend project scoping
--- here — otherwise a non-empty user filter silently bypasses project isolation.
+-- | Build a WHERE body always scoped to the project, ANDed with the user
+-- filters and the date-range clause. `QueryComponents.whereClause` carries only
+-- user-supplied filters (see `Pkg.Parser.sqlFromQueryComponents` where
+-- `project_id` is attached separately via `buildWhere`), so any caller that
+-- embeds `whereClause` into its own SQL must scope it here — otherwise a
+-- non-empty user filter silently bypasses project isolation.
 --
--- >>> scopedWhere "p1" Nothing
+-- >>> scopedWhere "p1" Nothing ""
 -- "project_id='p1'"
--- >>> scopedWhere "p1" (Just "")
+-- >>> scopedWhere "p1" (Just "") ""
 -- "project_id='p1'"
--- >>> scopedWhere "p1" (Just "level='error'")
--- "project_id='p1' AND (level='error')"
-scopedWhere :: Text -> Maybe Text -> Text
-scopedWhere pidTxt mUser =
-  let base = "project_id='" <> pidTxt <> "'"
-   in case mUser of
-        Just w | not (T.null w) -> base <> " AND (" <> w <> ")"
-        _ -> base
+-- >>> scopedWhere "p1" (Just "level='error'") "timestamp > now()"
+-- "project_id='p1' AND (level='error') AND timestamp > now()"
+scopedWhere :: Text -> Maybe Text -> Text -> Text
+scopedWhere pidTxt mUser dateClause =
+  T.intercalate " AND " $ ("project_id='" <> pidTxt <> "'") : filter (not . T.null) [foldMap parens mUser, dateClause]
+  where
+    parens w = if T.null w then "" else "(" <> w <> ")"
+
+
+-- | Parse @queryAST@ against a fresh 'defSqlQueryCfg' and build its scoped WHERE
+-- clause in one step. Shared by 'fetchLogPatterns', 'fetchSessions', and
+-- 'fetchEventExamples', which all otherwise repeat this three-line dance.
+scopedQueryWhere :: Projects.ProjectId -> UTCTime -> Maybe Sources -> (Maybe UTCTime, Maybe UTCTime) -> [Section] -> Text
+scopedQueryWhere pid now source dateRange queryAST =
+  let sqlCfg = (defSqlQueryCfg pid now source Nothing){dateRange}
+      (_, qc) = queryASTToComponents sqlCfg queryAST
+   in scopedWhere pid.toText qc.whereClause (buildDateRange sqlCfg)
+
+
+-- | One row of the precomputed patterns query in 'fetchLogPatterns' (persisted
+-- @apis.log_patterns@, LEFT JOINed against its merged members).
+data PrecomputedPattern = PrecomputedPattern
+  { logPattern :: Text
+  , totalCount :: Int64
+  , logLevel :: Maybe Text
+  , serviceName :: Maybe Text
+  , patternHash :: Text
+  , mergedCount :: Int
+  , totalPatterns :: Int
+  , isError :: Bool
+  }
+  deriving stock (Generic, Show)
+  deriving anyclass (HI.DecodeRow)
 
 
 fetchLogPatterns
@@ -538,26 +535,22 @@ fetchLogPatterns
   -> Eff es (Int, [PatternRow])
 fetchLogPatterns enableTfReads pid queryAST dateRange sourceM targetM skip = do
   now <- Time.currentTime
-  let sqlCfg = (defSqlQueryCfg pid now sourceM Nothing){dateRange}
-      (_, queryComponents) = queryASTToComponents sqlCfg queryAST
-      pidTxt = pid.toText
-      dateRangeClause = buildDateRange sqlCfg
-      whereCondition = scopedWhere pidTxt queryComponents.whereClause
-      fullWhere = whereCondition <> if T.null dateRangeClause then "" else " AND " <> dateRangeClause
+  let pidTxt = pid.toText
+      fullWhere = scopedQueryWhere pid now sourceM dateRange queryAST
       target = fromMaybe "summary" targetM
   Log.logTrace "fetchLogPatterns: start"
     $ AE.object
       ["project_id" AE..= pid, "target" AE..= target, "skip" AE..= skip, "date_range" AE..= show dateRange]
   let (dateFrom, dateTo) = dateRange
-  precomputed :: [(Text, Int64, Maybe Text, Maybe Text, Text, Int, Int, Bool)] <-
+  precomputed :: [PrecomputedPattern] <-
     if target `elem` map fst LogPatterns.knownPatternFields
       then Hasql.interp [HI.sql|SELECT lp.log_pattern, (lp.occurrence_count + COALESCE(m.member_count, 0))::BIGINT as total_count, lp.log_level, lp.service_name, lp.pattern_hash, COALESCE(m.member_cnt, 0)::BIGINT as merged_count, COUNT(*) OVER()::BIGINT as total_patterns, (lp.is_error OR COALESCE(m.member_err, FALSE)) as is_error FROM apis.log_patterns lp LEFT JOIN LATERAL (SELECT SUM(occurrence_count) as member_count, COUNT(*)::BIGINT as member_cnt, bool_or(is_error) as member_err FROM apis.log_patterns WHERE canonical_id = lp.id) m ON TRUE WHERE lp.project_id = #{pid} AND lp.source_field = #{target} AND lp.canonical_id IS NULL AND (#{dateFrom} IS NULL OR lp.last_seen_at >= #{dateFrom}) AND (#{dateTo} IS NULL OR lp.last_seen_at <= #{dateTo}) ORDER BY total_count DESC OFFSET #{skip} LIMIT #{aggregatePageSize}|]
       else pure []
   if not (null precomputed)
     then do
       Log.logTrace "fetchLogPatterns: using precomputed" $ AE.object ["count" AE..= length precomputed]
-      let totalPatterns = maybe 0 (\(_, _, _, _, _, _, n, _) -> n) $ listToMaybe precomputed
-          hashes = V.fromList $ map (view _5) precomputed
+      let totalPatterns = maybe 0 (.totalPatterns) $ listToMaybe precomputed
+          hashes = V.fromList $ map (.patternHash) precomputed
           hourlyFrom = fromMaybe (addUTCTime (-(24 * 3600)) now) dateFrom
           hourlyTo = fromMaybe now dateTo
       -- Fetch member hashes for merged patterns so their hourly stats are included
@@ -572,7 +565,7 @@ fetchLogPatterns enableTfReads pid queryAST dateRange sourceM targetM skip = do
       -- Only summary patterns tag their rows with pat:<hash>, so only they can be
       -- expanded by tag match; other source fields carry no hashes (empty).
       let patHashes h = if target == "summary" then h : fromMaybe [] (HM.lookup h memberHashMap) else []
-          mkRow (pat, _allTime, lvl, svc, h, mc, _, isErr) = let vol = lookupVolume h in PatternRow{logPattern = pat, count = fromIntegral (sum vol), level = lvl, service = svc, volume = vol, mergedCount = mc, isError = isErr, hashes = patHashes h}
+          mkRow p = let vol = lookupVolume p.patternHash in PatternRow{logPattern = p.logPattern, count = fromIntegral (sum vol), level = p.logLevel, service = p.serviceName, volume = vol, mergedCount = p.mergedCount, isError = p.isError, hashes = patHashes p.patternHash}
       pure (totalPatterns, sortOn (Down . (.count)) $ map mkRow precomputed)
     else do
       Log.logTrace "fetchLogPatterns: falling back to on-the-fly query" $ AE.object ["full_where" AE..= fullWhere]
@@ -582,8 +575,7 @@ fetchLogPatterns enableTfReads pid queryAST dateRange sourceM targetM skip = do
         Just (Left colExpr) ->
           Hasql.interp $ rawSql ("SELECT " <> colExpr <> "::text, " <> bucketCol <> " as bi, count(*)::BIGINT as cnt, mode() WITHIN GROUP (ORDER BY level) as lvl, mode() WITHIN GROUP (ORDER BY resource___service___name) as svc FROM otel_logs_and_spans WHERE project_id=") <> [HI.sql|#{pidTxt} |] <> rawSql (" AND " <> fullWhere <> " AND " <> colExpr <> " IS NOT NULL GROUP BY 1, 2 ORDER BY cnt DESC LIMIT 20000")
         Just (Right pathParts) ->
-          let pathPartsList = V.toList pathParts
-           in Hasql.interp $ [HI.sql|SELECT attributes #>> #{pathPartsList}, |] <> rawSql (bucketCol <> " as bi, count(*)::BIGINT as cnt, mode() WITHIN GROUP (ORDER BY level) as lvl, mode() WITHIN GROUP (ORDER BY resource___service___name) as svc FROM otel_logs_and_spans WHERE project_id=") <> [HI.sql|#{pidTxt} |] <> rawSql (" AND " <> fullWhere) <> [HI.sql| AND attributes #>> #{pathPartsList} IS NOT NULL GROUP BY 1, 2 ORDER BY cnt DESC LIMIT 20000|]
+          Hasql.interp $ [HI.sql|SELECT attributes #>> #{pathParts}, |] <> rawSql (bucketCol <> " as bi, count(*)::BIGINT as cnt, mode() WITHIN GROUP (ORDER BY level) as lvl, mode() WITHIN GROUP (ORDER BY resource___service___name) as svc FROM otel_logs_and_spans WHERE project_id=") <> [HI.sql|#{pidTxt} |] <> rawSql (" AND " <> fullWhere) <> [HI.sql| AND attributes #>> #{pathParts} IS NOT NULL GROUP BY 1, 2 ORDER BY cnt DESC LIMIT 20000|]
         Nothing -> pure []
       Log.logTrace "fetchLogPatterns: on-the-fly query done" $ AE.object ["raw_results" AE..= length rawResults]
       let agg (c1, l1, s1, b1) (c2, l2, s2, b2) = (c1 + c2, l1 <|> l2, s1 <|> s2, b1 ++ b2)
@@ -593,14 +585,14 @@ fetchLogPatterns enableTfReads pid queryAST dateRange sourceM targetM skip = do
               [(replaceAllFormats val, (cnt, lvl, svc, [(bi, cnt)])) | (val, bi, cnt, lvl, svc) <- rawResults, not (T.null val)]
           drainTree =
             let keys = V.fromList $ HM.keys grouped
-             in Drain.buildDrainTree Drain.tokenizeForDrain Relude.id (const Nothing) Drain.emptyDrainTree keys now
+             in Drain.buildDrainTree Drain.tokenizeForDrain id (const Nothing) Drain.emptyDrainTree keys now
           merged =
             HM.fromListWith
               agg
               [ (dr.templateStr, foldl' agg (0, Nothing, Nothing, []) $ mapMaybe (`HM.lookup` grouped) $ V.toList dr.logIds)
               | dr <- V.toList $ Drain.getAllLogGroups drainTree
               ]
-          sorted = take 100 $ drop skip $ sortOn (Down . (\(c, _, _, _) -> c) . snd) $ HM.toList merged
+          sorted = take aggregatePageSize $ drop skip $ sortOn (Down . (\(c, _, _, _) -> c) . snd) $ HM.toList merged
           range = bucketRange [bi | (_, (_, _, _, bs)) <- sorted, (bi, _) <- bs]
       Log.logTrace "fetchLogPatterns: normalization done" $ AE.object ["patterns" AE..= HM.size merged]
       pure (HM.size merged, [PatternRow{logPattern = pat, count = fromIntegral cnt, level = lvl, service = svc, volume = densifyBuckets range bs, mergedCount = 0, isError = maybe False ((== "error") . T.toLower) lvl, hashes = []} | (pat, (cnt, lvl, svc, bs)) <- sorted])
@@ -614,7 +606,7 @@ fetchLogPatterns enableTfReads pid queryAST dateRange sourceM targetM skip = do
       | f == "summary" = Just $ Left "array_to_string(summary, chr(30))"
       | f `S.member` flattenedOtelAttributes = Just $ Left $ transformFlattenedAttribute f
       | f `elem` rootColumns = Just $ Left f
-      | "attributes." `T.isPrefixOf` f = let parts = drop 1 $ T.splitOn "." f in if null parts || parts == [""] then Nothing else Just $ Right $ V.fromList parts
+      | Just rest <- T.stripPrefix "attributes." f, not (T.null rest) = Just $ Right $ T.splitOn "." rest
       | otherwise = Nothing
     rootColumns = ["body", "level", "kind", "name", "status_code", "status_message"] :: [Text]
 
@@ -629,12 +621,7 @@ fetchLogPatterns enableTfReads pid queryAST dateRange sourceM targetM skip = do
 fetchSessions :: (DB es, Labeled "timefusion" Hasql :> es, Log :> es, Time.Time :> es) => Bool -> Projects.ProjectId -> [Section] -> (Maybe UTCTime, Maybe UTCTime) -> Maybe Text -> Int -> Eff es (SessionSummary, Int, [SessionRow])
 fetchSessions enableTfReads pid queryAST dateRange sortByM skip = do
   now <- Time.currentTime
-  let sqlCfg = (defSqlQueryCfg pid now (Just SSpans) Nothing){dateRange}
-      (_, queryComponents) = queryASTToComponents sqlCfg queryAST
-      pidTxt = pid.toText
-      dateRangeClause = buildDateRange sqlCfg
-      whereCondition = scopedWhere pidTxt queryComponents.whereClause
-      fullWhere = whereCondition <> if T.null dateRangeClause then "" else " AND " <> dateRangeClause
+  let fullWhere = scopedQueryWhere pid now (Just SSpans) dateRange queryAST
       bucketW = bucketWidthSecs dateRange now
       sortCol = case sortByM of
         Just "duration" -> "duration_ns" :: Text
@@ -828,12 +815,7 @@ fetchEventExamples
   -> Eff es (V.Vector (V.Vector AE.Value), [Text])
 fetchEventExamples enableTfReads pid queryAST dateRange expandKind skip limitN = do
   now <- Time.currentTime
-  let sqlCfg = (defSqlQueryCfg pid now (Just SSpans) Nothing){dateRange}
-      (_, qc) = queryASTToComponents sqlCfg queryAST
-      pidTxt = pid.toText
-      dateRangeClause = buildDateRange sqlCfg
-      whereCondition = scopedWhere pidTxt qc.whereClause
-      fullWhereSql = rawSql (whereCondition <> if T.null dateRangeClause then "" else " AND " <> dateRangeClause)
+  let fullWhereSql = rawSql $ scopedQueryWhere pid now (Just SSpans) dateRange queryAST
       expandFilter = case expandKind of
         ExpandSession sid -> [HI.sql| AND attributes___session___id = #{sid}|]
         -- Prefer tag match: the key is a comma-joined list of pat:<hash> tags
@@ -845,8 +827,7 @@ fetchEventExamples enableTfReads pid queryAST dateRange expandKind skip limitN =
           Nothing -> [HI.sql| AND array_to_string(summary, chr(30)) ILIKE #{templateToLike key}|]
       cols = defaultSelectSqlQuery (Just SSpans)
       -- Mirror selectLogTable's summary column handling: wrap TEXT[] as JSON for row output.
-      processedCols = map (\c -> if c == "summary" || "summary" `T.isSuffixOf` c then "to_json(summary)" else c) $ colsNoAsClause cols
-      selectClause = T.intercalate ", " processedCols
+      selectClause = T.intercalate ", " $ map (\c -> if "summary" `T.isSuffixOf` c then "to_json(summary)" else c) $ colsNoAsClause cols
       -- Sessions: fetch one root event per trace via DISTINCT ON so [+N] expansion
       -- covers all traces.  Patterns/other: fetch raw events as before.
       --
@@ -861,7 +842,7 @@ fetchEventExamples enableTfReads pid queryAST dateRange expandKind skip limitN =
             <> fullWhereSql
             <> expandFilter
             <> [HI.sql| ORDER BY context___trace_id, parent_id ASC NULLS FIRST, timestamp ASC) sub ORDER BY ts ASC OFFSET #{skip}::BIGINT LIMIT #{limitN}::BIGINT|]
-        _ ->
+        ExpandPattern _ ->
           rawSql ("SELECT jsonb_build_array(" <> selectClause <> ") FROM otel_logs_and_spans WHERE ")
             <> fullWhereSql
             <> expandFilter
@@ -871,7 +852,7 @@ fetchEventExamples enableTfReads pid queryAST dateRange expandKind skip limitN =
     Hasql.withHasqlTimefusion enableTfReads
       $ checkpoint (toAnnotation ("fetchEventExamples" :: Text, pid))
       $ Hasql.interp q
-  pure (V.fromList $ mapMaybe jsonArrayToVector rawRows, listToColNames cols)
+  pure (jsonArrayRows rawRows, listToColNames cols)
 
 
 -- | Page size for patterns and sessions aggregations. The JSON encoder
@@ -963,16 +944,12 @@ buildHourlyBuckets :: UTCTime -> [(UTCTime, Int)] -> [Int]
 buildHourlyBuckets now pairs = [fromMaybe 0 $ HM.lookup i bucketMap | i <- [0 .. 23]]
   where
     startHour = addUTCTime (-(23 * 3600)) $ truncateToHour now
-    bucketMap = HM.fromListWith (+) [(hourIndex t, c) | (t, c) <- pairs, let idx = hourIndex t, idx >= 0 && idx < 24]
+    bucketMap = HM.fromListWith (+) [(idx, c) | (t, c) <- pairs, let idx = hourIndex t, idx >= 0, idx < 24]
     hourIndex t = floor (diffUTCTime (truncateToHour t) startHour / 3600) :: Int
     truncateToHour t = let s = utcTimeToPOSIXSeconds t in posixSecondsToUTCTime $ fromIntegral (floor s `div` 3600 * 3600 :: Int)
 
 
 getLastSevenDaysTotalRequest :: (DB es, Time.Time :> es) => Projects.ProjectId -> Eff es Int
-getLastSevenDaysTotalRequest = getRequestCountForInterval "7 days"
-
-
-getRequestCountForInterval :: (DB es, Time.Time :> es) => Text -> Projects.ProjectId -> Eff es Int
-getRequestCountForInterval interval pid = do
+getLastSevenDaysTotalRequest pid = do
   now <- Time.currentTime
-  fromMaybe 0 <$> Hasql.interpOne ([HI.sql| SELECT count(*)::BIGINT FROM otel_logs_and_spans WHERE project_id=#{pid.toText}::text AND timestamp > #{now}::timestamptz - interval |] <> rawSql ("'" <> interval <> "'"))
+  fromMaybe 0 <$> Hasql.interpOne [HI.sql| SELECT count(*)::BIGINT FROM otel_logs_and_spans WHERE project_id=#{pid.toText}::text AND timestamp > #{now}::timestamptz - interval '7 days'|]

--- a/src/Models/Apis/Monitors.hs
+++ b/src/Models/Apis/Monitors.hs
@@ -182,10 +182,15 @@ monitorToggleActiveById mid = do
         where id=#{mid}|]
 
 
+-- | Shared shape for the "stamp a single timestamptz column, guarded by IS NULL" updates
+-- (deactivate / soft-delete). Each caller supplies the column-specific SQL given @now@.
+setTimestampColByIds :: (DB es, Time :> es) => (UTCTime -> HI.Sql) -> Eff es Int64
+setTimestampColByIds mkSql = Time.currentTime >>= Hasql.interpExecute . mkSql
+
+
 monitorDeactivateByIds :: (DB es, Time :> es) => [QueryMonitorId] -> Eff es Int64
 monitorDeactivateByIds ids =
-  Time.currentTime >>= \now ->
-    Hasql.interpExecute [HI.sql| UPDATE monitors.query_monitors SET deactivated_at = #{now} WHERE id = ANY(#{ids}::uuid[]) AND deactivated_at IS NULL |]
+  setTimestampColByIds \now -> [HI.sql| UPDATE monitors.query_monitors SET deactivated_at = #{now} WHERE id = ANY(#{ids}::uuid[]) AND deactivated_at IS NULL |]
 
 
 monitorReactivateByIds :: DB es => [QueryMonitorId] -> Eff es Int64
@@ -213,8 +218,7 @@ monitorResolveByIds ids =
 
 monitorSoftDeleteByIds :: (DB es, Time :> es) => [QueryMonitorId] -> Eff es Int64
 monitorSoftDeleteByIds ids =
-  Time.currentTime >>= \now ->
-    Hasql.interpExecute [HI.sql| UPDATE monitors.query_monitors SET deleted_at = #{now} WHERE id = ANY(#{ids}::uuid[]) AND deleted_at IS NULL |]
+  setTimestampColByIds \now -> [HI.sql| UPDATE monitors.query_monitors SET deleted_at = #{now} WHERE id = ANY(#{ids}::uuid[]) AND deleted_at IS NULL |]
 
 
 queryMonitorsAll :: DB es => Projects.ProjectId -> Eff es [QueryMonitor]

--- a/src/Models/Apis/Monitors.hs
+++ b/src/Models/Apis/Monitors.hs
@@ -57,12 +57,8 @@ newtype QueryMonitorId = QueryMonitorId {unQueryMonitorId :: UUID.UUID}
   deriving anyclass (HI.DecodeRow)
 
 
-instance HasField "toText" QueryMonitorId Text where
-  getField = UUID.toText . unQueryMonitorId
-
-
-instance ToParamSchema QueryMonitorId where
-  toParamSchema _ = toParamSchema (Proxy @UUID.UUID)
+instance HasField "toText" QueryMonitorId Text where getField = UUID.toText . unQueryMonitorId
+instance ToParamSchema QueryMonitorId where toParamSchema _ = toParamSchema (Proxy @UUID.UUID)
 
 
 data MonitorStatus = MSNormal | MSWarning | MSAlerting
@@ -186,15 +182,10 @@ monitorToggleActiveById mid = do
         where id=#{mid}|]
 
 
--- | Shared shape for the "stamp a single timestamptz column, guarded by IS NULL" updates
--- (deactivate / soft-delete). Each caller supplies the column-specific SQL given @now@.
-setTimestampColByIds :: (DB es, Time :> es) => (UTCTime -> HI.Sql) -> Eff es Int64
-setTimestampColByIds mkSql = Time.currentTime >>= Hasql.interpExecute . mkSql
-
-
 monitorDeactivateByIds :: (DB es, Time :> es) => [QueryMonitorId] -> Eff es Int64
 monitorDeactivateByIds ids =
-  setTimestampColByIds \now -> [HI.sql| UPDATE monitors.query_monitors SET deactivated_at = #{now} WHERE id = ANY(#{ids}::uuid[]) AND deactivated_at IS NULL |]
+  Time.currentTime >>= \now ->
+    Hasql.interpExecute [HI.sql| UPDATE monitors.query_monitors SET deactivated_at = #{now} WHERE id = ANY(#{ids}::uuid[]) AND deactivated_at IS NULL |]
 
 
 monitorReactivateByIds :: DB es => [QueryMonitorId] -> Eff es Int64
@@ -222,7 +213,8 @@ monitorResolveByIds ids =
 
 monitorSoftDeleteByIds :: (DB es, Time :> es) => [QueryMonitorId] -> Eff es Int64
 monitorSoftDeleteByIds ids =
-  setTimestampColByIds \now -> [HI.sql| UPDATE monitors.query_monitors SET deleted_at = #{now} WHERE id = ANY(#{ids}::uuid[]) AND deleted_at IS NULL |]
+  Time.currentTime >>= \now ->
+    Hasql.interpExecute [HI.sql| UPDATE monitors.query_monitors SET deleted_at = #{now} WHERE id = ANY(#{ids}::uuid[]) AND deleted_at IS NULL |]
 
 
 queryMonitorsAll :: DB es => Projects.ProjectId -> Eff es [QueryMonitor]

--- a/src/Models/Apis/PatternMerge.hs
+++ b/src/Models/Apis/PatternMerge.hs
@@ -21,16 +21,16 @@ module Models.Apis.PatternMerge (
 where
 
 import Data.Effectful.Hasql qualified as Hasql
-import Data.Map.Lazy qualified as Map
+import Data.Map.Strict qualified as Map
 import Data.Vector qualified as V
 import Effectful (Eff)
 import Hasql.Interpolate qualified as HI
-import Models.Apis.ErrorPatterns (ErrorPattern, ErrorPatternId (..))
+import Models.Apis.ErrorPatterns (ErrorPattern, ErrorPatternId)
 import Models.Apis.LogPatterns (LogPattern, LogPatternId)
 import Models.Projects.Projects qualified as Projects
 import Pkg.DeriveUtils (showPGFloatArray)
 import Pkg.PatternMerge (embeddingTextForError)
-import Relude hiding (id)
+import Relude
 import System.Types (DB)
 
 
@@ -158,5 +158,5 @@ fetchLogSamples :: DB es => [LogPatternId] -> Eff es (Map LogPatternId Text)
 fetchLogSamples [] = pure mempty
 fetchLogSamples ids =
   Map.fromList
-    . mapMaybe (\(pid, mSample) -> (pid,) <$> mSample)
+    . mapMaybe sequenceA
     <$> Hasql.interp [HI.sql| SELECT id, sample_message FROM apis.log_patterns WHERE id = ANY(#{ids}) |]

--- a/src/Models/Apis/PrometheusScrapeConfigs.hs
+++ b/src/Models/Apis/PrometheusScrapeConfigs.hs
@@ -1,6 +1,6 @@
 module Models.Apis.PrometheusScrapeConfigs (
   PrometheusScrapeConfig (..),
-  PrometheusScrapeConfigId (..),
+  PrometheusScrapeConfigId,
   insertConfig,
   updateConfig,
   configsByProjectId,
@@ -20,19 +20,13 @@ import Control.Lens ((.~))
 import Data.Aeson qualified as AE
 import Data.Aeson.Key qualified as AEK
 import Data.Aeson.KeyMap qualified as AEKM
-import Data.Default (Default)
 import Data.Effectful.Hasql qualified as Hasql
 import Data.List (partition)
-import Data.OpenApi (ToParamSchema (..), ToSchema (..), declareNamedSchema)
 import Data.Text qualified as T
 import Data.These qualified as These
 import Data.Time (UTCTime)
 import Data.Time.Clock.POSIX (posixSecondsToUTCTime)
-import Data.UUID qualified as UUID
 import Data.Vector qualified as V
-import Database.PostgreSQL.Simple (FromRow, ToRow)
-import Database.PostgreSQL.Simple.FromField (FromField)
-import Database.PostgreSQL.Simple.ToField (ToField)
 import Effectful (Eff, type (:>))
 import Effectful.Concurrent (Concurrent)
 import Effectful.Ki qualified as Ki
@@ -40,7 +34,6 @@ import Effectful.Labeled (Labeled)
 import Effectful.Log (Log)
 import Effectful.Log qualified as Log
 import Effectful.Reader.Static qualified as Eff
-import GHC.Records (HasField (getField))
 import Hasql.Interpolate qualified as HI
 import Models.Projects.Projects qualified as Projects
 import Models.Telemetry.Telemetry qualified as Telemetry
@@ -48,24 +41,15 @@ import Network.HTTP.Client (managerResponseTimeout, responseTimeoutMicro)
 import Network.HTTP.Client.TLS (tlsManagerSettings)
 import Network.Wreq (defaults, header)
 import Network.Wreq qualified as Wreq
-import Pkg.DeriveUtils (unUUIDId)
+import Pkg.DeriveUtils (UUIDId, unUUIDId)
 import Pkg.Prometheus qualified as Prom
 import Relude
-import Servant.API (FromHttpApiData)
 import System.Config (AuthContext (..), EnvConfig (..))
 import System.Types (DB)
 import UnliftIO (throwIO)
 
 
-newtype PrometheusScrapeConfigId = PrometheusScrapeConfigId {unPrometheusScrapeConfigId :: UUID.UUID}
-  deriving stock (Generic, Show)
-  deriving newtype (AE.FromJSON, AE.ToJSON, Default, Eq, FromField, FromHttpApiData, HI.DecodeValue, HI.EncodeValue, NFData, ToField)
-  deriving anyclass (FromRow, ToRow)
-
-
-instance ToSchema PrometheusScrapeConfigId where declareNamedSchema _ = declareNamedSchema (Proxy @UUID.UUID)
-instance ToParamSchema PrometheusScrapeConfigId where toParamSchema _ = toParamSchema (Proxy @UUID.UUID)
-instance HasField "toText" PrometheusScrapeConfigId Text where getField = UUID.toText . unPrometheusScrapeConfigId
+type PrometheusScrapeConfigId = UUIDId "prometheus_scrape_config"
 
 
 data PrometheusScrapeConfig = PrometheusScrapeConfig
@@ -90,6 +74,10 @@ selectCols :: HI.Sql
 selectCols = [HI.sql|id, project_id, created_at, updated_at, name, url, scrape_interval_seconds, auth_header, extra_labels, enabled, last_scraped_at, last_status|]
 
 
+selectFrom :: HI.Sql
+selectFrom = [HI.sql|SELECT |] <> selectCols <> [HI.sql| FROM apis.prometheus_scrape_configs |]
+
+
 insertConfig :: DB es => Projects.ProjectId -> Text -> Text -> Int -> Maybe Text -> AE.Value -> Eff es Int64
 insertConfig pid name url interval authHeader extraLabels =
   Hasql.interpExecute
@@ -107,19 +95,19 @@ updateConfig pid cid name url interval authHeader extraLabels =
 
 
 configsByProjectId :: DB es => Projects.ProjectId -> Eff es (V.Vector PrometheusScrapeConfig)
-configsByProjectId pid = V.fromList <$> Hasql.interp ([HI.sql|SELECT |] <> selectCols <> [HI.sql| FROM apis.prometheus_scrape_configs WHERE project_id = #{pid} ORDER BY created_at DESC|])
+configsByProjectId pid = V.fromList <$> Hasql.interp (selectFrom <> [HI.sql|WHERE project_id = #{pid} ORDER BY created_at DESC|])
 
 
 -- | Unscoped lookup — only for trusted internal callers that already hold a claimed id
 -- (the background scrape worker). Request handlers must use 'getConfigByProject'.
 getConfig :: DB es => PrometheusScrapeConfigId -> Eff es (Maybe PrometheusScrapeConfig)
-getConfig cid = Hasql.interpOne ([HI.sql|SELECT |] <> selectCols <> [HI.sql| FROM apis.prometheus_scrape_configs WHERE id = #{cid}|])
+getConfig cid = Hasql.interpOne (selectFrom <> [HI.sql|WHERE id = #{cid}|])
 
 
 -- | Project-scoped lookup for request handlers, so a foreign id can never load another
 -- project's row (and its auth token) into the request context.
 getConfigByProject :: DB es => Projects.ProjectId -> PrometheusScrapeConfigId -> Eff es (Maybe PrometheusScrapeConfig)
-getConfigByProject pid cid = Hasql.interpOne ([HI.sql|SELECT |] <> selectCols <> [HI.sql| FROM apis.prometheus_scrape_configs WHERE id = #{cid} AND project_id = #{pid}|])
+getConfigByProject pid cid = Hasql.interpOne (selectFrom <> [HI.sql|WHERE id = #{cid} AND project_id = #{pid}|])
 
 
 deleteConfig :: DB es => Projects.ProjectId -> PrometheusScrapeConfigId -> Eff es Int64
@@ -174,12 +162,11 @@ ingestScrapedBody :: (Concurrent :> es, DB es, Eff.Reader AuthContext :> es, Ki.
 ingestScrapedBody cfg now body = do
   appCtx :: AuthContext <- Eff.ask
   let (finite, nonFinite) = partition Prom.isFiniteSample (Prom.parsePrometheus (decodeUtf8 body))
-      records = V.fromList (map (sampleToMetricRecord cfg now) finite)
-      dropped = length nonFinite
-  when (dropped > 0) $ Log.logInfo "Prometheus scrape dropped non-finite samples" (AE.object ["config_id" AE..= cfg.id.toText, "dropped" AE..= dropped])
-  let target = Telemetry.writeTargetFor appCtx.env.enablePostgresTelemetryWrites appCtx.env.enableTimefusionWrites Nothing
+      records = V.fromList (sampleToMetricRecord cfg now <$> finite)
+      target = Telemetry.writeTargetFor appCtx.env.enablePostgresTelemetryWrites appCtx.env.enableTimefusionWrites Nothing
+  unless (null nonFinite) $ Log.logInfo "Prometheus scrape dropped non-finite samples" (AE.object ["config_id" AE..= cfg.id.toText, "dropped" AE..= length nonFinite])
   Telemetry.bulkInsertOtelMetrics appCtx.metricCatalogBuffer appCtx.hasqlTimefusionUsesPgTypes target records >>= \case
-    Left failure -> liftIO $ throwIO $ These.these (\e -> e) (\e -> e) (\e _ -> e) failure
+    Left failure -> liftIO $ throwIO $ These.mergeThese const failure
     Right () -> pure (V.length records)
 
 
@@ -208,43 +195,35 @@ sampleToMetricRecord cfg now s =
     , metricMetadata = AE.object []
     , exemplars = AE.Null
     , flags = 0
-    , aggregationTemporality = bool Nothing (Just Telemetry.ATCumulative) isCounter
-    , isMonotonic = bool Nothing (Just True) isCounter
+    , aggregationTemporality = Telemetry.ATCumulative <$ guard isCounter
+    , isMonotonic = True <$ guard isCounter
     , messageSizeBytes = 0
     }
   where
     svc = if T.null cfg.name then "prometheus" else cfg.name
     -- Only TYPE counter maps to MTSum. Histogram/summary _count/_sum sub-series are
-    -- cumulative-monotonic too, but we ingest them as plain gauges (their family TYPE is
-    -- histogram/summary, not counter) — enough to chart/query, but downstream rate() that
-    -- keys off aggregationTemporality will treat them as instantaneous. Intentional: see
-    -- the module-header note on per-series ingestion.
+    -- cumulative-monotonic too but stay gauges (their family TYPE isn't counter), so a
+    -- downstream rate() keying off aggregationTemporality treats them as instantaneous.
     isCounter = s.sampleType == Prom.Counter
-    (mtype, mval) =
-      if isCounter
-        then (Telemetry.MTSum, Telemetry.SumValue (Telemetry.GaugeSum (Just s.value) Nothing))
-        else (Telemetry.MTGauge, Telemetry.GaugeValue (Telemetry.GaugeSum (Just s.value) Nothing))
+    gs = Telemetry.GaugeSum (Just s.value) Nothing
+    (mtype, mval) = bool (Telemetry.MTGauge, Telemetry.GaugeValue gs) (Telemetry.MTSum, Telemetry.SumValue gs) isCounter
     labelMap = AEKM.fromList [(AEK.fromText k, AE.String v) | (k, v) <- s.labels]
     -- KeyMap (<>) is left-biased, so the scraped per-sample labels (specific) must come
     -- first to win over the config's static extraLabels (general context) on key collisions.
-    attrs = AE.Object $ case cfg.extraLabels of
-      AE.Object o -> labelMap <> o
-      _ -> labelMap
+    attrs =
+      AE.Object $ labelMap <> case cfg.extraLabels of
+        AE.Object o -> o
+        _ -> mempty
 
 
--- | Per-scrape HTTP response timeout (µs). A dead/slow endpoint must never wedge a worker.
-prometheusScrapeTimeoutMicros :: Int
-prometheusScrapeTimeoutMicros = 10 * 1000000
-
-
--- | wreq Options for a scrape: hard response timeout, no redirect following, and an optional
--- Authorization header. Shared by the background worker and the settings Test button so the
--- two never drift on timeout or header wiring (the Test button exists to mirror the real scrape).
+-- | wreq Options for a scrape: hard 10s response timeout (a dead/slow endpoint must never wedge
+-- a worker), no redirect following, and an optional Authorization header. Shared by the background
+-- worker and the settings Test button so the two never drift on timeout or header wiring.
 prometheusScrapeOpts :: Maybe Text -> Wreq.Options
 prometheusScrapeOpts authHeader =
   defaults
     & Wreq.manager
-    .~ Left tlsManagerSettings{managerResponseTimeout = responseTimeoutMicro prometheusScrapeTimeoutMicros}
+    .~ Left tlsManagerSettings{managerResponseTimeout = responseTimeoutMicro 10_000_000}
       -- Don't follow redirects: http-client (unlike browsers) re-sends Authorization across a
       -- cross-host 3xx, so a target answering 302 -> attacker could exfiltrate the bearer token.
       & Wreq.redirects

--- a/src/Models/Apis/SchemaCatalog.hs
+++ b/src/Models/Apis/SchemaCatalog.hs
@@ -113,7 +113,10 @@ upsertTemplates rows =
   where
     hashes = V.map (.templateHash) rows
     kinds = V.map (.keyKind) rows
-    fieldsJson = V.map (HI.AsJsonb . (.fields)) rows
+    -- Scrubbed like every sibling jsonb write: one NUL in a field path would
+    -- otherwise 22P05-poison the whole batch. The template_hash is computed over
+    -- the unscrubbed structure, which is fine — unscrubbed rows never stored.
+    fieldsJson = V.map (asScrubbedJsonb . (.fields)) rows
     seens = V.map (.lastSeenAt) rows
 
 

--- a/src/Models/Apis/SchemaCatalog.hs
+++ b/src/Models/Apis/SchemaCatalog.hs
@@ -87,6 +87,12 @@ data CatalogRow = CatalogRow
   deriving anyclass (NFData)
 
 
+-- | JSON-encode then strip NULs (PG @jsonb@ rejects @\\u0000@) before wrapping
+-- for a jsonb column. Shared by every jsonb-bearing upsert below.
+asScrubbedJsonb :: AE.ToJSON a => a -> HI.AsJsonb AE.Value
+asScrubbedJsonb = HI.AsJsonb . scrubNulValue . AE.toJSON
+
+
 -- ---------------------------------------------------------------------------
 -- Upserts. Both are multi-row INSERTs over @unnest@ so a single round-trip
 -- handles the dirty subset of an entire shard.
@@ -145,11 +151,9 @@ upsertCatalogRows rows =
     kinds = V.map (.keyKind) rows
     khs = V.map (.keyHash) rows
     ths = V.map (.templateHash) rows
-    asScrubbed :: AE.ToJSON a => a -> HI.AsJsonb AE.Value
-    asScrubbed = HI.AsJsonb . scrubNulValue . AE.toJSON
-    scopes = V.map (asScrubbed . (.scope)) rows
-    vds = V.map (asScrubbed . (.valuesDelta)) rows
-    cnts = V.map (asScrubbed . (.counts)) rows
+    scopes = V.map (asScrubbedJsonb . (.scope)) rows
+    vds = V.map (asScrubbedJsonb . (.valuesDelta)) rows
+    cnts = V.map (asScrubbedJsonb . (.counts)) rows
     ss = V.map (fromIntegral @Word64 @Int64 . (.sampleCount)) rows
     firsts = V.map (.firstSeen) rows
     lasts = V.map (.lastSeen) rows
@@ -160,7 +164,7 @@ upsertCatalogRows rows =
 
 -- | Decoded result of a join across @apis.schema_catalog@ ⨝ @apis.schema_template@.
 data CatalogReadRow = CatalogReadRow
-  { projectId :: UUID.UUID
+  { projectId :: UUID
   , keyKind :: Catalog.KeyKind
   , keyHash :: Text
   , templateHash :: Text
@@ -178,20 +182,16 @@ data CatalogReadRow = CatalogReadRow
 
 readRowToEntry :: CatalogReadRow -> Catalog.CatalogEntry
 readRowToEntry r =
-  let HI.AsJsonb sc = r.scope
-      HI.AsJsonb tf = r.templateFields
-      HI.AsJsonb vd = r.valuesDelta
-      HI.AsJsonb ct = r.counts
-   in Catalog.CatalogEntry
-        { scope = sc
-        , template = Catalog.Template r.keyKind tf
-        , valuesDelta = vd
-        , counts = ct
-        , sampleCount = fromIntegral r.sampleCount
-        , firstSeen = r.firstSeen
-        , lastSeen = r.lastSeen
-        , dirty = False
-        }
+  Catalog.CatalogEntry
+    { scope = coerce r.scope
+    , template = Catalog.Template r.keyKind (coerce r.templateFields)
+    , valuesDelta = coerce r.valuesDelta
+    , counts = coerce r.counts
+    , sampleCount = fromIntegral r.sampleCount
+    , firstSeen = r.firstSeen
+    , lastSeen = r.lastSeen
+    , dirty = False
+    }
 
 
 -- | Bulk variant: fetches catalog rows for a heterogeneous (project, key_hash)
@@ -204,8 +204,7 @@ getByKeysBatch
 getByKeysBatch pairs
   | V.null pairs = pure HM.empty
   | otherwise = do
-      let pids = V.map fst pairs
-          khs = V.map snd pairs
+      let (pids, khs) = V.unzip pairs
       rows :: [CatalogReadRow] <-
         Hasql.interp
           [HI.sql| SELECT c.project_id, c.key_kind, c.key_hash, c.template_hash,
@@ -229,11 +228,9 @@ newtype SummaryRow = SummaryRow {doc :: HI.AsJsonb Catalog.SummaryDoc}
 -- | Read the materialised AI/query-editor doc for a project.
 getSummary :: DB es => Projects.ProjectId -> Eff es (Maybe Catalog.SummaryDoc)
 getSummary pid =
-  fmap unwrap
+  fmap (\(SummaryRow (HI.AsJsonb d)) -> d)
     <$> Hasql.interpOne
       [HI.sql| SELECT doc FROM apis.schema_summary WHERE project_id = #{pid} |]
-  where
-    unwrap (SummaryRow (HI.AsJsonb d)) = d
 
 
 -- | Batched per-project summary upsert. One round trip regardless of how many
@@ -249,10 +246,8 @@ getSummary pid =
 -- project can't block the rest.
 upsertSummary :: DB es => V.Vector (Projects.ProjectId, Catalog.SummaryDoc) -> Eff es ()
 upsertSummary rows0 = unless (V.null rows0) $ do
-  let rows = V.map (second (HI.AsJsonb . scrubNulValue . AE.toJSON)) rows0
-  tryAny (batch rows) >>= \case
-    Right () -> pass
-    Left _ -> V.forM_ rows (void . tryAny . batch . V.singleton)
+  let rows = V.map (second asScrubbedJsonb) rows0
+  whenLeftM_ (tryAny (batch rows)) \_ -> V.forM_ rows (void . tryAny . batch . V.singleton)
   where
     batch xs =
       let (pids, docs) = V.unzip xs
@@ -276,7 +271,7 @@ freshSummaryProjects
 freshSummaryProjects pids
   | V.null pids = pure HS.empty
   | otherwise = do
-      rows :: [UUID.UUID] <-
+      rows :: [UUID] <-
         Hasql.interp
           [HI.sql| SELECT project_id FROM apis.schema_summary
                    WHERE project_id = ANY(#{pids}::uuid[])
@@ -405,8 +400,7 @@ existingEndpointHashes
 existingEndpointHashes pairs
   | V.null pairs = pure HS.empty
   | otherwise = do
-      let pids = V.map fst pairs
-          hashes = V.map snd pairs
+      let (pids, hashes) = V.unzip pairs
       rows :: [(UUID, Text)] <-
         Hasql.interp
           [HI.sql| SELECT e.project_id, e.hash
@@ -414,7 +408,7 @@ existingEndpointHashes pairs
                    JOIN unnest(#{pids}::uuid[], #{hashes}::text[]) m(pid, h)
                      ON e.project_id = m.pid AND e.hash = m.h
                    WHERE e.created_at < now() - interval '5 minutes' |]
-      pure $ HS.fromList [(UUIDId pid, h) | (pid, h) <- rows]
+      pure $ HS.fromList (first UUIDId <$> rows)
 
 
 -- | Bulk-insert anomalies. The unique @(project_id, target_hash)@ index
@@ -449,8 +443,7 @@ enqueueAnomalyJobs rows = do
   let groups :: HM.HashMap (Projects.ProjectId, Text) [Text]
       groups = HM.fromListWith (<>) [((r.projectId, r.anomalyType), [r.targetHash]) | r <- V.toList rows]
   forM_ (HM.toList groups) \((pid, atype), ths) -> do
-    let payload :: V.Vector Text
-        payload = V.fromList ths
+    let payload = V.fromList ths
     Hasql.interpExecute_
       [HI.sql|
         WITH existing AS (

--- a/src/Models/Projects/Dashboards.hs
+++ b/src/Models/Projects/Dashboards.hs
@@ -190,7 +190,7 @@ readDashboardsFromDirectory dir = do
 readDashboardFile :: FilePath -> FilePath -> IO (Maybe Dashboard)
 readDashboardFile dir file = do
   raw <- try @SomeException $ readFileBS path
-  let parsed = first show raw >>= first show . Yml.decodeEither' :: Either String Dashboard
+  let parsed = first (("read error: " <>) . show) raw >>= first (("YAML error: " <>) . show) . Yml.decodeEither' :: Either String Dashboard
   parsed
     & either
       (\e -> Nothing <$ putStrLn ("Error loading dashboard " <> path <> ": " <> e))

--- a/src/Models/Projects/Dashboards.hs
+++ b/src/Models/Projects/Dashboards.hs
@@ -168,52 +168,46 @@ data Tab = Tab
 
 
 insert :: DB es => DashboardVM -> Eff es Int64
-insert DashboardVM{id = did, projectId, createdAt, updatedAt, createdBy, baseTemplate, schema, starredSince, homepageSince, tags, title, teams, filePath, fileSha} =
+insert d =
   Hasql.interpExecute
     [HI.sql| INSERT INTO projects.dashboards (id, project_id, created_at, updated_at, created_by, base_template, schema, starred_since, homepage_since, tags, title, teams, file_path, file_sha)
-           VALUES (#{did}, #{projectId}, #{createdAt}, #{updatedAt}, #{createdBy}, #{baseTemplate}, #{schema}, #{starredSince}, #{homepageSince}, #{tags}, #{title}, #{teams}::uuid[], #{filePath}, #{fileSha}) |]
+           VALUES (#{d.id}, #{d.projectId}, #{d.createdAt}, #{d.updatedAt}, #{d.createdBy}, #{d.baseTemplate}, #{d.schema}, #{d.starredSince}, #{d.homepageSince}, #{d.tags}, #{d.title}, #{d.teams}::uuid[], #{d.filePath}, #{d.fileSha}) |]
+
+
+yamlFiles :: FilePath -> IO [FilePath]
+yamlFiles dir = sort . filter (".yaml" `L.isSuffixOf`) <$> listDirectory dir
 
 
 -- | Read dashboard YAML files from directory at compile time via TH
 readDashboardsFromDirectory :: FilePath -> Q Exp
 readDashboardsFromDirectory dir = do
-  files <- runIO $ listDirectory dir
-  let files' = sort $ filter (".yaml" `L.isSuffixOf`) files
-  mapM_ (THS.addDependentFile . (dir </>)) files'
-  dashboards <- runIO $ catMaybes <$> mapM (readDashboardFile dir) files'
-  THS.lift dashboards
+  files <- runIO $ yamlFiles dir
+  mapM_ (THS.addDependentFile . (dir </>)) files
+  runIO (mapMaybeM (readDashboardFile dir) files) >>= THS.lift
 
 
 -- | Read single dashboard YAML file
 readDashboardFile :: FilePath -> FilePath -> IO (Maybe Dashboard)
 readDashboardFile dir file = do
-  let filePath = dir </> file
-  result <- try $ readFileBS filePath :: IO (Either SomeException ByteString)
-  case result of
-    Left err -> do
-      putStrLn $ "Error reading file " ++ filePath ++ ": " ++ show err
-      pure Nothing
-    Right content ->
-      case Yml.decodeEither' content of
-        Left err -> do
-          putStrLn $ "Error decoding YAML in file: " ++ filePath ++ ": " ++ show err
-          pure Nothing
-        Right dashboard -> pure (Just $ dashboard{file = Just $ fromString file})
+  raw <- try @SomeException $ readFileBS path
+  let parsed = first show raw >>= first show . Yml.decodeEither' :: Either String Dashboard
+  parsed
+    & either
+      (\e -> Nothing <$ putStrLn ("Error loading dashboard " <> path <> ": " <> e))
+      (\d -> pure $ Just d{file = Just $ fromString file})
+  where
+    path = dir </> file
 
 
 readDashboardsFromDisk :: FilePath -> IO [Dashboard]
-readDashboardsFromDisk dir = do
-  files <- sort . filter (".yaml" `L.isSuffixOf`) <$> listDirectory dir
-  catMaybes <$> mapM (readDashboardFile dir) files
+readDashboardsFromDisk dir = yamlFiles dir >>= mapMaybeM (readDashboardFile dir)
 
 
 readDashboardEndpoint :: (Error ServerError :> es, HTTP :> es) => Text -> Eff es Dashboard
 readDashboardEndpoint uri = do
   fileResp <- W.get (toString uri)
-  Yml.decodeEither' (toStrict $ fileResp ^. W.responseBody)
-    & either
-      (\e -> throwError $ err404{errBody = "Error decoding dashboard: " <> show e})
-      pure
+  either (\e -> throwError err404{errBody = "Error decoding dashboard: " <> show e}) pure
+    $ Yml.decodeEither' (toStrict $ fileResp ^. W.responseBody)
 
 
 replaceQueryVariables :: Projects.ProjectId -> Maybe UTCTime -> Maybe UTCTime -> [(Text, Maybe Text)] -> UTCTime -> Variable -> Variable
@@ -293,6 +287,4 @@ deleteDashboard dashId = Hasql.interpExecute [HI.sql| DELETE FROM projects.dashb
 
 getDashboardByBaseTemplate :: DB es => Projects.ProjectId -> Text -> Eff es (Maybe DashboardId)
 getDashboardByBaseTemplate pid baseTemplate =
-  fmap (.id)
-    <$> Hasql.interpOne @DashboardVM
-      (selectFrom @DashboardVM <> [HI.sql| WHERE project_id = #{pid} AND base_template = #{baseTemplate} |])
+  Hasql.interpOne [HI.sql| SELECT id FROM projects.dashboards WHERE project_id = #{pid} AND base_template = #{baseTemplate} |]

--- a/src/Models/Projects/GitSync.hs
+++ b/src/Models/Projects/GitSync.hs
@@ -47,8 +47,8 @@ import Data.Effectful.Wreq qualified as W
 import Data.Generics.Labels ()
 import Data.Map.Strict qualified as M
 import Data.Text qualified as T
-import Data.Time (UTCTime (..), fromGregorian, secondsToDiffTime)
-import Data.Time.Clock.POSIX (getPOSIXTime)
+import Data.Time (UTCTime)
+import Data.Time.Clock.POSIX (getPOSIXTime, posixSecondsToUTCTime)
 import Data.UUID qualified as UUID
 import Data.Vector qualified as V
 import Data.Yaml qualified as Yaml
@@ -108,7 +108,7 @@ data GitHubSync = GitHubSync
 instance Default GitHubSync where
   def = GitHubSync (UUIDId UUID.nil) (UUIDId UUID.nil) "" "" "main" Nothing Nothing "" Nothing Nothing True epoch epoch
     where
-      epoch = UTCTime (fromGregorian 1970 1 1) (secondsToDiffTime 0)
+      epoch = posixSecondsToUTCTime 0
 
 
 data TreeEntry = TreeEntry
@@ -139,10 +139,8 @@ encryptToken encKey = extractBase64 . B64.encodeBase64 . encryptAPIKey encKey . 
 -- SECURITY: Never falls back to plaintext - callers must handle Left appropriately.
 decryptToken :: ByteString -> Text -> Either Text Text
 decryptToken encKey encryptedB64 =
-  first (("Base64 decode failed: " <>) . toText . show)
-    $ decodeUtf8
-    . decryptAPIKey encKey
-    <$> B64.decodeBase64Untyped (encodeUtf8 encryptedB64)
+  bimap ("Base64 decode failed: " <>) (decodeUtf8 . decryptAPIKey encKey)
+    $ B64.decodeBase64Untyped (encodeUtf8 encryptedB64)
 
 
 -- | Decrypt a GitHubSync's access token if present. Returns Left with error if decryption fails.
@@ -160,14 +158,10 @@ getGitHubSync pid =
     (selectFrom @GitHubSync <> [HI.sql| WHERE project_id = #{pid} |])
 
 
--- | Helper to decrypt sync config, logging on failure
-withDecryption :: (AE.ToJSON ctx, DB es, Log :> es) => ByteString -> ctx -> Eff es (Maybe GitHubSync) -> Eff es (Maybe GitHubSync)
-withDecryption encKey ctx fetch =
-  fetch >>= maybe (pure Nothing) (either (\err -> logWarn "GitHub sync token decryption failed" (ctx, err) $> Nothing) (pure . Just) . decryptSync encKey)
-
-
 getGitHubSyncDecrypted :: (DB es, Log :> es) => ByteString -> ProjectId -> Eff es (Maybe GitHubSync)
-getGitHubSyncDecrypted encKey pid = withDecryption encKey pid $ getGitHubSync pid
+getGitHubSyncDecrypted encKey pid =
+  getGitHubSync pid
+    >>= maybe (pure Nothing) (either (\err -> logWarn "GitHub sync token decryption failed" (pid, err) $> Nothing) (pure . Just) . decryptSync encKey)
 
 
 getGitHubSyncByRepo :: DB es => Text -> Text -> Eff es (Maybe GitHubSync)
@@ -264,36 +258,33 @@ fetchGitTree token sync = do
 fetchFileContent :: (IOE :> es, W.HTTP :> es) => Text -> GitHubSync -> Text -> Eff es (Either Text ByteString)
 fetchFileContent token sync path = do
   let url = "https://api.github.com/repos/" <> sync.owner <> "/" <> sync.repo <> "/contents/" <> path <> "?ref=" <> sync.branch
-  result <- try $ W.getWith (githubOpts token) (toString url)
-  pure $ case result of
-    Left (err :: HttpException) -> Left $ formatHttpError err
-    Right resp -> case resp ^. W.responseBody . key "content" . _String of
-      "" -> Left "No content field"
-      b64Content -> first (toText . show) $ B64.decodeBase64Untyped $ encodeUtf8 $ T.filter (/= '\n') b64Content
+  result <- tryHttp $ W.getWith (githubOpts token) (toString url)
+  pure $ result >>= \resp -> case resp ^. W.responseBody . key "content" . _String of
+    "" -> Left "No content field"
+    b64Content -> B64.decodeBase64Untyped $ encodeUtf8 $ T.filter (/= '\n') b64Content
 
 
 -- | Push a file to GitHub. Returns (fileSha, treeSha) on success.
 pushFileToGit :: (IOE :> es, W.HTTP :> es) => Text -> GitHubSync -> Text -> ByteString -> Maybe Text -> Text -> Eff es (Either Text (Text, Text))
 pushFileToGit token sync path content existingSha message = do
   let url = "https://api.github.com/repos/" <> sync.owner <> "/" <> sync.repo <> "/contents/" <> path
-      b64Content = extractBase64 $ B64.encodeBase64 content
       payload =
         AE.object
-          $ catMaybes
-            [ Just $ "message" AE..= message
-            , Just $ "content" AE..= b64Content
-            , Just $ "branch" AE..= sync.branch
-            , ("sha" AE..=) <$> existingSha
+          $ [ "message" AE..= message
+            , "content" AE..= extractBase64 (B64.encodeBase64 content)
+            , "branch" AE..= sync.branch
             ]
-  result <- try $ W.putWith (githubOpts token) (toString url) payload
-  pure $ case result of
-    Left (err :: HttpException) -> Left $ formatHttpError err
-    Right resp ->
-      let fileSha = resp ^? W.responseBody . key "content" . key "sha" . _String
-          treeSha = resp ^? W.responseBody . key "commit" . key "tree" . key "sha" . _String
-       in case (fileSha, treeSha) of
-            (Just f, Just t) -> Right (f, t)
-            _ -> Left "Missing sha in response"
+          <> maybeToList (("sha" AE..=) <$> existingSha)
+  result <- tryHttp $ W.putWith (githubOpts token) (toString url) payload
+  pure $ result >>= \resp ->
+    maybe (Left "Missing sha in response") Right
+      $ (,)
+      <$> (resp ^? W.responseBody . key "content" . key "sha" . _String)
+      <*> (resp ^? W.responseBody . key "commit" . key "tree" . key "sha" . _String)
+
+
+tryHttp :: IOE :> es => Eff es a -> Eff es (Either Text a)
+tryHttp = fmap (first formatHttpError) . try
 
 
 formatHttpError :: HttpException -> Text
@@ -302,32 +293,27 @@ formatHttpError (InvalidUrlException url reason) = "Invalid URL (" <> toText url
 
 
 githubOpts :: Text -> W.Options
-githubOpts token =
+githubOpts = githubOptsUA "Monoscope"
+
+
+githubOptsUA :: ByteString -> Text -> W.Options
+githubOptsUA ua token =
   W.defaults
     & W.header "Authorization"
     .~ [encodeUtf8 $ "Bearer " <> token]
       & W.header "Accept"
     .~ ["application/vnd.github+json"]
       & W.header "User-Agent"
-    .~ ["Monoscope"]
+    .~ [ua]
       & W.header "X-GitHub-Api-Version"
     .~ ["2022-11-28"]
 
 
 -- | Detect the default branch of a repo, or return "main" for empty repos
--- Tries to get repo info first, falls back to checking main/master branches
 detectDefaultBranch :: (IOE :> es, W.HTTP :> es) => Text -> Text -> Text -> Eff es Text
-detectDefaultBranch token owner repo = do
-  let repoUrl = "https://api.github.com/repos/" <> owner <> "/" <> repo
-  result <- try $ W.getWith (githubOpts token) (toString repoUrl)
-  pure $ case result of
-    Left (_ :: HttpException) -> "main" -- Default to main if can't access repo
-    Right resp -> fromMaybe "main" $ resp ^? W.responseBody . key "default_branch" . _String
-
-
--- Constants
-yamlExtensions :: [Text]
-yamlExtensions = [".yaml", ".yml"]
+detectDefaultBranch token owner repo =
+  tryHttp (W.getWith (githubOpts token) (toString $ "https://api.github.com/repos/" <> owner <> "/" <> repo))
+    <&> either (const "main") (fromMaybe "main" . (^? W.responseBody . key "default_branch" . _String))
 
 
 -- | Get the dashboards folder path including prefix
@@ -338,29 +324,23 @@ getDashboardsPath sync
 
 
 isDashboardFile :: Text -> TreeEntry -> Bool
-isDashboardFile prefix e = e._teType == "blob" && prefix `T.isPrefixOf` e.path && any (`T.isSuffixOf` e.path) yamlExtensions
+isDashboardFile prefix e = e._teType == "blob" && prefix `T.isPrefixOf` e.path && any (`T.isSuffixOf` e.path) [".yaml", ".yml"]
 
 
 -- Sync Logic
 buildSyncPlan :: Text -> [TreeEntry] -> M.Map Text (DashboardId, Text) -> [SyncAction]
-buildSyncPlan prefix entries dbState = renames <> realCreates <> updates <> realDeletes
+buildSyncPlan prefix entries dbState = renames <> creates <> updates <> deletes
   where
-    stripPrefix p = fromMaybe p $ T.stripPrefix prefix p
-    gitFiles = M.fromList [(stripPrefix e.path, (e.path, e.sha)) | e <- entries, isDashboardFile prefix e]
+    gitFiles = M.fromList [(fromMaybe e.path $ T.stripPrefix prefix e.path, (e.path, e.sha)) | e <- entries, isDashboardFile prefix e]
     newFiles = gitFiles `M.difference` dbState
-    removedFiles = dbState `M.difference` (fst <$> gitFiles)
-    -- Build map of SHA -> (DashboardId, oldPath) for removed files to detect renames
-    removedBySha = M.fromList [(sha, (rid, p)) | (p, (rid, sha)) <- M.toList removedFiles]
-    -- Detect renames: new files whose SHA matches a removed file
-    (renameActions, unmatchedCreates) = M.foldrWithKey checkRename ([], []) newFiles
-    checkRename _ (fullPath, sha) (rens, crs) = case M.lookup sha removedBySha of
-      Just (rid, _) -> (SyncRename fullPath sha rid : rens, crs)
-      Nothing -> (rens, SyncCreate fullPath sha : crs)
-    renames = renameActions
-    realCreates = unmatchedCreates
-    -- Remove renamed files from deletes
+    removedFiles = dbState `M.difference` gitFiles
+    removedBySha = M.fromList [(sha, rid) | (rid, sha) <- M.elems removedFiles]
+    -- A new file whose SHA matches a removed file is a rename, not a create+delete
+    (renames, creates) =
+      partitionEithers
+        [maybe (Right $ SyncCreate p s) (Left . SyncRename p s) (M.lookup s removedBySha) | (p, s) <- M.elems newFiles]
     renamedIds = [rid | SyncRename _ _ rid <- renames]
-    realDeletes = [SyncDelete p rid | (p, (rid, _)) <- M.toList removedFiles, rid `notElem` renamedIds]
+    deletes = [SyncDelete p rid | (p, (rid, _)) <- M.toList removedFiles, rid `notElem` renamedIds]
     updates = M.foldMapWithKey (\relPath (fullPath, s) -> case M.lookup relPath dbState of Just (rid, oldSha) | s /= oldSha -> [SyncUpdate fullPath s rid]; _ -> []) gitFiles
 
 
@@ -380,8 +360,7 @@ titleToFilePath = (<> ".yaml") . toText . toKebab . fromAny . toString . T.strip
 -- | Compute Git blob SHA (SHA1 of "blob <size>\0<content>")
 computeContentSha :: ByteString -> Text
 computeContentSha content =
-  let blobHeader = "blob " <> show (BS.length content) <> "\0"
-   in decodeUtf8 $ B16.encode $ BA.convert (hash (encodeUtf8 blobHeader <> content) :: Digest SHA1)
+  decodeUtf8 $ B16.encode $ BA.convert (hash ("blob " <> show (BS.length content) <> "\0" <> content) :: Digest SHA1)
 
 
 -- | Build a Dashboard schema with title, tags, and team handles populated
@@ -418,12 +397,9 @@ data InstallationToken = InstallationToken
   deriving (AE.FromJSON, AE.ToJSON) via DAE.CustomJSON '[DAE.FieldLabelModifier '[DAE.CamelToSnake]] InstallationToken
 
 
-data ReposResponse = ReposResponse
-  { totalCount :: Int
-  , repositories :: [GitHubRepo]
-  }
-  deriving stock (Generic, Show)
-  deriving (AE.FromJSON, AE.ToJSON) via DAE.CustomJSON '[DAE.FieldLabelModifier '[DAE.CamelToSnake]] ReposResponse
+newtype ReposResponse = ReposResponse {repositories :: [GitHubRepo]}
+  deriving stock (Generic)
+  deriving (AE.FromJSON) via DAE.CustomJSON '[DAE.FieldLabelModifier '[DAE.CamelToSnake]] ReposResponse
 
 
 generateAppJWT :: Text -> Text -> IO (Either Text Text)
@@ -445,55 +421,27 @@ generateAppJWT appId privateKeyB64 = do
       withSystemTempFile "github-key.pem" $ \tmpPath h -> do
         BS.hPut h pemBytes
         hClose h
-        keys <- readKeyFile tmpPath
-        case keys of
+        readKeyFile tmpPath >>= \case
+          (PrivKeyRSA rsaKey : _) ->
+            bimap (("Failed to sign JWT: " <>) . toText . show) (\(Jwt jwtBytes) -> decodeUtf8 jwtBytes)
+              <$> Jws.rsaEncode RS256 rsaKey (toStrict payload)
           [] -> pure $ Left "No private key found in PEM"
-          (PrivKeyRSA rsaKey : _) -> do
-            result <- Jws.rsaEncode RS256 rsaKey (toStrict payload)
-            pure $ case result of
-              Left err -> Left $ "Failed to sign JWT: " <> toText (show err)
-              Right (Jwt jwtBytes) -> Right $ decodeUtf8 jwtBytes
           _ -> pure $ Left "Unsupported key type (expected RSA)"
 
 
 getInstallationToken :: (IOE :> es, W.HTTP :> es) => Text -> Text -> Int64 -> Eff es (Either Text InstallationToken)
-getInstallationToken appId privateKeyB64 installationId = do
-  jwtResult <- liftIO $ generateAppJWT appId privateKeyB64
-  case jwtResult of
-    Left err -> pure $ Left err
-    Right jwt -> do
-      let url = "https://api.github.com/app/installations/" <> show installationId <> "/access_tokens"
-          opts =
-            W.defaults
-              & W.header "Authorization"
-              .~ ["Bearer " <> encodeUtf8 jwt]
-                & W.header "Accept"
-              .~ ["application/vnd.github+json"]
-                & W.header "X-GitHub-Api-Version"
-              .~ ["2022-11-28"]
-                & W.header "User-Agent"
-              .~ ["Monoscope-App"]
-      response <- W.postWith opts (toString url) ("" :: ByteString)
-      let body = response ^. W.responseBody
-      case AE.eitherDecode body of
-        Left err -> pure $ Left $ "Failed to parse token response: " <> toText err
-        Right token -> pure $ Right token
+getInstallationToken appId privateKeyB64 installationId =
+  liftIO (generateAppJWT appId privateKeyB64) >>= either (pure . Left) \jwt -> do
+    let url = "https://api.github.com/app/installations/" <> show installationId <> "/access_tokens"
+    response <- W.postWith (githubOptsUA "Monoscope-App" jwt) (toString url) ("" :: ByteString)
+    pure $ decodeGitHub "token" $ response ^. W.responseBody
 
 
 listInstallationRepos :: W.HTTP :> es => Text -> Eff es (Either Text [GitHubRepo])
 listInstallationRepos accessToken = do
-  let opts =
-        W.defaults
-          & W.header "Authorization"
-          .~ ["Bearer " <> encodeUtf8 accessToken]
-            & W.header "Accept"
-          .~ ["application/vnd.github+json"]
-            & W.header "X-GitHub-Api-Version"
-          .~ ["2022-11-28"]
-            & W.header "User-Agent"
-          .~ ["Monoscope-App"]
-  response <- W.getWith opts "https://api.github.com/installation/repositories?per_page=100"
-  let body = response ^. W.responseBody
-  case AE.eitherDecode body of
-    Left err -> pure $ Left $ "Failed to parse repos response: " <> toText err
-    Right (repos :: ReposResponse) -> pure $ Right repos.repositories
+  response <- W.getWith (githubOptsUA "Monoscope-App" accessToken) "https://api.github.com/installation/repositories?per_page=100"
+  pure $ (.repositories) <$> (decodeGitHub "repos" (response ^. W.responseBody) :: Either Text ReposResponse)
+
+
+decodeGitHub :: AE.FromJSON a => Text -> LByteString -> Either Text a
+decodeGitHub what = first (\err -> "Failed to parse " <> what <> " response: " <> toText err) . AE.eitherDecode

--- a/src/Models/Projects/GitSync.hs
+++ b/src/Models/Projects/GitSync.hs
@@ -70,6 +70,7 @@ import Network.HTTP.Client (HttpException (..), HttpExceptionContent (..), respo
 import Network.HTTP.Types.Status (statusCode)
 import Pkg.DeriveUtils (DB, UUIDId (..), selectFrom)
 import Relude
+import Relude.Extra.Bifunctor (bimapF, firstF)
 import System.IO (hClose)
 import System.IO.Temp (withSystemTempFile)
 import System.Logging (logWarn)
@@ -277,14 +278,14 @@ pushFileToGit token sync path content existingSha message = do
           <> maybeToList (("sha" AE..=) <$> existingSha)
   result <- tryHttp $ W.putWith (githubOpts token) (toString url) payload
   pure $ result >>= \resp ->
-    maybe (Left "Missing sha in response") Right
+    maybeToRight "Missing sha in response"
       $ (,)
       <$> (resp ^? W.responseBody . key "content" . key "sha" . _String)
       <*> (resp ^? W.responseBody . key "commit" . key "tree" . key "sha" . _String)
 
 
 tryHttp :: IOE :> es => Eff es a -> Eff es (Either Text a)
-tryHttp = fmap (first formatHttpError) . try
+tryHttp = firstF formatHttpError . try
 
 
 formatHttpError :: HttpException -> Text
@@ -423,8 +424,8 @@ generateAppJWT appId privateKeyB64 = do
         hClose h
         readKeyFile tmpPath >>= \case
           (PrivKeyRSA rsaKey : _) ->
-            bimap (("Failed to sign JWT: " <>) . toText . show) (\(Jwt jwtBytes) -> decodeUtf8 jwtBytes)
-              <$> Jws.rsaEncode RS256 rsaKey (toStrict payload)
+            bimapF (("Failed to sign JWT: " <>) . toText . show) (\(Jwt jwtBytes) -> decodeUtf8 jwtBytes)
+              $ Jws.rsaEncode RS256 rsaKey (toStrict payload)
           [] -> pure $ Left "No private key found in PEM"
           _ -> pure $ Left "Unsupported key type (expected RSA)"
 

--- a/src/Models/Projects/ProjectApiKeys.hs
+++ b/src/Models/Projects/ProjectApiKeys.hs
@@ -1,5 +1,3 @@
-{-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
-
 module Models.Projects.ProjectApiKeys (
   ProjectApiKey (..),
   ProjectApiKeyId (..),
@@ -83,18 +81,14 @@ data ProjectApiKey = ProjectApiKey
 newProjectApiKeys :: Time :> es => Projects.ProjectId -> UUID.UUID -> Text -> Text -> Eff es ProjectApiKey
 newProjectApiKeys projectId projectKeyUUID title keyPrefix = do
   createdAt <- Time.currentTime
-  let updatedAt = createdAt
-      deletedAt = Nothing
-      active = True
-      id = ProjectApiKeyId projectKeyUUID
-  pure $ ProjectApiKey{..}
+  pure ProjectApiKey{id = ProjectApiKeyId projectKeyUUID, updatedAt = createdAt, deletedAt = Nothing, active = True, ..}
 
 
 insertProjectApiKey :: DB es => ProjectApiKey -> Eff es ()
-insertProjectApiKey ProjectApiKey{id = kid, createdAt, updatedAt, deletedAt, active, projectId, title, keyPrefix} =
+insertProjectApiKey ProjectApiKey{..} =
   Hasql.interpExecute_
     [HI.sql| INSERT INTO projects.project_api_keys (id, created_at, updated_at, deleted_at, active, project_id, title, key_prefix)
-           VALUES (#{kid}, #{createdAt}, #{updatedAt}, #{deletedAt}, #{active}, #{projectId}, #{title}, #{keyPrefix}) |]
+           VALUES (#{id}, #{createdAt}, #{updatedAt}, #{deletedAt}, #{active}, #{projectId}, #{title}, #{keyPrefix}) |]
 
 
 projectApiKeysByProjectId :: DB es => Projects.ProjectId -> Eff es [ProjectApiKey]
@@ -119,36 +113,23 @@ getProjectApiKey :: DB es => ProjectApiKeyId -> Eff es (Maybe ProjectApiKey)
 getProjectApiKey kid = Hasql.interp (selectFrom @ProjectApiKey <> [HI.sql| WHERE id = #{kid} AND active = true |])
 
 
+-- | Cache-backed lookup. DB-level failures (connection refused, pool exhausted, …)
+-- throw 'Hasql.HasqlException' so the caller (ultimately 'Pkg.Queue') routes the batch
+-- to the DLQ; a clean @Nothing@ stays the legitimate "key not in DB" signal.
 getProjectIdByApiKey :: (DB es, Effectful.Reader Config.AuthContext :> es) => Text -> Eff es (Maybe Projects.ProjectId)
 getProjectIdByApiKey projectKey = do
   appCtx <- Effectful.ask @Config.AuthContext
-  liftIO $ Cache.fetchWithCache appCtx.projectKeyCache projectKey \_ ->
-    queryProjectIdByKey appCtx.hasqlPool projectKey
+  liftIO $ Cache.fetchWithCache appCtx.projectKeyCache projectKey \key ->
+    OHasql.use appCtx.hasqlPool (Session.statement () (HI.interp True [HI.sql| SELECT project_id FROM projects.project_api_keys WHERE key_prefix = #{key} |]))
+      >>= either (throwIO . Hasql.HasqlException) pure
 
 
 projectIdsByProjectApiKeys :: (DB es, Effectful.Reader Config.AuthContext :> es) => V.Vector Text -> Eff es (V.Vector (Text, Projects.ProjectId))
-projectIdsByProjectApiKeys projectKeys = do
-  appCtx <- Effectful.ask @Config.AuthContext
-  liftIO $ do
-    results <- forM (V.toList projectKeys) $ \key -> do
-      maybeProjectId <- Cache.fetchWithCache appCtx.projectKeyCache key $ \k ->
-        queryProjectIdByKey appCtx.hasqlPool k
-      pure $ (key,) <$> maybeProjectId
-    pure $ V.fromList $ catMaybes results
+projectIdsByProjectApiKeys projectKeys =
+  V.catMaybes <$> forM projectKeys \key -> fmap (key,) <$> getProjectIdByApiKey key
 
 
--- | IO-level helper for cache callbacks that need to query hasql directly.
--- DB-level failures (connection refused, pool exhausted, …) throw
--- 'Hasql.HasqlException' so the caller (and ultimately 'Pkg.Queue') can route
--- the batch to the DLQ. A clean @Right Nothing@ is preserved as the
--- legitimate "key not in DB" signal — only infrastructure failures throw.
-queryProjectIdByKey :: OHasql.TracedPool -> Text -> IO (Maybe Projects.ProjectId)
-queryProjectIdByKey hpool key =
-  OHasql.use hpool (Session.statement () (HI.interp True [HI.sql| SELECT project_id FROM projects.project_api_keys WHERE key_prefix = #{key} |]))
-    >>= either (throwIO . Hasql.HasqlException) pure
-
-
--- AES256 encryption
+-- | AES256-CTR; symmetric, so 'decryptAPIKey' is the same function.
 encryptAPIKey :: ByteString -> ByteString -> ByteString
 encryptAPIKey key = ctrCombine ctx nullIV
   where
@@ -156,7 +137,7 @@ encryptAPIKey key = ctrCombine ctx nullIV
     ctx = throwCryptoError $ cipherInit key
 
 
--- | decryptAPIKey :: secretKey -> TextToDecrypt -> DecryptedText as bytestring
+-- | @decryptAPIKey secretKey ciphertext@ — inverse of 'encryptAPIKey'.
 decryptAPIKey :: ByteString -> ByteString -> ByteString
 decryptAPIKey = encryptAPIKey
 

--- a/src/Models/Projects/ProjectMembers.hs
+++ b/src/Models/Projects/ProjectMembers.hs
@@ -351,10 +351,11 @@ getTeams pid =
     (selectFrom @Team <> [HI.sql| WHERE project_id = #{pid} AND deleted_at IS NULL |])
 
 
-getTeamsVM :: DB es => Projects.ProjectId -> Eff es [TeamVM]
-getTeamsVM pid =
-  Hasql.interp
-    [HI.sql|
+-- | The one 'TeamVM' projection (teams + their member objects); the caller only
+-- supplies the extra WHERE predicate, so the member aggregation can't drift.
+teamsVMQuery :: HI.Sql -> HI.Sql
+teamsVMQuery cond =
+  [HI.sql|
       SELECT
         t.id,
         t.created_at,
@@ -384,11 +385,16 @@ getTeamsVM pid =
       FROM projects.teams t
       LEFT JOIN unnest(t.members) AS mid ON true
       LEFT JOIN users.users u ON u.id = mid
-      WHERE t.project_id = #{pid} AND t.deleted_at IS NULL
+      WHERE t.deleted_at IS NULL AND |]
+    <> cond
+    <> [HI.sql|
       GROUP BY t.id, t.created_at, t.updated_at, t.created_by, t.name, t.handle,
                t.description, t.notify_emails, t.slack_channels, t.discord_channels, t.phone_numbers, t.pagerduty_services, t.disabled_channels, t.is_everyone
-      ORDER BY t.is_everyone DESC, t.created_at ASC
-    |]
+      ORDER BY t.is_everyone DESC, t.created_at ASC |]
+
+
+getTeamsVM :: DB es => Projects.ProjectId -> Eff es [TeamVM]
+getTeamsVM pid = Hasql.interp $ teamsVMQuery [HI.sql| t.project_id = #{pid} |]
 
 
 data TeamVM = TeamVM
@@ -438,12 +444,9 @@ deleteTeams pid tids
 
 
 getTeamsById :: DB es => Projects.ProjectId -> V.Vector UUID.UUID -> Eff es [Team]
-getTeamsById pid tids =
-  if V.null tids
-    then pure []
-    else
-      Hasql.interp
-        (selectFrom @Team <> [HI.sql| WHERE project_id = #{pid} AND id = ANY(#{tids}::uuid[]) AND deleted_at IS NULL |])
+getTeamsById pid tids
+  | V.null tids = pure []
+  | otherwise = Hasql.interp (selectFrom @Team <> [HI.sql| WHERE project_id = #{pid} AND id = ANY(#{tids}::uuid[]) AND deleted_at IS NULL |])
 
 
 getTeamById :: DB es => Projects.ProjectId -> UUID.UUID -> Eff es (Maybe Team)
@@ -452,48 +455,12 @@ getTeamById pid tid =
     (selectFrom @Team <> [HI.sql| WHERE project_id = #{pid} AND id = #{tid} AND deleted_at IS NULL |])
 
 
--- | Bulk fetch teams by handles - more efficient than mapping getTeamByHandle
+-- | Bulk fetch teams by handles — one round trip instead of mapping getTeamByHandle.
 getTeamsByHandles :: DB es => Projects.ProjectId -> [Text] -> Eff es [TeamVM]
 getTeamsByHandles _ [] = pure []
-getTeamsByHandles pid handles =
-  Hasql.interp
-    [HI.sql|
-      SELECT
-        t.id,
-        t.created_at,
-        t.updated_at,
-        t.created_by,
-        t.name,
-        t.handle,
-        t.description,
-        t.notify_emails,
-        t.slack_channels,
-        t.discord_channels,
-        t.phone_numbers,
-        t.pagerduty_services,
-        t.disabled_channels,
-        t.is_everyone,
-        COALESCE(
-          array_agg(
-            jsonb_build_object(
-              'memberId', u.id,
-              'memberName', concat_ws(' ', u.first_name, u.last_name),
-              'memberEmail', u.email,
-              'memberAvatar', '/api/avatar/' || u.id::text
-            ) ORDER BY u.first_name, u.last_name
-          ) FILTER (WHERE u.id IS NOT NULL),
-          '{}'
-        ) AS members
-      FROM projects.teams t
-      LEFT JOIN unnest(t.members) AS mid ON true
-      LEFT JOIN users.users u ON u.id = mid
-      WHERE t.project_id = #{pid} AND t.handle = ANY(#{handles}) AND t.deleted_at IS NULL
-      GROUP BY t.id, t.created_at, t.updated_at, t.created_by, t.name, t.handle,
-               t.description, t.notify_emails, t.slack_channels, t.discord_channels, t.phone_numbers, t.pagerduty_services, t.disabled_channels, t.is_everyone
-    |]
+getTeamsByHandles pid handles = Hasql.interp $ teamsVMQuery [HI.sql| t.project_id = #{pid} AND t.handle = ANY(#{handles}) |]
 
 
--- | Convert Team to TeamDetails for updates
 teamToDetails :: Team -> TeamDetails
 teamToDetails t = TeamDetails{name = t.name, description = t.description, handle = t.handle, members = t.members, notifyEmails = t.notify_emails, slackChannels = t.slack_channels, discordChannels = t.discord_channels, phoneNumbers = t.phone_numbers, pagerdutyServices = t.pagerduty_services, disabledChannels = t.disabled_channels}
 
@@ -504,39 +471,37 @@ teamToDetails t = TeamDetails{name = t.name, description = t.description, handle
 -- write succeeded and surface a success toast; silence here hides real bugs.
 modifyEveryoneTeamDetails :: (DB es, Log :> es) => Projects.ProjectId -> (TeamDetails -> TeamDetails) -> Eff es ()
 modifyEveryoneTeamDetails pid f =
-  getEveryoneTeam pid >>= \case
-    Nothing -> Log.logAttention "modifyEveryoneTeamDetails: no @everyone team; write ignored" (AE.object ["project_id" AE..= pid])
-    Just team -> void $ updateTeam pid team.id $ f (teamToDetails team)
+  getEveryoneTeam pid
+    >>= maybe
+      (Log.logAttention "modifyEveryoneTeamDetails: no @everyone team; write ignored" (AE.object ["project_id" AE..= pid]))
+      (\team -> void $ updateTeam pid team.id $ f (teamToDetails team))
 
 
--- | Race-free idempotent append to one of @everyone's text[] fields. Returns True
+-- | Race-free idempotent append to one of @everyone's text[] columns. Returns True
 -- if the value was actually added, False if it was already present (or there was
 -- no team). Single UPDATE, no read-modify-write window.
+appendEveryoneTarget :: DB es => HI.Sql -> Projects.ProjectId -> Text -> Eff es Bool
+appendEveryoneTarget col pid val =
+  (> 0)
+    <$> Hasql.interpExecute
+      ( [HI.sql| UPDATE projects.teams SET |]
+          <> col
+          <> [HI.sql| = array_append(|]
+          <> col
+          <> [HI.sql|, #{val})
+             WHERE project_id = #{pid} AND is_everyone = TRUE AND deleted_at IS NULL AND NOT (#{val} = ANY(|]
+          <> col
+          <> [HI.sql|))|]
+      )
+
+
 addSlackChannelToEveryoneTeam
   , addDiscordChannelToEveryoneTeam
   , addPagerdutyServiceToEveryoneTeam
     :: DB es => Projects.ProjectId -> Text -> Eff es Bool
-addSlackChannelToEveryoneTeam pid val =
-  (> 0)
-    <$> Hasql.interpExecute
-      [HI.sql|
-    UPDATE projects.teams SET slack_channels = array_append(slack_channels, #{val})
-    WHERE project_id = #{pid} AND is_everyone = TRUE AND deleted_at IS NULL
-      AND NOT (#{val} = ANY(slack_channels))|]
-addDiscordChannelToEveryoneTeam pid val =
-  (> 0)
-    <$> Hasql.interpExecute
-      [HI.sql|
-    UPDATE projects.teams SET discord_channels = array_append(discord_channels, #{val})
-    WHERE project_id = #{pid} AND is_everyone = TRUE AND deleted_at IS NULL
-      AND NOT (#{val} = ANY(discord_channels))|]
-addPagerdutyServiceToEveryoneTeam pid val =
-  (> 0)
-    <$> Hasql.interpExecute
-      [HI.sql|
-    UPDATE projects.teams SET pagerduty_services = array_append(pagerduty_services, #{val})
-    WHERE project_id = #{pid} AND is_everyone = TRUE AND deleted_at IS NULL
-      AND NOT (#{val} = ANY(pagerduty_services))|]
+addSlackChannelToEveryoneTeam = appendEveryoneTarget [HI.sql|slack_channels|]
+addDiscordChannelToEveryoneTeam = appendEveryoneTarget [HI.sql|discord_channels|]
+addPagerdutyServiceToEveryoneTeam = appendEveryoneTarget [HI.sql|pagerduty_services|]
 
 
 removeSlackChannelsFromEveryoneTeam

--- a/src/Models/Projects/Projects.hs
+++ b/src/Models/Projects/Projects.hs
@@ -14,7 +14,6 @@ module Models.Projects.Projects (
   ProjectListItem (..),
   ProjectId,
   CreateProject (..),
-  OnboardingStep (..),
   ProjectS3Bucket (..),
   insertProject,
   projectIdFromText,
@@ -236,11 +235,6 @@ type ProjectId = UUIDId "project"
 
 projectIdFromText :: Text -> Maybe ProjectId
 projectIdFromText = idFromText
-
-
-data OnboardingStep = Info | Survey | CreateMonitor | NotifChannel | Integration | Pricing | Complete
-  deriving stock (Eq, Generic, Read, Show)
-  deriving (AE.FromJSON, AE.ToJSON, FromField, NFData, ToField) via OnboardingStep
 
 
 data Project = Project
@@ -700,9 +694,6 @@ addSubscription s =
     |]
 
 
--- | Sum of requests for the given project since `start`, using window_start
--- (when events occurred) rather than created_at (when the job ran). Pre-migration
--- rows without window_start are excluded from billing calculations.
 -- | (totalRequests, totalBytes) since `start`, using window_start (when events
 -- occurred) rather than created_at. Pre-migration rows without window_start
 -- are excluded from billing calculations.
@@ -741,7 +732,7 @@ getDailyUsageBreakdown pid start =
 -- (Lemon Squeezy rejects quantities > 1,000,000; 900k leaves headroom). The
 -- smart constructor is the only public way in; splitUsageIntoChunks is the
 -- only producer in the codebase.
-newtype ChunkQuantity = ChunkQuantity Int
+newtype ChunkQuantity = ChunkQuantity {chunkQuantityInt :: Int}
   deriving stock (Eq, Generic)
   deriving newtype (FromField, HI.DecodeValue, HI.EncodeValue, NFData, Show, ToField)
 
@@ -766,10 +757,6 @@ mkChunkQuantity :: Int -> Maybe ChunkQuantity
 mkChunkQuantity n
   | n > 0 && n <= 900_000 = Just (ChunkQuantity n)
   | otherwise = Nothing
-
-
-chunkQuantityInt :: ChunkQuantity -> Int
-chunkQuantityInt (ChunkQuantity n) = n
 
 
 -- | State of a submission chunk. Collapses (status, submitted_at, last_error)
@@ -866,7 +853,7 @@ recordUsageWindow
 recordUsageWindow pid wStart wEnd totals chunks = do
   chunkIds <- replicateM (length chunks) genUUID
   let exec :: HI.Sql -> Tx.Transaction ()
-      exec s = Tx.statement () (HI.interp True s :: Statement () HI.RowsAffected) $> ()
+      exec s = void $ Tx.statement () (HI.interp True s :: Statement () HI.RowsAffected)
       -- total_requests historically = events + metrics (drives splitUsageIntoChunks
       -- and getTotalUsage). Preserve that invariant; new columns are additive.
       totalUsage = totals.events + totals.metrics
@@ -1177,19 +1164,15 @@ sessionAndProject
   -> Eff es (Session, Project)
 sessionAndProject pid = do
   sess <- getSession
-  let projects = sess.persistentSession.projects.getProjects
-  case V.find (\v -> v.id == pid) projects of
+  let redirect = throwError $ err302{errHeaders = [("Location", "/?missingProjectPermission")]}
+      fetch = projectById pid >>= maybe redirect (pure . (sess,))
+  case V.find ((== pid) . (.id)) sess.persistentSession.projects.getProjects of
+    -- Onboarding projects in the session cache are stale; re-read them.
     Just p | not (isOnboarding p.paymentPlan) -> pure (sess, p)
-    Just _ ->
-      projectById pid >>= \case
-        Just p -> pure (sess, p)
-        Nothing -> throwError $ err302{errHeaders = [("Location", "/?missingProjectPermission")]}
-    _
-      | pid == UUIDId UUID.nil || sess.user.isSudo ->
-          projectById pid >>= \case
-            Just p -> pure (sess, p)
-            Nothing -> throwError $ err302{errHeaders = [("Location", "/?missingProjectPermission")]}
-    _ -> throwError $ err302{errHeaders = [("Location", "/?missingProjectPermission")]}
+    Just _ -> fetch
+    Nothing
+      | pid == UUIDId UUID.nil || sess.user.isSudo -> fetch
+      | otherwise -> redirect
 
 
 ----------------------------------------------------------------------

--- a/src/Models/Telemetry/Schema.hs
+++ b/src/Models/Telemetry/Schema.hs
@@ -15,7 +15,6 @@ import Data.Map qualified as Map
 import Data.OpenApi (ToSchema)
 import Data.Set qualified as S
 import Data.Text qualified as T
-import Deriving.Aeson qualified as DAE
 import Deriving.Aeson.Stock qualified as DAE
 import Pkg.DeriveUtils (SnakeSchema (..))
 import Relude
@@ -203,13 +202,11 @@ generateSchemaForAI schema =
       , ("Network:", filterByPrefixes ["attributes.client", "attributes.server", "attributes.network"])
       ]
 
-    filterByPrefixes prefixes = filter (matchesAnyPrefix prefixes . fst) fields
-    matchesAnyPrefix prefixes name = any (`T.isPrefixOf` name) prefixes || name `elem` prefixes
+    filterByPrefixes prefixes = filter (\(name, _) -> any (`T.isPrefixOf` name) prefixes) fields
 
-    renderCategory (title, categoryFields) =
-      if null categoryFields
-        then []
-        else title : map renderField (take 10 categoryFields) ++ [""]
+    renderCategory (title, categoryFields)
+      | null categoryFields = []
+      | otherwise = title : map renderField (take 10 categoryFields) <> [""]
 
     renderField (name, info) = "- " <> name <> maybe "" (\vals -> " (" <> T.intercalate ", " vals <> ")") info.examples
 
@@ -296,16 +293,8 @@ popularOtelQueriesJson = AE.toJSON popularOtelQueries
 -- duration, body) aren't in the flattened set and are kept unconditionally.
 deriveSchema :: Set Text -> Schema
 deriveSchema liveAttrs =
-  let handCoded = telemetrySchema.fields
-      bareDefault = FieldInfo "text" "" Nothing
-      -- Top-level fields aren't in the flattened set; keep their hand-coded
-      -- entries (timestamp, name, kind, severity.text → severity.severity_text,
-      -- duration, body, etc.). Drop only the dotted-form entries that the
-      -- live set doesn't confirm.
-      isTopLevel k = not ("." `T.isInfixOf` k)
-      keepHand k _ = isTopLevel k || k `S.member` liveAttrs
-      kept = Map.filterWithKey keepHand handCoded
-      -- For any live column not already in 'kept', add a bare entry.
-      missing = [k | k <- toList liveAttrs, not (Map.member k kept)]
-      enriched = foldl' (\m k -> Map.insert k bareDefault m) kept missing
-   in Schema{fields = enriched}
+  -- union is left-biased: hand-coded entries win over the bare live ones.
+  Schema{fields = Map.filterWithKey keepHand telemetrySchema.fields `Map.union` Map.fromSet (const bareDefault) liveAttrs}
+  where
+    bareDefault = FieldInfo "text" "" Nothing
+    keepHand k _ = not ("." `T.isInfixOf` k) || k `S.member` liveAttrs

--- a/src/Models/Telemetry/Telemetry.hs
+++ b/src/Models/Telemetry/Telemetry.hs
@@ -70,7 +70,6 @@ module Models.Telemetry.Telemetry (
   resourceServiceName,
   metricServiceNameFromResource,
   SpanEvent (..),
-  SpanLink (..),
   atMapText,
   atMapInt,
   spanServiceName,
@@ -86,7 +85,6 @@ module Models.Telemetry.Telemetry (
 where
 
 import Control.Concurrent.STM qualified as STM
-import Control.Lens ((.~))
 import Data.Aeson qualified as AE
 import Data.Aeson.Key qualified as AEK
 import Data.Aeson.KeyMap qualified as KEM
@@ -95,7 +93,6 @@ import Data.ByteString.Base16 qualified as B16
 import Data.Default (Default (..))
 import Data.Effectful.Hasql (Hasql)
 import Data.Effectful.Hasql qualified as Hasql
-import Data.Generics.Labels ()
 import Data.HashMap.Strict qualified as HM
 import Data.List.Extra (chunksOf)
 import Data.List.NonEmpty qualified as NE
@@ -142,7 +139,7 @@ import System.Logging qualified as Log
 import System.Tracing (forkWithCtx)
 import Text.Regex.TDFA.Text ()
 import UnliftIO (throwIO, tryAny)
-import Utils (extractMessageFromLog, getDurationNSMS, lookupValueText, scrubNulText, scrubNulValue)
+import Utils (extractMessageFromLog, getDurationNSMS, lookupValueText, nonEmptyT, scrubNulText, scrubNulValue)
 
 
 -- Helper function to get nested value from a map using dot notation
@@ -150,11 +147,7 @@ getNestedValue :: [Text] -> Map Text AE.Value -> Maybe AE.Value
 getNestedValue [] _ = Nothing
 getNestedValue [k] m = Map.lookup k m
 getNestedValue ks@(k : rest) m =
-  Map.lookup (T.intercalate "." ks) m <|> do
-    v <- Map.lookup k m
-    case v of
-      AE.Object obj -> getNestedValue rest (KEM.toMapText obj)
-      _ -> Nothing
+  Map.lookup (T.intercalate "." ks) m <|> (getNestedValue rest =<< objectToMap =<< Map.lookup k m)
 
 
 -- | Render a JSON leaf as Text (strings scrubbed of NULs, numbers shown).
@@ -188,27 +181,20 @@ atMapText key maybeMap = valText =<< getNestedValue (T.split (== '.') key) =<< m
 
 
 atMapInt :: Text -> Maybe (Map Text AE.Value) -> Maybe Int
-atMapInt key maybeMap = do
-  m <- maybeMap
-  val <- getNestedValue (T.split (== '.') key) m
-  case val of
+atMapInt key maybeMap =
+  (getNestedValue (T.split (== '.') key) =<< maybeMap) >>= \case
     AE.Number n -> Just $ round n
     AE.String t -> readMaybe $ toString t
     _ -> Nothing
 
 
 spanServiceName :: OtelLogsAndSpans -> Maybe Text
-spanServiceName s = resourceServiceName (unAesonTextMaybe s.resource)
+spanServiceName = resourceServiceName . unAesonTextMaybe . (.resource)
 
 
+-- | 'atMapText' already tries the flat @"service.name"@ key before descending.
 resourceServiceName :: Maybe (Map Text AE.Value) -> Maybe Text
-resourceServiceName resource =
-  atMapText "service.name" resource
-    <|> flatAttrText "service.name" resource
-
-
-flatAttrText :: Text -> Maybe (Map Text AE.Value) -> Maybe Text
-flatAttrText key maybeMap = valText =<< Map.lookup key =<< maybeMap
+resourceServiceName = atMapText "service.name"
 
 
 data SeverityLevel = SLTrace | SLDebug | SLInfo | SLWarn | SLError | SLFatal
@@ -352,19 +338,6 @@ data SpanEvent = SpanEvent
   deriving (AE.FromJSON, AE.ToJSON) via DAE.Snake SpanEvent
 
 
-data SpanLink = SpanLink
-  { linkTraceId :: Text
-  , linkSpanId :: Text
-  , linkAttributes :: AE.Value
-  , linkDroppedAttributesCount :: Int
-  , linkFlags :: Int
-  }
-  deriving (Generic, Show)
-  deriving anyclass (FromRow, NFData, ToRow)
-  deriving (FromField, ToField) via Aeson SpanLink
-  deriving (AE.FromJSON, AE.ToJSON) via DAE.Snake SpanLink
-
-
 data MetricRecord = MetricRecord
   { id :: Maybe UUID.UUID
   , projectId :: UUID.UUID
@@ -426,7 +399,7 @@ enqueueMetricCatalog (MetricCatalogBuffer ref) rows = STM.atomically do
     else Just . V.fromList . Map.elems <$> STM.swapTVar ref mempty
 
 
-flushMetricCatalog :: (Hasql :> es, IOE :> es) => MetricCatalogBuffer -> Eff es ()
+flushMetricCatalog :: DB es => MetricCatalogBuffer -> Eff es ()
 flushMetricCatalog (MetricCatalogBuffer ref) = do
   rows <- liftIO $ V.fromList . Map.elems <$> STM.atomically (STM.swapTVar ref mempty)
   upsertMetricMetadata rows
@@ -434,7 +407,7 @@ flushMetricCatalog (MetricCatalogBuffer ref) = do
 
 -- | Rebuild recent catalog descriptors from durable raw points. This heals a
 -- process crash or a failed buffered flush without replaying telemetry.
-reconcileMetricCatalog :: (Hasql :> es, IOE :> es) => Eff es ()
+reconcileMetricCatalog :: DB es => Eff es ()
 reconcileMetricCatalog =
   Hasql.interpExecute_
     [HI.sql|INSERT INTO otel_metrics_meta (
@@ -454,19 +427,6 @@ ON CONFLICT (project_id, metric_name, metric_type, metric_unit, service_name, sc
   last_seen_at = GREATEST(otel_metrics_meta.last_seen_at, EXCLUDED.last_seen_at),
   first_timestamp = LEAST(otel_metrics_meta.first_timestamp, EXCLUDED.first_timestamp),
   last_timestamp = GREATEST(otel_metrics_meta.last_timestamp, EXCLUDED.last_timestamp)|]
-
-
-data MetricMeta = MetricMeta
-  { projectId :: UUID.UUID
-  , metricName :: Text
-  , metricType :: MetricType
-  , metricUnit :: Text
-  , metricDescription :: Text
-  , serviceName :: Text
-  }
-  deriving (Generic, Show)
-  deriving anyclass (FromRow, NFData, ToRow)
-  deriving (AE.FromJSON, AE.ToJSON) via DAE.Snake MetricMeta
 
 
 data MetricValue
@@ -546,15 +506,6 @@ data Quantile = Quantile
   deriving (Generic, Show)
   deriving anyclass (NFData)
   deriving (AE.FromJSON, AE.ToJSON) via DAE.Snake Quantile
-
-
-data Exemplar = Exemplar
-  { value :: Double
-  , timestamp :: UTCTime
-  , attributes :: AE.Value
-  }
-  deriving (Generic, Show)
-  deriving (AE.FromJSON, AE.ToJSON)
 
 
 data NativeMetricColumns = NativeMetricColumns
@@ -665,7 +616,7 @@ getTraceDetails useTf pid trId tme now = do
       let spans = toList ne
           start = minimum1 $ (.start_time) <$> ne
           end = maximum1 $ (\r -> fromMaybe r.start_time r.end_time) <$> ne
-          services = V.fromList $ ordNub $ mapMaybe (atMapText "service.name" . unAesonTextMaybe . (.resource)) spans
+          services = V.fromList $ ordNub $ mapMaybe spanServiceName spans
           duration = floor $ diffUTCTime end start * 1000000000
        in (Trace trId start end duration (length spans) $ if V.null services then Nothing else Just services, spans)
 
@@ -722,7 +673,7 @@ lookupOtelRecord pidTxt createdAt rdId =
 -- "First" and "Recent" page loads. We UNION ALL two index-friendly subqueries (one per
 -- url-path source) instead of OR'ing them in a single WHERE, so each side can hit its own
 -- expression index and avoid a 7d seq scan on otel_logs_and_spans.
-getEndpointTraceId :: (Hasql :> es, IOE :> es) => Projects.ProjectId -> Text -> Text -> Bool -> UTCTime -> Eff es (Maybe (Text, UTCTime))
+getEndpointTraceId :: DB es => Projects.ProjectId -> Text -> Text -> Bool -> UTCTime -> Eff es (Maybe (Text, UTCTime))
 getEndpointTraceId pid method urlPath isFirst now =
   Hasql.interpOne
     $ [HI.sql| SELECT context___trace_id, start_time FROM ( |]
@@ -893,7 +844,7 @@ getMetricData pid metricName = do
 
 
 getTotalEventsToReport :: DB es => Projects.ProjectId -> UTCTime -> Eff es Int
-getTotalEventsToReport pid lastReported = do
+getTotalEventsToReport pid lastReported =
   fromMaybe 0 <$> Hasql.interpOne [HI.sql| SELECT count(*)::bigint FROM otel_logs_and_spans WHERE project_id=#{pid.toText} AND timestamp > #{lastReported}|]
 
 
@@ -997,7 +948,7 @@ deterministicOtelId r = UUID.toText $ UUIDv5.generateNamed otelIdNamespace $ int
 -- the caller's vector ids match what lands in the DB (the extraction-worker
 -- hand-off relies on this).
 mintOtelLogIds :: V.Vector OtelLogsAndSpans -> V.Vector OtelLogsAndSpans
-mintOtelLogIds = V.map \r -> r & #id .~ deterministicOtelId r
+mintOtelLogIds = V.map \r -> (r :: OtelLogsAndSpans){id = deterministicOtelId r}
 
 
 -- | This = PG failed; That = TF failed; These = both. Both stores are mandatory
@@ -1050,14 +1001,7 @@ type PoisonMsg =
 -- a count; the dual-write cross-check ('unaccountedRows') compares it against
 -- the submitted total to catch a store that acked but silently under-persisted.
 newtype BulkInsertResult = BulkInsertResult {rowsInserted :: Int64}
-
-
-instance Semigroup BulkInsertResult where
-  BulkInsertResult a <> BulkInsertResult b = BulkInsertResult (a + b)
-
-
-instance Monoid BulkInsertResult where
-  mempty = BulkInsertResult 0
+  deriving (Monoid, Semigroup) via Sum Int64
 
 
 -- | A store accepted a bulk write without raising an error, yet persisted
@@ -1275,34 +1219,22 @@ dualWrite submitted target writePg writeTf = case target of
   where
     lostOf = unaccountedRows submitted
     fullyPersisted = either (const False) ((== 0) . lostOf)
+    -- Log a failed leg and yield the matching 'WriteFailure'.
+    logFail name kvs wf = Log.logAttention name (AE.object (("record_count" AE..= submitted) : kvs)) $> Left wf
     -- Classify one store's result; @side@ is 'This'/'That' for the written leg,
     -- @losts@ places the under-persist count on that leg ((l,0) for pg, (0,l) for tf).
     singleLeg store side losts = \case
       Right bir
         | lost <- lostOf bir, lost > 0 -> (,False) <$> underPersist (losts lost)
         | otherwise -> pure (Right (), True)
-      Left e -> do
-        Log.logAttention (T.toUpper store <> "_WRITE_FAILED") (AE.object ["record_count" AE..= submitted, "error" AE..= show @Text e])
-        pure (Left (side e), False)
+      Left e -> (,False) <$> logFail (T.toUpper store <> "_WRITE_FAILED") ["error" AE..= show @Text e] (side e)
     classify (Right pgBir) (Right tfBir) = case (lostOf pgBir, lostOf tfBir) of
       (0, 0) -> pure (Right ())
       losts -> underPersist losts
-    classify (Left ePg) (Right _) = do
-      Log.logAttention "PG_WRITE_FAILED"
-        $ AE.object ["record_count" AE..= submitted, "error" AE..= show @Text ePg]
-      pure (Left (This ePg))
-    classify (Right _) (Left eTf) = do
-      Log.logAttention "TF_WRITE_FAILED"
-        $ AE.object ["record_count" AE..= submitted, "error" AE..= show @Text eTf]
-      pure (Left (That eTf))
-    classify (Left ePg) (Left eTf) = do
-      Log.logAttention "BOTH_WRITES_FAILED"
-        $ AE.object
-          [ "record_count" AE..= submitted
-          , "pg_error" AE..= show @Text ePg
-          , "tf_error" AE..= show @Text eTf
-          ]
-      pure (Left (These ePg eTf))
+    classify (Left ePg) (Right _) = logFail "PG_WRITE_FAILED" ["error" AE..= show @Text ePg] (This ePg)
+    classify (Right _) (Left eTf) = logFail "TF_WRITE_FAILED" ["error" AE..= show @Text eTf] (That eTf)
+    classify (Left ePg) (Left eTf) =
+      logFail "BOTH_WRITES_FAILED" ["pg_error" AE..= show @Text ePg, "tf_error" AE..= show @Text eTf] (These ePg eTf)
 
     -- Build the Left WriteFailure for a detected silent under-persist. A side
     -- with lost == 0 is healthy and dropped from the These.
@@ -1343,13 +1275,12 @@ insertAndHandOff
   -> Eff es (Either WriteFailure ())
 insertAndHandOff tfPgTypes target worker caches records
   | V.null records = pure (Right ())
-  | otherwise =
-      do
-        res <- bulkInsertOtelLogsAndSpansTF tfPgTypes target records
-        -- Hand-off only when every row landed on every required store; a
-        -- failed batch stays Left → DLQ.
-        when (isRight res) $ liftIO $ handOffBatches worker caches records
-        pure res
+  | otherwise = do
+      res <- bulkInsertOtelLogsAndSpansTF tfPgTypes target records
+      -- Hand-off only when every row landed on every required store; a
+      -- failed batch stays Left → DLQ.
+      when (isRight res) $ liftIO $ handOffBatches worker caches records
+      pure res
 
 
 -- | Group `records` by `project_id`, build one `ExtractionBatch` per group, and
@@ -1371,10 +1302,8 @@ handOffBatches worker caches records = do
         Nothing -> pass -- safety-net picks these up via processed_at IS NULL
         Just cache -> do
           let rows = V.fromList (toList rowsNE)
-              extractSpanId r = fromMaybe "" (r.context >>= (.span_id))
-              extractTraceId r = fromMaybe "" (r.context >>= (.trace_id))
-              spanIds = V.map extractSpanId rows
-              traceIds = V.map extractTraceId rows
+              spanIds = V.map (\r -> fromMaybe "" (r.context >>= (.span_id))) rows
+              traceIds = V.map (\r -> fromMaybe "" (r.context >>= (.trace_id))) rows
               timestamps = (.timestamp) <$> rowsNE
               batch =
                 EW.ExtractionBatch
@@ -1405,7 +1334,7 @@ handOffBatches worker caches records = do
 -- 0x1F-joined and are rebuilt with @string_to_array(_, chr(31))@.
 -- | @usePgTypes@: 'True' for PostgreSQL/TimescaleDB (cast id/JSON to
 -- uuid/jsonb), 'False' for TimeFusion (bare text→Variant). See 'insertUnnestStmt'.
-bulkInsertOtelLogsAndSpans :: (Hasql :> es, IOE :> es, Log :> es) => Bool -> V.Vector OtelLogsAndSpans -> Eff es BulkInsertResult
+bulkInsertOtelLogsAndSpans :: (DB es, Log :> es) => Bool -> V.Vector OtelLogsAndSpans -> Eff es BulkInsertResult
 bulkInsertOtelLogsAndSpans usePgTypes records
   | V.null records = pure mempty
   | otherwise = do
@@ -1522,9 +1451,7 @@ splitColumn nm proj = (column nm (Just . joinUnit . proj)){selectExpr = \_ a -> 
 -- assignment cast); on TimeFusion the bare text coerces to Variant (the
 -- VariantInsertRewriter fires on the SELECT projection).
 jsonColumn :: Text -> (OtelRow -> Maybe AE.Value) -> OtelCol
-jsonColumn nm proj = (column nm (fmap enc . proj)){selectExpr = \usePgTypes a -> if usePgTypes then a <> "::jsonb" else a}
-  where
-    enc = decodeUtf8 . AE.encode . scrubNulValue :: AE.Value -> Text
+jsonColumn nm proj = (column nm (fmap (jsonText . scrubNulValue) . proj)){selectExpr = \usePgTypes a -> if usePgTypes then a <> "::jsonb" else a}
 
 
 -- | Thrown when an OtelLogsAndSpans row reaches the bulk insert path with an
@@ -1670,10 +1597,11 @@ mkOtelRow e = do
     Just t
       | T.toLower t `elem` ["true", "t", "1"] -> pure (Just True)
       | T.toLower t `elem` ["false", "f", "0"] -> pure (Just False)
-      | otherwise -> do
-          Log.logAttention "OTEL_UNPARSEABLE_IS_REMOTE"
-            $ AE.object ["error_id" AE..= ("OTEL_UNPARSEABLE_IS_REMOTE" :: Text), "value" AE..= t, "trace_id" AE..= (e.context >>= (.trace_id))]
-          pure Nothing
+      | otherwise ->
+          Nothing
+            <$ Log.logAttention
+              "OTEL_UNPARSEABLE_IS_REMOTE"
+              (AE.object ["error_id" AE..= ("OTEL_UNPARSEABLE_IS_REMOTE" :: Text), "value" AE..= t, "trace_id" AE..= (e.context >>= (.trace_id))])
   pure OtelRow{row = e, attrs = unAesonTextMaybe e.attributes, resource = unAesonTextMaybe e.resource, isRemote}
 
 
@@ -1749,11 +1677,11 @@ getErrorEvents :: OtelLogsAndSpans -> V.Vector AE.Value
 getErrorEvents OtelLogsAndSpans{events = Just (AesonText (AE.Array arr))} =
   V.filter isErrorEvent arr
   where
-    isErrorEvent (AE.Object o) =
-      case KEM.lookup "event_name" o of
-        Just (AE.String name) -> "exception" `T.isInfixOf` name || "error" `T.isInfixOf` name
-        _ -> False
-    isErrorEvent _ = False
+    isErrorEvent v =
+      maybe False (\n -> "exception" `T.isInfixOf` n || "error" `T.isInfixOf` n)
+        $ asTextRaw
+        =<< Map.lookup "event_name"
+        =<< objectToMap v
 getErrorEvents _ = []
 
 
@@ -1807,14 +1735,8 @@ extractATError _ _ = Nothing
 extractATErrorFromRecord :: OtelLogsAndSpans -> Maybe ErrorPatterns.ATError
 extractATErrorFromRecord spanObj =
   let attrs = unAesonTextMaybe spanObj.attributes
-      excAttr k = case attrs >>= Map.lookup "exception" of
-        Just (AE.Object o) -> case KEM.lookup (AEK.fromText k) o of
-          Just (AE.String s) -> Just s
-          _ -> Nothing
-        _ -> Nothing
-      bodyTxt = case unAesonTextMaybe spanObj.body of
-        Just (AE.String s) -> Just s
-        _ -> Nothing
+      excAttr k = asTextRaw =<< Map.lookup k =<< objectToMap =<< Map.lookup "exception" =<< attrs
+      bodyTxt = asTextRaw =<< unAesonTextMaybe spanObj.body
       typ = fromMaybe "Error" (excAttr "type")
       msg = fromMaybe "" $ excAttr "message" <|> bodyTxt <|> spanObj.status_message
       stack = fromMaybe "" (excAttr "stacktrace")
@@ -1830,24 +1752,17 @@ atErrorFrom spanObj typ msg stack =
   let attrs = unAesonTextMaybe spanObj.attributes
       resc = unAesonTextMaybe spanObj.resource
       getSpanAttr k = attrs >>= Map.lookup k >>= valText
-      getUserAttrM k v = case resc >>= Map.lookup v of
-        Just (AE.Object userAttrs) -> KEM.lookup k userAttrs >>= valText
-        _ -> Nothing
+      getUserAttrM k v = valText =<< Map.lookup k =<< objectToMap =<< Map.lookup v =<< resc
       method = getSpanAttr "http.request.method"
       urlPath = getSpanAttr "http.route" <|> getSpanAttr "http.target"
       -- TODO: parse telemetry.sdk.name to SDKTypes
-      tech = case resc >>= Map.lookup "telemetry" of
-        Just (AE.Object tel) ->
-          KEM.lookup "sdk" tel >>= \case
-            AE.Object sdkObj -> KEM.lookup "language" sdkObj >>= asTextRaw
-            _ -> Nothing
-        _ -> Nothing
+      tech = asTextRaw =<< Map.lookup "language" =<< objectToMap =<< Map.lookup "sdk" =<< objectToMap =<< Map.lookup "telemetry" =<< resc
       serviceName = resourceServiceName resc
       -- Empty (not "unknown") keeps hash inputs stable when runtime detection fails.
       rt = fromMaybe "" tech
       hashes = ErrorPatterns.computeErrorHashes spanObj.project_id serviceName spanObj.name rt typ msg stack
    in ErrorPatterns.ATError
-        { projectId = UUID.fromText spanObj.project_id >>= (Just . UUIDId)
+        { projectId = UUIDId <$> UUID.fromText spanObj.project_id
         , when = spanObj.timestamp
         , errorType = typ
         , rootErrorType = typ
@@ -1875,7 +1790,7 @@ atErrorFrom spanObj typ msg stack =
 
 
 getProjectStatsForReport :: DB es => Projects.ProjectId -> UTCTime -> UTCTime -> Eff es [(Text, Int, Int)]
-getProjectStatsForReport projectId start end = do
+getProjectStatsForReport projectId start end =
   Hasql.interp
     [HI.sql| SELECT resource___service___name AS service_name,  (COUNT(*) FILTER ( WHERE status_code = 'ERROR' OR attributes___exception___type IS NOT NULL))::bigint AS total_error_events, COUNT(*)::bigint AS total_events
          FROM otel_logs_and_spans
@@ -1886,7 +1801,7 @@ getProjectStatsForReport projectId start end = do
 
 
 getProjectStatsBySpanType :: DB es => Projects.ProjectId -> UTCTime -> UTCTime -> Eff es [(Text, Int, Int)]
-getProjectStatsBySpanType projectId start end = do
+getProjectStatsBySpanType projectId start end =
   Hasql.interp
     [HI.sql|
         SELECT
@@ -1911,7 +1826,7 @@ getProjectStatsBySpanType projectId start end = do
 
 
 getEndpointStats :: DB es => Projects.ProjectId -> UTCTime -> UTCTime -> Eff es [(Text, Text, Text, Int64, Int64)]
-getEndpointStats projectId start end = do
+getEndpointStats projectId start end =
   Hasql.interp
     [HI.sql|
 SELECT
@@ -1933,11 +1848,10 @@ ORDER BY
     |]
 
 
-getDBQueryStats :: (Hasql :> es, IOE :> es) => Projects.ProjectId -> UTCTime -> UTCTime -> Eff es [(Text, Int, Int)]
-getDBQueryStats projectId start end = do
-  rows :: V.Vector (Text, Int64, Int64) <-
-    Hasql.interp
-      [HI.sql| SELECT
+getDBQueryStats :: DB es => Projects.ProjectId -> UTCTime -> UTCTime -> Eff es [(Text, Int, Int)]
+getDBQueryStats projectId start end =
+  Hasql.interp
+    [HI.sql| SELECT
         attributes___db___query___text AS query,
         ROUND(AVG(duration))::int8 AS avg_duration,
         COUNT(*)::int8 AS count
@@ -1950,7 +1864,6 @@ getDBQueryStats projectId start end = do
       GROUP BY attributes___db___query___text
       HAVING ROUND(AVG(duration)/1000000) > 500
       ORDER BY avg_duration DESC LIMIT 10 |]
-  pure [(q, fromIntegral d, fromIntegral c) | (q, d, c) <- V.toList rows]
 
 
 getTraceShapes :: (DB es, Time.Time :> es) => Projects.ProjectId -> V.Vector Text -> Eff es [(Text, Text, Int, Int)]
@@ -2071,7 +1984,7 @@ insertSystemLog enablePg enableTf tfPgTypes otelLog = do
   -- System logs are best-effort. The inner write logs its own failure via
   -- logAttention; surface a higher-level "system log dropped" so an incident
   -- triager investigating the original event can see that its trail was lost.
-  bulkInsertOtelLogsAndSpansTF tfPgTypes (writeTargetFor enablePg enableTf Nothing) minted >>= flip whenLeft_ \wf ->
+  whenLeftM_ (bulkInsertOtelLogsAndSpansTF tfPgTypes (writeTargetFor enablePg enableTf Nothing) minted) \wf ->
     Log.logAttention "SYSTEM_LOG_DROPPED" (AE.object ["reason" AE..= writeFailureSummary wf])
 
 
@@ -2100,10 +2013,6 @@ truncT n t = if T.length t > n then T.take (n - 3) t <> "..." else t
 
 encTrunc :: AE.ToJSON a => Int -> a -> T.Text
 encTrunc n = truncT n . decodeUtf8 . AE.encode
-
-
-nonEmptyT :: Maybe T.Text -> Maybe T.Text
-nonEmptyT = mfilter (not . T.null)
 
 
 generateLogSummary :: OtelLogsAndSpans -> V.Vector T.Text
@@ -2384,14 +2293,15 @@ metricIdNamespace :: UUID.UUID
 metricIdNamespace = [uuid|5a5e99db-2f4d-58c6-9f8a-b9db1f6139aa|]
 
 
+-- | v5 id over 0x1F-joined key parts, in 'metricIdNamespace'.
+metricUuid :: [Text] -> UUID.UUID
+metricUuid = UUIDv5.generateNamed metricIdNamespace . BS.unpack . encodeUtf8 . T.intercalate "\x1f"
+
+
 metricSeriesId :: MetricRecord -> Text
 metricSeriesId MetricRecord{projectId, metricName, metricType, metricUnit, resource, attributes, instrumentationScope} =
   UUID.toText
-    $ UUIDv5.generateNamed metricIdNamespace
-    . BS.unpack
-    . encodeUtf8
-    $ T.intercalate
-      "\x1f"
+    $ metricUuid
       [ "series"
       , UUID.toText projectId
       , metricName
@@ -2405,17 +2315,13 @@ metricSeriesId MetricRecord{projectId, metricName, metricType, metricUnit, resou
 
 metricId :: MetricRecord -> UUID.UUID
 metricId r@MetricRecord{metricTime, startTimestamp, metricValue} =
-  UUIDv5.generateNamed metricIdNamespace
-    . BS.unpack
-    . encodeUtf8
-    $ T.intercalate
-      "\x1f"
-      [ "point"
-      , metricSeriesId r
-      , toText $ iso8601Show metricTime
-      , maybe "" (toText . iso8601Show) startTimestamp
-      , jsonText $ AE.toJSON metricValue
-      ]
+  metricUuid
+    [ "point"
+    , metricSeriesId r
+    , toText $ iso8601Show metricTime
+    , maybe "" (toText . iso8601Show) startTimestamp
+    , jsonText $ AE.toJSON metricValue
+    ]
 
 
 jsonText :: AE.Value -> Text
@@ -2449,24 +2355,24 @@ bulkInsertOtelMetrics catalogBuffer tfPgTypes target records0 = do
           (labeled @"timefusion" @Hasql $ insertOtelMetrics tfPgTypes records)
   -- Raw storage is authoritative. Catalog work is buffered and only a full
   -- threshold batch is flushed on the ingestion path.
-  when rawPersisted $ liftIO (enqueueMetricCatalog catalogBuffer records) >>= \case
-    Nothing -> pass
-    Just batch ->
-      tryAny (upsertMetricMetadata batch) >>= \case
-        Left e -> Log.logAttention "OTEL_METRICS_META_WRITE_FAILED" (AE.object ["record_count" AE..= V.length batch, "error" AE..= show @Text e])
-        Right () -> pass
+  when rawPersisted $ whenJustM (liftIO $ enqueueMetricCatalog catalogBuffer records) \batch ->
+    whenLeftM_ (tryAny $ upsertMetricMetadata batch) \e ->
+      Log.logAttention "OTEL_METRICS_META_WRITE_FAILED" (AE.object ["record_count" AE..= V.length batch, "error" AE..= show @Text e])
   pure result
 
 
 -- | Insert one chunk into a single store. Values are sent as text for the
 -- TimeFusion leg where JSON must arrive as Variant-compatible text; the PG
 -- projection casts JSON and ids to their native types.
-insertOtelMetrics :: (Hasql :> es, IOE :> es) => Bool -> V.Vector MetricRecord -> Eff es BulkInsertResult
-insertOtelMetrics usePgTypes records = do
-  affected <- fmap (foldl' (+) 0) $ forM (chunksOf 350 $ V.toList records) $ \chunk -> do
-    void
-      $ Hasql.interpExecute_
-        ( [HI.sql|INSERT INTO otel_metrics (
+insertOtelMetrics :: DB es => Bool -> V.Vector MetricRecord -> Eff es BulkInsertResult
+insertOtelMetrics usePgTypes records =
+  -- A chunk either lands whole or throws, so the row count is the submitted total.
+  BulkInsertResult (fromIntegral $ V.length records)
+    <$ traverse_ insertChunk (chunksOf 350 $ V.toList records)
+  where
+    insertChunk chunk =
+      Hasql.interpExecute_
+        $ [HI.sql|INSERT INTO otel_metrics (
       project_id, timestamp, date, start_timestamp, ingested_at, id, series_id,
       metric_name, metric_description, metric_unit, metric_type, aggregation_temporality, is_monotonic, flags,
       resource, resource_schema_url, scope_name, scope_version, scope_schema_url, attributes, dropped_attributes_count, exemplars,
@@ -2483,11 +2389,8 @@ insertOtelMetrics usePgTypes records = do
       exp_hist_pos_offset, exp_hist_pos_buckets, exp_hist_neg_offset, exp_hist_neg_buckets,
       summary_quantiles, summary_values, message_size_bytes
     ) VALUES |]
-            <> mconcat (intersperse [HI.sql|,|] (metricRowSql usePgTypes <$> chunk))
-            <> if usePgTypes then [HI.sql| ON CONFLICT (project_id, timestamp, id) DO NOTHING|] else mempty
-        )
-    pure $ fromIntegral $ length chunk
-  pure $ BulkInsertResult affected
+        <> mconcat (intersperse [HI.sql|,|] (metricRowSql usePgTypes <$> chunk))
+        <> if usePgTypes then [HI.sql| ON CONFLICT (project_id, timestamp, id) DO NOTHING|] else mempty
 
 
 metricRowSql :: Bool -> MetricRecord -> HI.Sql
@@ -2496,7 +2399,8 @@ metricRowSql usePgTypes r@MetricRecord{projectId, id = metricIdM, metricName, me
       attrField k = atMapText k (objectToMap attributes)
       attrFieldInt k = atMapInt k (objectToMap attributes)
       resourceField k = atMapText k (objectToMap resource)
-      serviceName = resourceField "service.name" <|> Just (metricServiceNameFromResource metricName resource)
+      -- 'metricServiceNameFromResource' already tries resource service.name first.
+      serviceName = Just (metricServiceNameFromResource metricName resource)
       serviceNamespace = resourceField "service.namespace"
       serviceInstanceId = resourceField "service.instance.id"
       serviceVersion = resourceField "service.version"
@@ -2531,7 +2435,7 @@ metricRowSql usePgTypes r@MetricRecord{projectId, id = metricIdM, metricName, me
       metricDate = toText $ iso8601Show (utctDay metricTime)
       val = [HI.sql|(#{projectIdText}, #{metricTime}, #{metricDate}::date, #{startTimestamp}, #{timestamp}, |]
    in val
-        <> idSql usePgTypes metricIdText
+        <> castSql "uuid" usePgTypes metricIdText
         <> [HI.sql|, #{seriesId}, #{metricName}, #{metricDescription}, #{metricUnit}, #{metricType}, #{aggregationTemporality}, #{isMonotonic}, #{flagsInt64}, |]
         <> jsonSql usePgTypes resource
         <> [HI.sql|, #{resourceSchemaUrl}, #{scopeName}, #{scopeVersion}, #{scopeSchemaUrl}, |]
@@ -2562,45 +2466,42 @@ metricRowSql usePgTypes r@MetricRecord{projectId, id = metricIdM, metricName, me
         <> [HI.sql|, #{messageSizeBytes})|]
 
 
-idSql :: Bool -> Text -> HI.Sql
-idSql usePgTypes x
-  | usePgTypes = [HI.sql|#{x}::uuid|]
-  | otherwise = [HI.sql|#{x}|]
+-- | Bare text on TimeFusion (coerced to Variant); explicitly cast on Postgres,
+-- which has no text→uuid/jsonb assignment cast.
+castSql :: Text -> Bool -> Text -> HI.Sql
+castSql pgType usePgTypes x = [HI.sql|#{x}|] <> if usePgTypes then fromString (toString ("::" <> pgType)) else mempty
 
 
 jsonSql :: Bool -> AE.Value -> HI.Sql
-jsonSql usePgTypes x
-  | usePgTypes = [HI.sql|#{jsonText x}::jsonb|]
-  | otherwise = [HI.sql|#{jsonText x}|]
+jsonSql usePgTypes = castSql "jsonb" usePgTypes . jsonText
 
 
 -- Existing metric value arrays are JSON-backed. Re-encode them as typed SQL
 -- arrays at the storage boundary so histogram queries never parse JSON.
-jsonArraySql :: Text -> Maybe AE.Value -> HI.Sql
-jsonArraySql typ = \case
-  Nothing -> [HI.sql|NULL|]
+elemArraySql :: Text -> (AE.Value -> Maybe Text) -> Maybe AE.Value -> HI.Sql
+elemArraySql typ pick = \case
   Just (AE.Array xs) ->
-    let values = T.intercalate "\x1f" $ jsonText <$> V.toList xs
+    let values = T.intercalate "\x1f" $ mapMaybe pick $ V.toList xs
      in [HI.sql|string_to_array(#{values}, chr(31))::|] <> fromString (toString typ) <> [HI.sql|[]|]
-  Just _ -> [HI.sql|NULL|]
+  _ -> [HI.sql|NULL|]
 
 
+jsonArraySql :: Text -> Maybe AE.Value -> HI.Sql
+jsonArraySql typ = elemArraySql typ (Just . jsonText)
+
+
+-- | Quantile objects fan out into two parallel double arrays: keys, then values.
 summaryArraySql :: Bool -> Maybe AE.Value -> HI.Sql
-summaryArraySql wantQuantiles = \case
-  Nothing -> [HI.sql|NULL|]
-  Just (AE.Array xs) ->
-    let pick = \case
-          AE.Object o -> KEM.lookup (if wantQuantiles then "quantile" else "value") o >>= \case AE.Number n -> Just (toText $ show n); _ -> Nothing
-          _ -> Nothing
-        values = T.intercalate "\x1f" $ mapMaybe pick $ V.toList xs
-     in [HI.sql|string_to_array(#{values}, chr(31))::double precision[]|]
-  Just _ -> [HI.sql|NULL|]
+summaryArraySql wantQuantiles =
+  elemArraySql "double precision" \case
+    AE.Object o -> KEM.lookup (if wantQuantiles then "quantile" else "value") o >>= \case AE.Number n -> Just (toText $ show n); _ -> Nothing
+    _ -> Nothing
 
 
 -- | Catalog rows are one per metric descriptor, never one per data point.
 -- Callers batch this after raw persistence; it intentionally uses the ordinary
 -- Hasql interpreter because the catalog is TimescaleDB-only.
-upsertMetricMetadata :: (Hasql :> es, IOE :> es) => V.Vector MetricRecord -> Eff es ()
+upsertMetricMetadata :: DB es => V.Vector MetricRecord -> Eff es ()
 upsertMetricMetadata records = unless (V.null records) do
   let rows = ordNub $ V.toList $ V.map catalogRow records
   Hasql.interpExecute_

--- a/src/Pages/Anomalies.hs
+++ b/src/Pages/Anomalies.hs
@@ -1,7 +1,6 @@
 module Pages.Anomalies (
   anomalyListGetH,
   anomalyBulkActionsPostH,
-  escapedQueryPartial,
   acknowledgeAnomalyGetH,
   archiveAnomalyGetH,
   anomalyDetailGetH,
@@ -55,7 +54,6 @@ import Effectful.Concurrent.Async (concurrently)
 import Effectful.Error.Static (throwError)
 import Effectful.Reader.Static (ask)
 import Effectful.Time qualified as Time
-import GHC.Records (HasField)
 import Hasql.Interpolate qualified as HI
 import Lucid
 import Lucid.Aria qualified as Aria
@@ -90,12 +88,11 @@ import Pkg.DeriveUtils (UUIDId (..), hashAssetFile)
 import Pkg.SchemaLearning.Catalog (FacetData (..), FacetSummary (..), FacetValue (..))
 import PyF (fmt)
 import Relude hiding (ask)
-import Relude.Unsafe qualified as Unsafe
 import Servant (err400, errBody)
 import System.Config (AuthContext (..), EnvConfig (..))
 import System.Types (ATAuthCtx, RespHeaders, addErrorToast, addRespHeaders, addSuccessToast, addTriggerEvent)
 import Text.Time.Pretty (prettyTimeAuto)
-import Utils (LoadingSize (..), LoadingType (..), checkFreeTierStatus, escapedQueryPartial, faSprite_, formatOffset, formatUTC, formatWithCommas, htmxOverlayIndicator_, loadingIndicator_, lookupValueText, renderMarkdown, toUriStr)
+import Utils (LoadingSize (..), LoadingType (..), checkFreeTierStatus, faSprite_, formatOffset, formatUTC, formatWithCommas, htmxOverlayIndicator_, loadingIndicator_, lookupValueText, renderMarkdown, toUriStr)
 import Web.FormUrlEncoded (FromForm)
 
 
@@ -263,7 +260,7 @@ anomalyDetailCore pid firstM sinceM fetchIssue = do
                           LIMIT 1 |]
             pure $ viaNonEmpty head rows
           else pure Nothing
-      addRespHeaders $ PageCtx bwconf $ anomalyDetailPage pid issue trItem spanRecs errorM now (isJust firstM) members tp sampleOverride
+      addRespHeaders $ PageCtx bwconf $ anomalyDetailPage pid issue trItem spanRecs errorM now isFirst members tp sampleOverride
 
 
 -- | Unescape JSON-ish whitespace/quotes embedded in summary tokens.
@@ -274,11 +271,9 @@ unescSummary = T.replace "\\\"" "\"" . T.replace "\\n" " " . T.replace "\\t" " "
 -- | Style->class mapping shared by the chip and inline-text summary renderers.
 -- When @wrap@ is True (chips) the classes gain whitespace-pre-wrap/break-* suffixes.
 summaryTokenClass :: Bool -> Text -> Text
-summaryTokenClass wrap style = case style of
+summaryTokenClass wrap = \case
   s | "badge-" `T.isPrefixOf` s -> "cbadge-sm " <> s <> badgeWrap
-  "neutral" -> "cbadge-sm badge-neutral" <> badgeWrap
-  "text-textWeak" -> "text-textWeak text-xs" <> textWrap
-  "text-weak" -> "text-textWeak text-xs" <> textWrap
+  s | s `elem` ["text-textWeak", "text-weak"] -> "text-textWeak text-xs" <> textWrap
   "text-textStrong" -> "text-textStrong text-xs font-medium" <> textWrap
   _ -> "cbadge-sm badge-neutral" <> badgeWrap
   where
@@ -286,22 +281,19 @@ summaryTokenClass wrap style = case style of
     textWrap = bool "" " whitespace-pre-wrap break-words" wrap
 
 
--- | Render a span/log @summary@ array element-wise as styled chips; each
--- element stays one chip even with internal whitespace, and right-rail
--- metadata renders subdued so the primary fields stay dominant.
-renderSummaryChips_ :: Monad m => V.Vector Text -> HtmlT m ()
-renderSummaryChips_ summary = V.forM_ summary \token ->
-  case T.breakOn "\8658" token of
-    (_, "") -> span_ [class_ "text-textWeak text-xs whitespace-pre-wrap break-words"] $ toHtml $ unescSummary token
-    (left, rest) -> do
-      let value = unescSummary $ T.drop 1 rest
-          (field, style) = case T.breakOn ";" left of
-            (f, s) | not (T.null s) -> (f, T.drop 1 s)
-            _ -> ("", left)
-          baseStyle = fromMaybe style $ T.stripPrefix "right-" style
-          cls = summaryTokenClass True baseStyle
-          tipAttr = [term "data-tippy-content" field | not (T.null field)]
-      span_ ([class_ $ cls <> " inline-block max-w-full"] <> tipAttr) $ toHtml value
+-- | Render one @field;style⇒value@ summary token. In chip mode (@wrap@) whitespace
+-- is preserved and the @right-@ style prefix (subdued right-rail metadata) is honoured.
+summaryToken_ :: Monad m => Bool -> Text -> HtmlT m ()
+summaryToken_ wrap token = case T.breakOn "⇒" token of
+  (_, "") -> span_ [class_ $ bool "mr-1" "text-textWeak text-xs whitespace-pre-wrap break-words" wrap] $ toHtml $ unescSummary token
+  (left, rest) ->
+    let (field, style) = case T.breakOn ";" left of
+          (f, s) | not (T.null s) -> (f, T.drop 1 s)
+          _ -> ("", left)
+        cls = summaryTokenClass wrap $ bool style (fromMaybe style $ T.stripPrefix "right-" style) wrap
+     in span_
+          ([class_ $ cls <> bool " mr-1 inline-block" " inline-block max-w-full" wrap] <> [term "data-tippy-content" field | not (T.null field)])
+          (toHtml $ unescSummary $ T.drop 1 rest)
 
 
 -- | Smart default time range based on anomaly age.
@@ -407,15 +399,13 @@ extractBreadcrumbs spans =
 
 -- | Icon id + tailwind colour class for a breadcrumb @type@.
 breadcrumbVisual :: Text -> (Text, Text)
-breadcrumbVisual t = case t of
-  "click" -> ("arrow-pointer", "text-fillBrand-strong")
-  "navigation" -> ("globe", "text-fillSuccess-strong")
-  "nav" -> ("globe", "text-fillSuccess-strong")
-  "xhr" -> ("wifi", "text-fillInformation-strong")
-  "fetch" -> ("wifi", "text-fillInformation-strong")
-  "console.error" -> ("terminal", "text-fillError-strong")
-  "console.warn" -> ("terminal", "text-fillWarning-strong")
-  _ -> ("terminal", "text-textWeak")
+breadcrumbVisual t
+  | t == "click" = ("arrow-pointer", "text-fillBrand-strong")
+  | t `elem` ["navigation", "nav"] = ("globe", "text-fillSuccess-strong")
+  | t `elem` ["xhr", "fetch"] = ("wifi", "text-fillInformation-strong")
+  | t == "console.error" = ("terminal", "text-fillError-strong")
+  | t == "console.warn" = ("terminal", "text-fillWarning-strong")
+  | otherwise = ("terminal", "text-textWeak")
 
 
 -- | Compact selector / url summary from a breadcrumb's @data@ blob.
@@ -492,12 +482,24 @@ activityPanel_ pid issueId extraClass spans = do
       $ loadingIndicator_ LdSM LdDots
 
 
--- | One labelled icon+value row used in the Error/Endpoint detail panels.
-detailItem_ :: (Text, Text, Text, Text) -> Html ()
-detailItem_ (icn, iconColor, lbl, value) = div_ [class_ "flex items-center gap-1.5 whitespace-nowrap"] do
-  faSprite_ icn "regular" $ "w-3 h-3 " <> iconColor
-  span_ [class_ "text-xs text-textWeak"] $ toHtml lbl <> ":"
-  span_ [class_ "text-xs font-medium"] $ toHtml value
+-- | A wrapping row of @(icon, iconColour, label, value)@ entries, as used by the
+-- Error/Endpoint detail panels.
+detailRow_ :: [(Text, Text, Text, Text)] -> Html ()
+detailRow_ =
+  div_ [class_ "flex flex-wrap items-center gap-x-5 gap-y-2"] . mapM_ \(icn, iconColor, lbl, value) ->
+    div_ [class_ "flex items-center gap-1.5 whitespace-nowrap"] do
+      faSprite_ icn "regular" $ "w-3 h-3 " <> iconColor
+      span_ [class_ "text-xs text-textWeak"] $ toHtml lbl <> ":"
+      span_ [class_ "text-xs font-medium"] $ toHtml value
+
+
+-- | Right-hand "<title> details" card shown next to the volume chart.
+detailCard_ :: Text -> Html () -> Html ()
+detailCard_ title body = div_ [class_ "lg:w-72 shrink-0 surface-raised rounded-2xl overflow-hidden"] do
+  div_ [class_ "px-4 py-3 border-b border-strokeWeak flex items-center gap-2"] do
+    faSprite_ "circle-info" "regular" "w-3.5 h-3.5 text-textWeak"
+    span_ [class_ "text-xs font-semibold text-textWeak uppercase tracking-wide"] $ toHtml title
+  div_ [class_ "p-4 flex flex-col gap-3"] body
 
 
 anomalyDetailPage :: Projects.ProjectId -> Issues.Issue -> Maybe Telemetry.Trace -> V.Vector Telemetry.SpanRecord -> Maybe ErrorPatterns.ErrorPatternL -> UTCTime -> Bool -> V.Vector ProjectMembers.ProjectMemberVM -> TimePicker.TimePicker -> Maybe (V.Vector Text) -> Html ()
@@ -524,22 +526,19 @@ anomalyDetailPage pid issue tr spanRecs errM now isFirst members tp sampleOverri
           -- vector — render each element as a single chip so values with
           -- internal whitespace (user-agents, page titles) stay intact.
           logPatternCards sourceField logPattern sampleMessage = div_ [class_ "flex flex-col gap-4"] do
-            _ <- div_ [class_ "surface-raised rounded-2xl overflow-hidden"] do
+            div_ [class_ "surface-raised rounded-2xl overflow-hidden"] do
               div_ [class_ "px-4 py-3 border-b border-strokeWeak flex items-center gap-2"] do
                 span_ [class_ "text-xs font-semibold text-textWeak uppercase tracking-wide"] "Log Pattern"
                 span_ [class_ "badge badge-sm badge-ghost"] $ toHtml $ sourceFieldLabel sourceField
               renderLogContent_ logPattern
-            let renderSample body = div_ [class_ "surface-raised rounded-2xl overflow-hidden"] do
-                  _ <- div_ [class_ "px-4 py-3 border-b border-strokeWeak"] $ span_ [class_ "text-xs font-semibold text-textWeak uppercase tracking-wide"] "Sample Message"
+            let renderSample :: Html () -> Html ()
+                renderSample body = div_ [class_ "surface-raised rounded-2xl overflow-hidden"] do
+                  div_ [class_ "px-4 py-3 border-b border-strokeWeak"] $ span_ [class_ "text-xs font-semibold text-textWeak uppercase tracking-wide"] "Sample Message"
                   body
-            case sampleOverride of
-              Just summary
-                | not (V.null summary) ->
-                    renderSample $ div_ [class_ "flex flex-wrap items-center gap-1 p-4 max-h-80 overflow-y-auto"] $ renderSummaryChips_ summary
-              _ ->
-                whenJust
-                  (mfilter ((/= T.strip logPattern) . T.strip) sampleMessage)
-                  (renderSample . renderLogContent_)
+            maybe
+              (whenJust (mfilter ((/= T.strip logPattern) . T.strip) sampleMessage) (renderSample . renderLogContent_))
+              (renderSample . div_ [class_ "flex flex-wrap items-center gap-1 p-4 max-h-80 overflow-y-auto"] . V.mapM_ (summaryToken_ True))
+              (mfilter (not . V.null) sampleOverride)
       div_ [class_ "flex flex-wrap gap-2 items-center"] do
         severityBadge (display issue.severity)
         issueTypeLabel issue.issueType issue.critical
@@ -603,27 +602,19 @@ anomalyDetailPage pid issue tr spanRecs errM now isFirst members tp sampleOverri
             div_ [class_ "min-w-0 flex-1"] $ volumeChart_ "Error Frequency"
             whenJust errM \errL -> do
               let err = errL.base
-              div_ [class_ "lg:w-72 shrink-0 surface-raised rounded-2xl overflow-hidden"] do
-                div_ [class_ "px-4 py-3 border-b border-strokeWeak flex items-center gap-2"] do
-                  faSprite_ "circle-info" "regular" "w-3.5 h-3.5 text-textWeak"
-                  span_ [class_ "text-xs font-semibold text-textWeak uppercase tracking-wide"] "Error Details"
-                div_ [class_ "p-4 flex flex-col gap-3"] do
-                  whenJust ((,) <$> exceptionData.requestMethod <*> exceptionData.requestPath) \(method, path) ->
-                    div_ [class_ "mb-1"] do
-                      span_ [class_ $ "relative cbadge-sm badge-" <> method <> " whitespace-nowrap"] $ toHtml method
-                      span_ [class_ "ml-2 text-sm text-textWeak"] $ toHtml path
-                  div_ [class_ "flex flex-wrap items-center gap-x-5 gap-y-2"]
-                    $ forM_
-                      [ ("calendar" :: Text, "text-fillBrand-strong" :: Text, "First seen" :: Text, compactTimeAgo $ toText $ prettyTimeAuto now (zonedTimeToUTC err.createdAt))
-                      , ("calendar" :: Text, "text-fillBrand-strong" :: Text, "Last seen" :: Text, compactTimeAgo $ toText $ prettyTimeAuto now (zonedTimeToUTC err.updatedAt))
-                      ]
-                      detailItem_
-                  div_ [class_ "flex flex-wrap items-center gap-x-5 gap-y-2"]
-                    $ forM_
-                      [ ("code" :: Text, "text-fillWarning-strong" :: Text, "Stack" :: Text, fromMaybe "Unknown stack" err.errorData.runtime)
-                      , ("server" :: Text, "text-fillSuccess-strong" :: Text, "Service" :: Text, fromMaybe "Unknown service" err.errorData.serviceName)
-                      ]
-                      detailItem_
+              detailCard_ "Error Details" do
+                whenJust ((,) <$> exceptionData.requestMethod <*> exceptionData.requestPath) \(method, path) ->
+                  div_ [class_ "mb-1"] do
+                    span_ [class_ $ "relative cbadge-sm badge-" <> method <> " whitespace-nowrap"] $ toHtml method
+                    span_ [class_ "ml-2 text-sm text-textWeak"] $ toHtml path
+                detailRow_
+                  [ ("calendar", "text-fillBrand-strong", "First seen", compactTimeAgo $ toText $ prettyTimeAuto now (zonedTimeToUTC err.createdAt))
+                  , ("calendar", "text-fillBrand-strong", "Last seen", compactTimeAgo $ toText $ prettyTimeAuto now (zonedTimeToUTC err.updatedAt))
+                  ]
+                detailRow_
+                  [ ("code", "text-fillWarning-strong", "Stack", fromMaybe "Unknown stack" err.errorData.runtime)
+                  , ("server", "text-fillSuccess-strong", "Service", fromMaybe "Unknown service" err.errorData.serviceName)
+                  ]
           -- Stack trace + Activity (Activity column merges User Journey + issue events)
           div_ [class_ "flex flex-col lg:flex-row gap-4 lg:items-start"] do
             div_ [class_ "min-w-0 flex-1"]
@@ -678,23 +669,15 @@ anomalyDetailPage pid issue tr spanRecs errM now isFirst members tp sampleOverri
           -- Chart + endpoint details panel side-by-side
           div_ [class_ "flex flex-col lg:flex-row gap-4 lg:items-start"] do
             div_ [class_ "min-w-0 flex-1"] $ volumeChart_ "Request Trend"
-            div_ [class_ "lg:w-72 shrink-0 surface-raised rounded-2xl overflow-hidden"] do
-              div_ [class_ "px-4 py-3 border-b border-strokeWeak flex items-center gap-2"] do
-                faSprite_ "circle-info" "regular" "w-3.5 h-3.5 text-textWeak"
-                span_ [class_ "text-xs font-semibold text-textWeak uppercase tracking-wide"] "Endpoint Details"
-              div_ [class_ "p-4 flex flex-col gap-3"] do
-                div_ [class_ "flex flex-wrap items-center gap-x-5 gap-y-2"]
-                  $ forM_
-                    [ ("calendar" :: Text, "text-fillBrand-strong" :: Text, "First seen" :: Text, compactTimeAgo $ toText $ prettyTimeAuto now (zonedTimeToUTC issue.createdAt))
-                    , ("calendar" :: Text, "text-fillBrand-strong" :: Text, "Last seen" :: Text, compactTimeAgo $ toText $ prettyTimeAuto now (zonedTimeToUTC issue.updatedAt))
-                    ]
-                    detailItem_
-                div_ [class_ "flex flex-wrap items-center gap-x-5 gap-y-2"]
-                  $ forM_
-                    [ ("server" :: Text, "text-fillSuccess-strong" :: Text, "Service" :: Text, fromMaybe "Unknown service" issue.service)
-                    , ("hashtag" :: Text, "text-fillBrand-strong" :: Text, "Requests" :: Text, formatWithCommas (fromIntegral issue.affectedRequests :: Double))
-                    ]
-                    detailItem_
+            detailCard_ "Endpoint Details" do
+              detailRow_
+                [ ("calendar", "text-fillBrand-strong", "First seen", compactTimeAgo $ toText $ prettyTimeAuto now (zonedTimeToUTC issue.createdAt))
+                , ("calendar", "text-fillBrand-strong", "Last seen", compactTimeAgo $ toText $ prettyTimeAuto now (zonedTimeToUTC issue.updatedAt))
+                ]
+              detailRow_
+                [ ("server", "text-fillSuccess-strong", "Service", fromMaybe "Unknown service" issue.service)
+                , ("hashtag", "text-fillBrand-strong", "Requests", formatWithCommas (fromIntegral issue.affectedRequests :: Double))
+                ]
           -- Field changes (or "new endpoint" hint) + Activity panel
           div_ [class_ "flex flex-col lg:flex-row gap-4 lg:items-start"] do
             div_ [class_ "min-w-0 flex-1"]
@@ -715,13 +698,15 @@ anomalyDetailPage pid issue tr spanRecs errM now isFirst members tp sampleOverri
                     "This endpoint started receiving traffic. Inspect the originating request in Investigation below to see headers, body, and call site."
             activityPanel_ pid issueId "lg:w-80 shrink-0" spanRecs
       let isLogPatternIssue = issue.issueType `elem` [Issues.LogPattern, Issues.LogPatternRateChange]
-      div_ [class_ "surface-raised rounded-2xl overflow-hidden", id_ "error-details-container", makeAttribute "tabindex" "-1", onkeydown_ "if(event.key==='Escape'&&this.classList.contains('investigation-fullscreen'))document.getElementById('investigation-fullscreen-btn').click()"] do
+      div_ [class_ "surface-raised rounded-2xl overflow-hidden group/inv", id_ "error-details-container", makeAttribute "tabindex" "-1", [__|on keydown[key is 'Escape'] if I match .investigation-fullscreen remove .investigation-fullscreen from me then call window.scrollTo({top:0})|]] do
         div_ [class_ "max-md:px-3 px-4 border-b border-strokeWeak flex max-md:flex-col md:items-center md:justify-between"] do
           div_ [class_ "flex items-center gap-2 max-md:py-1.5"] do
             faSprite_ "magnifying-glass-chart" "regular" "w-3.5 h-3.5 text-textWeak"
             h3_ [class_ "text-xs font-semibold text-textWeak uppercase tracking-wide"] "Investigation"
-            button_ [class_ "p-1 rounded hover:bg-fillWeaker cursor-pointer transition-colors max-md:hidden", Aria.label_ "Toggle fullscreen", id_ "investigation-fullscreen-btn", onclick_ "var c=document.getElementById('error-details-container'),u=this.querySelector('use'),h=u.getAttribute('href');c.classList.toggle('investigation-fullscreen');u.setAttribute('href',c.classList.contains('investigation-fullscreen')?h.replace('#expand','#compress'):h.replace('#compress','#expand'));window.scrollTo({top:0})"] do
-              faSprite_ "expand" "regular" "w-3 h-3 text-textWeak"
+            -- Icon state is CSS-driven off the container's fullscreen class; the click handler only toggles it.
+            button_ [class_ "p-1 rounded hover:bg-fillWeaker cursor-pointer transition-colors max-md:hidden", Aria.label_ "Toggle fullscreen", [__|on click toggle .investigation-fullscreen on #error-details-container then call window.scrollTo({top:0})|]] do
+              faSprite_ "expand" "regular" "w-3 h-3 text-textWeak group-[.investigation-fullscreen]/inv:hidden"
+              faSprite_ "compress" "regular" "w-3 h-3 text-textWeak hidden group-[.investigation-fullscreen]/inv:block"
           div_ [class_ "flex items-center max-md:overflow-x-auto max-md:-mx-4 max-md:px-4 max-md:pb-1.5"] do
             let aUrl = "/p/" <> pid.toText <> "/issues/" <> issueId
                 navLink (href, isActive, tooltip, lbl) = a_ [href_ href, class_ $ bool "text-textWeak hover:text-textStrong" "text-textBrand font-medium" isActive <> " text-xs py-2.5 max-md:px-2 px-3 cursor-pointer transition-colors", term "data-tippy-content" tooltip] $ toHtml lbl
@@ -842,15 +827,13 @@ errorResolveAction pid errId errState canResolve =
             span_ [class_ "max-md:hidden"] "Resolve"
 
 
-errorSubscriptionAction :: (HasField "id" err ErrorPatterns.ErrorPatternId, HasField "notifyEveryMinutes" err Int, HasField "subscribed" err Bool) => Projects.ProjectId -> err -> Html ()
+errorSubscriptionAction :: Projects.ProjectId -> ErrorPatterns.ErrorPattern -> Html ()
 errorSubscriptionAction pid err = do
   let isActive = err.subscribed
-  let notifyEvery = err.notifyEveryMinutes
-  let actionUrl = "/p/" <> pid.toText <> "/issues/errors/" <> UUID.toText err.id.unErrorPatternId <> "/subscribe"
   form_
     [ id_ "issue-subscription-action"
     , class_ "flex items-center gap-2"
-    , hxPost_ actionUrl
+    , hxPost_ $ "/p/" <> pid.toText <> "/issues/errors/" <> UUID.toText err.id.unErrorPatternId <> "/subscribe"
     , hxTarget_ "#issue-subscription-action"
     , hxSwap_ "outerHTML"
     , hxTrigger_ "change"
@@ -861,10 +844,8 @@ errorSubscriptionAction pid err = do
         span_ [class_ "max-md:hidden"] "Notify every"
       select_ [class_ "select select-sm max-md:w-20 w-36", name_ "notifyEveryMinutes", Aria.label_ "Notification frequency"] do
         option_ ([value_ "0"] <> [selected_ "true" | not isActive]) "Off"
-        let opts :: [(Int, Text)]
-            opts = [(10, "10 min"), (20, "20 min"), (30, "30 min"), (60, "1 hr"), (360, "6 hrs"), (1440, "24 hrs")]
-        forM_ opts \(val, label) ->
-          option_ ([value_ (show val)] <> [selected_ "true" | isActive && val == notifyEvery]) (toHtml label)
+        forM_ ([(10, "10 min"), (20, "20 min"), (30, "30 min"), (60, "1 hr"), (360, "6 hrs"), (1440, "24 hrs")] :: [(Int, Text)]) \(val, label) ->
+          option_ ([value_ (show val)] <> [selected_ "true" | isActive && val == err.notifyEveryMinutes]) (toHtml label)
 
 
 newtype AssignErrorForm = AssignErrorForm
@@ -1017,10 +998,8 @@ aiChatPostH pid issueId form
       addRespHeaders $ aiChatResponse_ pid form.query response widgets toolCalls systemPromptM
 
     processIssue appCtx now convId issue = do
-      -- Build system prompt (shared logic)
       fullSystemPrompt <- buildSystemPromptForIssue pid issue now
-      let systemPrompt = anomalySystemPrompt now
-          config = (AI.defaultAgenticConfig pid){AI.facetContext = Nothing, AI.customContext = Just fullSystemPrompt, AI.conversationId = Just convId, AI.conversationType = Just Issues.CTAnomaly, AI.systemPromptOverride = Just systemPrompt}
+      let config = (AI.defaultAgenticConfig pid){AI.facetContext = Nothing, AI.customContext = Just fullSystemPrompt, AI.conversationId = Just convId, AI.conversationType = Just Issues.CTAnomaly, AI.systemPromptOverride = Just $ anomalySystemPrompt now}
       result <- AI.runAgenticChatWithHistory config form.query appCtx.config.openaiModel appCtx.config.openaiApiKey
       either
         (\err -> respond (Just fullSystemPrompt) convId ("I encountered an error while analyzing this issue: " <> err) Nothing Nothing False)
@@ -1066,12 +1045,17 @@ buildSystemPromptForIssue pid issue now = do
       metricsData <- Charts.queryMetrics Nothing (Just Charts.DTMetric) (Just pid) (Just alertData.queryExpression) Nothing Nothing (Just $ show twoDaysAgo) (Just $ show now) Nothing []
       pure $ Just (alertData, monitorM, metricsData)
     _ -> pure Nothing
-  let issueContext = unlines ["--- ISSUE CONTEXT ---", buildAIContext issue errorM traceDataM spans alertContextM]
-      dayAgo = addUTCTime (-86400) now
-  facetSummaryM <- SchemaCatalog.getFacetSummary pid "otel_logs_and_spans" dayAgo now
-  let systemPrompt = anomalySystemPrompt now
-      fullSystemPrompt = unlines [systemPrompt, "", "--- FACET SUMMARY ---", maybe "" formatFacetSummaryForAI facetSummaryM, "", issueContext]
-  pure fullSystemPrompt
+  facetSummaryM <- SchemaCatalog.getFacetSummary pid "otel_logs_and_spans" (addUTCTime (-86400) now) now
+  pure
+    $ unlines
+      [ anomalySystemPrompt now
+      , ""
+      , "--- FACET SUMMARY ---"
+      , maybe "" formatFacetSummaryForAI facetSummaryM
+      , ""
+      , "--- ISSUE CONTEXT ---"
+      , buildAIContext issue errorM traceDataM spans alertContextM
+      ]
   where
     fetchTrace useTf err =
       fromMaybe (Nothing, V.empty) <$> runMaybeT do
@@ -1192,13 +1176,12 @@ buildSystemPromptForIssue pid issue now = do
     formatFacetSummaryForAI summary =
       let FacetData facetMap = summary.facetJson
           formatField (fieldName, values) =
-            let topValues = take 10 values
-                formattedValues = map (\fv -> fv.value <> " (" <> show fv.count <> ")") topValues
-                valueStr = T.intercalate ", " formattedValues
-                ellipsis = if length values > 10 then ", ..." else ""
-             in "- " <> fieldName <> ": " <> valueStr <> ellipsis
-          sortedFields = sortOn (\(_, vs) -> negate $ sum $ map (.count) vs) $ HM.toList facetMap
-          topFields = take 30 sortedFields
+            "- "
+              <> fieldName
+              <> ": "
+              <> T.intercalate ", " (map (\fv -> fv.value <> " (" <> show fv.count <> ")") $ take 10 values)
+              <> bool "" ", ..." (length values > 10)
+          topFields = take 30 $ sortOn (\(_, vs) -> negate $ sum $ map (.count) vs) $ HM.toList facetMap
        in unlines
             $ "Available telemetry fields (top values by frequency):"
             : map formatField topFields
@@ -1386,8 +1369,8 @@ anomalyListGetH pid layoutM filterTM sortM timeFilter pageM perPageM loadM endpo
         _ -> (Just False, Just False, "Inbox")
 
   let filterV = fromMaybe "14d" timeFilter
-      pageInt = maybe 0 (Unsafe.read . toString) pageM
-      perPage = maybe 25 (Unsafe.read . toString) perPageM
+      pageInt = fromMaybe 0 $ readMaybe . toString =<< pageM
+      perPage = fromMaybe 25 $ readMaybe . toString =<< perPageM
       currentSort = fromMaybe "-created_at" sortM
 
   freeTierStatus <- checkFreeTierStatus pid project.paymentPlan
@@ -1396,7 +1379,7 @@ anomalyListGetH pid layoutM filterTM sortM timeFilter pageM perPageM loadM endpo
   let period = fromMaybe "24h" periodM
   ((issues, totalCount), (availableServices, availableTypes)) <-
     concurrently
-      (Issues.selectIssues pid Nothing ackd archived perPage (pageInt * perPage) Nothing (Just currentSort) period serviceFilters typeFilters)
+      (Issues.selectIssues pid ackd archived perPage (pageInt * perPage) Nothing (Just currentSort) period serviceFilters typeFilters)
       ( concurrently
           (Hasql.interp [HI.sql| SELECT DISTINCT service FROM apis.issues WHERE project_id = #{pid} AND service IS NOT NULL |])
           (Hasql.interp [HI.sql| SELECT DISTINCT issue_type::text FROM apis.issues WHERE project_id = #{pid} |])
@@ -1414,7 +1397,7 @@ anomalyListGetH pid layoutM filterTM sortM timeFilter pageM perPageM loadM endpo
           }
   let serviceMenu = FilterMenu{label = "Service", paramName = "service", multiSelect = True, options = map (\s -> FilterOption{label = s, value = s, isActive = s `elem` serviceFilters}) availableServices}
       typeMenu = FilterMenu{label = "Type", paramName = "type", multiSelect = True, options = map (\t -> FilterOption{label = t, value = t, isActive = t `elem` typeFilters}) availableTypes}
-      issuesVM = V.fromList $ map (IssueVM False False currTime filterV) issues
+      issuesVM = V.fromList $ map (IssueVM False currTime filterV) issues
       tableActions =
         TableHeaderActions
           { baseUrl
@@ -1503,7 +1486,7 @@ instance ToHtml AnomalyListGet where
 
 
 issueRowAttrs :: IssueVM -> [Attribute]
-issueRowAttrs (IssueVM _ _ _ _ issue) = [class_ $ "group/row hover:bg-fillWeaker " <> bg] <> sty
+issueRowAttrs (IssueVM _ _ _ issue) = [class_ $ "group/row hover:bg-fillWeaker " <> bg] <> sty
   where
     (bg, sty) = case display issue.base.severity of
       "critical" -> ("bg-fillError-weak", [style_ "box-shadow: inset 3px 0 0 var(--color-fillError-strong)"])
@@ -1512,7 +1495,7 @@ issueRowAttrs (IssueVM _ _ _ _ issue) = [class_ $ "group/row hover:bg-fillWeaker
 
 
 issueRowId :: IssueVM -> Text
-issueRowId (IssueVM _ _ _ _ issue) = Issues.issueIdText issue.base.id
+issueRowId (IssueVM _ _ _ issue) = Issues.issueIdText issue.base.id
 
 
 -- | (icon, iconStyle, colorClass, tooltip) — uses shape+color so status isn't color-only
@@ -1524,7 +1507,7 @@ anomalyStatusIndicator False False "warning" = ("triangle-alert", "regular", "te
 anomalyStatusIndicator False False _ = ("circle-alert", "regular", "text-textWeak", "Active")
 
 
-data IssueVM = IssueVM Bool Bool UTCTime Text Issues.IssueL
+data IssueVM = IssueVM Bool UTCTime Text Issues.IssueL
   deriving stock (Show)
 
 
@@ -1538,7 +1521,7 @@ issueColumns pid period toggleM =
 
 
 renderIssueEventsCol :: IssueVM -> Html ()
-renderIssueEventsCol (IssueVM _ isWidget _ _ issue) =
+renderIssueEventsCol (IssueVM isWidget _ _ issue) =
   unless isWidget
     $ span_ [class_ $ "tabular-nums font-medium " <> countStyle issue.eventCount]
     $ toHtml
@@ -1551,12 +1534,12 @@ renderIssueEventsCol (IssueVM _ isWidget _ _ issue) =
 
 
 renderIssueDateCol :: IssueVM -> Html ()
-renderIssueDateCol (IssueVM _ _ currTime _ issue) =
+renderIssueDateCol (IssueVM _ currTime _ issue) =
   span_ [class_ "text-xs text-textWeak"] $ toHtml $ compactTimeAgo $ toText $ prettyTimeAuto currTime $ zonedTimeToUTC issue.base.createdAt
 
 
 renderIssueChartCol :: IssueVM -> Html ()
-renderIssueChartCol (IssueVM _ _ _ _ issue) = sparkline_ $ V.toList issue.activityBuckets
+renderIssueChartCol (IssueVM _ _ _ issue) = sparkline_ $ V.toList issue.activityBuckets
 
 
 highlightJsHead_ :: Monad m => HtmlT m ()
@@ -1586,17 +1569,7 @@ renderLogContent_ txt =
 
 
 renderSummaryText_ :: Monad m => Text -> HtmlT m ()
-renderSummaryText_ txt = forM_ (words txt) \token ->
-  case T.breakOn "⇒" token of
-    (_, "") -> span_ [class_ "mr-1"] $ toHtml $ unescSummary token
-    (left, rest) -> do
-      let value = unescSummary $ T.drop 1 rest
-          (field, style) = case T.breakOn ";" left of
-            (f, s) | not (T.null s) -> (f, T.drop 1 s)
-            _ -> ("", left)
-          cls = summaryTokenClass False style
-          tipAttr = [term "data-tippy-content" field | not (T.null field)]
-      span_ ([class_ $ cls <> " mr-1 inline-block"] <> tipAttr) $ toHtml value
+renderSummaryText_ = traverse_ (summaryToken_ False) . words
 
 
 renderIssueTitle_ :: Issues.IssueL -> Html ()
@@ -1606,11 +1579,11 @@ renderIssueTitle_ Issues.IssueL{base}
   | looksLikeRawPattern title = span_ [class_ "font-mono text-xs break-all"] $ renderWithPlaceholders_ title
   | otherwise = renderWithPlaceholders_ title
   where
-    title = stripIssuePrefix base.title
-    stripIssuePrefix =
-      foldl' (\t pfx -> fromMaybe t $ T.stripPrefix pfx t)
-        <*> const
-          ["New Log Pattern: ", "Log Pattern Spike: ", "Log Pattern Drop: ", "New Log Pattern Detected: "]
+    title =
+      foldl'
+        (\t pfx -> fromMaybe t $ T.stripPrefix pfx t)
+        base.title
+        ["New Log Pattern: ", "Log Pattern Spike: ", "Log Pattern Drop: ", "New Log Pattern Detected: "]
     looksLikeRawPattern t = any (`T.isInfixOf` t) [";right-", "v{", "<*>", "]{", "ERROR ERROR"]
 
 
@@ -1625,7 +1598,7 @@ renderWithPlaceholders_ = go
 
 
 renderIssueMainCol :: Projects.ProjectId -> IssueVM -> Html ()
-renderIssueMainCol pid (IssueVM _ _ currTime period issue) = do
+renderIssueMainCol pid (IssueVM _ currTime period issue) = do
   let b = issue.base
       isAcknowledged = isJust b.acknowledgedAt
       isArchived = isJust b.archivedAt
@@ -1774,16 +1747,10 @@ issueTypeBadge issueType critical = span_ [class_ $ "flex items-center gap-1 tex
 logLevelChip_ :: Monad m => Maybe Text -> Text -> HtmlT m ()
 logLevelChip_ logLevel pat =
   let normalized = T.toUpper <$> logLevel
-      hasErrorStatus =
-        "status;badge-error⇒ERROR"
-          `T.isInfixOf` pat
-          || "status_code;badge-4xx"
-          `T.isInfixOf` pat
-          || "status_code;badge-5xx"
-          `T.isInfixOf` pat
+      hasErrorStatus = any (`T.isInfixOf` pat) ["status;badge-error⇒ERROR", "status_code;badge-4xx", "status_code;badge-5xx"]
       effective
-        | normalized == Just "ERROR" || normalized == Just "FATAL" || normalized == Just "CRITICAL" = Just "ERROR"
-        | normalized == Just "WARN" || normalized == Just "WARNING" = Just "WARN"
+        | normalized `elem` ([Just "ERROR", Just "FATAL", Just "CRITICAL"] :: [Maybe Text]) = Just "ERROR"
+        | normalized `elem` ([Just "WARN", Just "WARNING"] :: [Maybe Text]) = Just "WARN"
         | hasErrorStatus = Just "ERROR"
         | otherwise = normalized
       (cls, icon, label) = case effective of

--- a/src/Pages/BodyWrapper.hs
+++ b/src/Pages/BodyWrapper.hs
@@ -116,6 +116,9 @@ onboardingChecklist_ project = do
                 span_ [class_ "truncate"] $ toHtml label
 
 
+type role PageCtx representational
+
+
 data PageCtx a = PageCtx
   { conf :: BWConfig
   , content :: a

--- a/src/Pages/BodyWrapper.hs
+++ b/src/Pages/BodyWrapper.hs
@@ -3,7 +3,7 @@ module Pages.BodyWrapper (bodyWrapper, BWConfig (..), PageCtx (..), mkPageCtx, w
 import Data.CaseInsensitive qualified as CI
 import Data.Default (Default, def)
 import Data.Text qualified as T
-import Data.Tuple.Extra (fst3)
+import Data.Tuple.Extra (fst3, uncurry3)
 import Data.Vector qualified as V
 import Effectful.Reader.Static qualified as EffReader
 import Lucid
@@ -53,40 +53,37 @@ withSettingsPage pid title build = do
 
 menu :: I18n.Language -> Projects.ProjectId -> [(Text, Text, Text)]
 menu lang pid =
-  [ (I18n.t lang "nav.dashboards", "/p/" <> pid.toText <> "/dashboards", "dashboard")
-  , (I18n.t lang "nav.explorer", "/p/" <> pid.toText <> "/log_explorer", "explore")
-  , (I18n.t lang "nav.api_catalog", "/p/" <> pid.toText <> "/api_catalog", "swap")
-  , (I18n.t lang "nav.issues", "/p/" <> pid.toText <> "/issues", "bug")
-  , (I18n.t lang "nav.monitors", "/p/" <> pid.toText <> "/monitors", "list-check")
-  , (I18n.t lang "nav.reports", "/p/" <> pid.toText <> "/reports", "chart-simple")
+  [ (I18n.t lang "nav.dashboards", p "/dashboards", "dashboard")
+  , (I18n.t lang "nav.explorer", p "/log_explorer", "explore")
+  , (I18n.t lang "nav.api_catalog", p "/api_catalog", "swap")
+  , (I18n.t lang "nav.issues", p "/issues", "bug")
+  , (I18n.t lang "nav.monitors", p "/monitors", "list-check")
+  , (I18n.t lang "nav.reports", p "/reports", "chart-simple")
   ]
+  where
+    p path = "/p/" <> pid.toText <> path
 
 
 -- | Onboarding checklist widget for the sidenav
 onboardingChecklist_ :: Projects.Project -> Html ()
 onboardingChecklist_ project = do
-  let steps = project.onboardingStepsCompleted
-      pid = project.id.toText
-      hasEvents = V.elem "Integration" steps || V.elem "has_events" steps
-      exploredLogs = V.elem "explored_logs" steps
-      createdMonitor = V.elem "created_monitor" steps
-      setupNotifs = V.elem "NotifChannel" steps
+  let pid = project.id.toText
+      has = (`V.elem` project.onboardingStepsCompleted)
       items =
-        [ (hasEvents, "Send first event", "/p/" <> pid <> "/onboarding?step=Integration", "paper-plane")
-        , (exploredLogs, "Explore logs", "/p/" <> pid <> "/log_explorer", "magnifying-glass")
-        , (createdMonitor, "Create a monitor", "/p/" <> pid <> "/monitors", "bell")
-        , (setupNotifs, "Set up notifications", "/p/" <> pid <> "/settings/integrations", "envelope")
+        [ (has "Integration" || has "has_events", ("Send first event", "/p/" <> pid <> "/onboarding?step=Integration", "paper-plane"))
+        , (has "explored_logs", ("Explore logs", "/p/" <> pid <> "/log_explorer", "magnifying-glass"))
+        , (has "created_monitor", ("Create a monitor", "/p/" <> pid <> "/monitors", "bell"))
+        , (has "NotifChannel", ("Set up notifications", "/p/" <> pid <> "/settings/integrations", "envelope"))
         ]
-          :: [(Bool, Text, Text, Text)]
-      doneCount = sum [1 :: Int | (True, _, _, _) <- items]
+          :: [(Bool, (Text, Text, Text))]
+      doneCount = length $ filter fst items
       totalCount = length items
-      allDone = doneCount == totalCount
-      dismissed = V.elem "checklist_dismissed" steps
-  unless (allDone || dismissed)
+      progress = show doneCount <> "/" <> show totalCount :: Text
+  unless (doneCount == totalCount || has "checklist_dismissed")
     $ div_ [id_ "onboarding-checklist", class_ "mt-5 pt-3 border-t border-strokeWeak"] do
       -- Collapsed state: rocket icon
       div_ [class_ "flex justify-center group-has-[#sidenav-toggle:checked]/pg:hidden"] do
-        a_ [href_ $ "/p/" <> pid <> "/onboarding", class_ "relative tap-target", term "data-tippy-placement" "right", term "data-tippy-content" $ "Getting Started (" <> show doneCount <> "/" <> show totalCount <> ")"] do
+        a_ [href_ $ "/p/" <> pid <> "/onboarding", class_ "relative tap-target", term "data-tippy-placement" "right", term "data-tippy-content" $ "Getting Started (" <> progress <> ")"] do
           faSprite_ "rocket" "regular" "w-4 h-4 text-textWeak"
       -- Expanded state: full checklist
       div_ [class_ "hidden group-has-[#sidenav-toggle:checked]/pg:block bg-fillWeaker rounded-lg p-2.5"] do
@@ -95,7 +92,7 @@ onboardingChecklist_ project = do
             faSprite_ "rocket" "regular" "w-2.5 h-2.5 text-textWeak"
             span_ [class_ "text-xs font-medium text-textStrong"] "Getting Started"
           div_ [class_ "flex items-center gap-3"] do
-            span_ [class_ "text-xs text-textWeak tabular-nums"] $ toHtml @Text $ show doneCount <> "/" <> show totalCount
+            span_ [class_ "text-xs text-textWeak tabular-nums"] $ toHtml progress
             button_
               [ class_ "text-textWeak opacity-50 hover:opacity-100 hover:text-textStrong tap-target cursor-pointer"
               , Aria.label_ "Dismiss getting started checklist"
@@ -104,12 +101,10 @@ onboardingChecklist_ project = do
               , hxSwap_ "delete"
               ]
               $ faSprite_ "xmark" "regular" "w-2.5 h-2.5"
-        div_ [class_ "h-0.5 w-full bg-strokeWeak rounded-full overflow-hidden mb-2"] do
-          let pct = show (doneCount * 100 `div` totalCount :: Int)
-          div_ [class_ "h-full bg-strokeBrand-strong rounded-full transition-all", style_ $ "width:" <> toText pct <> "%"] ""
-        let sorted = sortOn (Down . (\(d, _, _, _) -> d)) items
+        div_ [class_ "h-0.5 w-full bg-strokeWeak rounded-full overflow-hidden mb-2"]
+          $ div_ [class_ "h-full bg-strokeBrand-strong rounded-full transition-all", style_ $ "width:" <> show (doneCount * 100 `div` totalCount) <> "%"] ""
         div_ [class_ "flex flex-col gap-0.5"] do
-          forM_ sorted \(done, label, link, icon) ->
+          forM_ (sortOn (Down . fst) items) \(done, (label, link, icon)) ->
             a_
               [ href_ link
               , class_ $ "flex items-center gap-2 px-2 py-1 rounded-md text-xs transition-colors " <> if done then "text-textWeak opacity-60" else "text-textStrong font-medium hover:bg-fillWeak"
@@ -119,9 +114,6 @@ onboardingChecklist_ project = do
                   then faSprite_ "circle-check" "solid" "w-3.5 h-3.5 text-textSuccess shrink-0"
                   else faSprite_ icon "regular" "w-3.5 h-3.5 shrink-0"
                 span_ [class_ "truncate"] $ toHtml label
-
-
-type role PageCtx representational
 
 
 data PageCtx a = PageCtx
@@ -165,91 +157,103 @@ data BWConfig = BWConfig
 
 bodyWrapper :: BWConfig -> Html () -> Html ()
 bodyWrapper bcfg child = do
+  let isProd = bcfg.config.environment /= Dev
   doctype_
   html_ [lang_ "en"] do
-    head_
-      do
-        title_ $ toHtml bcfg.pageTitle
-        meta_ [charset_ "UTF-8"]
-        meta_ [name_ "viewport", content_ "width=device-width, initial-scale=1.0"]
-        meta_ [name_ "description", content_ $ "Monoscope — " <> bcfg.pageTitle]
-        meta_ [httpEquiv_ "X-UA-Compatible", content_ "ie=edge"]
-        meta_ [name_ "htmx-config", content_ [text|{"selfRequestsOnly":false}|]]
-        -- favicon items
-        link_ [rel_ "apple-touch-icon", sizes_ "180x180", href_ "/public/apple-touch-icon.png"]
-        link_ [rel_ "icon", type_ "image/png", sizes_ "32x32", href_ "/public/favicon-32x32.png"]
-        link_ [rel_ "icon", type_ "image/png", sizes_ "16x16", href_ "/public/favicon-16x16.png"]
-        link_ [rel_ "manifest", href_ "/public/site.webmanifest"]
-        link_ [rel_ "mask-icon", href_ "/public/safari-pinned-tab.svg", term "color" "#5bbad5"]
-        meta_ [name_ "msapplication-TileColor", content_ "#da532c"]
-        meta_ [name_ "theme-color", content_ "#ffffff"]
+    head_ do
+      title_ $ toHtml bcfg.pageTitle
+      meta_ [charset_ "UTF-8"]
+      meta_ [name_ "viewport", content_ "width=device-width, initial-scale=1.0"]
+      meta_ [name_ "description", content_ $ "Monoscope — " <> bcfg.pageTitle]
+      meta_ [httpEquiv_ "X-UA-Compatible", content_ "ie=edge"]
+      meta_ [name_ "htmx-config", content_ [text|{"selfRequestsOnly":false}|]]
+      -- favicon items
+      link_ [rel_ "apple-touch-icon", sizes_ "180x180", href_ "/public/apple-touch-icon.png"]
+      link_ [rel_ "icon", type_ "image/png", sizes_ "32x32", href_ "/public/favicon-32x32.png"]
+      link_ [rel_ "icon", type_ "image/png", sizes_ "16x16", href_ "/public/favicon-16x16.png"]
+      link_ [rel_ "manifest", href_ "/public/site.webmanifest"]
+      link_ [rel_ "mask-icon", href_ "/public/safari-pinned-tab.svg", term "color" "#5bbad5"]
+      meta_ [name_ "msapplication-TileColor", content_ "#da532c"]
+      meta_ [name_ "theme-color", content_ "#ffffff"]
 
-        -- Resource hints for faster loading
-        link_ [rel_ "preconnect", href_ "https://www.gravatar.com"]
-        link_ [rel_ "preconnect", href_ "https://ui-avatars.com"]
-        link_ [rel_ "dns-prefetch", href_ "https://cdn.jsdelivr.net"]
-        link_ [rel_ "dns-prefetch", href_ "https://unpkg.com"]
+      -- Resource hints for faster loading
+      link_ [rel_ "preconnect", href_ "https://www.gravatar.com"]
+      link_ [rel_ "preconnect", href_ "https://ui-avatars.com"]
+      link_ [rel_ "dns-prefetch", href_ "https://cdn.jsdelivr.net"]
+      link_ [rel_ "dns-prefetch", href_ "https://unpkg.com"]
 
-        -- Preload critical CSS
-        link_ [rel_ "preload", href_ $(hashAssetFile "/public/assets/css/tailwind.min.css"), term "as" "style"]
+      -- Preload critical CSS
+      link_ [rel_ "preload", href_ $(hashAssetFile "/public/assets/css/tailwind.min.css"), term "as" "style"]
 
-        -- View Transitions API (Chrome 111+, graceful fallback for others)
-        meta_ [name_ "view-transition", content_ "same-origin"]
-        style_
-          """
-          @supports (view-transition-name: root) {
-            ::view-transition-old(root) { animation: vt-fade-out 150ms ease-out; }
-            ::view-transition-new(root) { animation: vt-fade-in 150ms ease-in; }
-          }
-          @keyframes vt-fade-out { from { opacity: 1; } to { opacity: 0; } }
-          @keyframes vt-fade-in { from { opacity: 0; } to { opacity: 1; } }
-          """
+      -- View Transitions API (Chrome 111+, graceful fallback for others)
+      meta_ [name_ "view-transition", content_ "same-origin"]
+      style_
+        """
+        @supports (view-transition-name: root) {
+          ::view-transition-old(root) { animation: vt-fade-out 150ms ease-out; }
+          ::view-transition-new(root) { animation: vt-fade-in 150ms ease-in; }
+        }
+        @keyframes vt-fade-out { from { opacity: 1; } to { opacity: 0; } }
+        @keyframes vt-fade-in { from { opacity: 0; } to { opacity: 1; } }
+        """
 
-        link_ [rel_ "stylesheet", type_ "text/css", href_ $(hashAssetFile "/public/assets/css/thirdparty/notyf3.min.css")]
-        link_ [rel_ "stylesheet", href_ $(hashAssetFile "/public/assets/css/thirdparty/tagify.min.css"), type_ "text/css"]
-        when bcfg.needsGridStack $ link_ [rel_ "stylesheet", href_ $(hashAssetFile "/public/assets/deps/gridstack/gridstack.min.css")]
-        link_ [rel_ "stylesheet", href_ $(hashAssetFile "/public/assets/css/thirdparty/rrweb.css")]
+      let css href = link_ [rel_ "stylesheet", type_ "text/css", href_ href]
+          deferScript src = script_ [src_ src, defer_ "true"] ("" :: Text)
+      mapM_
+        css
+        [ $(hashAssetFile "/public/assets/css/thirdparty/notyf3.min.css")
+        , $(hashAssetFile "/public/assets/css/thirdparty/tagify.min.css")
+        ]
+      when bcfg.needsGridStack $ css $(hashAssetFile "/public/assets/deps/gridstack/gridstack.min.css")
+      mapM_
+        css
+        [ $(hashAssetFile "/public/assets/css/thirdparty/rrweb.css")
+        , $(hashAssetFile "/public/assets/css/tailwind.min.css")
+        , $(hashAssetFile "/public/assets/web-components/dist/css/index.css")
+        ]
 
-        link_ [rel_ "stylesheet", type_ "text/css", href_ $(hashAssetFile "/public/assets/css/tailwind.min.css")]
-        link_ [rel_ "stylesheet", type_ "text/css", href_ $(hashAssetFile "/public/assets/web-components/dist/css/index.css")]
+      fold bcfg.headContent
 
-        -- Include optional head content from the page
-        whenJust bcfg.headContent id
+      mapM_
+        deferScript
+        [ "https://cdn.jsdelivr.net/npm/htmx.org@2.0.8/dist/htmx.min.js"
+        , $(hashAssetFile "/public/assets/js/main.js")
+        , $(hashAssetFile "/public/assets/deps/htmx/multi-swap.js")
+        , $(hashAssetFile "/public/assets/deps/htmx/preload.js")
+        , $(hashAssetFile "/public/assets/deps/htmx/json-enc-2.js")
+        , $(hashAssetFile "/public/assets/deps/htmx/response-targets.js")
+        , $(hashAssetFile "/public/assets/deps/htmx/idiomorph-ext.min.js")
+        , $(hashAssetFile "/public/assets/js/thirdparty/_hyperscript_web0_9_93.min.js")
+        , $(hashAssetFile "/public/assets/deps/tagify/tagify.min.js")
+        , $(hashAssetFile "/public/assets/js/thirdparty/notyf3.min.js")
+        ]
+      script_ [src_ $(hashAssetFile "/public/assets/deps/lit/lit-html.js"), type_ "module", defer_ "true"] ("" :: Text)
+      when bcfg.needsGridStack $ deferScript $(hashAssetFile "/public/assets/deps/gridstack/gridstack-all.js")
+      mapM_
+        deferScript
+        [ $(hashAssetFile "/public/assets/deps/easepick/bundle.min.js")
+        , $(hashAssetFile "/public/assets/js/thirdparty/luxon.min.js")
+        , $(hashAssetFile "/public/assets/js/thirdparty/popper2_11_4.min.js")
+        , $(hashAssetFile "/public/assets/js/thirdparty/tippy6_3_7.umd.min.js")
+        ]
 
-        script_ [src_ "https://cdn.jsdelivr.net/npm/htmx.org@2.0.8/dist/htmx.min.js", defer_ "true"] ("" :: Text)
-        script_ [src_ $(hashAssetFile "/public/assets/js/main.js"), defer_ "true"] ("" :: Text)
-        script_ [src_ $(hashAssetFile "/public/assets/deps/htmx/multi-swap.js"), defer_ "true"] ("" :: Text)
-        script_ [src_ $(hashAssetFile "/public/assets/deps/htmx/preload.js"), defer_ "true"] ("" :: Text)
-        script_ [src_ $(hashAssetFile "/public/assets/deps/htmx/json-enc-2.js"), defer_ "true"] ("" :: Text)
-        script_ [src_ $(hashAssetFile "/public/assets/deps/htmx/response-targets.js"), defer_ "true"] ("" :: Text)
-        script_ [src_ $(hashAssetFile "/public/assets/deps/htmx/idiomorph-ext.min.js"), defer_ "true"] ("" :: Text)
-        script_ [src_ $(hashAssetFile "/public/assets/js/thirdparty/_hyperscript_web0_9_93.min.js"), defer_ "true"] ("" :: Text)
-        script_ [src_ $(hashAssetFile "/public/assets/deps/tagify/tagify.min.js"), defer_ "true"] ("" :: Text)
-        script_ [src_ $(hashAssetFile "/public/assets/js/thirdparty/notyf3.min.js"), defer_ "true"] ("" :: Text)
-        script_ [src_ $(hashAssetFile "/public/assets/deps/lit/lit-html.js"), type_ "module", defer_ "true"] ("" :: Text)
-        when bcfg.needsGridStack $ script_ [src_ $(hashAssetFile "/public/assets/deps/gridstack/gridstack-all.js"), defer_ "true"] ("" :: Text)
-        script_ [src_ $(hashAssetFile "/public/assets/deps/easepick/bundle.min.js"), defer_ "true"] ("" :: Text)
-        script_ [src_ $(hashAssetFile "/public/assets/js/thirdparty/luxon.min.js"), defer_ "true"] ("" :: Text)
-        script_ [src_ $(hashAssetFile "/public/assets/js/thirdparty/popper2_11_4.min.js"), defer_ "true"] ("" :: Text)
-        script_ [src_ $(hashAssetFile "/public/assets/js/thirdparty/tippy6_3_7.umd.min.js"), defer_ "true"] ("" :: Text)
+      when (isProd && bcfg.config.enableBrowserMonitoring) $ script_ [src_ "https://unpkg.com/@monoscopetech/browser@0.11.6/dist/monoscope.min.js"] ("" :: Text)
 
-        when (bcfg.config.environment /= Dev && bcfg.config.enableBrowserMonitoring) $ script_ [src_ "https://unpkg.com/@monoscopetech/browser@0.11.6/dist/monoscope.min.js"] ("" :: Text)
+      -- Flag for widget initialization - set to true after web-components loads
+      script_ "window.widgetDepsReady = false;"
+      script_ [type_ "module", src_ $(hashAssetFile "/public/assets/web-components/dist/js/index.js")] ("" :: Text)
 
-        -- Flag for widget initialization - set to true after web-components loads
-        script_ "window.widgetDepsReady = false;"
-        script_ [type_ "module", src_ $(hashAssetFile "/public/assets/web-components/dist/js/index.js")] ("" :: Text)
-
-        unless (bcfg.config.environment == Dev)
-          $ script_
-            [text|
+      when isProd
+        $ script_
+          [text|
         !function(e,t,n,s,u,a){e.twq||(s=e.twq=function(){s.exe?s.exe.apply(s,arguments):s.queue.push(arguments);},s.version='1.1',s.queue=[],u=t.createElement(n),u.async=!0,u.src='https://static.ads-twitter.com/uwt.js',
         a=t.getElementsByTagName(n)[0],a.parentNode.insertBefore(u,a))}(window,document,'script');
         twq('config','om5gt');
         |]
 
-        let swURI = $(hashAssetFile "/public/sw.js")
-        script_
-          [text|
+      let swURI = $(hashAssetFile "/public/sw.js")
+      script_
+        [text|
         if("serviceWorker" in navigator) {
             window.addEventListener("load", () => {
               navigator.serviceWorker.register("${swURI}").then(swReg => {}).catch(err => {
@@ -258,8 +262,8 @@ bodyWrapper bcfg child = do
           });
         }
           |]
-        script_
-          [raw|
+      script_
+        [raw|
 
 
         function navigatable(me, target, container, activeClass, tabPrefix)  {
@@ -472,9 +476,9 @@ bodyWrapper bcfg child = do
     }
 
       |]
-        script_
-          [type_ "text/hyperscript"]
-          [text|
+      script_
+        [type_ "text/hyperscript"]
+        [text|
           behavior LogItemMenuable
             on click
               if I match <.with-context-menu/> then
@@ -507,64 +511,50 @@ bodyWrapper bcfg child = do
       -- HTMX progress bar for long operations
       div_ [id_ "htmx-progress", class_ "htmx-progress"] ""
       case bcfg.sessM of
-        Nothing -> do
+        Nothing ->
           main_ [class_ "flex flex-col grow  h-screen overflow-y-hidden", id_ "main-content"]
-            $ section_
-              [class_ "flex-1 overflow-y-auto"]
-              child
-        Just sess ->
-          let currUser = sess.persistentSession.user.getUser
-              sideNav' = bcfg.currProject & maybe "" \project -> sideNav sess project (fromMaybe bcfg.pageTitle bcfg.prePageTitle) bcfg.menuItem
-           in do
-                -- Command palette (shell rendered inline, dynamic items lazy-loaded)
-                whenJust bcfg.currProject \p ->
-                  CommandPalette.paletteShell_ p.id
-                -- Mobile nav toggle (CSS-only sidebar control, only rendered when sidebar exists)
-                input_ [type_ "checkbox", class_ "hidden", id_ "mobile-nav-toggle", [__|on load if window.innerWidth < 768 then set #sidenav-toggle.checked to true|]]
-                section_ [class_ "flex flex-row grow-0 h-screen overflow-hidden"] do
-                  sideNav'
-                  section_ [class_ "h-full overflow-y-hidden grow flex flex-col"] do
-                    when
-                      (currUser.email == "hello@monoscope.tech")
-                      loginBanner
-                    if bcfg.isSettingsPage || bcfg.hideNavbar
-                      then do
-                        -- Empty navbar anchor so OOB morph can remove non-settings navbar
-                        nav_ [id_ "main-navbar", class_ "hidden"] ""
-                      else navbar bcfg.currProject (maybe [] (\p -> menu sess.lang p.id) bcfg.currProject) currUser bcfg.prePageTitle bcfg.pageTitle bcfg.pageTitleSuffix bcfg.pageTitleModalId bcfg.pageTitleSuffixModalId bcfg.docsLink bcfg.navTabs bcfg.pageActions
-                    main_ [id_ "main-content", class_ "overflow-y-auto h-full grow"] do
-                      whenJust bcfg.currProject (\p -> freeTierUsageBanner p.id.toText bcfg.freeTierStatus)
-                      if bcfg.isSettingsPage
-                        then maybe child (\p -> settingsWrapper p.id bcfg.pageTitle child) bcfg.currProject
-                        else child
-                    div_ [class_ "h-0 shrink"] do
-                      Components.drawer_ "global-data-drawer" (isJust bcfg.globalDrawerContent) Nothing bcfg.globalDrawerContent ""
-                      template_ [id_ "loader-tmp"] Components.drawerLoadingSkeleton_
-                      -- Modal for copying widgets to other dashboards
-                      Components.modal_ "dashboards-modal" "" do
-                        -- Hidden fields to store widget and dashboard IDs
-                        input_ [type_ "hidden", id_ "dashboards-modal-widget-id", name_ "widget_id"]
-                        input_ [type_ "hidden", id_ "dashboards-modal-source-dashboard-id", name_ "source_dashboard_id"]
-
-                        div_
-                          [ id_ "dashboards-modal-content"
-                          , class_ "dashboards-list space-y-3 max-h-160 overflow-y-auto"
-                          , hxGet_ ("/p/" <> maybe "" (.id.toText) bcfg.currProject <> "/dashboards?embedded=true")
-                          , hxTrigger_ "loadDashboards"
-                          , hxSelect_ "#itemsListPage"
-                          , hxSwap_ "innerHTML"
-                          , hxVals_ "js:{copy_widget_id: document.getElementById('dashboards-modal-widget-id').value, source_dashboard_id: document.getElementById('dashboards-modal-source-dashboard-id').value}"
-                          ]
-                          do
-                            div_ [class_ "skeleton h-16 w-full"] ""
-                            div_ [class_ "skeleton h-16 w-full"] ""
-                            div_ [class_ "skeleton h-16 w-full"] ""
+            $ section_ [class_ "flex-1 overflow-y-auto"] child
+        Just sess -> do
+          -- Command palette (shell rendered inline, dynamic items lazy-loaded)
+          whenJust bcfg.currProject \p -> CommandPalette.paletteShell_ p.id
+          -- Mobile nav toggle (CSS-only sidebar control, only rendered when sidebar exists)
+          input_ [type_ "checkbox", class_ "hidden", id_ "mobile-nav-toggle", [__|on load if window.innerWidth < 768 then set #sidenav-toggle.checked to true|]]
+          section_ [class_ "flex flex-row grow-0 h-screen overflow-hidden"] do
+            foldMap (\project -> sideNav sess project (fromMaybe bcfg.pageTitle bcfg.prePageTitle) bcfg.menuItem) bcfg.currProject
+            section_ [class_ "h-full overflow-y-hidden grow flex flex-col"] do
+              when (sess.persistentSession.user.getUser.email == "hello@monoscope.tech") loginBanner
+              -- Empty navbar anchor so OOB morph can remove non-settings navbar
+              if bcfg.isSettingsPage || bcfg.hideNavbar
+                then nav_ [id_ "main-navbar", class_ "hidden"] ""
+                else navbar bcfg (foldMap (\p -> menu sess.lang p.id) bcfg.currProject)
+              main_ [id_ "main-content", class_ "overflow-y-auto h-full grow"] do
+                whenJust bcfg.currProject (\p -> freeTierUsageBanner p.id.toText bcfg.freeTierStatus)
+                if bcfg.isSettingsPage
+                  then maybe child (\p -> settingsWrapper p.id bcfg.pageTitle child) bcfg.currProject
+                  else child
+              div_ [class_ "h-0 shrink"] do
+                Components.drawer_ "global-data-drawer" (isJust bcfg.globalDrawerContent) Nothing bcfg.globalDrawerContent ""
+                template_ [id_ "loader-tmp"] Components.drawerLoadingSkeleton_
+                -- Modal for copying widgets to other dashboards
+                Components.modal_ "dashboards-modal" "" do
+                  input_ [type_ "hidden", id_ "dashboards-modal-widget-id", name_ "widget_id"]
+                  input_ [type_ "hidden", id_ "dashboards-modal-source-dashboard-id", name_ "source_dashboard_id"]
+                  div_
+                    [ id_ "dashboards-modal-content"
+                    , class_ "dashboards-list space-y-3 max-h-160 overflow-y-auto"
+                    , hxGet_ ("/p/" <> foldMap (.id.toText) bcfg.currProject <> "/dashboards?embedded=true")
+                    , hxTrigger_ "loadDashboards"
+                    , hxSelect_ "#itemsListPage"
+                    , hxSwap_ "innerHTML"
+                    , hxVals_ "js:{copy_widget_id: document.getElementById('dashboards-modal-widget-id').value, source_dashboard_id: document.getElementById('dashboards-modal-source-dashboard-id').value}"
+                    ]
+                    $ replicateM_ 3 (div_ [class_ "skeleton h-16 w-full"] "")
 
       -- Mobile nav backdrop (at body level, after section, so it paints on top)
       label_ [term "for" "mobile-nav-toggle", class_ "fixed inset-0 bg-black/50 backdrop-blur-xs z-40 hidden group-has-[#mobile-nav-toggle:checked]/pg:max-md:block cursor-default", Aria.label_ "Close menu"] ""
-      unless (bcfg.config.environment == Dev) $ externalHeadScripts_ bcfg.config
+      when isProd $ externalHeadScripts_ bcfg.config
       globalTemplates_
-      unless (bcfg.config.environment == Dev) $ script_ [async_ "true", src_ "https://www.googletagmanager.com/gtag/js?id=AW-11285541899"] ("" :: Text)
+      when isProd $ script_ [async_ "true", src_ "https://www.googletagmanager.com/gtag/js?id=AW-11285541899"] ("" :: Text)
       script_
         [text|
           window.dataLayer = window.dataLayer || [];
@@ -584,36 +574,23 @@ bodyWrapper bcfg child = do
           }
 
           
-          // Dark mode toggle function - disables transitions during theme switch
-          function toggleDarkMode() {
-            const currentTheme = document.body.getAttribute('data-theme');
-            const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
+          function syncThemeToggles(theme) {
+            ['dark-mode-toggle', 'dark-mode-toggle-swap', 'dark-mode-toggle-navbar'].forEach(id => {
+              const el = document.getElementById(id);
+              if (el) el.checked = theme === 'dark';
+            });
+          }
 
-            // Disable transitions during theme switch to prevent flash
+          // Dark mode toggle - disables transitions during theme switch to prevent flash
+          function toggleDarkMode() {
+            const newTheme = document.body.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
             document.documentElement.classList.add('no-transition');
             document.body.setAttribute('data-theme', newTheme);
             setCookie('theme', newTheme, 365);
-
-            // Update all toggle states
-            const toggle = document.getElementById('dark-mode-toggle');
-            const swapToggle = document.getElementById('dark-mode-toggle-swap');
-            const navbarToggle = document.getElementById('dark-mode-toggle-navbar');
-            if (toggle) {
-              toggle.checked = newTheme === 'dark';
-            }
-            if (swapToggle) {
-              swapToggle.checked = newTheme === 'dark';
-            }
-            if (navbarToggle) {
-              navbarToggle.checked = newTheme === 'dark';
-            }
-
-            // Re-enable transitions after paint
-            requestAnimationFrame(() => {
-              document.documentElement.classList.remove('no-transition');
-            });
+            syncThemeToggles(newTheme);
+            requestAnimationFrame(() => document.documentElement.classList.remove('no-transition'));
           }
-          
+
           // System theme detection - respect OS preference if user hasn't manually set
           (function() {
             const savedTheme = getCookie('theme');
@@ -631,30 +608,15 @@ bodyWrapper bcfg child = do
             });
           })();
 
-          // Initialize toggle state on page load
-          window.addEventListener('DOMContentLoaded', function() {
-            // Set initial toggle state based on data-theme attribute
-            const currentTheme = document.body.getAttribute('data-theme');
-            const toggle = document.getElementById('dark-mode-toggle');
-            const swapToggle = document.getElementById('dark-mode-toggle-swap');
-            const navbarToggle = document.getElementById('dark-mode-toggle-navbar');
-            if (toggle) {
-              toggle.checked = currentTheme === 'dark';
-            }
-            if (swapToggle) {
-              swapToggle.checked = currentTheme === 'dark';
-            }
-            if (navbarToggle) {
-              navbarToggle.checked = currentTheme === 'dark';
-            }
-          });
+          window.addEventListener('DOMContentLoaded', () => syncThemeToggles(document.body.getAttribute('data-theme')));
       |]
-      let email = show $ maybe "" ((.persistentSession.user.getUser.email)) bcfg.sessM
-      let name = maybe "" (\sess -> sess.persistentSession.user.getUser.firstName <> " " <> sess.persistentSession.user.getUser.lastName) bcfg.sessM
-      let pidT = maybe "" (.id.toText) bcfg.currProject
-      let pTitle = maybe "" (.title) bcfg.currProject
-      let telemetryApiKey = bcfg.config.telemetryApiKey
-      let telemetryServiceName = bcfg.config.telemetryServiceName
+      let userM = (.persistentSession.user.getUser) <$> bcfg.sessM
+          email = show $ maybe "" (.email) userM
+          name = maybe "" (\u -> u.firstName <> " " <> u.lastName) userM
+          pidT = foldMap (.id.toText) bcfg.currProject
+          pTitle = foldMap (.title) bcfg.currProject
+          telemetryApiKey = bcfg.config.telemetryApiKey
+          telemetryServiceName = bcfg.config.telemetryServiceName
       script_
         [text| window.addEventListener("load", (event) => {
                   if (typeof posthog !== 'undefined' && posthog && posthog.people && posthog.people.set_once) {
@@ -759,51 +721,37 @@ sideNav sess project pageTitle menuItem = aside_ [class_ "relative bg-fillWeaker
       -- Collapsed: search icon
       button_ [class_ "group-has-[#sidenav-toggle:checked]/pg:hidden flex items-center justify-center p-2 rounded-lg border border-strokeWeak hover:border-strokeStrong hover:bg-fillWeak text-textWeak cursor-pointer transition-colors", searchScript, Aria.label_ "Search", term "data-tippy-placement" "right", term "data-tippy-content" "Search (\x2318K)"] do
         faSprite_ "magnifying-glass" "regular" "w-4 h-4"
-    let mainNavActiveStyles = "[&_.main-nav-link.active]:bg-fillBrand-weak [&_.main-nav-link.active]:text-textStrong [&_.main-nav-link.active]:font-medium [&_.main-nav-link.active]:border-l-strokeBrand-strong [&_.main-nav-link.active]:border-y-transparent [&_.main-nav-link.active]:border-r-transparent [&_.main-nav-link.active_.nav-icon]:text-textBrand"
-    nav_ [id_ "main-sidenav", class_ $ "mt-2 flex flex-col gap-1 text-textWeak " <> mainNavActiveStyles, [__|on click set #mobile-nav-toggle.checked to false end on htmx:pushedIntoHistory from window or popstate from window settle then set p to window.location.pathname then for link in .main-nav-link set h to link.getAttribute('href') set extra to (link.getAttribute('data-match') or '') set matched to (p is h or p.startsWith(h + '/')) if not matched and extra is not '' for m in extra.split(' ') if m is not '' and (p is m or p.startsWith(m + '/')) set matched to true end end end if matched add .active to link else remove .active from link end end|]] do
+    nav_ [id_ "main-sidenav", class_ "mt-2 flex flex-col gap-1 text-textWeak [&_.main-nav-link.active]:bg-fillBrand-weak [&_.main-nav-link.active]:text-textStrong [&_.main-nav-link.active]:font-medium [&_.main-nav-link.active]:border-l-strokeBrand-strong [&_.main-nav-link.active]:border-y-transparent [&_.main-nav-link.active]:border-r-transparent [&_.main-nav-link.active_.nav-icon]:text-textBrand", [__|on click set #mobile-nav-toggle.checked to false end on htmx:pushedIntoHistory from window or popstate from window settle then set p to window.location.pathname then for link in .main-nav-link set h to link.getAttribute('href') set extra to (link.getAttribute('data-match') or '') set matched to (p is h or p.startsWith(h + '/')) if not matched and extra is not '' for m in extra.split(' ') if m is not '' and (p is m or p.startsWith(m + '/')) set matched to true end end end if matched add .active to link else remove .active from link end end|]] do
       let navLinkCls activeCls = "main-nav-link relative group-has-[#sidenav-toggle:checked]/pg:px-4 gap-3 py-2 flex no-wrap shrink-0 justify-center group-has-[#sidenav-toggle:checked]/pg:justify-start items-center rounded-lg overflow-x-hidden overflow-y-hidden hover:bg-fillWeak hover:text-textStrong transition-colors duration-100" <> activeCls
-      let pidTxt = project.id.toText
-          flyoutCls = "invisible opacity-0 group-hover/flyout:visible group-hover/flyout:opacity-100 absolute left-full top-0 ml-1 z-50 min-w-44 bg-bgRaised border border-strokeWeak rounded-lg shadow-md py-1.5 transition-all duration-150"
+          pidTxt = project.id.toText
           flyoutLink (linkText, link) =
-            a_
-              ( [ href_ link
-                , class_ "flex gap-2.5 items-center px-3 py-2 text-sm text-textWeak hover:bg-fillWeak hover:text-textStrong whitespace-nowrap"
-                ]
-                  <> navTabAttrs
-              )
+            a_ ([href_ link, class_ "flex gap-2.5 items-center px-3 py-2 text-sm text-textWeak hover:bg-fillWeak hover:text-textStrong whitespace-nowrap"] <> navTabAttrs)
               $ span_ [] (toHtml linkText)
-          renderNavItem mTitle mUrl fIcon flyoutItems = do
-            let isActive = maybe (pageTitle == mTitle) (== mTitle) menuItem
-                activeCls = if isActive then " active" else ""
+          renderNavItem mTitle mUrl fIcon = do
+            let activeCls = if maybe (pageTitle == mTitle) (== mTitle) menuItem then " active" else ""
+                flyoutItems = navFlyoutItems pidTxt mTitle
                 hasFlyout = not (null flyoutItems)
-                extraMatch
-                  | "/api_catalog" `T.isSuffixOf` mUrl = [term "data-match" $ "/p/" <> pidTxt <> "/endpoints"]
-                  | otherwise = []
+                extraMatch = [term "data-match" ("/p/" <> pidTxt <> "/endpoints") | "/api_catalog" `T.isSuffixOf` mUrl]
             (if hasFlyout then div_ [class_ "relative group/flyout"] else id) do
               a_
-                ( [ href_ mUrl
-                  , class_ $ navLinkCls activeCls
-                  ]
+                ( [href_ mUrl, class_ $ navLinkCls activeCls]
                     <> extraMatch
-                    <> if hasFlyout
-                      then []
-                      else
-                        [term "data-tippy-placement" "right", term "data-tippy-content" mTitle]
-                          <> navTabAttrs
+                    <> if hasFlyout then [] else [term "data-tippy-placement" "right", term "data-tippy-content" mTitle] <> navTabAttrs
                 )
                 do
                   faSprite_ fIcon "regular" "nav-icon w-4 h-4 shrink-0"
                   span_ [class_ "hidden group-has-[#sidenav-toggle:checked]/pg:block whitespace-nowrap truncate"] $ toHtml mTitle
                   when hasFlyout $ span_ [class_ "hidden group-has-[#sidenav-toggle:checked]/pg:block ml-auto text-textWeak"] $ faSprite_ "chevron-right" "regular" "w-3 h-3"
-              when hasFlyout $ div_ [class_ flyoutCls] $ mapM_ flyoutLink flyoutItems
-      let items = menu sess.lang project.id
-          (primary, secondary) = splitAt 2 items
-      mapM_ (\(mTitle, mUrl, fIcon) -> renderNavItem mTitle mUrl fIcon (navFlyoutItems pidTxt mTitle)) primary
+              when hasFlyout
+                $ div_ [class_ "invisible opacity-0 group-hover/flyout:visible group-hover/flyout:opacity-100 absolute left-full top-0 ml-1 z-50 min-w-44 bg-bgRaised border border-strokeWeak rounded-lg shadow-md py-1.5 transition-all duration-150"]
+                $ mapM_ flyoutLink flyoutItems
+      let (primary, secondary) = splitAt 2 $ menu sess.lang project.id
+      mapM_ (uncurry3 renderNavItem) primary
       div_ [class_ "border-t border-strokeWeak/50 my-1.5 mx-2"] ""
-      mapM_ (\(mTitle, mUrl, fIcon) -> renderNavItem mTitle mUrl fIcon (navFlyoutItems pidTxt mTitle)) secondary
+      mapM_ (uncurry3 renderNavItem) secondary
       onboardingChecklist_ project
       div_ [class_ "border-t border-strokeWeak my-2"] ""
-      renderNavItem "Settings" ("/p/" <> pidTxt <> "/settings") "gear" (map (\(_, t, l) -> (t, l)) $ navBottomList pidTxt)
+      renderNavItem "Settings" ("/p/" <> pidTxt <> "/settings") "gear"
       a_
         [ href_ "https://monoscope.tech/docs/"
         , target_ "blank"
@@ -819,12 +767,7 @@ sideNav sess project pageTitle menuItem = aside_ [class_ "relative bg-fillWeaker
 
   div_ [class_ "py-2.5 px-2 group-has-[#sidenav-toggle:checked]/pg:px-3 border-t border-strokeWeak flex flex-col gap-1"] do
     let currUser = sess.persistentSession.user.getUser
-        userIdentifier =
-          if currUser.firstName /= "" || currUser.lastName /= ""
-            then currUser.firstName <> " " <> currUser.lastName
-            else CI.original currUser.email
-        avatarUrl = "/api/avatar/" <> currUser.id.toText
-
+        userIdentifier = bool (CI.original currUser.email) (currUser.firstName <> " " <> currUser.lastName) (currUser.firstName /= "" || currUser.lastName /= "")
     -- Dark mode toggle
     -- Expanded: sun + toggle + moon
     label_ [class_ "hidden group-has-[#sidenav-toggle:checked]/pg:flex cursor-pointer gap-2 items-center px-2 py-2 rounded-lg hover:bg-fillWeak transition-colors duration-100", Aria.label_ "Toggle dark mode"] do
@@ -847,7 +790,7 @@ sideNav sess project pageTitle menuItem = aside_ [class_ "relative bg-fillWeaker
             <> popoverTrigger_ "user-menu-pop"
         )
         do
-          img_ [class_ "w-8 h-8 rounded-full bg-fillPress shrink-0", src_ avatarUrl, alt_ userIdentifier, term "data-tippy-placement" "right", term "data-tippy-content" userIdentifier]
+          img_ [class_ "w-8 h-8 rounded-full bg-fillPress shrink-0", src_ $ "/api/avatar/" <> currUser.id.toText, alt_ userIdentifier, term "data-tippy-placement" "right", term "data-tippy-content" userIdentifier]
           span_ [class_ "hidden group-has-[#sidenav-toggle:checked]/pg:flex items-center gap-1 overflow-hidden flex-1"] do
             span_ [class_ "truncate text-sm"] $ toHtml userIdentifier
             faSprite_ "chevron-down" "regular" "w-3 h-3 text-textWeak shrink-0 ml-auto transition-transform duration-150 rotate-180 group-focus-within/user:rotate-0"
@@ -857,60 +800,52 @@ sideNav sess project pageTitle menuItem = aside_ [class_ "relative bg-fillWeaker
           div_ [class_ "text-textWeak text-xs truncate"] $ toHtml $ CI.original currUser.email
         div_ [class_ "divider my-0"] ""
         li_ [class_ "menu-title px-3 pt-2"] $ toHtml $ I18n.t sess.lang "nav.language"
-        li_ [] $ a_
-          [ href_ "/set_language/en?redirect_to=/"
-          , class_ "flex items-center justify-between"
-          , -- Rewrite the redirect to the current path on click so the user
-            -- stays where they were instead of being bounced to /.
-            onclick_ "this.href='/set_language/en?redirect_to='+encodeURIComponent(location.pathname+location.search);return true;"
-          ]
-          do
-            toHtml $ I18n.t sess.lang "nav.language.english"
-            when (sess.lang == I18n.En) $ faSprite_ "check" "regular" "w-3 h-3"
-        li_ [] $ a_
-          [ href_ "/set_language/es?redirect_to=/"
-          , class_ "flex items-center justify-between"
-          , onclick_ "this.href='/set_language/es?redirect_to='+encodeURIComponent(location.pathname+location.search);return true;"
-          ]
-          do
-            toHtml $ I18n.t sess.lang "nav.language.spanish"
-            when (sess.lang == I18n.Es) $ faSprite_ "check" "regular" "w-3 h-3"
+        -- onclick rewrites the redirect to the current path so the user stays put instead of bouncing to /.
+        let langLink code lang labelKey =
+              li_ [] $ a_
+                [ href_ $ "/set_language/" <> code <> "?redirect_to=/"
+                , class_ "flex items-center justify-between"
+                , onclick_ $ "this.href='/set_language/" <> code <> "?redirect_to='+encodeURIComponent(location.pathname+location.search);return true;"
+                ]
+                do
+                  toHtml $ I18n.t sess.lang labelKey
+                  when (sess.lang == lang) $ faSprite_ "check" "regular" "w-3 h-3"
+        langLink "en" I18n.En "nav.language.english"
+        langLink "es" I18n.Es "nav.language.spanish"
         div_ [class_ "divider my-0"] ""
         li_ [] $ a_ [href_ "/logout", class_ "flex items-center gap-2 text-textError", [__| on click js posthog.reset(); end |]] do
           faSprite_ "arrow-right-from-bracket" "regular" "w-4 h-4"
           toHtml $ I18n.t sess.lang "nav.logout"
 
 
--- mapM_ renderNavBottomItem $ navBottomList project.id.toText
-
-navbar :: Maybe Projects.Project -> [(Text, Text, Text)] -> Projects.User -> Maybe Text -> Text -> Maybe Text -> Maybe Text -> Maybe Text -> Maybe Text -> Maybe (Html ()) -> Maybe (Html ()) -> Html ()
-navbar projectM menuL currUser prePageTitle pageTitle pageTitleSuffix pageTitleMonadId pageTitleSuffixModalId docsLink tabsM pageActionsM =
+navbar :: BWConfig -> [(Text, Text, Text)] -> Html ()
+navbar bcfg menuL =
   nav_ [id_ "main-navbar", class_ "w-full max-md:px-2 max-md:py-1.5 px-4 py-2 flex flex-row flex-wrap border-b border-strokeWeak items-center"] do
     div_ [class_ "flex-1 flex items-center text-textStrong gap-1 min-w-0 overflow-hidden"] do
-      whenJust projectM \_ -> do
+      whenJust bcfg.currProject \_ -> do
         label_ [term "for" "mobile-nav-toggle", class_ "md:!hidden max-md:flex group-has-[#mobile-nav-toggle:checked]/pg:max-md:!hidden cursor-pointer text-strokeStrong p-2 -m-2 items-center justify-center", Aria.label_ "Open menu"] $ faSprite_ "side-chevron-left-in-box" "regular" "h-5 w-5 rotate-180 pointer-events-none"
         div_ [class_ "md:!hidden max-md:block group-has-[#mobile-nav-toggle:checked]/pg:max-md:!hidden w-px h-5 bg-strokeWeak ml-2"] ""
-      whenJust prePageTitle \pt -> whenJust (find (\a -> fst3 a == pt) menuL) \(_, url, icon) -> do
+      whenJust bcfg.prePageTitle \pt -> whenJust (find ((== pt) . fst3) menuL) \(_, url, icon) -> do
         a_ ([class_ "max-md:hidden p-1 hover:bg-fillWeak inline-flex items-center justify-center gap-1 rounded-md text-sm", href_ url] <> navTabAttrs) do
           faSprite_ icon "regular" "w-4 h-4 text-strokeStrong"
           toHtml pt
         faSprite_ "chevron-right" "regular" "w-3 h-3 max-md:hidden"
-      let targetPage = Components.getTargetPage pageTitle
-          titleBase = "font-normal text-xl max-md:text-base p-1 rounded-md leading-none truncate"
-      if targetPage /= "" && isJust pageTitleSuffix
-        then whenJust projectM \p -> a_ ([class_ $ titleBase <> " cursor-pointer hover:bg-fillWeak", href_ $ "/p/" <> p.id.toText <> targetPage, id_ "pageTitleText"] <> navTabAttrs) $ toHtml pageTitle
-        else label_ [class_ $ titleBase <> " cursor-pointer hover:bg-fillWeak", Lucid.for_ $ maybeToMonoid pageTitleMonadId, id_ "pageTitleText"] $ toHtml pageTitle
+      let targetPage = Components.getTargetPage bcfg.pageTitle
+          titleBase = "font-normal text-xl max-md:text-base p-1 rounded-md leading-none truncate cursor-pointer hover:bg-fillWeak"
+      if targetPage /= "" && isJust bcfg.pageTitleSuffix
+        then whenJust bcfg.currProject \p -> a_ ([class_ titleBase, href_ $ "/p/" <> p.id.toText <> targetPage, id_ "pageTitleText"] <> navTabAttrs) $ toHtml bcfg.pageTitle
+        else label_ [class_ titleBase, Lucid.for_ $ maybeToMonoid bcfg.pageTitleModalId, id_ "pageTitleText"] $ toHtml bcfg.pageTitle
       -- Show tab/suffix in breadcrumbs if present (with ID for htmx out-of-band updates)
-      span_ [id_ "pageTitleSuffix", class_ "max-md:hidden flex items-center gap-1"] $ whenJust pageTitleSuffix \suffix -> do
+      span_ [id_ "pageTitleSuffix", class_ "max-md:hidden flex items-center gap-1"] $ whenJust bcfg.pageTitleSuffix \suffix -> do
         faSprite_ "chevron-right" "regular" "w-3 h-3"
         -- Make tab name clickable if modal ID is provided
-        case pageTitleSuffixModalId of
+        case bcfg.pageTitleSuffixModalId of
           Just modalId -> label_ [class_ "font-normal text-xl p-1 leading-none text-textWeak cursor-pointer hover:bg-fillWeak rounded-md", Lucid.for_ modalId, id_ "pageTitleSuffixText"] $ toHtml suffix
           Nothing -> span_ [class_ "font-normal text-xl p-1 leading-none text-textWeak", id_ "pageTitleSuffixText"] $ toHtml suffix
-      whenJust docsLink \link -> a_ [class_ "max-md:hidden text-iconBrand -mt-1", href_ link, Aria.label_ "Open Documentation", term "data-tippy-placement" "right", term "data-tippy-content" "Open Documentation"] $ faSprite_ "circle-question" "regular" "w-4 h-4"
-    whenJust tabsM $ div_ [class_ $ bool "" "max-md:order-last max-md:w-full max-md:pt-1" (isJust pageActionsM)]
-    div_ [class_ $ "flex-1 flex items-center justify-end gap-2 text-sm" <> maybe " max-md:hidden" (const "") pageActionsM] do
-      whenJust pageActionsM id
+      whenJust bcfg.docsLink \link -> a_ [class_ "max-md:hidden text-iconBrand -mt-1", href_ link, Aria.label_ "Open Documentation", term "data-tippy-placement" "right", term "data-tippy-content" "Open Documentation"] $ faSprite_ "circle-question" "regular" "w-4 h-4"
+    whenJust bcfg.navTabs $ div_ [class_ $ bool "" "max-md:order-last max-md:w-full max-md:pt-1" (isJust bcfg.pageActions)]
+    div_ [class_ $ "flex-1 flex items-center justify-end gap-2 text-sm" <> bool " max-md:hidden" "" (isJust bcfg.pageActions)]
+      $ fold bcfg.pageActions
 
 
 globalTemplates_ :: Html ()
@@ -918,14 +853,13 @@ globalTemplates_ = do
   template_ [id_ "log-item-context-menu-tmpl"] do
     ul_ [class_ "log-item-cloned-menu dropdown-content z-50 menu p-2 shadow-sm bg-bgRaised rounded-box w-96 max-w-[92vw] absolute", tabindex_ "0"] do
       fieldContextMenuItems_ DynamicField fieldMenuActions
-  template_ [id_ "successToastTmpl"] do
-    div_ [role_ "alert", class_ "alert alert-success max-md:w-full md:w-96 cursor-pointer toast-animate", [__|init wait for click or 30s then transition my opacity to 0 then remove me|]] do
-      faSprite_ "circle-check" "solid" "stroke-current shrink-0 w-6 h-6"
-      span_ [class_ "title"] "Something succeeded"
-  template_ [id_ "errorToastTmpl"] do
-    div_ [role_ "alert", class_ "alert alert-error max-md:w-full md:w-96 cursor-pointer toast-animate", [__|init wait for click or 30s then transition my opacity to 0 then remove me|]] do
-      faSprite_ "circle-exclamation" "solid" "stroke-current shrink-0 w-6 h-6"
-      span_ [class_ "title"] "Something failed"
+  let toastTmpl tmplId variant icon fallback =
+        template_ [id_ tmplId]
+          $ div_ [role_ "alert", class_ $ "alert " <> variant <> " max-md:w-full md:w-96 cursor-pointer toast-animate", [__|init wait for click or 30s then transition my opacity to 0 then remove me|]] do
+            faSprite_ icon "solid" "stroke-current shrink-0 w-6 h-6"
+            span_ [class_ "title"] fallback
+  toastTmpl "successToastTmpl" "alert-success" "circle-check" "Something succeeded"
+  toastTmpl "errorToastTmpl" "alert-error" "circle-exclamation" "Something failed"
   section_ [class_ "fixed top-0 right-0 z-50 pt-14 pr-5 max-md:left-0 max-md:px-4 space-y-3 pointer-events-none [&>*]:pointer-events-auto", id_ "toastsParent"] ""
   script_
     [type_ "text/javascript"]
@@ -958,13 +892,11 @@ loginBanner = do
 
 
 settingsWrapper :: Projects.ProjectId -> Text -> Html () -> Html ()
-settingsWrapper pid current pageHtml = do
-  let
-    navActiveStyles = "[&_.settings-nav-link]:hover:bg-fillWeak [&_.settings-nav-link]:text-textWeak [&_.settings-nav-link.active]:bg-fillBrand-weak [&_.settings-nav-link.active]:text-textBrand [&_.settings-nav-link.active]:hover:bg-fillBrand-weak"
+settingsWrapper pid current pageHtml =
   section_ [class_ "flex max-md:flex-col h-full w-full"] do
     nav_ [id_ "settings-nav", class_ "md:w-52 shrink-0 md:h-full max-md:px-3 max-md:py-2.5 p-4 md:pt-8 max-md:border-b max-md:border-b-strokeWeak md:border-r md:border-r-strokeWeak max-md:overflow-x-auto max-md:scrollbar-hide", term "preload" "mouseover"] do
       h1_ [class_ "text-lg pl-3 font-semibold text-textStrong max-md:hidden"] "Settings"
-      ul_ [class_ $ "flex max-md:flex-row max-md:flex-nowrap md:flex-col md:mt-4 gap-0.5 w-full " <> navActiveStyles] do
+      ul_ [class_ "flex max-md:flex-row max-md:flex-nowrap md:flex-col md:mt-4 gap-0.5 w-full [&_.settings-nav-link]:hover:bg-fillWeak [&_.settings-nav-link]:text-textWeak [&_.settings-nav-link.active]:bg-fillBrand-weak [&_.settings-nav-link.active]:text-textBrand [&_.settings-nav-link.active]:hover:bg-fillBrand-weak"] do
         li_ [class_ "md:hidden shrink-0"]
           $ label_ [term "for" "mobile-nav-toggle", class_ "flex items-center px-2.5 py-2 rounded-lg cursor-pointer text-strokeStrong hover:bg-fillWeak", Aria.label_ "Open menu"]
           $ faSprite_ "side-chevron-left-in-box" "regular" "shrink-0 h-4.5 w-4.5 rotate-180"
@@ -992,6 +924,7 @@ navFlyoutItems pidTxt = \case
   "API Catalog" -> [("Incoming", p "/api_catalog?request_type=Incoming"), ("Outgoing", p "/api_catalog?request_type=Outgoing")]
   "Issues" -> [("Inbox", p "/issues?filter=Inbox"), ("Acknowledged", p "/issues?filter=Acknowledged"), ("Archived", p "/issues?filter=Archived")]
   "Monitors" -> [("Active", p "/monitors?filter=Active"), ("Inactive", p "/monitors?filter=Inactive"), ("New Monitor", p "/log_explorer#create-alert-toggle")]
+  "Settings" -> [(t, l) | (_, t, l) <- navBottomList pidTxt]
   _ -> []
   where
     p path = "/p/" <> pidTxt <> path
@@ -1037,29 +970,12 @@ externalHeadScripts_ config = do
             window.dataLayer = window.dataLayer || [];
             function gtag(){{dataLayer.push(arguments);}}
             gtag('js', new Date());
-            gtag('config', '{conversionId}');
-
-            function gtag_report_conversion(url) {{
-              var callback = function () {{
-                if (typeof(url) != 'undefined') {{
-                  window.location = url;
-                }}
-              }};
-              gtag('event', 'conversion', {{
-                  'send_to': '{conversionId}/IUBqCKOA-8sYEIvoroUq',
-                  'event_callback': callback
-              }});
-              return false;
-            }} |]
+            gtag('config', '{conversionId}'); |]
 
   -- Facebook Pixel Code
   when (isJust config.facebookPixelId1 || isJust config.facebookPixelId2) $ do
-    let pixelInitScript =
-          mconcat
-            $ catMaybes
-              [ config.facebookPixelId1 <&> \pixelId -> [fmt|fbq('init', '{pixelId}'); fbq('track', 'PageView');|]
-              , config.facebookPixelId2 <&> \pixelId -> [fmt|fbq('init', '{pixelId}'); fbq('track', 'PageView');|]
-              ]
+    let fbInit pixelId = [fmt|fbq('init', '{pixelId}'); fbq('track', 'PageView');|]
+        pixelInitScript = foldMap fbInit $ catMaybes [config.facebookPixelId1, config.facebookPixelId2]
     script_
       [fmt|
           setTimeout(function(){{

--- a/src/Pages/BodyWrapper.hs
+++ b/src/Pages/BodyWrapper.hs
@@ -76,7 +76,7 @@ onboardingChecklist_ project = do
         , (has "NotifChannel", ("Set up notifications", "/p/" <> pid <> "/settings/integrations", "envelope"))
         ]
           :: [(Bool, (Text, Text, Text))]
-      doneCount = length $ filter fst items
+      doneCount = sum $ map (fromEnum . fst) items
       totalCount = length items
       progress = show doneCount <> "/" <> show totalCount :: Text
   unless (doneCount == totalCount || has "checklist_dismissed")
@@ -104,7 +104,7 @@ onboardingChecklist_ project = do
         div_ [class_ "h-0.5 w-full bg-strokeWeak rounded-full overflow-hidden mb-2"]
           $ div_ [class_ "h-full bg-strokeBrand-strong rounded-full transition-all", style_ $ "width:" <> show (doneCount * 100 `div` totalCount) <> "%"] ""
         div_ [class_ "flex flex-col gap-0.5"] do
-          forM_ (sortOn (Down . fst) items) \(done, (label, link, icon)) ->
+          forM_ (sortWith (Down . fst) items) \(done, (label, link, icon)) ->
             a_
               [ href_ link
               , class_ $ "flex items-center gap-2 px-2 py-1 rounded-md text-xs transition-colors " <> if done then "text-textWeak opacity-60" else "text-textStrong font-medium hover:bg-fillWeak"

--- a/src/Pages/Bots/Discord.hs
+++ b/src/Pages/Bots/Discord.hs
@@ -5,11 +5,10 @@ import Data.ByteString qualified as BS
 import Data.ByteString.Base16 qualified as Base16
 import Data.Default (Default (def))
 import Data.Text qualified as T
-import Data.Vector qualified as V
 import Deriving.Aeson qualified as DAE
 import Effectful.Error.Static (throwError)
 import Effectful.Ki qualified as Ki
-import Effectful.Reader.Static (ask, asks)
+import Effectful.Reader.Static (asks)
 import Models.Apis.Integrations (DiscordData (..), getDashboardsForDiscord, getDiscordData, insertDiscordData)
 import Models.Projects.ProjectMembers qualified as ProjectMembers
 import Models.Projects.Projects qualified as Projects
@@ -27,10 +26,8 @@ import Data.Effectful.Wreq (
   postWith,
   responseBody,
  )
-import Data.Time qualified as Time
 import Effectful (Eff, type (:>))
 import Effectful.Log qualified as Log
-import Effectful.Time qualified as Time
 import Models.Apis.Issues qualified as Issues
 import Models.Projects.Dashboards qualified as Dashboards
 import Network.Wreq qualified as Wreq
@@ -49,34 +46,27 @@ import System.Types (ATBaseCtx)
 linkDiscordGetH :: Maybe Text -> Maybe Text -> Maybe Text -> ATBaseCtx (Headers '[Header "Location" Text] BotResponse)
 linkDiscordGetH pidM' codeM guildIdM = do
   envCfg <- asks env
-  let res = pidM' >>= Just . T.splitOn "__"
-  let pidM = res >>= Projects.projectIdFromText . fromMaybe "" . viaNonEmpty head
-  let isOnboarding = maybe False (\r -> length r > 1) res
-  let bwconf =
-        (def :: BWConfig)
-          { sessM = Nothing
-          , currProject = Nothing
-          , pageTitle = "Discord app installed"
-          , config = envCfg
-          }
+  let parts = T.splitOn "__" <$> pidM'
+      pidM = parts >>= viaNonEmpty head >>= Projects.projectIdFromText
+      bwconf = (def :: BWConfig){sessM = Nothing, currProject = Nothing, pageTitle = "Discord app installed", config = envCfg}
+      discordErr = addHeader "" $ DiscordError $ PageCtx def ()
   case (pidM, codeM, guildIdM) of
     (Just pid, Just code, Just guildId) -> do
-      r' <- exchangeCodeForTokenDiscord envCfg.discordClientId envCfg.discordClientSecret code envCfg.discordRedirectUri
-      case r' of
-        Just t -> do
+      ok <- exchangeCodeForTokenDiscord envCfg.discordClientId envCfg.discordClientSecret code envCfg.discordRedirectUri
+      if not ok
+        then pure discordErr
+        else do
           _ <- insertDiscordData pid guildId
-          _ <- registerDiscordCommands envCfg.discordClientId envCfg.discordBotToken guildId
-          if isOnboarding
-            then pure $ addHeader ("/p/" <> pid.toText <> "/onboarding?step=NotifChannel") $ NoContent $ PageCtx bwconf ()
-            else pure $ addHeader "" $ BotLinked $ PageCtx bwconf ("Discord", Just pid)
-        Nothing -> pure $ addHeader "" $ DiscordError $ PageCtx def ()
-    _ ->
-      pure $ addHeader "" $ DiscordError $ PageCtx def ()
+          registerDiscordCommands envCfg.discordClientId envCfg.discordBotToken guildId
+          pure
+            $ if maybe False ((> 1) . length) parts
+              then addHeader ("/p/" <> pid.toText <> "/onboarding?step=NotifChannel") $ NoContent $ PageCtx bwconf ()
+              else addHeader "" $ BotLinked $ PageCtx bwconf ("Discord", Just pid)
+    _ -> pure discordErr
 
 
-exchangeCodeForTokenDiscord :: HTTP :> es => Text -> Text -> Text -> Text -> Eff es (Maybe Text)
+exchangeCodeForTokenDiscord :: HTTP :> es => Text -> Text -> Text -> Text -> Eff es Bool
 exchangeCodeForTokenDiscord clientId clientSecret code redirectUri = do
-  let url = "https://discord.com/api/oauth2/token"
   let body :: [FormParam]
       body =
         [ "client_id" Wreq.:= clientId
@@ -85,37 +75,21 @@ exchangeCodeForTokenDiscord clientId clientSecret code redirectUri = do
         , "code" Wreq.:= code
         , "redirect_uri" Wreq.:= redirectUri
         ]
-      opts = defaults & header "Content-Type" .~ ["application/x-www-form-urlencoded"]
-
-  res <- postWith opts url body
-
+  res <- postWith (defaults & header "Content-Type" .~ ["application/x-www-form-urlencoded"]) "https://discord.com/api/oauth2/token" body
   let status = res ^. Wreq.responseStatus . Wreq.statusCode
-  if status >= 200 && status < 300
-    then pure (Just "success")
-    else pure Nothing
+  pure $ status >= 200 && status < 300
 
 
--- Discord interaction type
-data InteractionType = Ping | ApplicationCommand | MessageComponent
+-- | Discord interaction type. Discord sends 1 for PING; every other numeric type
+-- (application command, message component, …) is dispatched down the same path.
+data InteractionType = Ping | ApplicationCommand
   deriving (Eq, Show)
 
 
 instance AE.FromJSON InteractionType where
-  parseJSON = AE.withScientific "InteractionType" \n -> case round n of
-    1 -> pure Ping
-    _ -> pure ApplicationCommand
+  parseJSON = AE.withScientific "InteractionType" \n -> pure $ bool ApplicationCommand Ping (round n == (1 :: Int))
 
 
--- Discord response type helpers
-pongResponse :: AE.Value
-pongResponse = AE.object ["type" AE..= (1 :: Int)]
-
-
-deferredResponse :: AE.Value
-deferredResponse = AE.object ["type" AE..= (5 :: Int)]
-
-
--- Interaction data
 data DiscordInteraction = Interaction
   { interaction_type :: InteractionType
   , id :: Text
@@ -129,25 +103,11 @@ data DiscordInteraction = Interaction
   deriving (AE.FromJSON) via DAE.CustomJSON '[DAE.FieldLabelModifier '[DAE.Rename "interaction_type" "type", DAE.Rename "data_i" "data"]] DiscordInteraction
 
 
-data ThreadMetadata = ThreadMetadata
-  { archive_timestamp :: Text
-  , archived :: Bool
-  , auto_archive_duration :: Int
-  , create_timestamp :: Text
-  , locked :: Bool
-  }
-  deriving stock (Generic, Show)
-  deriving anyclass (AE.FromJSON)
-
-
 data DiscordThreadChannel = DiscordThreadChannel
   { id :: Text
-  , name :: Text
-  , guild_id :: Maybe Text
   , type_ :: Int
+  , guild_id :: Maybe Text
   , parent_id :: Maybe Text
-  , owner_id :: Maybe Text
-  , thread_metadata :: Maybe ThreadMetadata
   }
   deriving stock (Generic, Show)
   deriving (AE.FromJSON) via DAE.CustomJSON '[DAE.FieldLabelModifier '[DAE.StripSuffix "_"]] DiscordThreadChannel
@@ -161,7 +121,6 @@ data InteractionOption = InteractionOption
   deriving anyclass (AE.FromJSON, AE.ToJSON)
 
 
--- Slash command data
 data InteractionData
   = CommandData
       { name :: Text
@@ -177,265 +136,214 @@ data InteractionData
 
 
 instance AE.FromJSON InteractionData where
-  parseJSON = AE.withObject "InteractionData" $ \v -> do
-    componentType <- v AE..:? "component_type"
-    case componentType of
-      Just 3 ->
-        MessageComponentData
-          <$> v
-          AE..: "component_type"
-          <*> v
-          AE..: "custom_id"
-          <*> v
-          AE..: "values"
-      _ ->
-        CommandData
-          <$> v
-          AE..: "name"
-          <*> v
-          AE..:? "options"
+  parseJSON = AE.withObject "InteractionData" \v ->
+    v AE..:? "component_type" >>= \case
+      Just (3 :: Int) -> MessageComponentData <$> v AE..: "component_type" <*> v AE..: "custom_id" <*> v AE..: "values"
+      _ -> CommandData <$> v AE..: "name" <*> v AE..:? "options"
 
 
 getDiscordChannels :: (HTTP :> es, Log.Log :> es) => Text -> Text -> Eff es [Channel]
 getDiscordChannels token guildId = do
-  let url = "https://discord.com/api/v10/guilds/" <> toString guildId <> "/channels"
-      opts = defaults & header "Authorization" .~ ["Bot " <> encodeUtf8 token]
-  r <- getWith opts url
-  let body = r ^. responseBody
-  case AE.eitherDecode body of
-    Right val -> return val
-    Left err -> do
-      Log.logAttention ("Error decoding discord channels response: " <> toText err) ()
-      return []
+  r <- getWith (defaults & header "Authorization" .~ ["Bot " <> encodeUtf8 token]) (toString $ "https://discord.com/api/v10/guilds/" <> guildId <> "/channels")
+  either (\err -> [] <$ Log.logAttention ("Error decoding discord channels response: " <> toText err) ()) pure $ AE.eitherDecode (r ^. responseBody)
 
 
 discordInteractionsH :: BS.ByteString -> Maybe BS.ByteString -> Maybe BS.ByteString -> ATBaseCtx AE.Value
 discordInteractionsH rawBody signatureM timestampM = do
-  authCtx <- Effectful.Reader.Static.ask @AuthContext
-  let envCfg = authCtx.env
+  envCfg <- asks @AuthContext env
   validateSignature envCfg signatureM timestampM rawBody
-  interaction <- parseInteraction rawBody
+  interaction <- either (const $ throwError err404{errBody = "Invalid interaction data"}) pure $ AE.eitherDecode (fromStrict rawBody)
   Log.logTrace ("Discord interaction received" :: Text) $ AE.object ["type" AE..= show interaction.interaction_type, "guild_id" AE..= interaction.guild_id, "channel_id" AE..= interaction.channel_id, "data" AE..= interaction.data_i]
 
   case interaction.interaction_type of
-    Ping -> pure pongResponse
-    ApplicationCommand -> handleApplicationCommand interaction envCfg authCtx
-    MessageComponent -> handleApplicationCommand interaction envCfg authCtx
+    Ping -> pure $ AE.object ["type" AE..= (1 :: Int)]
+    ApplicationCommand -> handleApplicationCommand interaction envCfg
   where
-    validateSignature envCfg (Just sig) (Just tme) body = do
-      valid <- verifyDiscordSignature (encodeUtf8 envCfg.discordPublicKey) sig tme body
+    validateSignature envCfg sigM tmeM body = do
+      valid <- maybe (pure False) (\(sig, tme) -> verifyDiscordSignature (encodeUtf8 envCfg.discordPublicKey) sig tme body) ((,) <$> sigM <*> tmeM)
       unless valid $ throwError err401{errBody = "Invalid or missing signature"}
-    validateSignature _ _ _ _ = throwError err401{errBody = "Invalid or missing signature"}
 
-    handleApplicationCommand :: DiscordInteraction -> EnvConfig -> AuthContext -> ATBaseCtx AE.Value
-    handleApplicationCommand interaction envCfg authCtx = do
-      cmdData <- case data_i interaction of
-        Nothing -> throwError err400{errBody = "No command data provided"}
-        Just cmd -> pure cmd
-      guildId <- case maybe interaction.guild_id (\c -> c.guild_id) interaction.channel of
-        Nothing -> throwError err400{errBody = "Missing guild_id in interaction"}
-        Just gid -> pure gid
-      discordData <- getDiscordData guildId
-      case discordData of
-        Nothing -> pure $ AE.object ["type" AE..= (4 :: Int), "data" AE..= formatBotError Discord ServiceError]
-        Just d -> handleCommand cmdData interaction envCfg authCtx d
+    handleApplicationCommand :: DiscordInteraction -> EnvConfig -> ATBaseCtx AE.Value
+    handleApplicationCommand interaction envCfg = do
+      cmdData <- maybe (throwError err400{errBody = "No command data provided"}) pure interaction.data_i
+      guildId <- maybe (throwError err400{errBody = "Missing guild_id in interaction"}) pure $ maybe interaction.guild_id (.guild_id) interaction.channel
+      maybe (pure $ AE.object ["type" AE..= (4 :: Int), "data" AE..= formatBotError Discord ServiceError]) (handleCommand cmdData interaction envCfg) =<< getDiscordData guildId
 
-    parseInteraction :: BS.ByteString -> ATBaseCtx DiscordInteraction
-    parseInteraction rawBody' = do
-      case AE.eitherDecode (fromStrict rawBody') of
-        Left e -> throwError err404{errBody = "Invalid interaction data"}
-        Right interaction -> pure interaction
+    handleCommand :: InteractionData -> DiscordInteraction -> EnvConfig -> DiscordData -> ATBaseCtx AE.Value
+    handleCommand cmdData interaction envCfg discordData = case cmdData of
+      CommandData name options -> case name of
+        "monoscope" -> AE.object [] <$ handleAskCommand options interaction envCfg discordData
+        -- The guild is implicit: `discordData` was resolved from interaction.guild_id above,
+        -- so discordData.projectId IS this guild's project. We only need the channel used.
+        "here" -> case interaction.channel_id of
+          Just channelId -> hereSuccessResponse <$ ProjectMembers.addDiscordChannelToEveryoneTeam discordData.projectId channelId
+          Nothing -> pure $ contentResponse "No channel ID provided"
+        "dashboard" -> do
+          deferAck envCfg interaction
+          dashboards <- getDashboardsForDiscord (fromMaybe "" interaction.guild_id)
+          AE.object [] <$ followup envCfg interaction (discordSelectContent dashboards "dashboard-select" "Select a dashboard")
+        _ -> pure $ contentResponse "The command is not recognized"
+      MessageComponentData{custom_id, values} -> do
+        let selected = fromMaybe "" $ viaNonEmpty head values
+        case custom_id of
+          "dashboard-select" -> do
+            deferAck envCfg interaction
+            withDashboard selected \dashboard -> do
+              let widgets = (\w -> let t = fromMaybe "Untitled-" w.title in (t, t <> "___" <> selected)) <$> dashboard.widgets
+              followup envCfg interaction $ discordSelectContent widgets "widget-select" "Select a widget"
+          "widget-select" -> do
+            deferAck envCfg interaction
+            case T.splitOn "___" selected of
+              [widget, dashboardId] -> withDashboard dashboardId \dashboard ->
+                whenJust (find (\w -> fromMaybe "Untitled-" w.title == widget) dashboard.widgets) \w -> do
+                  chartUrl <- widgetPngUrl envCfg.apiKeyEncryptionSecretKey envCfg.hostUrl discordData.projectId w Nothing Nothing Nothing
+                  followup envCfg interaction $ sharedWidgetContent widget chartUrl (envCfg.hostUrl <> "p/" <> discordData.projectId.toText <> "/dashboards/" <> dashboardId)
+              _ -> pass
+          _ -> pass
+        pure $ AE.object []
 
-    handleCommand :: InteractionData -> DiscordInteraction -> EnvConfig -> AuthContext -> DiscordData -> ATBaseCtx AE.Value
-    handleCommand cmdData interaction envCfg authCtx discordData =
-      case cmdData of
-        CommandData name options -> do
-          case name of
-            "monoscope" -> do
-              handleAskCommand options interaction envCfg authCtx discordData
-              pure $ AE.object []
-            "here" -> do
-              -- The guild is implicit: `discordData` was resolved from interaction.guild_id
-              -- at the top of handleInteraction, so discordData.projectId IS this guild's
-              -- project. We only need the channel the user typed /here in.
-              case interaction.channel_id of
-                Just channelId -> do
-                  void $ ProjectMembers.addDiscordChannelToEveryoneTeam discordData.projectId channelId
-                  pure hereSuccessResponse
-                Nothing -> pure $ contentResponse "No channel ID provided"
-            "dashboard" -> do
-              handleDashboard options interaction envCfg authCtx discordData
-              pure $ AE.object []
-            _ -> pure $ contentResponse "The command is not recognized"
-        MessageComponentData{..} -> do
-          case custom_id of
-            "dashboard-select" -> do
-              _ <- sendDeferredResponse interaction.id interaction.token envCfg.discordBotToken
-              let dashboardId = fromMaybe "" $ viaNonEmpty head values
-              dashboardVMM <- maybe (pure Nothing) Dashboards.getDashboardById (idFromText dashboardId)
-              case dashboardVMM of
-                Nothing -> pass
-                Just dashboardVM -> do
-                  dashboardM <- liftIO $ Dashboards.readDashboardFile "static/public/dashboards" (toString $ fromMaybe "_overview.yaml" dashboardVM.baseTemplate)
-                  whenJust dashboardM $ \dashboard -> do
-                    let widgets' = (\w -> (fromMaybe "Untitled-" w.title, fromMaybe "Untitled-" w.title)) <$> dashboard.widgets
-                        widgets = V.fromList $ (\(k, id') -> (k, id' <> "___" <> dashboardId)) <$> widgets'
-                        contents = discordSelectContent widgets "widget-select" "Select a widget"
-                    sendJsonFollowupResponse envCfg.discordClientId interaction.token envCfg.discordBotToken contents
-            "widget-select" -> do
-              _ <- sendDeferredResponse interaction.id interaction.token envCfg.discordBotToken
-              let val = T.splitOn "___" $ fromMaybe "" $ viaNonEmpty head values
-              case val of
-                [widget, dashboardId] -> do
-                  dashboardVMM <- maybe (pure Nothing) Dashboards.getDashboardById (idFromText dashboardId)
-                  case dashboardVMM of
-                    Nothing -> pass
-                    Just dashboardVM -> do
-                      dashboardM <- liftIO $ Dashboards.readDashboardFile "static/public/dashboards" (toString $ fromMaybe "_overview.yaml" dashboardVM.baseTemplate)
-                      whenJust dashboardM $ \dashboard -> do
-                        let widgetM = find (\w -> fromMaybe "Untitled-" w.title == widget) dashboard.widgets
-                        whenJust widgetM $ \w -> do
-                          chartUrl' <- widgetPngUrl envCfg.apiKeyEncryptionSecretKey envCfg.hostUrl discordData.projectId w Nothing Nothing Nothing
-                          let url = envCfg.hostUrl <> "p/" <> discordData.projectId.toText <> "/dashboards/" <> dashboardId
-                              content = sharedWidgetContent widget chartUrl' url
-                          sendJsonFollowupResponse envCfg.discordClientId interaction.token envCfg.discordBotToken content
-                _ -> pass
-              pass
-            _ -> pass
-          pure $ AE.object []
+    -- Resolve a dashboard id to its on-disk template, running the continuation if both exist.
+    withDashboard :: Text -> (Dashboards.Dashboard -> ATBaseCtx ()) -> ATBaseCtx ()
+    withDashboard dashboardId act = whenJust (idFromText dashboardId) \did ->
+      whenJustM (Dashboards.getDashboardById did) \dashboardVM -> do
+        dashboardM <- liftIO $ Dashboards.readDashboardFile "static/public/dashboards" (toString $ fromMaybe "_overview.yaml" dashboardVM.baseTemplate)
+        whenJust dashboardM act
 
-    handleDashboard :: Maybe [InteractionOption] -> DiscordInteraction -> EnvConfig -> AuthContext -> DiscordData -> ATBaseCtx ()
-    handleDashboard cmData interaction envCfg authCtx discordData = do
-      _ <- sendDeferredResponse interaction.id interaction.token envCfg.discordBotToken
-      dashboards <- getDashboardsForDiscord (fromMaybe "" interaction.guild_id)
-      let content = discordSelectContent (V.fromList dashboards) "dashboard-select" "Select a dashboard"
-      sendJsonFollowupResponse envCfg.discordClientId interaction.token envCfg.discordBotToken content
-
-    handleAskCommand :: Maybe [InteractionOption] -> DiscordInteraction -> EnvConfig -> AuthContext -> DiscordData -> ATBaseCtx ()
-    handleAskCommand options interaction envCfg authCtx discordData = do
-      now <- Time.currentTime
-      _ <- sendDeferredResponse interaction.id interaction.token envCfg.discordBotToken
-
-      -- Extract user query from options
-      let userQuery = case options of
-            Just (InteractionOption{value = AE.String q} : _) -> q
-            _ -> ""
-
-      -- Check for report intent first (fast path)
+    handleAskCommand :: Maybe [InteractionOption] -> DiscordInteraction -> EnvConfig -> DiscordData -> ATBaseCtx ()
+    handleAskCommand options interaction envCfg discordData = do
+      deferAck envCfg interaction
+      let userQuery = optionText options ""
+          send = followup envCfg interaction
+          runQuery ctx = processAIQuery envCfg.enableTimefusionReads discordData.projectId userQuery ctx envCfg.openaiModel envCfg.openaiApiKey
+          respond = either (const $ send $ formatBotError Discord ServiceError) \resp ->
+            dispatchAIResponse Discord envCfg discordData.projectId (optionText options "[?]") resp send getBotContentWithUrl
       case detectReportIntent userQuery of
-        ReportIntent reportType -> do
-          reportResult <- processReportQuery discordData.projectId reportType envCfg
-          case reportResult of
-            Left err -> sendJsonFollowupResponse envCfg.discordClientId interaction.token envCfg.discordBotToken (AE.object ["content" AE..= err])
-            Right (report, eventsUrl, errorsUrl) -> sendJsonFollowupResponse envCfg.discordClientId interaction.token envCfg.discordBotToken $ formatReportForDiscord report discordData.projectId envCfg eventsUrl errorsUrl
+        ReportIntent reportType ->
+          processReportQuery discordData.projectId reportType envCfg
+            >>= send
+            . either (\err -> AE.object ["content" AE..= err]) (\(report, eventsUrl, errorsUrl) -> formatReportForDiscord report discordData.projectId envCfg eventsUrl errorsUrl)
         GeneralQueryIntent -> case interaction.channel of
           Just DiscordThreadChannel{type_ = 11, id = threadId} -> do
             let convId = Issues.discordThreadToConversationId threadId
             _ <- Issues.getOrCreateConversation discordData.projectId convId Issues.CTDiscordThread (AE.object ["channel_id" AE..= interaction.channel_id, "guild_id" AE..= interaction.guild_id])
             existingHistory <- Issues.selectChatHistory convId
-            when (null existingHistory) $ do
-              -- Use advisory lock to prevent race condition in thread migration
-              lockAcquired <- Issues.tryAcquireChatMigrationLock convId
-              when lockAcquired $ do
-                msgs <- getThreadStarterMessage interaction envCfg.discordBotToken
-                for_ msgs \messages -> forM_ messages \m ->
-                  let role = if m.author.username `elem` ["APItoolkit", "Monoscope"] then Issues.ChatAssistant else Issues.ChatUser
-                   in Issues.insertChatMessage discordData.projectId convId role m.content Nothing Nothing
-            dbMessages <- Issues.selectChatHistory convId
-            let threadContext = formatHistoryAsContext "Discord" $ map AI.dbMessageToLLMMessage dbMessages
-            result <- processAIQuery envCfg.enableTimefusionReads discordData.projectId userQuery (Just threadContext) envCfg.openaiModel envCfg.openaiApiKey
+            -- Advisory lock: only one interaction seeds the thread's history.
+            when (null existingHistory) $ whenM (Issues.tryAcquireChatMigrationLock convId) do
+              msgs <- getThreadStarterMessage interaction envCfg.discordBotToken
+              for_ (fold msgs) \m ->
+                Issues.insertChatMessage discordData.projectId convId (if m.author.username `elem` ["APItoolkit", "Monoscope"] then Issues.ChatAssistant else Issues.ChatUser) m.content Nothing Nothing
+            threadContext <- formatHistoryAsContext "Discord" . map AI.dbMessageToLLMMessage <$> Issues.selectChatHistory convId
+            result <- runQuery (Just threadContext)
             Issues.insertChatMessage discordData.projectId convId Issues.ChatUser userQuery Nothing Nothing
-            case result of
-              Left _ -> sendJsonFollowupResponse envCfg.discordClientId interaction.token envCfg.discordBotToken (formatBotError Discord ServiceError)
-              Right resp -> do
-                whenJust resp.query \q -> Issues.insertChatMessage discordData.projectId convId Issues.ChatAssistant q Nothing Nothing
-                sendDiscordResponse options interaction envCfg authCtx discordData resp now
-          _ -> do
-            result <- processAIQuery envCfg.enableTimefusionReads discordData.projectId userQuery Nothing envCfg.openaiModel envCfg.openaiApiKey
-            case result of
-              Left _ -> sendJsonFollowupResponse envCfg.discordClientId interaction.token envCfg.discordBotToken (formatBotError Discord ServiceError)
-              Right resp -> sendDiscordResponse options interaction envCfg authCtx discordData resp now
+            whenRight_ result \resp -> whenJust resp.query \q -> Issues.insertChatMessage discordData.projectId convId Issues.ChatAssistant q Nothing Nothing
+            respond result
+          _ -> runQuery Nothing >>= respond
 
 
-sendDiscordResponse :: Maybe [InteractionOption] -> DiscordInteraction -> EnvConfig -> AuthContext -> DiscordData -> AI.LLMResponse -> Time.UTCTime -> ATBaseCtx ()
-sendDiscordResponse options interaction envCfg _authCtx discordData resp _now =
-  let question = case options of
-        Just (InteractionOption{value = AE.String q} : _) -> q
-        _ -> "[?]"
-   in dispatchAIResponse
-        Discord
-        envCfg
-        discordData.projectId
-        question
-        resp
-        (sendJsonFollowupResponse envCfg.discordClientId interaction.token envCfg.discordBotToken)
-        getBotContentWithUrl
+-- | First slash-command option's string value, or a fallback.
+optionText :: Maybe [InteractionOption] -> Text -> Text
+optionText options fallback = case options of
+  Just (InteractionOption{value = AE.String q} : _) -> q
+  _ -> fallback
 
 
 contentResponse :: Text -> AE.Value
 contentResponse msg = AE.object ["type" AE..= 4, "data" AE..= AE.object ["content" AE..= msg]]
 
 
--- | Structured success response for /here command
+-- Discord "components v2" building blocks (flag 32768 opts the message into the new layout).
+containerContent :: Int -> [AE.Value] -> AE.Value
+containerContent accent components =
+  AE.object ["flags" AE..= (32768 :: Int), "components" AE..= ([AE.object ["type" AE..= (17 :: Int), "accent_color" AE..= accent, "components" AE..= components]] :: [AE.Value])]
+
+
+textComponent :: Text -> AE.Value
+textComponent content = AE.object ["type" AE..= (10 :: Int), "content" AE..= content]
+
+
+galleryComponent :: Text -> Text -> AE.Value
+galleryComponent url description = AE.object ["type" AE..= (12 :: Int), "items" AE..= ([AE.object ["media" AE..= AE.object ["url" AE..= url], "description" AE..= description]] :: [AE.Value])]
+
+
+linkButton :: Text -> Text -> AE.Value
+linkButton label url = AE.object ["type" AE..= (1 :: Int), "components" AE..= ([AE.object ["type" AE..= (2 :: Int), "label" AE..= label, "url" AE..= url, "style" AE..= (5 :: Int)]] :: [AE.Value])]
+
+
 hereSuccessResponse :: AE.Value
 hereSuccessResponse =
   AE.object
     [ "type" AE..= (4 :: Int)
     , "data"
-        AE..= AE.object
-          [ "flags" AE..= (32768 :: Int)
-          , "components"
-              AE..= AE.Array
-                ( V.singleton
-                    $ AE.object
-                      [ "type" AE..= (17 :: Int)
-                      , "accent_color" AE..= (5763719 :: Int) -- Green accent
-                      , "components"
-                          AE..= AE.Array
-                            ( V.fromList
-                                [ AE.object ["type" AE..= (10 :: Int), "content" AE..= (botEmoji "success" <> " **Notification channel set**")]
-                                , AE.object ["type" AE..= (10 :: Int), "content" AE..= "This channel will now receive:"]
-                                , AE.object ["type" AE..= (10 :: Int), "content" AE..= ("• " <> botEmoji "error" <> " Error alerts\n• " <> botEmoji "chart" <> " Daily & weekly reports\n• " <> botEmoji "warning" <> " Anomaly detections")]
-                                ]
-                            )
-                      ]
-                )
+        AE..= containerContent
+          5763719 -- Green accent
+          [ textComponent $ botEmoji "success" <> " **Notification channel set**"
+          , textComponent "This channel will now receive:"
+          , textComponent $ "• " <> botEmoji "error" <> " Error alerts\n• " <> botEmoji "chart" <> " Daily & weekly reports\n• " <> botEmoji "warning" <> " Anomaly detections"
           ]
     ]
 
 
-sendDeferredResponse :: HTTP :> es => Text -> Text -> Text -> Eff es ()
-sendDeferredResponse interactionId interactionToken botToken = do
-  let url = toString $ "https://discord.com/api/v10/interactions/" <> interactionId <> "/" <> interactionToken <> "/callback"
-      payload = AE.encode deferredResponse
-  _ <- postWith (defaults & authHeader botToken & contentTypeHeader "application/json") url payload
-  pass
+getBotContentWithUrl :: Text -> Text -> Text -> Text -> AE.Value
+getBotContentWithUrl question query query_url imageUrl =
+  containerContent
+    26879
+    [ textComponent $ botEmoji "chart" <> " **" <> question <> "**"
+    , galleryComponent imageUrl ("Chart visualization: " <> question)
+    , textComponent $ "**Query:** `" <> query <> "`"
+    , linkButton (botEmoji "search" <> " View in Log Explorer") query_url
+    ]
 
 
-sendJsonFollowupResponse :: (HTTP :> es, Log.Log :> es) => Text -> Text -> Text -> AE.Value -> Eff es ()
-sendJsonFollowupResponse appId interactionToken botToken content = do
+sharedWidgetContent :: Text -> Text -> Text -> AE.Value
+sharedWidgetContent widgetTitle chartUrl dashboardUrl =
+  containerContent
+    26879
+    [ textComponent $ botEmoji "chart" <> " **" <> widgetTitle <> "**"
+    , galleryComponent chartUrl ("Dashboard widget: " <> widgetTitle)
+    , linkButton "Open dashboard" dashboardUrl
+    ]
+
+
+discordSelectContent :: [(Text, Text)] -> Text -> Text -> AE.Value
+discordSelectContent choices sId placeholder =
+  AE.object
+    [ "flags" AE..= 64
+    , "components"
+        AE..= ( [ AE.object
+                    [ "type" AE..= (1 :: Int)
+                    , "components" AE..= ([AE.object ["type" AE..= (3 :: Int), "custom_id" AE..= sId, "placeholder" AE..= placeholder, "options" AE..= map (\(t, v) -> AE.object ["label" AE..= t, "value" AE..= v]) choices]] :: [AE.Value])
+                    ]
+                ]
+                  :: [AE.Value]
+              )
+    ]
+
+
+discordJsonPost :: HTTP :> es => Text -> Text -> AE.Value -> Eff es ()
+discordJsonPost botToken url payload = void $ postWith (defaults & authHeader "Bot" botToken & contentTypeHeader "application/json") (toString url) payload
+
+
+-- | ACK the interaction within Discord's 3s window so the real answer can be sent as a followup.
+deferAck :: HTTP :> es => EnvConfig -> DiscordInteraction -> Eff es ()
+deferAck envCfg i = discordJsonPost envCfg.discordBotToken ("https://discord.com/api/v10/interactions/" <> i.id <> "/" <> i.token <> "/callback") (AE.object ["type" AE..= (5 :: Int)])
+
+
+followup :: (HTTP :> es, Log.Log :> es) => EnvConfig -> DiscordInteraction -> AE.Value -> Eff es ()
+followup envCfg i content = do
   Log.logTrace ("Discord followup response" :: Text) content
-  let followupUrl = toString $ "https://discord.com/api/v10/webhooks/" <> appId <> "/" <> interactionToken
-  _ <- postWith (defaults & authHeader botToken & contentTypeHeader "application/json") followupUrl content
-  pass
+  discordJsonPost envCfg.discordBotToken ("https://discord.com/api/v10/webhooks/" <> envCfg.discordClientId <> "/" <> i.token) content
 
 
 verifyDiscordSignature :: Log.Log :> es => ByteString -> ByteString -> ByteString -> ByteString -> Eff es Bool
-verifyDiscordSignature publicKey signatureHex timestamp rawBody = do
-  let result = do
-        s <- first show $ Base16.decode signatureHex
-        sig <- first show $ Crypto.eitherCryptoError $ Ed25519.signature s
-        pkBytes <- first show $ Base16.decode publicKey
-        pk <- first show $ Crypto.eitherCryptoError $ Ed25519.publicKey pkBytes
-        pure $ Ed25519.verify pk (timestamp <> rawBody) sig
-  case result of
-    Right valid -> pure valid
-    Left err -> do
-      Log.logTrace ("Discord signature verification failed: " <> toText err) ()
-      pure False
+verifyDiscordSignature publicKey signatureHex timestamp rawBody =
+  either (\err -> False <$ Log.logTrace ("Discord signature verification failed: " <> toText err) ()) pure result
+  where
+    result = do
+      sig <- first show . Crypto.eitherCryptoError . Ed25519.signature =<< first show (Base16.decode signatureHex)
+      pk <- first show . Crypto.eitherCryptoError . Ed25519.publicKey =<< first show (Base16.decode publicKey)
+      pure $ Ed25519.verify pk (timestamp <> rawBody) sig
 
 
--- Data types for Discord API responses
 newtype DiscordUser = DiscordUser
   { username :: Text
   }
@@ -446,121 +354,42 @@ newtype DiscordUser = DiscordUser
 data DiscordMessage = DiscordMessage
   { content :: Text
   , author :: DiscordUser
-  , embeds :: AE.Value
-  , timestamp :: Text
   }
   deriving (Generic, Show)
   deriving anyclass (AE.FromJSON)
 
 
 getThreadStarterMessage :: (HTTP :> es, Ki.StructuredConcurrency :> es, Log.Log :> es) => DiscordInteraction -> Text -> Eff es (Maybe [DiscordMessage])
-getThreadStarterMessage interaction botToken = do
-  case interaction.channel_id of
-    Just channelId -> case interaction.channel of
-      Just DiscordThreadChannel{type_ = 11, parent_id = Just pId} -> do
-        let baseUrl = "https://discord.com/api/v10/channels/"
-            url = toString $ baseUrl <> channelId <> "/messages?limit=50"
-            starterMessageUrl = toString $ baseUrl <> pId <> "/messages/" <> channelId
-            opts = defaults & authHeader botToken & contentTypeHeader "application/json"
-        -- Plain Ki.fork (not forkWithCtx): Data.Effectful.Wreq.getWith is not
-        -- OTel-instrumented, so the child fibers emit no spans — there is
-        -- nothing to parent and propagation would only add IOE constraint
-        -- noise to this signature.
-        (response, response') <- Ki.scoped \scope -> do
-          t1 <- Ki.fork scope $ getWith opts url
-          t2 <- Ki.fork scope $ getWith opts starterMessageUrl
-          liftA2 (,) (Ki.atomically $ Ki.await t1) (Ki.atomically $ Ki.await t2)
-        case AE.eitherDecode (response ^. responseBody) of
-          Left err -> do
-            Log.logAttention ("Error decoding Discord thread messages: " <> toText err) ()
-            return Nothing
-          Right messages -> do
-            case AE.eitherDecode (response' ^. responseBody) of
-              Left err -> return $ Just messages
-              Right (message :: DiscordMessage) -> return $ Just (messages <> [message])
-      _ -> pure Nothing
-    Nothing -> pure Nothing
+getThreadStarterMessage interaction botToken = case (interaction.channel_id, interaction.channel) of
+  (Just channelId, Just DiscordThreadChannel{type_ = 11, parent_id = Just pId}) -> do
+    let baseUrl = "https://discord.com/api/v10/channels/"
+        opts = defaults & authHeader "Bot" botToken & contentTypeHeader "application/json"
+    -- Plain Ki.fork (not forkWithCtx): Data.Effectful.Wreq.getWith is not
+    -- OTel-instrumented, so the child fibers emit no spans — there is
+    -- nothing to parent and propagation would only add IOE constraint
+    -- noise to this signature.
+    (response, response') <- Ki.scoped \scope -> do
+      t1 <- Ki.fork scope $ getWith opts (toString $ baseUrl <> channelId <> "/messages?limit=50")
+      t2 <- Ki.fork scope $ getWith opts (toString $ baseUrl <> pId <> "/messages/" <> channelId)
+      liftA2 (,) (Ki.atomically $ Ki.await t1) (Ki.atomically $ Ki.await t2)
+    case AE.eitherDecode (response ^. responseBody) of
+      Left err -> Nothing <$ Log.logAttention ("Error decoding Discord thread messages: " <> toText err) ()
+      Right messages -> pure $ Just $ messages <> maybeToList (rightToMaybe (AE.eitherDecode (response' ^. responseBody)) :: Maybe DiscordMessage)
+  _ -> pure Nothing
 
 
-getBotContentWithUrl :: Text -> Text -> Text -> Text -> AE.Value
-getBotContentWithUrl question query query_url imageUrl =
-  AE.object
-    [ "flags" AE..= (32768 :: Int)
-    , "components"
-        AE..= AE.Array
-          ( V.singleton
-              $ AE.object
-                [ "type" AE..= (17 :: Int)
-                , "accent_color" AE..= (26879 :: Int)
-                , "components"
-                    AE..= AE.Array
-                      ( V.fromList
-                          [ AE.object ["type" AE..= (10 :: Int), "content" AE..= (botEmoji "chart" <> " **" <> question <> "**")]
-                          , AE.object ["type" AE..= (12 :: Int), "items" AE..= AE.Array (V.singleton $ AE.object ["media" AE..= AE.object ["url" AE..= imageUrl], "description" AE..= ("Chart visualization: " <> question)])]
-                          , AE.object ["type" AE..= (10 :: Int), "content" AE..= ("**Query:** `" <> query <> "`")]
-                          , AE.object ["type" AE..= (1 :: Int), "components" AE..= AE.Array (V.fromList [AE.object ["type" AE..= (2 :: Int), "label" AE..= (botEmoji "search" <> " View in Log Explorer"), "url" AE..= query_url, "style" AE..= (5 :: Int)]])]
-                          ]
-                      )
-                ]
-          )
-    ]
-
-
-sharedWidgetContent :: Text -> Text -> Text -> AE.Value
-sharedWidgetContent widgetTitle chartUrl dashboardUrl =
-  AE.object
-    [ "flags" AE..= (32768 :: Int)
-    , "components"
-        AE..= AE.Array
-          ( V.singleton
-              $ AE.object
-                [ "type" AE..= (17 :: Int)
-                , "accent_color" AE..= (26879 :: Int)
-                , "components"
-                    AE..= AE.Array
-                      ( V.fromList
-                          [ AE.object ["type" AE..= (10 :: Int), "content" AE..= (botEmoji "chart" <> " **" <> widgetTitle <> "**")]
-                          , AE.object ["type" AE..= (12 :: Int), "items" AE..= AE.Array (V.singleton $ AE.object ["media" AE..= AE.object ["url" AE..= chartUrl], "description" AE..= ("Dashboard widget: " <> widgetTitle)])]
-                          , AE.object ["type" AE..= (1 :: Int), "components" AE..= AE.Array (V.fromList [AE.object ["type" AE..= (2 :: Int), "label" AE..= "Open dashboard", "url" AE..= dashboardUrl, "style" AE..= (5 :: Int)]])]
-                          ]
-                      )
-                ]
-          )
-    ]
-
-
-discordSelectContent :: V.Vector (Text, Text) -> Text -> Text -> AE.Value
-discordSelectContent dashboards sId placeholder =
-  AE.object
-    [ "flags" AE..= 64
-    , "components"
-        AE..= AE.Array
-          ( V.fromList
-              [ AE.object
-                  [ "type" AE..= 1
-                  , "components" AE..= AE.Array (V.fromList [AE.object ["type" AE..= 3, "custom_id" AE..= sId, "placeholder" AE..= placeholder, "options" AE..= opts]])
-                  ]
-              ]
-          )
-    ]
+registerDiscordCommands :: HTTP :> es => Text -> Text -> Text -> Eff es ()
+registerDiscordCommands appId botToken guildId =
+  for_ commands
+    $ discordJsonPost botToken ("https://discord.com/api/v10/applications/" <> appId <> "/guilds/" <> guildId <> "/commands")
   where
-    opts = AE.Array $ V.map (\(t, i) -> AE.object ["label" AE..= t, "value" AE..= i]) dashboards
-
-
-registerDiscordCommands :: HTTP :> es => Text -> Text -> Text -> Eff es (Either Text ())
-registerDiscordCommands appId botToken guildId = do
-  let url = toString $ "https://discord.com/api/v10/applications/" <> appId <> "/guilds/" <> guildId <> "/commands"
-      monoscopeCommand =
-        AE.object
+    commands =
+      [ AE.object
           [ "name" AE..= ("monoscope" :: Text)
           , "description" AE..= ("Ask about your project or get reports" :: Text)
           , "type" AE..= (1 :: Int)
-          , "options" AE..= AE.Array (V.fromList [AE.object ["name" AE..= ("question" :: Text), "description" AE..= ("Your question in natural language" :: Text), "type" AE..= (3 :: Int), "required" AE..= True]])
+          , "options" AE..= ([AE.object ["name" AE..= ("question" :: Text), "description" AE..= ("Your question in natural language" :: Text), "type" AE..= (3 :: Int), "required" AE..= True]] :: [AE.Value])
           ]
-      hereCommand = AE.object ["name" AE..= ("here" :: Text), "description" AE..= ("Channel for monoscope to send notifications" :: Text), "type" AE..= (1 :: Int)]
-      dashboard = AE.object ["name" AE..= ("dashboard" :: Text), "description" AE..= ("Select and share dashboard widget" :: Text), "type" AE..= (1 :: Int)]
-      opts = defaults & authHeader botToken & contentTypeHeader "application/json"
-  _ <- postWith opts url (AE.encode monoscopeCommand)
-  _ <- postWith opts url (AE.encode hereCommand)
-  _ <- postWith opts url (AE.encode dashboard)
-  pure $ Right ()
+      , AE.object ["name" AE..= ("here" :: Text), "description" AE..= ("Channel for monoscope to send notifications" :: Text), "type" AE..= (1 :: Int)]
+      , AE.object ["name" AE..= ("dashboard" :: Text), "description" AE..= ("Select and share dashboard widget" :: Text), "type" AE..= (1 :: Int)]
+      ]

--- a/src/Pages/Bots/Slack.hs
+++ b/src/Pages/Bots/Slack.hs
@@ -1,5 +1,3 @@
-{-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
-
 module Pages.Bots.Slack (linkProjectGetH, slackActionsH, SlackEventPayload, slackEventsPostH, getSlackChannels, getSlackChannelInfo, SlackChannelsResponse (..), SlackActionForm, externalOptionsH, slackInteractionsH, SlackInteraction (..), sendSlackWelcomeMessage, sendSlackWelcomeViaWebhook, logWelcomeMessageFailure) where
 
 import BackgroundJobs qualified as BgJobs
@@ -9,14 +7,11 @@ import Data.Aeson qualified as AE
 import Data.Aeson.Key qualified as KEM
 import Data.Aeson.KeyMap qualified as AEKM
 import Data.Aeson.Lens (key, _Bool, _String)
-
-import Data.Aeson.Types (parseMaybe)
 import Data.Default (Default (def))
 import Data.Effectful.Wreq (
   HTTP,
   defaults,
   getWith,
-  header,
   postWith,
   responseBody,
  )
@@ -30,7 +25,6 @@ import Effectful (Eff, IOE, type (:>))
 import Effectful.Error.Static (throwError)
 import Effectful.Log qualified as Log
 import Effectful.Reader.Static (ask, asks)
-import Effectful.Time qualified as Time
 import Models.Apis.Integrations (SlackData (..), getDashboardsForSlack, getProjectSlackData, getSlackDataByTeamId, insertAccessToken, updateSlackDefaultChannel)
 import Models.Apis.Issues qualified as Issues
 import Models.Projects.Dashboards qualified as Dashboards
@@ -41,7 +35,7 @@ import Network.Wreq qualified as Wreq
 import Network.Wreq.Types (FormParam)
 import OddJobs.Job (createJob)
 import Pages.BodyWrapper (BWConfig, PageCtx (..), currProject, pageTitle, sessM)
-import Pages.Bots.Utils (BotErrorType (..), BotResponse (..), BotType (..), Channel, QueryIntent (..), botEmoji, contentTypeHeader, detectReportIntent, dispatchAIResponse, formatBotError, formatHistoryAsContext, formatReportForSlack, getLoadingMessage, processAIQuery, processReportQuery)
+import Pages.Bots.Utils (BotErrorType (..), BotResponse (..), BotType (..), Channel, QueryIntent (..), authHeader, botEmoji, contentTypeHeader, detectReportIntent, dispatchAIResponse, elemsBlock, formatBotError, formatHistoryAsContext, formatReportForSlack, getLoadingMessage, imageBlock, linkButton, mrkdwn, plainTxt, processAIQuery, processReportQuery, textBlock)
 import Pkg.AI qualified as AI
 import Pkg.Components.Widget (Widget (..), widgetPngUrl)
 import Pkg.DeriveUtils (idFromText)
@@ -59,22 +53,19 @@ import Web.FormUrlEncoded (FromForm)
 
 -- | Log-and-return-Nothing helper: missing slackData is always an anomaly (the caller
 -- either just received an event from Slack or is acting on behalf of an authed project).
-withSlackDataByTeam :: (DB es, Log.Log :> es) => Text -> Text -> (SlackData -> Eff es a) -> Eff es (Maybe a)
-withSlackDataByTeam ctx teamId k =
-  getSlackDataByTeamId teamId >>= \case
-    Nothing -> do
-      Log.logAttention ("Missing SlackData for team_id" :: Text) $ AE.object ["context" AE..= ctx, "team_id" AE..= teamId]
-      pure Nothing
+withSlackData :: Log.Log :> es => Text -> AE.Value -> Eff es (Maybe SlackData) -> (SlackData -> Eff es a) -> Eff es (Maybe a)
+withSlackData logMsg logFields lookupSlackData k =
+  lookupSlackData >>= \case
+    Nothing -> Nothing <$ Log.logAttention logMsg logFields
     Just sd -> Just <$> k sd
+
+
+withSlackDataByTeam :: (DB es, Log.Log :> es) => Text -> Text -> (SlackData -> Eff es a) -> Eff es (Maybe a)
+withSlackDataByTeam ctx teamId = withSlackData "Missing SlackData for team_id" (AE.object ["context" AE..= ctx, "team_id" AE..= teamId]) (getSlackDataByTeamId teamId)
 
 
 withProjectSlackDataLogged :: (DB es, Log.Log :> es) => Text -> Projects.ProjectId -> (SlackData -> Eff es a) -> Eff es (Maybe a)
-withProjectSlackDataLogged ctx pid k =
-  getProjectSlackData pid >>= \case
-    Nothing -> do
-      Log.logAttention ("Missing SlackData for project" :: Text) $ AE.object ["context" AE..= ctx, "project_id" AE..= pid]
-      pure Nothing
-    Just sd -> Just <$> k sd
+withProjectSlackDataLogged ctx pid = withSlackData "Missing SlackData for project" (AE.object ["context" AE..= ctx, "project_id" AE..= pid]) (getProjectSlackData pid)
 
 
 logWelcomeMessageFailure :: Log.Log :> es => Text -> SomeException -> Eff es ()
@@ -86,11 +77,10 @@ logWelcomeMessageFailure channelId err =
 data IncomingWebhook = IncomingWebhook
   { channel :: Text
   , channelId :: Text
-  , configurationUrl :: Text
   , url :: Text
   }
   deriving stock (Generic, Show)
-  deriving (AE.FromJSON, AE.ToJSON) via DAE.CustomJSON '[DAE.FieldLabelModifier '[DAE.CamelToSnake]] IncomingWebhook
+  deriving (AE.FromJSON) via DAE.CustomJSON '[DAE.FieldLabelModifier '[DAE.CamelToSnake]] IncomingWebhook
 
 
 data TokenResponseTeam = TokenResponseTeam
@@ -98,17 +88,18 @@ data TokenResponseTeam = TokenResponseTeam
   , name :: Text
   }
   deriving stock (Generic, Show)
-  deriving (AE.FromJSON, AE.ToJSON) via DAE.CustomJSON '[DAE.FieldLabelModifier '[DAE.CamelToSnake]] TokenResponseTeam
+  deriving (AE.FromJSON) via DAE.CustomJSON '[DAE.FieldLabelModifier '[DAE.CamelToSnake]] TokenResponseTeam
 
 
+-- | Only the fields we consume; a failed exchange has no @access_token@ so decoding
+-- fails there, which is the success check (no need to carry @ok@).
 data TokenResponse = TokenResponse
-  { ok :: Bool
-  , accessToken :: Text
+  { accessToken :: Text
   , incomingWebhook :: IncomingWebhook
   , team :: TokenResponseTeam
   }
   deriving stock (Generic, Show)
-  deriving (AE.FromJSON, AE.ToJSON) via DAE.CustomJSON '[DAE.FieldLabelModifier '[DAE.CamelToSnake]] TokenResponse
+  deriving (AE.FromJSON) via DAE.CustomJSON '[DAE.FieldLabelModifier '[DAE.CamelToSnake]] TokenResponse
 
 
 exchangeCodeForToken :: (HTTP :> es, Log.Log :> es) => Text -> Text -> Text -> Text -> Eff es (Maybe TokenResponse)
@@ -121,18 +112,15 @@ exchangeCodeForToken clientId clientSecret redirectUri code = do
         , "redirect_uri" Wreq.:= redirectUri
         ]
 
-  let hds = header "Content-Type" .~ ["application/x-www-form-urlencoded; charset=utf-8"]
-  response <- postWith (defaults & hds) "https://slack.com/api/oauth.v2.access" formData
+  response <- postWith (defaults & contentTypeHeader "application/x-www-form-urlencoded; charset=utf-8") "https://slack.com/api/oauth.v2.access" formData
   let responseBdy = response ^. responseBody
   case AE.decode responseBdy of
-    Just token -> return $ Just token
-    Nothing -> do
+    Just token -> pure $ Just token
+    Nothing ->
       -- Slack returns {"ok":false,"error":"bad_redirect_uri"} etc. here; log
       -- the error field so install failures are diagnosable. Never log raw
       -- body (could contain access_token on partial/odd responses).
-      let errTxt = fromMaybe "unparseable_response" $ (AE.decode responseBdy :: Maybe AE.Value) >>= (^? key "error" . _String)
-      Log.logAttention "Slack oauth.v2.access token exchange failed" $ AE.object ["error" AE..= errTxt]
-      return Nothing
+      Nothing <$ Log.logAttention "Slack oauth.v2.access token exchange failed" (AE.object ["error" AE..= either Relude.id (const "unparseable_response") (parseSlackOkOrErr responseBdy)])
 
 
 -- | Parse state parameter: "projectId" or "projectId__onboarding"
@@ -162,11 +150,9 @@ linkProjectGetH slack_code stateM = do
           -- old workspace are orphaned by the new bot token and would produce
           -- channel_not_found on every alert. Clear them before installing the new one.
           existing <- getProjectSlackData pid
-          case existing of
-            Just prev | prev.teamId /= token'.team.id -> do
-              Log.logAttention ("Slack re-install switching workspaces; clearing old channels" :: Text) $ AE.object ["project_id" AE..= pid, "old_team_id" AE..= prev.teamId, "new_team_id" AE..= token'.team.id]
-              ProjectMembers.removeSlackChannelsFromEveryoneTeam pid
-            _ -> pass
+          whenJust existing \prev -> when (prev.teamId /= token'.team.id) do
+            Log.logAttention ("Slack re-install switching workspaces; clearing old channels" :: Text) $ AE.object ["project_id" AE..= pid, "old_team_id" AE..= prev.teamId, "new_team_id" AE..= token'.team.id]
+            ProjectMembers.removeSlackChannelsFromEveryoneTeam pid
           void $ insertAccessToken pid token'.team.id token'.incomingWebhook.channelId token'.team.name token'.accessToken token'.incomingWebhook.channel token'.incomingWebhook.url
           void $ liftIO $ withResource pool $ \conn -> createJob conn "background_jobs" $ BgJobs.SlackNotification pid ("Monoscope Bot has been linked to your project: " <> project'.title)
           wasAdded <- ProjectMembers.addSlackChannelToEveryoneTeam pid token'.incomingWebhook.channelId
@@ -184,37 +170,28 @@ linkProjectGetH slack_code stateM = do
 slackInteractionsH :: SlackInteraction -> ATBaseCtx AE.Value
 slackInteractionsH interaction = do
   Log.logTrace ("Slack interaction received" :: Text) $ AE.object ["command" AE..= interaction.command, "text" AE..= interaction.text, "team_id" AE..= interaction.team_id, "channel_id" AE..= interaction.channel_id]
-  authCtx <- Effectful.Reader.Static.ask @AuthContext
+  authCtx <- ask @AuthContext
   case interaction.command of
-    "/monoscope-here" -> do
-      resp <-
-        withSlackDataByTeam "/monoscope-here" interaction.team_id (runMonoscopeHere interaction)
-          <&> fromMaybe workspaceNotLinkedResp
-      Log.logTrace ("Slack interaction response" :: Text) resp
-      pure resp
+    "/monoscope-here" ->
+      withSlackDataByTeam "/monoscope-here" interaction.team_id (runMonoscopeHere interaction)
+        <&> fromMaybe workspaceNotLinkedResp
+        >>= traceResp
     "/dashboard" -> do
-      dashboardsList <- getDashboardsForSlack interaction.team_id
-      let dashboards = V.fromList dashboardsList
+      dashboards <- V.fromList <$> getDashboardsForSlack interaction.team_id
       when (V.null dashboards) $ throwError err400{errBody = "No dashboards found for this project"}
       slackDataM <- withSlackDataByTeam "/dashboard" interaction.team_id \slackData ->
         triggerSlackModal slackData.botToken "open" $ AE.object ["trigger_id" AE..= interaction.trigger_id, "view" AE..= dashboardView interaction.channel_id (V.fromList [dashboardSelectBlock "dashboard-select" "*Select dashboard*" dashboards])]
-      case slackDataM of
-        Nothing -> throwError err400{errBody = "This Slack workspace is not linked to a Monoscope project. Please reinstall the Monoscope app."}
-        Just () -> do
-          let resp = AE.object ["text" AE..= "modal opened", "replace_original" AE..= True, "delete_original" AE..= True]
-          Log.logTrace ("Slack interaction response" :: Text) resp
-          pure resp
+      when (isNothing slackDataM) $ throwError err400{errBody = "This Slack workspace is not linked to a Monoscope project. Please reinstall the Monoscope app."}
+      traceResp $ textResp "modal opened"
     _ -> do
       slackDataM <- getSlackDataByTeamId interaction.team_id
       when (isNothing slackDataM) $ Log.logAttention ("Slack slash command for unlinked workspace" :: Text) $ AE.object ["team_id" AE..= interaction.team_id, "command" AE..= interaction.command]
-      forkBackground authCtx.backgroundScope ("Slack slash command (team " <> interaction.team_id <> ")") $ case slackDataM of
-        Nothing -> sendSlackFollowupResponse interaction.response_url (formatBotError Slack ServiceError)
-        Just slackData -> handleAskCommand interaction slackData authCtx
-      let loadingMsg = getLoadingMessage (detectReportIntent interaction.text)
-          resp = AE.object ["text" AE..= loadingMsg, "replace_original" AE..= True, "delete_original" AE..= True]
-      Log.logTrace ("Slack interaction response" :: Text) resp
-      pure resp
+      forkBackground authCtx.backgroundScope ("Slack slash command (team " <> interaction.team_id <> ")")
+        $ maybe (sendSlackFollowupResponse interaction.response_url (formatBotError Slack ServiceError)) (handleAskCommand interaction authCtx.env) slackDataM
+      traceResp $ textResp $ getLoadingMessage (detectReportIntent interaction.text)
   where
+    traceResp resp = resp <$ Log.logTrace ("Slack interaction response" :: Text) resp
+
     workspaceNotLinkedResp =
       AE.object
         [ "response_type" AE..= ("ephemeral" :: Text)
@@ -229,13 +206,11 @@ slackInteractionsH interaction = do
       -- ensure the team routes alerts there.
       _ <- updateSlackDefaultChannel inter.team_id inter.channel_id Nothing
       wasAdded <- ProjectMembers.addSlackChannelToEveryoneTeam slackData.projectId inter.channel_id
-      when wasAdded do
-        projectM <- Projects.projectById slackData.projectId
-        case projectM of
+      when wasAdded
+        $ Projects.projectById slackData.projectId
+        >>= \case
           Nothing -> Log.logAttention ("Slack install references missing project" :: Text) $ AE.object ["project_id" AE..= slackData.projectId, "team_id" AE..= inter.team_id]
-          Just project -> do
-            result <- tryAny $ sendSlackWelcomeMessage slackData.botToken inter.channel_id project.title
-            whenLeft_ result (logWelcomeMessageFailure inter.channel_id)
+          Just project -> flip whenLeft_ (logWelcomeMessageFailure inter.channel_id) =<< tryAny (sendSlackWelcomeMessage slackData.botToken inter.channel_id project.title)
       let channelDisplay = if T.null inter.channel_name then "this channel" else "#" <> inter.channel_name
       pure
         $ AE.object
@@ -243,53 +218,27 @@ slackInteractionsH interaction = do
           , "blocks"
               AE..= AE.Array
                 ( V.fromList
-                    [ AE.object ["type" AE..= ("header" :: Text), "text" AE..= AE.object ["type" AE..= ("plain_text" :: Text), "text" AE..= (botEmoji "success" <> " Notification channel set"), "emoji" AE..= True]]
-                    , AE.object ["type" AE..= ("section" :: Text), "text" AE..= AE.object ["type" AE..= ("mrkdwn" :: Text), "text" AE..= ("*" <> channelDisplay <> "* will now receive:")]]
-                    , AE.object
-                        [ "type" AE..= ("section" :: Text)
-                        , "text"
-                            AE..= AE.object
-                              [ "type" AE..= ("mrkdwn" :: Text)
-                              , "text" AE..= ("• " <> botEmoji "error" <> " Error alerts\n• " <> botEmoji "chart" <> " Daily & weekly reports\n• " <> botEmoji "warning" <> " Anomaly detections\n\nYou can also configure channels on the web dashboard.")
-                              ]
-                        ]
+                    [ textBlock "header" $ plainTxt (botEmoji "success" <> " Notification channel set")
+                    , textBlock "section" $ mrkdwn ("*" <> channelDisplay <> "* will now receive:")
+                    , textBlock "section" $ mrkdwn ("• " <> botEmoji "error" <> " Error alerts\n• " <> botEmoji "chart" <> " Daily & weekly reports\n• " <> botEmoji "warning" <> " Anomaly detections\n\nYou can also configure channels on the web dashboard.")
                     ]
                 )
           , "replace_original" AE..= True
           , "delete_original" AE..= True
           ]
 
-    handleAskCommand :: SlackInteraction -> SlackData -> AuthContext -> ATBaseCtx ()
-    handleAskCommand inter slackData authCtx = do
-      let envCfg = authCtx.env
-      case detectReportIntent inter.text of
-        ReportIntent reportType -> do
-          reportResult <- processReportQuery slackData.projectId reportType envCfg
-          case reportResult of
-            Left err -> do
-              let resp = AE.object ["text" AE..= err, "response_type" AE..= "in_channel", "replace_original" AE..= True, "delete_original" AE..= True]
-              Log.logTrace ("Slack followup response (report error)" :: Text) resp
-              sendSlackFollowupResponse inter.response_url resp
-            Right (report, eventsUrl, errorsUrl) -> do
-              let resp = formatReportForSlack report slackData.projectId envCfg eventsUrl errorsUrl inter.channel_id
-              Log.logTrace ("Slack followup response (report)" :: Text) resp
-              sendSlackFollowupResponse inter.response_url resp
-        GeneralQueryIntent -> do
-          result <- processAIQuery envCfg.enableTimefusionReads slackData.projectId inter.text Nothing envCfg.openaiModel envCfg.openaiApiKey
-          case result of
-            Left _ -> do
-              let resp = formatBotError Slack ServiceError
-              Log.logTrace ("Slack followup response (AI error)" :: Text) resp
-              sendSlackFollowupResponse inter.response_url resp
-            Right resp ->
-              dispatchAIResponse
-                Slack
-                envCfg
-                slackData.projectId
-                inter.text
-                resp
-                (sendSlackFollowupResponse inter.response_url)
-                getBotContentWithUrl
+    handleAskCommand :: SlackInteraction -> EnvConfig -> SlackData -> ATBaseCtx ()
+    handleAskCommand inter envCfg slackData = case detectReportIntent inter.text of
+      ReportIntent reportType ->
+        processReportQuery slackData.projectId reportType envCfg >>= \case
+          Left err -> send "Slack followup response (report error)" $ AE.object ["text" AE..= err, "response_type" AE..= "in_channel", "replace_original" AE..= True, "delete_original" AE..= True]
+          Right (report, eventsUrl, errorsUrl) -> send "Slack followup response (report)" $ formatReportForSlack report slackData.projectId envCfg eventsUrl errorsUrl
+      GeneralQueryIntent ->
+        processAIQuery envCfg.enableTimefusionReads slackData.projectId inter.text Nothing envCfg.openaiModel envCfg.openaiApiKey >>= \case
+          Left _ -> send "Slack followup response (AI error)" $ formatBotError Slack ServiceError
+          Right resp -> dispatchAIResponse Slack envCfg slackData.projectId inter.text resp (sendSlackFollowupResponse inter.response_url) getBotContentWithUrl
+      where
+        send label resp = Log.logTrace (label :: Text) resp >> sendSlackFollowupResponse inter.response_url resp
 
 
 newtype SlackActionForm = SlackActionForm {payload :: Text}
@@ -297,19 +246,13 @@ newtype SlackActionForm = SlackActionForm {payload :: Text}
   deriving anyclass (AE.FromJSON, FromForm)
 
 
-data SlackUser = SlackUser
-  { id :: Text
-  , username :: Text
-  , team_id :: Text
-  }
-  deriving (Generic, Show)
+newtype SlackUser = SlackUser {id :: Text}
+  deriving stock (Generic, Show)
   deriving anyclass (AE.FromJSON)
 
 
 data SlackAction = SlackAction
   { type_ :: Text
-  , token :: Text
-  , trigger_id :: Text
   , view :: SlackView
   , actions :: Maybe [SAction]
   , user :: SlackUser
@@ -320,7 +263,6 @@ data SlackAction = SlackAction
 
 data SlackView = SlackView
   { private_metadata :: Text
-  , blocks :: [AE.Value]
   , id :: Text
   , state :: Maybe AE.Value
   }
@@ -337,77 +279,55 @@ data SlackOption = SlackOption
 
 
 data SAction = SAction
-  { type_a :: Text
-  , action_id :: Text
-  , block_id :: Text
+  { action_id :: Text
   , selected_option :: Maybe SlackOption
-  , action_ts :: Text
   }
-  deriving stock (Generic, Show)
-  deriving (AE.FromJSON) via DAE.CustomJSON '[DAE.FieldLabelModifier '[DAE.Rename "type_a" "type"]] SAction
+  deriving (Generic, Show)
+  deriving anyclass (AE.FromJSON)
 
 
 slackActionsH :: SlackActionForm -> ATBaseCtx AE.Value
 slackActionsH action = do
-  authCtx <- Effectful.Reader.Static.ask @AuthContext
-  let result = AE.eitherDecode (encodeUtf8 action.payload) :: Either String SlackAction
-  case result of
-    Left err -> do
-      throwError err400{errBody = "Invalid action payload: " <> encodeUtf8 (toText err)}
-    Right slackAction -> handleSlackAction authCtx slackAction
-  where
-    handleSlackAction authCtx slackAction = case slackAction.type_ of
-      "block_actions" -> handleBlockActions authCtx slackAction
+  authCtx <- ask @AuthContext
+  case AE.eitherDecode @SlackAction (encodeUtf8 action.payload) of
+    Left err -> throwError err400{errBody = "Invalid action payload: " <> encodeUtf8 (toText err)}
+    Right slackAction -> case slackAction.type_ of
+      "block_actions" -> case slackAction.actions >>= viaNonEmpty head of
+        Just a | a.action_id == "dashboard-select" -> maybe (pure $ textResp "No dashboard selected") (handleDashboardSelect slackAction) a.selected_option
+        Just a | a.action_id == "widget-select" -> maybe noAction (updateWidgetModal authCtx slackAction . (.value)) a.selected_option
+        _ -> noAction
       "view_submission" -> handleViewSubmission authCtx slackAction
-      _ -> handleUnknownActionType
+      _ -> noAction
+  where
+    noAction = pure $ AE.object []
 
-    handleBlockActions authCtx slackAction =
-      case viaNonEmpty head $ fromMaybe [] slackAction.actions of
-        Nothing -> handleUnknownActionType
-        Just actionType -> case actionType.action_id of
-          "dashboard-select" -> handleDashboardSelect slackAction actionType
-          "widget-select" -> handleWidgetSelect authCtx slackAction actionType
-          _ -> handleUnknownActionType
-
-    handleDashboardSelect slackAction actionType = case actionType.selected_option of
-      Just opt -> do
-        dashboardVMM <- maybe (pure Nothing) Dashboards.getDashboardById (idFromText opt.value)
-        case dashboardVMM of
-          Nothing -> pure $ AE.object []
-          Just dashboardVM -> updateDashboardModal slackAction dashboardVM opt.text
-      Nothing -> pure $ AE.object ["text" AE..= "No dashboard selected", "replace_original" AE..= True, "delete_original" AE..= True]
-
-    handleWidgetSelect authCtx slackAction actionType = case actionType.selected_option of
-      Just opt -> updateWidgetModal authCtx slackAction opt.value
-      Nothing -> handleUnknownActionType
+    handleDashboardSelect slackAction opt =
+      maybe (pure Nothing) Dashboards.getDashboardById (idFromText opt.value)
+        >>= maybe noAction (\dashboardVM -> updateDashboardModal slackAction dashboardVM opt.text)
 
     handleViewSubmission authCtx slackAction = do
-      let view = slackAction.view
-          metas = T.splitOn "___" view.private_metadata
-          channelId = fromMaybe "" $ viaNonEmpty head metas
-          pid = fromMaybe "" $ viaNonEmpty head $ fromMaybe [] $ viaNonEmpty tail metas
-          image_url = fromMaybe "" $ viaNonEmpty last metas
-          dashBoardId = slackAction.view.state >>= lookupSelectedValueByKey "dashboard-select"
-          widgetTitle = slackAction.view.state >>= lookupSelectedValueByKey "widget-select"
-          url = authCtx.env.hostUrl <> "p/" <> pid <> "/dashboards/" <> fromMaybe "" dashBoardId
-          heading = "<" <> url <> "|" <> fromMaybe "" widgetTitle <> ">"
+      let meta = slackAction.view.private_metadata
+          pid = metaField 1 meta
+          widgetTitle = fromMaybe "" $ slackAction.view.state >>= lookupSelectedValueByKey "widget-select"
+          dashBoardId = fromMaybe "" $ slackAction.view.state >>= lookupSelectedValueByKey "dashboard-select"
+          heading = "<" <> authCtx.env.hostUrl <> "p/" <> pid <> "/dashboards/" <> dashBoardId <> "|" <> widgetTitle <> ">"
           content =
             AE.object
-              [ "channel" AE..= channelId
+              [ "channel" AE..= metaField 0 meta
               , "blocks"
                   AE..= AE.Array
                     ( V.fromList
-                        [ AE.object ["type" AE..= "section", "text" AE..= AE.object ["type" AE..= "mrkdwn", "text" AE..= heading]]
-                        , AE.object ["type" AE..= "section", "text" AE..= AE.object ["type" AE..= "mrkdwn", "text" AE..= ("Shared by <@" <> slackAction.user.id <> "> using /dashboard")]]
-                        , dashboardWidgetView image_url (fromMaybe "" widgetTitle)
+                        [ textBlock "section" (mrkdwn heading)
+                        , textBlock "section" $ mrkdwn ("Shared by <@" <> slackAction.user.id <> "> using /dashboard")
+                        , imageBlock (fromMaybe "" $ viaNonEmpty last $ T.splitOn "___" meta) widgetTitle
                         ]
                     )
               ]
       case idFromText pid of
-        Nothing -> Log.logAttention ("Slack view_submission with unparseable pid" :: Text) $ AE.object ["private_metadata" AE..= view.private_metadata]
+        Nothing -> Log.logAttention ("Slack view_submission with unparseable pid" :: Text) $ AE.object ["private_metadata" AE..= meta]
         Just projectId -> void $ withProjectSlackDataLogged "slackActionsH.view_submission" projectId \sd ->
           sendSlackChatMessage sd.botToken content
-      handleUnknownActionType
+      noAction
 
     updateDashboardModal slackAction dashboardVM dashboardText = do
       let baseTemplate = fromMaybe "" dashboardVM.baseTemplate
@@ -415,48 +335,51 @@ slackActionsH action = do
       case dashboardM of
         Nothing -> Log.logAttention "Slack updateDashboardModal: readDashboardFile failed" $ AE.object ["base_template" AE..= baseTemplate, "project_id" AE..= dashboardVM.projectId]
         Just dashboard -> do
-          let widgets = V.fromList $ (\w -> (fromMaybe "Untitled-" w.title, fromMaybe "Untitled-" w.title)) <$> dashboard.widgets
-              channelId = fromMaybe "" $ viaNonEmpty head $ T.splitOn "___" slackAction.view.private_metadata
-              pMeta = channelId <> "___" <> dashboardVM.projectId.toText <> "___" <> baseTemplate
+          let pMeta = T.intercalate "___" [metaField 0 slackAction.view.private_metadata, dashboardVM.projectId.toText, baseTemplate]
           void $ withProjectSlackDataLogged "slackActionsH.updateDashboardModal" dashboardVM.projectId \sd ->
-            triggerSlackModal sd.botToken "update" $ AE.object ["view_id" AE..= slackAction.view.id, "view" AE..= dashboardView pMeta (V.fromList [dashboardSelectBlock "dashboard-select" "*Select dashboard*" widgets, dashboardSelectBlock "widget-select" "*Select widget*" widgets])]
-      pure $ AE.object ["text" AE..= ("Selected dashboard: " <> show dashboardText), "replace_original" AE..= True, "delete_original" AE..= True]
+            triggerSlackModal sd.botToken "update" $ AE.object ["view_id" AE..= slackAction.view.id, "view" AE..= dashboardView pMeta (selectBlocks dashboard.widgets V.empty)]
+      pure $ textResp $ "Selected dashboard: " <> show dashboardText
 
     updateWidgetModal authCtx slackAction widgetTitle = do
-      let metas = T.splitOn "___" slackAction.view.private_metadata
-          channelId = fromMaybe "" $ viaNonEmpty head metas
-          res = fromMaybe [] $ viaNonEmpty tail metas
-          pid = fromMaybe "" $ viaNonEmpty head res
-          res' = fromMaybe [] $ viaNonEmpty tail res
-          baseTemplate = fromMaybe "" $ viaNonEmpty head res'
-
+      let meta = slackAction.view.private_metadata
+          pid = metaField 1 meta
+          baseTemplate = metaField 2 meta
       dashboardM <- liftIO $ Dashboards.readDashboardFile "static/public/dashboards" (toString baseTemplate)
       case dashboardM of
         Nothing -> Log.logAttention "Slack updateWidgetModal: readDashboardFile failed" $ AE.object ["base_template" AE..= baseTemplate, "project_id" AE..= pid]
-        Just dashboard -> do
-          let widgets = V.fromList $ (\w -> (fromMaybe "Untitled-" w.title, fromMaybe "Untitled-" w.title)) <$> dashboard.widgets
-              widget = find (\w -> fromMaybe "Untitled-" w.title == widgetTitle) dashboard.widgets
-          whenJust widget $ \w -> whenJust (idFromText pid) $ \projectId -> do
+        Just dashboard ->
+          whenJust (find ((== widgetTitle) . fromMaybe "Untitled-" . (.title)) dashboard.widgets) \w -> whenJust (idFromText pid) \projectId -> do
             chartUrl' <- widgetPngUrl authCtx.env.apiKeyEncryptionSecretKey authCtx.env.hostUrl projectId w Nothing Nothing Nothing
-            let blocks = V.fromList [dashboardSelectBlock "dashboard-select" "*Select dashboard*" widgets, dashboardSelectBlock "widget-select" "*Select widget*" widgets, dashboardWidgetView chartUrl' widgetTitle]
-                privateMeta = channelId <> "___" <> pid <> "___" <> baseTemplate <> "___" <> chartUrl'
+            let privateMeta = T.intercalate "___" [metaField 0 meta, pid, baseTemplate, chartUrl']
             void $ withProjectSlackDataLogged "slackActionsH.updateWidgetModal" projectId \sd ->
-              triggerSlackModal sd.botToken "update" $ AE.object ["view_id" AE..= slackAction.view.id, "view" AE..= dashboardView privateMeta blocks]
-      handleUnknownActionType
-
-    handleUnknownActionType = pure $ AE.object []
+              triggerSlackModal sd.botToken "update" $ AE.object ["view_id" AE..= slackAction.view.id, "view" AE..= dashboardView privateMeta (selectBlocks dashboard.widgets (V.singleton $ imageBlock chartUrl' widgetTitle))]
+      noAction
 
 
-lookupSelectedValueByKey :: Text -> AE.Value -> Maybe Text
-lookupSelectedValueByKey key' = parseMaybe parser
+-- | @private_metadata@ is a "___"-joined tuple: channelId, projectId, baseTemplate, chartUrl.
+metaField :: Int -> Text -> Text
+metaField i = fromMaybe "" . (!!? i) . T.splitOn "___"
+
+
+-- | The dashboard + widget pickers, plus any trailing blocks (e.g. a chart preview).
+selectBlocks :: [Widget] -> V.Vector AE.Value -> V.Vector AE.Value
+selectBlocks widgets extra =
+  V.fromList [dashboardSelectBlock "dashboard-select" "*Select dashboard*" opts, dashboardSelectBlock "widget-select" "*Select widget*" opts] <> extra
   where
-    kemKey = KEM.fromText key'
-    parser = AE.withObject "state" $ \o -> do
-      values <- o AE..: "values"
-      inner <- values AE..: kemKey
-      field <- inner AE..: kemKey
-      selected <- field AE..: "selected_option"
-      selected AE..: "value"
+    opts = V.fromList $ map ((\t -> (t, t)) . fromMaybe "Untitled-" . (.title)) widgets
+
+
+-- | Slash-command / modal reply that replaces the invoking message.
+textResp :: Text -> AE.Value
+textResp t = AE.object ["text" AE..= t, "replace_original" AE..= True, "delete_original" AE..= True]
+
+
+-- | Slack view state nests the selected value under @values.<blockId>.<actionId>@;
+-- both ids are the same here.
+lookupSelectedValueByKey :: Text -> AE.Value -> Maybe Text
+lookupSelectedValueByKey key' v = v ^? key "values" . key k . key k . key "selected_option" . key "value" . _String
+  where
+    k = KEM.fromText key'
 
 
 -- | Slack's response_url is ephemeral (30 min / 5 uses). A 4xx means the URL
@@ -478,9 +401,8 @@ sendSlackFollowupResponse responseUrl content = do
 -- view definition, etc. Log on non-ok so failed modals don't silently vanish
 -- (user clicks /dashboard, nothing happens, no trace in logs).
 triggerSlackModal :: Text -> Text -> AE.Value -> ATBaseCtx ()
-triggerSlackModal token action content = do
-  rs <- slackPost token ("https://slack.com/api/views." <> action) content
-  whenLeft_ (parseSlackOkOrErr (rs ^. Wreq.responseBody)) \err ->
+triggerSlackModal token action content =
+  whenLeftM_ (slackApi token ("views." <> action) content) \err ->
     Log.logAttention "Slack views API rejected" $ AE.object ["action" AE..= action, "error" AE..= err]
 
 
@@ -509,10 +431,10 @@ getBotContentWithUrl question query query_url imageUrl =
     [ "blocks"
         AE..= AE.Array
           ( V.fromList
-              [ AE.object ["type" AE..= ("header" :: Text), "text" AE..= AE.object ["type" AE..= ("plain_text" :: Text), "text" AE..= (botEmoji "chart" <> " " <> question), "emoji" AE..= True]]
-              , AE.object ["type" AE..= ("image" :: Text), "image_url" AE..= imageUrl, "alt_text" AE..= ("Chart: " <> question)]
-              , AE.object ["type" AE..= ("context" :: Text), "elements" AE..= AE.Array (V.fromList [AE.object ["type" AE..= ("mrkdwn" :: Text), "text" AE..= ("*Query:* `" <> query <> "`")]])]
-              , AE.object ["type" AE..= ("actions" :: Text), "elements" AE..= AE.Array (V.fromList [AE.object ["type" AE..= ("button" :: Text), "action_id" AE..= ("view-log-explorer" :: Text), "text" AE..= AE.object ["type" AE..= ("plain_text" :: Text), "text" AE..= (botEmoji "search" <> " View in Log Explorer"), "emoji" AE..= True], "url" AE..= query_url]])]
+              [ textBlock "header" $ plainTxt (botEmoji "chart" <> " " <> question)
+              , imageBlock imageUrl ("Chart: " <> question)
+              , elemsBlock "context" [mrkdwn ("*Query:* `" <> query <> "`")]
+              , elemsBlock "actions" [linkButton "view-log-explorer" (botEmoji "search" <> " View in Log Explorer") query_url]
               ]
           )
     , "response_type" AE..= ("in_channel" :: Text)
@@ -561,17 +483,8 @@ dashboardSelectBlock selectId heading options =
     opts = V.map (\(text, value) -> AE.object ["text" AE..= AE.object ["type" AE..= "plain_text", "text" AE..= if T.null text then "Untitled" else text], "value" AE..= value]) options
 
 
-dashboardWidgetView :: Text -> Text -> AE.Value
-dashboardWidgetView image_url widgetTitle =
-  AE.object
-    [ "type" AE..= "image"
-    , "image_url" AE..= image_url
-    , "alt_text" AE..= widgetTitle
-    ]
-
-
 externalOptionsH :: AE.Value -> ATBaseCtx AE.Value
-externalOptionsH val = do
+externalOptionsH _ =
   pure
     $ AE.object
       [ "options" AE..= AE.Array (V.fromList [AE.object ["text" AE..= "Option 1", "value" AE..= "option1"], AE.object ["text" AE..= "Option 2", "value" AE..= "option2"]])
@@ -583,39 +496,39 @@ externalOptionsH val = do
 -- Slack's REST endpoints (chat.postMessage, views.open, views.update, etc.)
 -- all return HTTP 200 on semantic failures; the real status is in the body.
 parseSlackOkOrErr :: LByteString -> Either Text ()
-parseSlackOkOrErr body = case (AE.decode body :: Maybe AE.Value) >>= (^? key "ok" . _Bool) of
-  Just True -> Right ()
-  _ -> Left $ fromMaybe "unparseable_response" $ (AE.decode body :: Maybe AE.Value) >>= (^? key "error" . _String)
+parseSlackOkOrErr body
+  | (v >>= (^? key "ok" . _Bool)) == Just True = Right ()
+  | otherwise = Left $ fromMaybe "unparseable_response" $ v >>= (^? key "error" . _String)
+  where
+    v = AE.decode @AE.Value body
 
 
-slackPost :: HTTP :> es => Text -> Text -> AE.Value -> Eff es (Wreq.Response LByteString)
-slackPost token url =
-  postWith (defaults & header "Content-Type" .~ ["application/json"] & header "Authorization" .~ [encodeUtf8 $ "Bearer " <> token]) (toString url)
+-- | POST to @https://slack.com/api/\<method\>@, decoding Slack's ok/error envelope.
+slackApi :: HTTP :> es => Text -> Text -> AE.Value -> Eff es (Either Text ())
+slackApi token method content =
+  parseSlackOkOrErr . (^. responseBody) <$> postWith (defaults & contentTypeHeader "application/json" & authHeader "Bearer" token) (toString $ "https://slack.com/api/" <> method) content
 
 
 -- | Post to chat.postMessage and log attention on non-ok responses so silent
 -- drops (bot not invited, archived channel, etc.) surface in monitoring.
 sendSlackChatMessage :: (HTTP :> es, Log.Log :> es) => Text -> AE.Value -> Eff es ()
-sendSlackChatMessage token content = do
-  rs <- slackPost token "https://slack.com/api/chat.postMessage" content
-  whenLeft_ (parseSlackOkOrErr (rs ^. Wreq.responseBody)) \err ->
-    let chan = fromMaybe "" $ content ^? key "channel" . _String
-     in Log.logAttention "Slack chat.postMessage rejected" $ AE.object ["channel_id" AE..= chan, "error" AE..= err]
+sendSlackChatMessage token content =
+  whenLeftM_ (slackApi token "chat.postMessage" content) \err ->
+    Log.logAttention "Slack chat.postMessage rejected" $ AE.object ["channel_id" AE..= fromMaybe "" (content ^? key "channel" . _String), "error" AE..= err]
 
 
 -- | Like 'sendSlackChatMessage' but throws on non-ok — for callers that
 -- wrap with 'tryAny' and want reachability as an exception (e.g. the
 -- integrations save handler's per-channel welcome probe).
 sendSlackChatMessageChecked :: (HTTP :> es, IOE :> es) => Text -> AE.Value -> Eff es ()
-sendSlackChatMessageChecked token content = do
-  rs <- slackPost token "https://slack.com/api/chat.postMessage" content
-  whenLeft_ (parseSlackOkOrErr (rs ^. Wreq.responseBody)) \err ->
+sendSlackChatMessageChecked token content =
+  whenLeftM_ (slackApi token "chat.postMessage" content) \err ->
     liftIO $ throwIO $ ErrorCall $ "slack chat.postMessage failed: " <> toString err
 
 
-welcomeBlocks :: Text -> AE.Value
+welcomeBlocks :: Text -> AE.Object
 welcomeBlocks projectTitle =
-  AE.object
+  AEKM.fromList
     [ "blocks"
         AE..= AE.Array
           ( V.fromList
@@ -636,11 +549,8 @@ This channel will now receive notifications for *{projectTitle}*.|]
 
 
 sendSlackWelcomeMessage :: (HTTP :> es, IOE :> es) => Text -> Text -> Text -> Eff es ()
-sendSlackWelcomeMessage token channelId projectTitle = do
-  let message = case welcomeBlocks projectTitle of
-        AE.Object blocks -> AE.Object (AEKM.insert "channel" (AE.String channelId) blocks)
-        v -> v -- unreachable: welcomeBlocks always returns an object
-  sendSlackChatMessageChecked token message
+sendSlackWelcomeMessage token channelId projectTitle =
+  sendSlackChatMessageChecked token $ AE.Object $ AEKM.insert "channel" (AE.String channelId) (welcomeBlocks projectTitle)
 
 
 -- | Post the welcome message via an OAuth-time incoming webhook. Used when
@@ -653,8 +563,7 @@ sendSlackWelcomeMessage token channelId projectTitle = do
 -- the failure as a welcome-message-failed log with context.
 sendSlackWelcomeViaWebhook :: (HTTP :> es, IOE :> es) => Text -> Text -> Eff es ()
 sendSlackWelcomeViaWebhook webhookUrl projectTitle = do
-  let opts = defaults & header "Content-Type" .~ ["application/json"]
-  rs <- postWith opts (toString webhookUrl) (welcomeBlocks projectTitle)
+  rs <- postWith (defaults & contentTypeHeader "application/json") (toString webhookUrl) (AE.Object $ welcomeBlocks projectTitle)
   let body = rs ^. Wreq.responseBody
   unless (body == "ok" || body == "\"ok\"")
     $ liftIO
@@ -664,133 +573,88 @@ sendSlackWelcomeViaWebhook webhookUrl projectTitle = do
     <> toString (decodeUtf8 @Text (toStrict body))
 
 
-data UrlVerificationData = UrlVerificationData
-  { token :: Text
-  , challenge :: Text
-  }
-  deriving stock (Generic, Show)
-  deriving anyclass (AE.FromJSON)
-
-
 data EventCallbackData = EventCallbackData
-  { token :: Text
-  , team_id :: Text
-  , api_app_id :: Text
+  { team_id :: Text
   , event :: SlackEvent
-  , event_id :: Text
-  , event_time :: Int
   }
   deriving stock (Generic, Show)
   deriving anyclass (AE.FromJSON)
 
 
 data SlackEventPayload
-  = UrlVerification UrlVerificationData
+  = UrlVerification Text
   | EventCallback EventCallbackData
-  deriving (Show)
+  deriving stock (Show)
 
 
 instance AE.FromJSON SlackEventPayload where
-  parseJSON = withObject "SlackEventPayload" \v -> do
-    typ <- v AE..: "type"
-    case typ of
-      "url_verification" -> UrlVerification <$> AE.parseJSON (AE.Object v)
+  parseJSON = withObject "SlackEventPayload" \v ->
+    v AE..: "type" >>= \case
+      ("url_verification" :: Text) -> UrlVerification <$> v AE..: "challenge"
       "event_callback" -> EventCallback <$> AE.parseJSON (AE.Object v)
-      other -> fail $ "Unsupported Slack event type: " ++ show other
+      other -> fail $ "Unsupported Slack event type: " <> show other
 
 
 data SlackEvent = SlackMessageEvent
-  { type_ :: Text
-  , user :: Text
-  , text :: Text
-  , ts :: Text
+  { text :: Text
   , channel :: Text
-  , event_ts :: Text
   , thread_ts :: Maybe Text
   }
   deriving stock (Generic, Show)
-  deriving (AE.FromJSON) via DAE.CustomJSON '[DAE.FieldLabelModifier '[DAE.StripSuffix "_"]] SlackEvent
+  deriving anyclass (AE.FromJSON)
 
 
 slackEventsPostH :: SlackEventPayload -> ATBaseCtx AE.Value
 slackEventsPostH payload = do
   envCfg <- asks env
   scopeM <- asks @AuthContext (.backgroundScope)
-  now <- Time.currentTime
   case payload of
-    UrlVerification (UrlVerificationData _ challenge) -> pure $ AE.object ["challenge" AE..= challenge]
+    UrlVerification challenge -> pure $ AE.object ["challenge" AE..= challenge]
     EventCallback cb -> do
-      forkBackground scopeM ("Slack event callback (team " <> cb.team_id <> ")") $ handleEventCallback envCfg cb.event cb.team_id now
+      forkBackground scopeM ("Slack event callback (team " <> cb.team_id <> ")") $ handleEventCallback envCfg cb.event cb.team_id
       pure $ AE.object []
   where
-    handleEventCallback envCfg event workspaceId now = void $ withSlackDataByTeam "handleEventCallback" workspaceId \slackData -> case event.thread_ts of
+    handleEventCallback envCfg event workspaceId = void $ withSlackDataByTeam "handleEventCallback" workspaceId \slackData -> case event.thread_ts of
       Nothing -> do
         Log.logTrace "Slack fallback_error_message (non-threaded event)" $ AE.object ["team_id" AE..= (workspaceId :: Text), "channel_id" AE..= event.channel]
         sendSlackChatMessage slackData.botToken (mergeSlackContent (formatBotError Slack ServiceError) (AE.object ["channel" AE..= event.channel]))
-      Just threadTs -> processThreadedEvent envCfg slackData event workspaceId threadTs now
+      Just threadTs -> processThreadedEvent envCfg slackData event workspaceId threadTs
 
-    processThreadedEvent envCfg slackData event workspaceId threadTs now = do
-      -- Generate deterministic conversation ID from channel + thread_ts
+    processThreadedEvent envCfg slackData event workspaceId threadTs = do
       let convId = Issues.slackThreadToConversationId event.channel threadTs
-
-      -- Ensure conversation exists
       _ <- Issues.getOrCreateConversation slackData.projectId convId Issues.CTSlackThread (AE.object ["channel_id" AE..= event.channel, "thread_ts" AE..= threadTs, "team_id" AE..= (workspaceId :: Text)])
-
-      -- Load existing history from DB
       existingHistory <- Issues.selectChatHistory convId
 
-      -- One-time migration: if DB is empty, fetch from Slack API and migrate
-      when (null existingHistory) $ do
+      -- One-time migration: if DB is empty, backfill the thread from Slack's API
+      when (null existingHistory) do
         lockAcquired <- Issues.tryAcquireChatMigrationLock convId
-        when lockAcquired $ do
-          result <- tryAny $ do
-            replies <- getChannelMessages slackData.botToken event.channel threadTs
-            case replies of
-              Nothing -> Log.logAttention "Slack chat migration: getChannelMessages failed" $ AE.object ["conv_id" AE..= show @Text convId, "channel" AE..= event.channel, "thread_ts" AE..= threadTs]
-              Just messages -> forM_ messages.messages \m ->
-                Issues.insertChatMessage slackData.projectId convId Issues.ChatUser m.text Nothing Nothing
+        when lockAcquired do
+          result <-
+            tryAny
+              $ getChannelMessages slackData.botToken event.channel threadTs
+              >>= \case
+                Nothing -> Log.logAttention "Slack chat migration: getChannelMessages failed" $ AE.object ["conv_id" AE..= show @Text convId, "channel" AE..= event.channel, "thread_ts" AE..= threadTs]
+                Just replies -> forM_ replies.messages \m ->
+                  Issues.insertChatMessage slackData.projectId convId Issues.ChatUser m.text Nothing Nothing
           Issues.releaseChatMigrationLock convId
           whenLeft_ result \err ->
             Log.logAttention "Slack chat migration failed" $ AE.object ["error" AE..= show @Text err, "conv_id" AE..= show @Text convId]
 
-      processMessages envCfg event slackData convId threadTs now
-
-    processMessages envCfg event slackData convId threadTs now = do
-      -- Build thread context from DB history
-      dbMessages <- Issues.selectChatHistory convId
-      let threadContext = formatHistoryAsContext "Slack" $ map AI.dbMessageToLLMMessage dbMessages
-
-      -- Use processAIQuery with thread context
-      result <- processAIQuery envCfg.enableTimefusionReads slackData.projectId event.text (Just threadContext) envCfg.openaiModel envCfg.openaiApiKey
-      case result of
+      threadContext <- formatHistoryAsContext "Slack" . map AI.dbMessageToLLMMessage <$> Issues.selectChatHistory convId
+      processAIQuery envCfg.enableTimefusionReads slackData.projectId event.text (Just threadContext) envCfg.openaiModel envCfg.openaiApiKey >>= \case
         Left err -> do
           Log.logAttention "Slack fallback_error_message (threaded AI query failed)" $ AE.object ["team_id" AE..= slackData.teamId, "channel_id" AE..= event.channel, "thread_ts" AE..= threadTs, "ai_error" AE..= err]
           sendSlackChatMessage slackData.botToken (mergeSlackContent (formatBotError Slack ServiceError) (AE.object ["channel" AE..= event.channel, "thread_ts" AE..= threadTs]))
         Right resp -> do
-          -- Save user message and bot response to DB
           Issues.insertChatMessage slackData.projectId convId Issues.ChatUser event.text Nothing Nothing
           whenJust resp.query \q -> Issues.insertChatMessage slackData.projectId convId Issues.ChatAssistant q Nothing Nothing
-
           let addThread c = mergeSlackContent c (AE.object ["channel" AE..= event.channel, "thread_ts" AE..= threadTs])
-          dispatchAIResponse
-            Slack
-            envCfg
-            slackData.projectId
-            event.text
-            resp
-            (sendSlackChatMessage slackData.botToken . addThread)
-            getBotContentWithUrl
+          dispatchAIResponse Slack envCfg slackData.projectId event.text resp (sendSlackChatMessage slackData.botToken . addThread) getBotContentWithUrl
 
 
-data SlackThreadedMessage = SlackThreadedMessage
-  { type_ :: Text
-  , user :: Text
-  , text :: Text
-  , thread_ts :: Text
-  , ts :: Text
-  }
+newtype SlackThreadedMessage = SlackThreadedMessage {text :: Text}
   deriving stock (Generic, Show)
-  deriving (AE.FromJSON) via DAE.CustomJSON '[DAE.FieldLabelModifier '[DAE.StripSuffix "_"]] SlackThreadedMessage
+  deriving anyclass (AE.FromJSON)
 
 
 data SlackChannelsResponse = SlackChannelsResponse
@@ -816,8 +680,7 @@ data SlackChannelInfoResponse = SlackChannelInfoResponse
 
 getSlackChannelInfo :: (HTTP :> es, Log.Log :> es) => Text -> Text -> Eff es (Maybe Channel)
 getSlackChannelInfo token channelId = do
-  let opts = defaults & header "Authorization" .~ ["Bearer " <> encodeUtf8 token] & Wreq.param "channel" .~ [channelId]
-  r <- getWith opts "https://slack.com/api/conversations.info"
+  r <- getWith (defaults & authHeader "Bearer" token & Wreq.param "channel" .~ [channelId]) "https://slack.com/api/conversations.info"
   case AE.eitherDecode @SlackChannelInfoResponse (r ^. responseBody) of
     Right resp | resp.ok -> pure resp.channel
     Right resp -> Nothing <$ Log.logAttention "Slack conversations.info returned ok=false" (AE.object ["channel" AE..= channelId, "ok" AE..= resp.ok])
@@ -826,56 +689,29 @@ getSlackChannelInfo token channelId = do
 
 getSlackChannels :: (HTTP :> es, Log.Log :> es) => Text -> Text -> Eff es (Maybe SlackChannelsResponse)
 getSlackChannels token team_id = do
-  let url = "https://slack.com/api/conversations.list"
-      opts =
-        defaults
-          & header "Authorization"
-          .~ ["Bearer " <> encodeUtf8 token]
-            & Wreq.param "team_id"
-          .~ [team_id]
-            & Wreq.param "types"
-          .~ ["public_channel,private_channel"]
-            & Wreq.param "exclude_archived"
-          .~ ["true"]
-            & Wreq.param "limit"
-          .~ ["1000"]
-
-  r <- getWith opts url
+  let opts = defaults & authHeader "Bearer" token & Wreq.params .~ [("team_id", team_id), ("types", "public_channel,private_channel"), ("exclude_archived", "true"), ("limit", "1000")]
+  r <- getWith opts "https://slack.com/api/conversations.list"
   let resBody = r ^. responseBody
   case AE.eitherDecode resBody of
-    Right val -> do
-      unless val.ok
-        $ Log.logAttention "Slack conversations.list returned ok=false"
-        $ AE.object
-          [ "error" AE..= val.error
-          , "needed" AE..= val.needed
-          , "provided" AE..= val.provided
-          , "team_id" AE..= team_id
-          ]
-      pure $ Just val
-    Left err -> do
-      Log.logAttention "Error decoding Slack channels response"
-        $ AE.object ["error" AE..= err, "body" AE..= decodeUtf8 @Text (toStrict resBody)]
-      pure Nothing
+    Right val ->
+      Just val
+        <$ unless
+          val.ok
+          ( Log.logAttention "Slack conversations.list returned ok=false"
+              $ AE.object ["error" AE..= val.error, "needed" AE..= val.needed, "provided" AE..= val.provided, "team_id" AE..= team_id]
+          )
+    Left err -> Nothing <$ Log.logAttention "Error decoding Slack channels response" (AE.object ["error" AE..= err, "body" AE..= decodeUtf8 @Text (toStrict resBody)])
 
 
-data SlackThreadedMessageResponse = SlackThreadedMessageResponse
-  { ok :: Bool
-  , messages :: [SlackThreadedMessage]
-  }
-  deriving (Generic, Show)
+newtype SlackThreadedMessageResponse = SlackThreadedMessageResponse {messages :: [SlackThreadedMessage]}
+  deriving stock (Generic, Show)
   deriving anyclass (AE.FromJSON)
 
 
 getChannelMessages :: (HTTP :> es, Log.Log :> es) => Text -> Text -> Text -> Eff es (Maybe SlackThreadedMessageResponse)
 getChannelMessages token channelId ts = do
-  let url = "https://slack.com/api/conversations.replies"
-      opts = defaults & header "Content-Type" .~ ["application/json"] & header "Authorization" .~ [encodeUtf8 $ "Bearer " <> token]
-      params = [("channel", channelId), ("ts", ts)]
-  response <- getWith (opts & Wreq.params .~ params) (toString url)
+  response <- getWith (defaults & contentTypeHeader "application/json" & authHeader "Bearer" token & Wreq.params .~ [("channel", channelId), ("ts", ts)]) "https://slack.com/api/conversations.replies"
   let responseBdy = response ^. responseBody
   case AE.eitherDecode responseBdy of
     Right res -> pure $ Just res
-    Left err -> do
-      Log.logAttention "Slack conversations.replies decode failed" $ AE.object ["error" AE..= err, "channel" AE..= channelId, "ts" AE..= ts, "body" AE..= decodeUtf8 @Text (toStrict responseBdy)]
-      pure Nothing
+    Left err -> Nothing <$ Log.logAttention "Slack conversations.replies decode failed" (AE.object ["error" AE..= err, "channel" AE..= channelId, "ts" AE..= ts, "body" AE..= decodeUtf8 @Text (toStrict responseBdy)])

--- a/src/Pages/Bots/Slack.hs
+++ b/src/Pages/Bots/Slack.hs
@@ -41,6 +41,7 @@ import Pkg.Components.Widget (Widget (..), widgetPngUrl)
 import Pkg.DeriveUtils (idFromText)
 import PyF
 import Relude hiding (ask, asks)
+import Relude.Extra.Tuple (dup)
 import Servant.API (Header)
 import Servant.API.ResponseHeaders (Headers, addHeader)
 import Servant.Server (ServerError (errBody), err400)
@@ -366,7 +367,7 @@ selectBlocks :: [Widget] -> V.Vector AE.Value -> V.Vector AE.Value
 selectBlocks widgets extra =
   V.fromList [dashboardSelectBlock "dashboard-select" "*Select dashboard*" opts, dashboardSelectBlock "widget-select" "*Select widget*" opts] <> extra
   where
-    opts = V.fromList $ map ((\t -> (t, t)) . fromMaybe "Untitled-" . (.title)) widgets
+    opts = V.fromList $ map (dup . fromMaybe "Untitled-" . (.title)) widgets
 
 
 -- | Slash-command / modal reply that replaces the invoking message.

--- a/src/Pages/Bots/Slack.hs
+++ b/src/Pages/Bots/Slack.hs
@@ -320,7 +320,7 @@ slackActionsH action = do
                     ( V.fromList
                         [ textBlock "section" (mrkdwn heading)
                         , textBlock "section" $ mrkdwn ("Shared by <@" <> slackAction.user.id <> "> using /dashboard")
-                        , imageBlock (fromMaybe "" $ viaNonEmpty last $ T.splitOn "___" meta) widgetTitle
+                        , imageBlock (metaField 3 meta) widgetTitle
                         ]
                     )
               ]

--- a/src/Pages/Bots/Utils.hs
+++ b/src/Pages/Bots/Utils.hs
@@ -1,4 +1,4 @@
-module Pages.Bots.Utils (handleTableResponse, BotType (..), BotResponse (..), Channel (..), authHeader, contentTypeHeader, processAIQuery, formatHistoryAsContext, verifyWidgetSignature, QueryIntent (..), ReportType (..), detectReportIntent, processReportQuery, formatReportForSlack, formatReportForDiscord, formatReportForWhatsApp, BotErrorType (..), formatBotError, botEmoji, getLoadingMessage, formatTextResponse, dispatchAIResponse) where
+module Pages.Bots.Utils (handleTableResponse, BotType (..), BotResponse (..), Channel (..), authHeader, contentTypeHeader, mrkdwn, plainTxt, textBlock, elemsBlock, linkButton, imageBlock, slackResponse, processAIQuery, formatHistoryAsContext, verifyWidgetSignature, QueryIntent (..), ReportType (..), detectReportIntent, processReportQuery, formatReportForSlack, formatReportForDiscord, formatReportForWhatsApp, BotErrorType (..), formatBotError, botEmoji, getLoadingMessage, formatTextResponse, dispatchAIResponse) where
 
 import Control.Lens ((.~), (^?))
 import Data.Aeson qualified as AE
@@ -9,7 +9,6 @@ import Data.Default (def)
 import Data.Effectful.Hasql (Hasql)
 import Data.Effectful.LLM qualified as ELLM
 import Data.Effectful.Wreq (Options, header)
-import Data.HashMap.Strict qualified as HM
 import Data.Text qualified as T
 import Data.Time (addUTCTime, defaultTimeLocale, formatTime)
 import Data.Time.Format.ISO8601 (iso8601Show)
@@ -44,14 +43,18 @@ data BotType = Discord | Slack | WhatsApp
   deriving (Eq, Show)
 
 
--- | Status emoji constants for visual indicators (always paired with text for accessibility)
-botEmojiMap :: HM.HashMap Text Text
-botEmojiMap = HM.fromList [("success", "🟢"), ("warning", "🟡"), ("error", "🔴"), ("chart", "📊"), ("search", "🔍"), ("table", "📋"), ("loading", "⏳"), ("bell", "🔔")]
-{-# NOINLINE botEmojiMap #-}
-
-
+-- | Status emoji for visual indicators (always paired with text for accessibility)
 botEmoji :: Text -> Text
-botEmoji = HM.lookupDefault "" ?? botEmojiMap
+botEmoji = \case
+  "success" -> "🟢"
+  "warning" -> "🟡"
+  "error" -> "🔴"
+  "chart" -> "📊"
+  "search" -> "🔍"
+  "table" -> "📋"
+  "loading" -> "⏳"
+  "bell" -> "🔔"
+  _ -> ""
 
 
 -- | Error types for contextual error messages
@@ -61,23 +64,16 @@ data BotErrorType = QueryParseError Text | NoDataError | ServiceError | TimeoutE
 
 -- | Format error messages with context and guidance
 formatBotError :: BotType -> BotErrorType -> AE.Value
-formatBotError target = \case
-  QueryParseError snippet ->
-    let msg = botEmoji "warning" <> " Couldn't parse query\n`" <> T.take 50 snippet <> "`\nTry: 'show errors in last hour'"
-     in mkErrorResponse target msg
-  NoDataError ->
-    let msg = botEmoji "search" <> " No data found for your query\nTry expanding the time range or adjusting filters."
-     in mkErrorResponse target msg
-  ServiceError ->
-    let msg = botEmoji "error" <> " Something went wrong\nPlease try again in a moment."
-     in mkErrorResponse target msg
-  TimeoutError ->
-    let msg = botEmoji "error" <> " Query timed out\nThe data range might be too large. Try narrowing to last 24h."
-     in mkErrorResponse target msg
+formatBotError target err = case target of
+  Discord -> AE.object ["content" AE..= msg]
+  WhatsApp -> AE.object ["body" AE..= msg]
+  Slack -> AE.object ["text" AE..= msg, "response_type" AE..= "in_channel", "replace_original" AE..= True, "delete_original" AE..= True]
   where
-    mkErrorResponse Discord m = AE.object ["content" AE..= m]
-    mkErrorResponse WhatsApp m = AE.object ["body" AE..= m]
-    mkErrorResponse Slack m = AE.object ["text" AE..= m, "response_type" AE..= "in_channel", "replace_original" AE..= True, "delete_original" AE..= True]
+    msg = case err of
+      QueryParseError snippet -> botEmoji "warning" <> " Couldn't parse query\n`" <> T.take 50 snippet <> "`\nTry: 'show errors in last hour'"
+      NoDataError -> botEmoji "search" <> " No data found for your query\nTry expanding the time range or adjusting filters."
+      ServiceError -> botEmoji "error" <> " Something went wrong\nPlease try again in a moment."
+      TimeoutError -> botEmoji "error" <> " Query timed out\nThe data range might be too large. Try narrowing to last 24h."
 
 
 -- | Get loading message based on detected query intent
@@ -95,31 +91,59 @@ data BotResponse
 
 
 instance ToHtml BotResponse where
-  toHtml (BotLinked (PageCtx bwconf (bot, pidM))) = toHtml $ PageCtx bwconf $ installedSuccess bot pidM
-  toHtml (DiscordError (PageCtx bwconf ())) = toHtml $ PageCtx bwconf discordError
-  toHtml (NoTokenFound (PageCtx bwconf ())) = toHtml $ PageCtx bwconf noTokenFound
-  toHtml (NoContent (PageCtx bwconf ())) = toHtml $ PageCtx bwconf ""
+  toHtml = \case
+    BotLinked (PageCtx bwconf (bot, pidM)) -> toHtml $ PageCtx bwconf $ installedSuccess bot pidM
+    DiscordError (PageCtx bwconf ()) -> toHtml $ PageCtx bwconf discordError
+    NoTokenFound (PageCtx bwconf ()) -> toHtml $ PageCtx bwconf noTokenFound
+    NoContent (PageCtx bwconf ()) -> toHtml $ PageCtx bwconf ("" :: Html ())
   toHtmlRaw = toHtml
 
 
-authHeader :: Text -> Options -> Options
-authHeader token = header "Authorization" .~ [encodeUtf8 $ "Bot " <> token]
+-- | @authHeader "Bot" tok@ (Discord) / @authHeader "Bearer" tok@ (Slack).
+authHeader :: Text -> Text -> Options -> Options
+authHeader scheme token = header "Authorization" .~ [encodeUtf8 $ scheme <> " " <> token]
 
 
 contentTypeHeader :: Text -> Options -> Options
 contentTypeHeader contentType = header "Content-Type" .~ [encodeUtf8 contentType]
 
 
+-- Slack Block Kit / Discord component builders
+mrkdwn, plainTxt :: Text -> AE.Value
+mrkdwn t = AE.object ["type" AE..= ("mrkdwn" :: Text), "text" AE..= t]
+plainTxt t = AE.object ["type" AE..= ("plain_text" :: Text), "text" AE..= t, "emoji" AE..= True]
+
+
+textBlock :: Text -> AE.Value -> AE.Value
+textBlock ty t = AE.object ["type" AE..= ty, "text" AE..= t]
+
+
+elemsBlock :: Text -> [AE.Value] -> AE.Value
+elemsBlock ty es = AE.object ["type" AE..= ty, "elements" AE..= AE.Array (V.fromList es)]
+
+
+linkButton :: Text -> Text -> Text -> AE.Value
+linkButton actionId label url = AE.object ["type" AE..= ("button" :: Text), "action_id" AE..= actionId, "text" AE..= plainTxt label, "url" AE..= url]
+
+
+imageBlock :: Text -> Text -> AE.Value
+imageBlock url alt = AE.object ["type" AE..= ("image" :: Text), "image_url" AE..= url, "alt_text" AE..= alt]
+
+
+-- | Slack in-channel response replacing the ephemeral loading message.
+slackResponse :: [AE.Value] -> AE.Value
+slackResponse blocks = AE.object ["blocks" AE..= AE.Array (V.fromList blocks), "response_type" AE..= ("in_channel" :: Text), "replace_original" AE..= True, "delete_original" AE..= True]
+
+
 handleTableResponse :: BotType -> Either Text (V.Vector (V.Vector AE.Value), [Text], Int) -> EnvConfig -> Projects.ProjectId -> Text -> AE.Value
 handleTableResponse target tableAsVecE envCfg projectId query =
   case tableAsVecE of
-    Left err -> formatBotError target (QueryParseError query)
+    Left _ -> formatBotError target (QueryParseError query)
     Right (requestVecs, colNames, resultCount) ->
       if resultCount == 0
         then formatBotError target NoDataError
         else
-          let colIdxMap = listToIndexHashMap colNames
-              (tableData, shownCount) = recsVecToTableData requestVecs colIdxMap
+          let (tableData, shownCount) = recsVecToTableData requestVecs (listToIndexHashMap colNames)
               url' = envCfg.hostUrl <> "p/" <> projectId.toText <> "/log_explorer?query=" <> decodeUtf8 (urlEncode True $ encodeUtf8 query)
               explorerLink = "[View in Log Explorer →](" <> url' <> ")"
               moreText = if resultCount > shownCount then "\n_" <> show (resultCount - shownCount) <> " more results in Log Explorer_" else ""
@@ -130,65 +154,31 @@ handleTableResponse target tableAsVecE envCfg projectId query =
                 Discord -> AE.object ["content" AE..= (content <> "\n" <> explorerLink)]
                 WhatsApp -> AE.object ["body" AE..= (content <> "\n" <> url')]
                 Slack ->
-                  AE.object
-                    [ "blocks"
-                        AE..= AE.Array
-                          ( V.fromList
-                              [ AE.object ["type" AE..= "header", "text" AE..= AE.object ["type" AE..= "plain_text", "text" AE..= (headerEmoji <> " Query Results"), "emoji" AE..= True]]
-                              , AE.object ["type" AE..= "context", "elements" AE..= AE.Array (V.fromList [AE.object ["type" AE..= "mrkdwn", "text" AE..= ("Showing *" <> show shownCount <> "* of *" <> show resultCount <> "* events")]])]
-                              , AE.object ["type" AE..= "section", "text" AE..= AE.object ["type" AE..= "mrkdwn", "text" AE..= ("`" <> query <> "`")]]
-                              , AE.object ["type" AE..= "divider"]
-                              , AE.object ["type" AE..= "section", "text" AE..= AE.object ["type" AE..= "mrkdwn", "text" AE..= tableData]]
-                              , AE.object ["type" AE..= "actions", "elements" AE..= AE.Array (V.fromList [AE.object ["type" AE..= "button", "action_id" AE..= "view-log-explorer", "text" AE..= AE.object ["type" AE..= "plain_text", "text" AE..= (botEmoji "search" <> " View in Log Explorer"), "emoji" AE..= True], "url" AE..= url']])]
-                              ]
-                          )
-                    , "response_type" AE..= "in_channel"
-                    , "replace_original" AE..= True
-                    , "delete_original" AE..= True
+                  slackResponse
+                    [ textBlock "header" (plainTxt $ headerEmoji <> " Query Results")
+                    , elemsBlock "context" [mrkdwn $ "Showing *" <> show shownCount <> "* of *" <> show resultCount <> "* events"]
+                    , textBlock "section" (mrkdwn $ "`" <> query <> "`")
+                    , AE.object ["type" AE..= ("divider" :: Text)]
+                    , textBlock "section" (mrkdwn tableData)
+                    , elemsBlock "actions" [linkButton "view-log-explorer" (botEmoji "search" <> " View in Log Explorer") url']
                     ]
 
 
 recsVecToTableData :: V.Vector (V.Vector AE.Value) -> HashMap Text Int -> (Text, Int)
-recsVecToTableData recsVec colIdxMap =
-  let rows = V.toList (V.take 15 recsVec)
-      spans =
-        map
-          ( \v ->
-              TableData
-                { timestamp = fromMaybe "" $ lookupVecTextByKey v colIdxMap "timestamp"
-                , servicename = fromMaybe "" $ lookupVecTextByKey v colIdxMap "service"
-                , spanname = fromMaybe "" $ lookupVecTextByKey v colIdxMap "span_name"
-                , duration = toText $ getDurationNSMS $ fromIntegral $ lookupVecIntByKey v colIdxMap "duration"
-                , hasErrors = lookupVecBoolByKey v colIdxMap "errors"
-                }
-          )
-          rows
-   in (formatSpans spans, length rows)
-
-
-padRight :: Int -> Text -> Text
-padRight n s = T.take n (s <> T.replicate n " ")
-
-
-formatSpanRow :: TableData -> Text
-formatSpanRow spn = padRight 18 spn.timestamp <> " " <> padRight 15 spn.servicename <> " " <> padRight 20 spn.spanname <> " " <> padRight 8 spn.duration <> " " <> (if spn.hasErrors then "🔴" else "🟢")
-
-
-formatSpans :: [TableData] -> Text
-formatSpans spans =
-  let hd = padRight 20 "TIME" <> " " <> padRight 15 "SERVICE" <> " " <> padRight 20 "SPAN NAME" <> " " <> padRight 8 "DURATION" <> " STATUS"
-      rows = map formatSpanRow spans
-   in "```\n" <> unlines (hd : rows) <> "```"
-
-
-data TableData = TableData
-  { timestamp :: Text
-  , servicename :: Text
-  , spanname :: Text
-  , duration :: Text
-  , hasErrors :: Bool
-  }
-  deriving (Generic, Show)
+recsVecToTableData recsVec colIdxMap = ("```\n" <> unlines (hd : map row rows) <> "```", length rows)
+  where
+    rows = V.toList (V.take 15 recsVec)
+    pad n s = T.take n (s <> T.replicate n " ")
+    txt n v k = pad n $ fromMaybe "" $ lookupVecTextByKey v colIdxMap k
+    hd = unwords [pad 20 "TIME", pad 15 "SERVICE", pad 20 "SPAN NAME", pad 8 "DURATION", "STATUS"]
+    row v =
+      unwords
+        [ txt 18 v "timestamp"
+        , txt 15 v "service"
+        , txt 20 v "span_name"
+        , pad 8 (toText $ getDurationNSMS $ fromIntegral $ lookupVecIntByKey v colIdxMap "duration")
+        , botEmoji (if lookupVecBoolByKey v colIdxMap "errors" then "error" else "success")
+        ]
 
 
 noTokenFound :: Html ()
@@ -276,11 +266,8 @@ processAIQuery useTf pid userQuery threadCtx model apiKey = do
   facetSummaryM <- SchemaCatalog.getFacetSummary pid "otel_logs_and_spans" dayAgo now
   let config = (AI.defaultAgenticConfig pid){AI.facetContext = facetSummaryM, AI.customContext = threadCtx, AI.useTimefusion = useTf}
   result <- AI.runAgenticQuery config userQuery model apiKey
-  case result of
-    Left err -> do
-      Log.logAttention "processAIQuery failed" $ AE.object ["error" AE..= err, "userQuery" AE..= userQuery, "projectId" AE..= pid.toText]
-      pure $ Left err
-    Right resp -> pure $ Right resp
+  whenLeft_ result \err -> Log.logAttention "processAIQuery failed" $ AE.object ["error" AE..= err, "userQuery" AE..= userQuery, "projectId" AE..= pid.toText]
+  pure result
 
 
 formatHistoryAsContext :: Text -> [LLM.Message] -> Text
@@ -290,16 +277,13 @@ formatHistoryAsContext platform msgs =
     , "- this query is part of a " <> platform <> " conversation thread. Use previous messages for additional context if needed."
     , "- the user query is the main one to answer, but earlier messages may contain important clarifications or parameters."
     , "\nPrevious thread messages:\n"
-    , T.intercalate "\n" $ map formatMessage msgs
+    , T.intercalate "\n" ["[" <> show (LLM.role m) <> "] " <> LLM.content m | m <- msgs]
     ]
-  where
-    formatMessage m = "[" <> show (LLM.role m) <> "] " <> LLM.content m
 
 
 verifyWidgetSignature :: Text -> Projects.ProjectId -> Text -> Maybe Text -> Either LBS.ByteString ()
-verifyWidgetSignature secret pid widgetJson = \case
-  Nothing -> Left "Missing signature"
-  Just sig -> let expected = Widget.signWidgetUrl secret pid widgetJson in if BA.constEq (encodeUtf8 sig :: ByteString) (encodeUtf8 expected :: ByteString) then Right () else Left "Invalid signature"
+verifyWidgetSignature secret pid widgetJson = maybe (Left "Missing signature") \sig ->
+  unless (BA.constEq (encodeUtf8 sig :: ByteString) (encodeUtf8 (Widget.signWidgetUrl secret pid widgetJson) :: ByteString)) $ Left "Invalid signature"
 
 
 -- | Report query intent detection
@@ -340,47 +324,36 @@ detectReportIntent query =
 processReportQuery :: (DB es, Log :> es) => Projects.ProjectId -> ReportType -> EnvConfig -> Eff es (Either Text (Reports.Report, Text, Text))
 processReportQuery pid reportType envCfg = do
   let typeTxt = case reportType of DailyReport -> "daily"; WeeklyReport -> "weekly"
-  reportM <- Reports.getLatestReportByType pid typeTxt
-  case reportM of
+  Reports.getLatestReportByType pid typeTxt >>= \case
     Nothing -> pure $ Left $ "No " <> typeTxt <> " report found. Reports are generated automatically on schedule."
     Just report -> do
-      let startTxt = toText $ formatTime defaultTimeLocale "%Y-%m-%dT%H:%M:%SZ" report.startTime
-          endTxt = toText $ formatTime defaultTimeLocale "%Y-%m-%dT%H:%M:%SZ" report.endTime
-      eventsUrl <- Widget.widgetPngUrl envCfg.apiKeyEncryptionSecretKey envCfg.hostUrl pid def{Widget.wType = Widget.WTTimeseries, Widget.query = Just "summarize count(*) by bin_auto(timestamp), status_code"} Nothing (Just startTxt) (Just endTxt)
-      errorsUrl <- Widget.widgetPngUrl envCfg.apiKeyEncryptionSecretKey envCfg.hostUrl pid def{Widget.wType = Widget.WTTimeseries, Widget.query = Just "status_code == \"ERROR\" | summarize count(*) by bin_auto(timestamp), status_code", Widget.theme = Just "roma"} Nothing (Just startTxt) (Just endTxt)
-      pure $ Right (report, eventsUrl, errorsUrl)
+      let stamp = toText . formatTime defaultTimeLocale "%Y-%m-%dT%H:%M:%SZ"
+          png q theme = Widget.widgetPngUrl envCfg.apiKeyEncryptionSecretKey envCfg.hostUrl pid def{Widget.wType = Widget.WTTimeseries, Widget.query = Just q, Widget.theme = theme} Nothing (Just $ stamp report.startTime) (Just $ stamp report.endTime)
+      fmap Right $ (,,) report <$> png "summarize count(*) by bin_auto(timestamp), status_code" Nothing <*> png "status_code == \"ERROR\" | summarize count(*) by bin_auto(timestamp), status_code" (Just "roma")
 
 
 -- | Shared report-render preamble: (reportUrl, startTxt, endTxt, totalEvents, totalErrors)
 reportHeader :: Reports.Report -> Projects.ProjectId -> EnvConfig -> (Text, Text, Text, Int, Int)
 reportHeader report pid envCfg =
   let reportUrl = envCfg.hostUrl <> "p/" <> pid.toText <> "/reports/" <> report.id.toText
-      startTxt = T.take 10 $ toText $ formatTime defaultTimeLocale "%Y-%m-%d" report.startTime
-      endTxt = T.take 10 $ toText $ formatTime defaultTimeLocale "%Y-%m-%d" report.endTime
+      startTxt = toText $ formatTime defaultTimeLocale "%Y-%m-%d" report.startTime
+      endTxt = toText $ formatTime defaultTimeLocale "%Y-%m-%d" report.endTime
       (totalEvents, totalErrors) = parseReportStats report.reportJson
    in (reportUrl, startTxt, endTxt, totalEvents, totalErrors)
 
 
 -- | Format report for Slack
-formatReportForSlack :: Reports.Report -> Projects.ProjectId -> EnvConfig -> Text -> Text -> Text -> AE.Value
-formatReportForSlack report pid envCfg eventsUrl errorsUrl channelId =
+formatReportForSlack :: Reports.Report -> Projects.ProjectId -> EnvConfig -> Text -> Text -> AE.Value
+formatReportForSlack report pid envCfg eventsUrl errorsUrl =
   let (reportUrl, startTxt, endTxt, totalEvents, totalErrors) = reportHeader report pid envCfg
-   in AE.object
-        [ "blocks"
-            AE..= AE.Array
-              ( V.fromList
-                  [ AE.object ["type" AE..= "header", "text" AE..= AE.object ["type" AE..= "plain_text", "text" AE..= (botEmoji "chart" <> " " <> T.toTitle report.reportType <> " Report"), "emoji" AE..= True]]
-                  , AE.object ["type" AE..= "context", "elements" AE..= AE.Array (V.fromList [AE.object ["type" AE..= "mrkdwn", "text" AE..= ("*Period:* " <> startTxt <> " → " <> endTxt)]])]
-                  , AE.object ["type" AE..= "section", "text" AE..= AE.object ["type" AE..= "mrkdwn", "text" AE..= ("Total Events: *" <> show totalEvents <> "*  •  Total Errors: *" <> show totalErrors <> "*")]]
-                  , AE.object ["type" AE..= "divider"]
-                  , AE.object ["type" AE..= "image", "image_url" AE..= eventsUrl, "alt_text" AE..= ("Events chart for " <> report.reportType <> " report showing " <> show totalEvents <> " total events")]
-                  , AE.object ["type" AE..= "image", "image_url" AE..= errorsUrl, "alt_text" AE..= ("Errors chart for " <> report.reportType <> " report showing " <> show totalErrors <> " total errors")]
-                  , AE.object ["type" AE..= "actions", "elements" AE..= AE.Array (V.fromList [AE.object ["type" AE..= "button", "action_id" AE..= "view-full-report", "text" AE..= AE.object ["type" AE..= "plain_text", "text" AE..= (botEmoji "search" <> " View Full Report"), "emoji" AE..= True], "url" AE..= reportUrl]])]
-                  ]
-              )
-        , "response_type" AE..= "in_channel"
-        , "replace_original" AE..= True
-        , "delete_original" AE..= True
+   in slackResponse
+        [ textBlock "header" (plainTxt $ botEmoji "chart" <> " " <> T.toTitle report.reportType <> " Report")
+        , elemsBlock "context" [mrkdwn $ "*Period:* " <> startTxt <> " → " <> endTxt]
+        , textBlock "section" (mrkdwn $ "Total Events: *" <> show totalEvents <> "*  •  Total Errors: *" <> show totalErrors <> "*")
+        , AE.object ["type" AE..= ("divider" :: Text)]
+        , imageBlock eventsUrl $ "Events chart for " <> report.reportType <> " report showing " <> show totalEvents <> " total events"
+        , imageBlock errorsUrl $ "Errors chart for " <> report.reportType <> " report showing " <> show totalErrors <> " total errors"
+        , elemsBlock "actions" [linkButton "view-full-report" (botEmoji "search" <> " View Full Report") reportUrl]
         ]
 
 
@@ -399,23 +372,26 @@ formatReportForDiscord report pid envCfg eventsUrl errorsUrl =
                     , "components"
                         AE..= AE.Array
                           ( V.fromList
-                              [ AE.object ["type" AE..= (10 :: Int), "content" AE..= (botEmoji "chart" <> " **" <> T.toTitle report.reportType <> " Report**")]
-                              , AE.object ["type" AE..= (10 :: Int), "content" AE..= ("**Period:** " <> startTxt <> " → " <> endTxt)]
-                              , AE.object ["type" AE..= (10 :: Int), "content" AE..= ("Total Events: **" <> show totalEvents <> "**  •  Total Errors: **" <> show totalErrors <> "**")]
-                              , AE.object ["type" AE..= (12 :: Int), "items" AE..= AE.Array (V.fromList [AE.object ["media" AE..= AE.object ["url" AE..= eventsUrl], "description" AE..= ("Events chart for " <> report.reportType <> " report: " <> show totalEvents <> " total events")], AE.object ["media" AE..= AE.object ["url" AE..= errorsUrl], "description" AE..= ("Errors chart for " <> report.reportType <> " report: " <> show totalErrors <> " total errors")]])]
-                              , AE.object ["type" AE..= (1 :: Int), "components" AE..= AE.Array (V.fromList [AE.object ["type" AE..= (2 :: Int), "label" AE..= (botEmoji "search" <> " View Full Report"), "url" AE..= reportUrl, "style" AE..= (5 :: Int)]])]
+                              [ txtComp $ botEmoji "chart" <> " **" <> T.toTitle report.reportType <> " Report**"
+                              , txtComp $ "**Period:** " <> startTxt <> " → " <> endTxt
+                              , txtComp $ "Total Events: **" <> show totalEvents <> "**  •  Total Errors: **" <> show totalErrors <> "**"
+                              , AE.object ["type" AE..= (12 :: Int), "items" AE..= AE.Array (V.fromList [media eventsUrl $ "Events chart for " <> report.reportType <> " report: " <> show totalEvents <> " total events", media errorsUrl $ "Errors chart for " <> report.reportType <> " report: " <> show totalErrors <> " total errors"])]
+                              , AE.object ["type" AE..= (1 :: Int), "components" AE..= AE.Array (V.singleton $ AE.object ["type" AE..= (2 :: Int), "label" AE..= (botEmoji "search" <> " View Full Report"), "url" AE..= reportUrl, "style" AE..= (5 :: Int)])]
                               ]
                           )
                     ]
               )
         ]
+  where
+    txtComp c = AE.object ["type" AE..= (10 :: Int), "content" AE..= (c :: Text)]
+    media u d = AE.object ["media" AE..= AE.object ["url" AE..= (u :: Text)], "description" AE..= (d :: Text)]
 
 
 -- | Format report for WhatsApp
 formatReportForWhatsApp :: Reports.Report -> Projects.ProjectId -> EnvConfig -> Text
 formatReportForWhatsApp report pid envCfg =
   let (reportUrl, startTxt, endTxt, totalEvents, totalErrors) = reportHeader report pid envCfg
-   in "📊 " <> T.toTitle report.reportType <> " Report\nPeriod: " <> startTxt <> " - " <> endTxt <> "\nTotal Events: " <> show totalEvents <> "\nTotal Errors: " <> show totalErrors <> "\nView: " <> reportUrl
+   in botEmoji "chart" <> " " <> T.toTitle report.reportType <> " Report\nPeriod: " <> startTxt <> " - " <> endTxt <> "\nTotal Events: " <> show totalEvents <> "\nTotal Errors: " <> show totalErrors <> "\nView: " <> reportUrl
 
 
 -- | Parse total events and errors from report JSON
@@ -431,14 +407,15 @@ formatTextResponse Discord txt = AE.object ["content" AE..= txt]
 formatTextResponse WhatsApp txt = AE.object ["body" AE..= txt]
 formatTextResponse Slack txt =
   AE.object
-    [ "blocks" AE..= AE.Array (V.fromList [AE.object ["type" AE..= "section", "text" AE..= AE.object ["type" AE..= "mrkdwn", "text" AE..= txt]]])
+    [ "blocks" AE..= AE.Array (V.singleton $ textBlock "section" (mrkdwn txt))
     , "response_type" AE..= "in_channel"
     , "replace_original" AE..= True
     ]
 
 
--- | Generic AI response dispatch — handles the (hasQuery, hasExplanation) 4-way
--- pattern shared by all bot platforms, plus widget generation and table fallback.
+-- | Generic AI response dispatch — renders a widget when a query is present
+-- (plus any accompanying explanation), otherwise falls back to text-only.
+-- Shared by all bot platforms.
 dispatchAIResponse
   :: (DB es, Log :> es, Time.Time :> es, Tracing :> es)
   => BotType
@@ -456,27 +433,17 @@ dispatchAIResponse botType envCfg pid userQuestion resp sendResponse buildChartC
   now <- Time.currentTime
   let (fromTimeM, toTimeM, _) = maybe (Nothing, Nothing, Nothing) (TP.parseTimeRange now) resp.timeRange
       query = fromMaybe "" resp.query
-      hasQuery = isJust resp.query
-      hasExplanation = isJust resp.explanation
-  case (hasQuery, hasExplanation) of
-    (False, True) -> sendResponse $ formatTextResponse botType (fromMaybe "No insights available" resp.explanation)
-    (True, False) -> handleWidget now query resp.visualization fromTimeM toTimeM
-    (True, True) -> do
-      handleWidget now query resp.visualization fromTimeM toTimeM
-      whenJust resp.explanation $ sendResponse . formatTextResponse botType
-    (False, False) -> sendResponse $ formatTextResponse botType "No response available"
-  where
-    handleWidget _now query visualization fromTimeM toTimeM = case visualization of
-      Just vizType -> do
-        let wType = Widget.mapChatTypeToWidgetType vizType
-            chartType = Widget.mapWidgetTypeToChartType wType
-            queryUrl = envCfg.hostUrl <> "p/" <> pid.toText <> "/log_explorer?viz_type=" <> chartType <> "&query=" <> toUriStr query
-            fromISO = toText . iso8601Show <$> fromTimeM
-            toISO = toText . iso8601Show <$> toTimeM
-        imageUrl <- Widget.widgetPngUrl envCfg.apiKeyEncryptionSecretKey envCfg.hostUrl pid def{Widget.wType = wType, Widget.query = Just query} Nothing fromISO toISO
-        sendResponse $ buildChartContent userQuestion query queryUrl imageUrl
-      Nothing -> case parseQueryToAST query of
-        Left _ -> sendResponse $ formatBotError botType (QueryParseError query)
-        Right query' -> do
-          tableAsVecE <- LogQueries.selectLogTable pid query' query Nothing (fromTimeM, toTimeM) [] Nothing Nothing
-          sendResponse $ handleTableResponse botType tableAsVecE envCfg pid query
+      handleWidget = case resp.visualization of
+        Just vizType -> do
+          let wType = Widget.mapChatTypeToWidgetType vizType
+              queryUrl = envCfg.hostUrl <> "p/" <> pid.toText <> "/log_explorer?viz_type=" <> Widget.mapWidgetTypeToChartType wType <> "&query=" <> toUriStr query
+          imageUrl <- Widget.widgetPngUrl envCfg.apiKeyEncryptionSecretKey envCfg.hostUrl pid def{Widget.wType = wType, Widget.query = Just query} Nothing (toText . iso8601Show <$> fromTimeM) (toText . iso8601Show <$> toTimeM)
+          sendResponse $ buildChartContent userQuestion query queryUrl imageUrl
+        Nothing -> case parseQueryToAST query of
+          Left _ -> sendResponse $ formatBotError botType (QueryParseError query)
+          Right query' -> do
+            tableAsVecE <- LogQueries.selectLogTable pid query' query Nothing (fromTimeM, toTimeM) [] Nothing Nothing
+            sendResponse $ handleTableResponse botType tableAsVecE envCfg pid query
+  case resp.query of
+    Just _ -> handleWidget >> whenJust resp.explanation (sendResponse . formatTextResponse botType)
+    Nothing -> sendResponse $ formatTextResponse botType $ fromMaybe "No response available" resp.explanation

--- a/src/Pages/Bots/Whatsapp.hs
+++ b/src/Pages/Bots/Whatsapp.hs
@@ -1,4 +1,4 @@
-module Pages.Bots.Whatsapp (whatsappIncomingPostH, TwilioWhatsAppMessage (..)) where
+module Pages.Bots.Whatsapp (whatsappIncomingPostH, TwilioWhatsAppMessage (..), BodyType (..), parseWhatsappBody, getWhatsappList) where
 
 import Control.Lens ((.~), (?~))
 import Data.Aeson qualified as AE

--- a/src/Pages/Bots/Whatsapp.hs
+++ b/src/Pages/Bots/Whatsapp.hs
@@ -58,7 +58,7 @@ whatsappIncomingPostH val = do
       handleWidget widget dashboardId project = withDashboard dashboardId $ \dashboard ->
         whenJust (find (\w -> fromMaybe "Untitled-" w.title == widget) dashboard.widgets) $ \w -> do
           now <- Time.currentTime
-          let opts = "time=" <> toUriStr (show now) <> "&p=" <> project.id.toText <> "&widget=" <> toUriStr (decodeUtf8 $ toStrict $ AE.encode w)
+          let opts = "time=" <> toUriStr (show now) <> "&p=" <> project.id.toText <> "&widget=" <> toUriStr (decodeUtf8 @Text $ AE.encode w)
           sendWhatsappResponse (getBotContent val.body widget (project.id.toText <> "/dashboards") opts) val.from envCfg.whatsappBotChart Nothing
 
       handlePrompt project = do

--- a/src/Pages/Bots/Whatsapp.hs
+++ b/src/Pages/Bots/Whatsapp.hs
@@ -1,7 +1,6 @@
 module Pages.Bots.Whatsapp (whatsappIncomingPostH, TwilioWhatsAppMessage (..)) where
 
-import Control.Lens ((?~))
-import Control.Lens.Setter ((.~))
+import Control.Lens ((.~), (?~))
 import Data.Aeson qualified as AE
 import Data.Aeson.Key qualified as KEYM
 import Data.Aeson.KeyMap qualified as KEM
@@ -17,16 +16,15 @@ import Models.Apis.Integrations (getDashboardsForWhatsapp)
 import Models.Apis.LogQueries qualified as LogQueries
 import Models.Projects.Dashboards qualified as Dashboards
 import Models.Projects.Projects qualified as Projects
-import Network.HTTP.Types (urlEncode)
 import Network.Wreq
 import Pages.Bots.Utils (BotType (..), QueryIntent (..), botEmoji, detectReportIntent, formatReportForWhatsApp, handleTableResponse, processAIQuery, processReportQuery)
-import Pkg.AI qualified as AI
+import Pkg.AI (LLMResponse (..))
 import Pkg.Components.TimePicker qualified as TP
 import Pkg.Components.Widget qualified as Widget
 import Pkg.DeriveUtils (idFromText)
 import Pkg.Parser (parseQueryToAST)
 import Relude
-import System.Config (AuthContext (backgroundScope), EnvConfig)
+import System.Config (AuthContext (backgroundScope))
 import System.Config qualified as Config
 import System.Tracing (forkBackground)
 import System.Types (ATBaseCtx)
@@ -43,160 +41,117 @@ whatsappIncomingPostH val = do
   Log.logTrace ("WhatsApp interaction received" :: Text) $ AE.object ["from" AE..= val.from, "body" AE..= val.body]
   authCtx <- Effectful.Reader.Static.ask @AuthContext
   let envCfg = authCtx.config
-  let fromN = T.dropWhile (/= '+') val.from
+      fromN = T.dropWhile (/= '+') val.from
+
+      sendText t = sendWhatsappResponse (AE.object []) val.from envCfg.whatsappBotText (Just t)
+
+      withDashboard dashboardId act = do
+        dashboardVMM <- maybe (pure Nothing) Dashboards.getDashboardById (idFromText dashboardId)
+        whenJust dashboardVMM $ \dashboardVM -> do
+          dashboardM <- liftIO $ Dashboards.readDashboardFile "static/public/dashboards" (toString $ fromMaybe "_overview.yaml" dashboardVM.baseTemplate)
+          whenJust dashboardM act
+
+      handleDashboard dashboardId skip = withDashboard dashboardId $ \dashboard -> do
+        let widgets = V.fromList $ (\w -> let t = fromMaybe "Untitled-" w.title in (t, "widg" <> joiner <> t <> joiner <> dashboardId)) <$> dashboard.widgets
+        sendWhatsappResponse (getWhatsappList ("widget" <> joiner <> dashboardId) "Please select a widget" widgets skip) val.from envCfg.whatsappDashboardList Nothing
+
+      handleWidget widget dashboardId project = withDashboard dashboardId $ \dashboard ->
+        whenJust (find (\w -> fromMaybe "Untitled-" w.title == widget) dashboard.widgets) $ \w -> do
+          now <- Time.currentTime
+          let opts = "time=" <> toUriStr (show now) <> "&p=" <> project.id.toText <> "&widget=" <> toUriStr (decodeUtf8 $ toStrict $ AE.encode w)
+          sendWhatsappResponse (getBotContent val.body widget (project.id.toText <> "/dashboards") opts) val.from envCfg.whatsappBotChart Nothing
+
+      handlePrompt project = do
+        now <- Time.currentTime
+        case detectReportIntent val.body of
+          ReportIntent reportType ->
+            processReportQuery project.id reportType envCfg >>= \case
+              Left err -> sendText err
+              Right (report, _, _) -> sendText $ formatReportForWhatsApp report project.id envCfg
+          GeneralQueryIntent ->
+            processAIQuery envCfg.enableTimefusionReads project.id val.body Nothing envCfg.openaiModel envCfg.openaiApiKey >>= \case
+              Left _ -> sendText $ botEmoji "error" <> " Something went wrong. Please try again."
+              Right resp -> do
+                let (fromTimeM, toTimeM, _) = maybe (Nothing, Nothing, Nothing) (TP.parseTimeRange now) resp.timeRange
+                case (resp.query, resp.explanation) of
+                  (Just query, explM) -> do
+                    handleWidgetResponse now project query resp.visualization fromTimeM toTimeM
+                    whenJust explM sendText
+                  (Nothing, Just expl) -> sendText expl
+                  (Nothing, Nothing) -> sendText "No response available"
+
+      handleWidgetResponse now project query visualization fromTimeM toTimeM = case visualization of
+        Just vizType -> do
+          let chartType = Widget.mapWidgetTypeToChartType $ Widget.mapChatTypeToWidgetType vizType
+              iso = maybe "" (toText . iso8601Show)
+              opts =
+                "time=" <> toUriStr (show now) <> "&q=" <> toUriStr query <> "&p=" <> toUriStr project.id.toText <> "&t=" <> toUriStr chartType <> "&from=" <> toUriStr (iso fromTimeM) <> "&to=" <> toUriStr (iso toTimeM)
+              queryUrl = project.id.toText <> "/log_explorer?viz_type=" <> chartType <> "&query=" <> toUriStr query
+          sendWhatsappResponse (getBotContent val.body query queryUrl opts) val.from envCfg.whatsappBotChart Nothing
+        Nothing -> case parseQueryToAST query of
+          Left _ -> sendText $ botEmoji "warning" <> " Couldn't parse query. Try: 'show errors in last hour'"
+          Right query' -> do
+            tableAsVecE <- LogQueries.selectLogTable project.id query' query Nothing (fromTimeM, toTimeM) [] Nothing Nothing
+            sendText $ case handleTableResponse WhatsApp tableAsVecE envCfg project.id query of
+              AE.Object o | Just (AE.String c) <- KEM.lookup "body" o -> c
+              _ -> "Error processing query"
+
   projectM <- Projects.getProjectByPhoneNumber fromN
   Log.logTrace ("WhatsApp project lookup" :: Text) $ AE.object ["fromN" AE..= fromN, "found" AE..= isJust projectM]
-  let bodyType = parseWhatsappBody val.body
-  case projectM of
-    Just p -> do
-      case bodyType of
-        DashboardLoad skip -> do
-          dashboards' <- getDashboardsForWhatsapp fromN
-          let dashboards = V.fromList $ map (\(k, v) -> (k, "dash" <> joiner <> v)) dashboards'
-          let contentVars = getWhatsappList "dashboard" "Please select a dashboard" dashboards 0
-          sendWhatsappResponse contentVars val.from envCfg.whatsappDashboardList Nothing
-        WidgetsLoad dashboardId skip -> handleDashboard dashboardId skip val p envCfg
-        WidgetSelect widgetTitle dashboardId -> handleWidget widgetTitle dashboardId val p envCfg
-        Prompt _ -> forkBackground authCtx.backgroundScope ("WhatsApp prompt (" <> val.from <> ")") $ handlePrompt val envCfg p
-      pure $ AE.object []
-    _ -> pure $ AE.object []
-  where
-    handleDashboard :: Text -> Int -> TwilioWhatsAppMessage -> Projects.Project -> EnvConfig -> ATBaseCtx ()
-    handleDashboard dashboardId skip v p envCfg = do
-      dashboardVMM <- maybe (pure Nothing) Dashboards.getDashboardById (idFromText dashboardId)
-      case dashboardVMM of
-        Nothing -> pass
-        Just dashboardVM -> do
-          dashboardM <- liftIO $ Dashboards.readDashboardFile "static/public/dashboards" (toString $ fromMaybe "_overview.yaml" dashboardVM.baseTemplate)
-          whenJust dashboardM $ \dashboard -> do
-            let widgets' = (\w -> (fromMaybe "Untitled-" w.title, fromMaybe "Untitled-" w.title)) <$> dashboard.widgets
-                widgets = V.fromList $ (\(k, id') -> (k, "widg" <> joiner <> id' <> joiner <> dashboardId)) <$> widgets'
-            let contentVars = getWhatsappList ("widget" <> joiner <> dashboardId) "Please select a widget" widgets skip
-            sendWhatsappResponse contentVars val.from envCfg.whatsappDashboardList Nothing
-            pass
-
-    handleWidget :: Text -> Text -> TwilioWhatsAppMessage -> Projects.Project -> EnvConfig -> ATBaseCtx ()
-    handleWidget widget dashboardId reqBody project envCfg = do
-      dashboardVMM <- maybe (pure Nothing) Dashboards.getDashboardById (idFromText dashboardId)
-      case dashboardVMM of
-        Nothing -> pass
-        Just dashboardVM -> do
-          dashboardM <- liftIO $ Dashboards.readDashboardFile "static/public/dashboards" (toString $ fromMaybe "_overview.yaml" dashboardVM.baseTemplate)
-          whenJust dashboardM $ \dashboard -> do
-            let widgetM = find (\w -> fromMaybe "Untitled-" w.title == widget) dashboard.widgets
-            whenJust widgetM $ \w -> do
-              now <- Time.currentTime
-              let widgetQuery = "&widget=" <> decodeUtf8 (urlEncode True (toStrict $ AE.encode $ AE.toJSON w))
-                  opts = "time=" <> decodeUtf8 (urlEncode True (encodeUtf8 $ show now)) <> "&p=" <> project.id.toText <> widgetQuery
-                  query_url = project.id.toText <> "/dashboards"
-                  content' = getBotContent reqBody.body widget query_url opts
-              _ <- sendWhatsappResponse content' reqBody.from envCfg.whatsappBotChart Nothing
-              pass
-
-    handlePrompt :: TwilioWhatsAppMessage -> EnvConfig -> Projects.Project -> ATBaseCtx ()
-    handlePrompt reqBody envCfg project = do
-      now <- Time.currentTime
-      case detectReportIntent reqBody.body of
-        ReportIntent reportType -> do
-          reportResult <- processReportQuery project.id reportType envCfg
-          case reportResult of
-            Left err -> sendWhatsappResponse (AE.object []) reqBody.from envCfg.whatsappBotText (Just err)
-            Right (report, _, _) -> sendWhatsappResponse (AE.object []) reqBody.from envCfg.whatsappBotText (Just $ formatReportForWhatsApp report project.id envCfg)
-        GeneralQueryIntent -> do
-          result <- processAIQuery envCfg.enableTimefusionReads project.id reqBody.body Nothing envCfg.openaiModel envCfg.openaiApiKey
-          case result of
-            Left _ -> sendWhatsappResponse (AE.object []) reqBody.from envCfg.whatsappBotText (Just $ botEmoji "error" <> " Something went wrong. Please try again.")
-            Right resp -> do
-              let (fromTimeM, toTimeM, _) = maybe (Nothing, Nothing, Nothing) (TP.parseTimeRange now) resp.timeRange
-                  query = fromMaybe "" resp.query
-                  hasQuery = isJust resp.query
-                  hasExplanation = isJust resp.explanation
-              case (hasQuery, hasExplanation) of
-                (False, True) -> sendWhatsappResponse (AE.object []) reqBody.from envCfg.whatsappBotText (Just $ fromMaybe "No insights available" resp.explanation)
-                (True, False) -> handleWidgetResponse now reqBody envCfg project query resp.visualization fromTimeM toTimeM
-                (True, True) -> do
-                  handleWidgetResponse now reqBody envCfg project query resp.visualization fromTimeM toTimeM
-                  whenJust resp.explanation $ sendWhatsappResponse (AE.object []) reqBody.from envCfg.whatsappBotText . Just
-                (False, False) -> sendWhatsappResponse (AE.object []) reqBody.from envCfg.whatsappBotText (Just "No response available")
-
-    handleWidgetResponse now reqBody envCfg project query visualization fromTimeM toTimeM = case visualization of
-      Just vizType -> do
-        let chartType = Widget.mapWidgetTypeToChartType $ Widget.mapChatTypeToWidgetType vizType
-            fromISO = maybe "" (toText . iso8601Show) fromTimeM
-            toISO = maybe "" (toText . iso8601Show) toTimeM
-            opts = "time=" <> toUriStr (show now) <> "&q=" <> toUriStr query <> "&p=" <> toUriStr project.id.toText <> "&t=" <> toUriStr chartType <> "&from=" <> toUriStr fromISO <> "&to=" <> toUriStr toISO
-            query_url = project.id.toText <> "/log_explorer?viz_type=" <> chartType <> "&query=" <> toUriStr query
-            content' = getBotContent reqBody.body query query_url opts
-        _ <- sendWhatsappResponse content' reqBody.from envCfg.whatsappBotChart Nothing
-        pass
-      Nothing -> case parseQueryToAST query of
-        Left _ -> sendWhatsappResponse (AE.object []) reqBody.from envCfg.whatsappBotText (Just $ botEmoji "warning" <> " Couldn't parse query. Try: 'show errors in last hour'")
-        Right query' -> do
-          tableAsVecE <- LogQueries.selectLogTable project.id query' query Nothing (fromTimeM, toTimeM) [] Nothing Nothing
-          let content = case handleTableResponse WhatsApp tableAsVecE envCfg project.id query of
-                AE.Object o -> case KEM.lookup "body" o of
-                  Just (AE.String c) -> c
-                  _ -> "Error processing query"
-                _ -> "Error processing query"
-          sendWhatsappResponse (AE.object []) reqBody.from envCfg.whatsappBotText (Just content)
+  whenJust projectM $ \p -> case parseWhatsappBody val.body of
+    DashboardLoad skip -> do
+      dashboards <- V.fromList . map (second (("dash" <> joiner) <>)) <$> getDashboardsForWhatsapp fromN
+      sendWhatsappResponse (getWhatsappList "dashboard" "Please select a dashboard" dashboards skip) val.from envCfg.whatsappDashboardList Nothing
+    WidgetsLoad dashboardId skip -> handleDashboard dashboardId skip
+    WidgetSelect widgetTitle dashboardId -> handleWidget widgetTitle dashboardId p
+    Prompt -> forkBackground authCtx.backgroundScope ("WhatsApp prompt (" <> val.from <> ")") $ handlePrompt p
+  pure $ AE.object []
 
 
 data BodyType
   = WidgetsLoad Text Int
   | WidgetSelect Text Text
   | DashboardLoad Int
-  | Prompt Text
+  | Prompt
 
 
 parseWhatsappBody :: Text -> BodyType
-parseWhatsappBody body =
-  case body of
-    "/dashboard" -> DashboardLoad 0
-    _ ->
-      let parts = T.splitOn joiner body
-       in case parts of
-            ["dashboard", skip] -> DashboardLoad $ defaultZero skip
-            ["dash", dashboardId] -> WidgetsLoad dashboardId 0
-            ["dash", dashboardId, _] -> WidgetsLoad dashboardId 0
-            ["widget", dashboardId, skip] -> WidgetsLoad dashboardId (defaultZero skip)
-            ["widg", widgetTitle, dashboardId] -> WidgetSelect widgetTitle dashboardId
-            ["widg", widgetTitle, dashboardId, _] -> WidgetSelect widgetTitle dashboardId
-            _ -> Prompt body
+parseWhatsappBody "/dashboard" = DashboardLoad 0
+parseWhatsappBody body = case T.splitOn joiner body of
+  ["dashboard", skip] -> DashboardLoad (readInt0 skip)
+  ["dash", dashboardId] -> WidgetsLoad dashboardId 0
+  ["dash", dashboardId, _] -> WidgetsLoad dashboardId 0
+  ["widget", dashboardId, skip] -> WidgetsLoad dashboardId (readInt0 skip)
+  ["widg", widgetTitle, dashboardId] -> WidgetSelect widgetTitle dashboardId
+  ["widg", widgetTitle, dashboardId, _] -> WidgetSelect widgetTitle dashboardId
+  _ -> Prompt
   where
-    defaultZero skip = fromMaybe 0 (readMaybe (toString skip))
+    readInt0 = fromMaybe 0 . readMaybe . toString
 
 
 getBotContent :: Text -> Text -> Text -> Text -> AE.Value
-getBotContent question query query_url opts =
-  AE.object ["1" AE..= ("*" <> question <> "*"), "2" AE..= ("`" <> query <> "`"), "3" AE..= opts, "4" AE..= query_url]
+getBotContent question query queryUrl opts =
+  AE.object ["1" AE..= ("*" <> question <> "*"), "2" AE..= ("`" <> query <> "`"), "3" AE..= opts, "4" AE..= queryUrl]
 
 
+-- | Twilio content-template variables: "1" is the prompt, then alternating label/payload
+-- pairs from "2" on, with "6"/"7" reserved for the Load More button when the list overflows.
 getWhatsappList :: Text -> Text -> V.Vector (Text, Text) -> Int -> AE.Value
-getWhatsappList typ body vals' skip = AE.object $ ("1" AE..= body) : vars
+getWhatsappList typ body vals' skip = AE.object $ ("1" AE..= body) : buttons <> loadMore
   where
     vals = V.map (first (T.take 24)) (V.drop skip vals')
-    paddedVals =
-      let missing = 3 - V.length vals
-          duplicates' = case vals V.!? 0 of
-            Just v | V.length vals == 1 -> V.replicate missing v
-            _ -> V.take missing vals
-          duplicates = V.imap (\i (k, v) -> (k <> " " <> show (i + 1), v <> joiner <> show (i + 1))) duplicates'
-       in if missing > 0
-            then vals <> duplicates
-            else vals
-    vars
-      | V.length vals > 3 =
-          let firstTwo = V.take 2 paddedVals
-              loadMore = ("Load More", typ <> joiner <> show (skip + 2))
-              buttonPairs = V.toList $ V.imap (\i (k, v) -> [key (2 * i + 2) AE..= k, key (2 * i + 3) AE..= v]) firstTwo
-              flattened = concat buttonPairs
-           in flattened ++ ["6" AE..= fst loadMore, "7" AE..= snd loadMore]
-      | otherwise =
-          let buttonPairs = V.toList $ V.imap (\i (k, v) -> [key (2 * i + 2) AE..= k, key (2 * i + 3) AE..= v]) paddedVals
-           in concat buttonPairs
-
+    missing = 3 - V.length vals
+    -- Twilio rejects templates with unfilled variables, so pad short lists with suffixed copies.
+    padded
+      | missing <= 0 = vals
+      | otherwise = vals <> V.imap (\i (k, v) -> (k <> " " <> show (i + 1), v <> joiner <> show (i + 1))) (V.take missing $ V.concat $ replicate missing vals)
+    overflow = V.length vals > 3
+    buttons = concat $ V.toList $ V.imap (\i (k, v) -> [key (2 * i + 2) AE..= k, key (2 * i + 3) AE..= v]) (if overflow then V.take 2 padded else padded)
+    loadMore
+      | overflow = ["6" AE..= ("Load More" :: Text), "7" AE..= (typ <> joiner <> show (skip + 2))]
+      | otherwise = []
     key :: Int -> AE.Key
-    key = KEYM.fromText . toText . show
+    key = KEYM.fromText . show
 
 
 data TwilioWhatsAppMessage = TwilioWhatsAppMessage
@@ -222,55 +177,38 @@ data TwilioWhatsAppMessage = TwilioWhatsAppMessage
 instance FromForm TwilioWhatsAppMessage where
   fromForm f =
     TwilioWhatsAppMessage
-      <$> parseUnique' "MessageSid"
-      <*> parseUnique' "SmsSid"
-      <*> parseUnique' "SmsMessageSid"
-      <*> parseUnique' "AccountSid"
-      <*> parseOptional "MessagingServiceSid"
-      <*> parseUnique' "From"
-      <*> parseUnique' "To"
-      <*> parseUnique' "Body"
-      <*> parseFieldDefault "NumMedia" 0
-      <*> parseFieldDefault "NumSegments" 1
-      <*> parseOptional "ProfileName"
-      <*> parseOptional "WaId"
-      <*> parseOptionalBool "Forwarded"
-      <*> parseOptionalBool "FrequentlyForwarded"
-      <*> parseOptional "ButtonText"
+      <$> req "MessageSid"
+      <*> req "SmsSid"
+      <*> req "SmsMessageSid"
+      <*> req "AccountSid"
+      <*> opt "MessagingServiceSid"
+      <*> req "From"
+      <*> req "To"
+      <*> req "Body"
+      <*> num "NumMedia" 0
+      <*> num "NumSegments" 1
+      <*> opt "ProfileName"
+      <*> opt "WaId"
+      <*> flag "Forwarded"
+      <*> flag "FrequentlyForwarded"
+      <*> opt "ButtonText"
     where
-      parseUnique' key = case lookupMaybe key f of
-        Right (Just v) -> pure v
-        Right _ -> fail $ "Missing field: " ++ toString key
-        Left e -> fail $ toString e
-      parseOptional key = case lookupMaybe key f of
-        Right v -> pure v
-        _ -> pure Nothing
-      parseFieldDefault key def = case lookupMaybe key f of
-        Right v -> pure $ maybe def (fromMaybe def . readMaybeText) v
-        Left e -> fail $ toString e
-      parseOptionalBool key = case lookupMaybe key f of
-        Right v -> pure $ parseBool =<< v
-        Left e -> fail $ toString e
-      readMaybeText :: Read a => Text -> Maybe a
-      readMaybeText = readMaybe . toString
-      parseBool :: Text -> Maybe Bool
-      parseBool t =
-        case t of
-          "true" -> Just True
-          _ -> Just False
+      raw k = lookupMaybe k f
+      req k = raw k >>= maybe (fail $ "Missing field: " <> toString k) pure
+      opt k = pure $ fromRight Nothing (raw k)
+      num k d = maybe d (fromMaybe d . readMaybe . toString) <$> raw k
+      flag k = fmap (== "true") <$> raw k
 
 
 sendWhatsappResponse :: AE.Value -> Text -> Text -> Maybe Text -> ATBaseCtx ()
 sendWhatsappResponse contentVariables to template bodyM = do
   Log.logTrace ("WhatsApp response" :: Text) $ AE.object ["to" AE..= to, "template" AE..= template, "body" AE..= bodyM, "contentVariables" AE..= contentVariables]
   appCtx <- Effectful.Reader.Static.ask @AuthContext
-  let from = appCtx.config.whatsappFromNumber
-      accountSid = appCtx.config.twilioAccountSid
-      token = appCtx.config.twilioAuthToken
-      opts = defaults & header "Content-Type" .~ ["application/x-www-form-urlencoded"] & auth ?~ basicAuth (encodeUtf8 accountSid) (encodeUtf8 token)
+  let accountSid = appCtx.config.twilioAccountSid
+      opts = defaults & header "Content-Type" .~ ["application/x-www-form-urlencoded"] & auth ?~ basicAuth (encodeUtf8 accountSid) (encodeUtf8 appCtx.config.twilioAuthToken)
       url = toString $ "https://api.twilio.com/2010-04-01/Accounts/" <> accountSid <> "/Messages.json"
-      variables = toStrict $ AE.encode contentVariables
       payload :: [FormParam]
-      payload = ["To" := to, "From" := ("whatsapp:" <> from)] <> maybe ["ContentSid" := template, "ContentVariables" := variables] (\x -> ["Body" := x]) bodyM
-  _ <- Wreq.postWith opts url payload
-  pass
+      payload =
+        ["To" := to, "From" := ("whatsapp:" <> appCtx.config.whatsappFromNumber)]
+          <> maybe ["ContentSid" := template, "ContentVariables" := toStrict (AE.encode contentVariables)] (\x -> ["Body" := x]) bodyM
+  void $ Wreq.postWith opts url payload

--- a/src/Pages/Charts/Charts.hs
+++ b/src/Pages/Charts/Charts.hs
@@ -6,7 +6,6 @@ import Control.Exception.Annotated (checkpoint, try)
 import Data.Aeson qualified as AE
 import Data.Annotation (toAnnotation)
 import Data.Default
-import Data.List qualified as L (maximum)
 import Data.Map.Strict qualified as M
 import Data.Pool (withResource)
 import Data.Time (UTCTime, addUTCTime)
@@ -14,7 +13,7 @@ import Data.Time.Clock.POSIX (utcTimeToPOSIXSeconds)
 import Data.Tuple.Extra (fst3, snd3, thd3)
 import Data.Vector qualified as V
 import Data.Vector.Algorithms.Intro qualified as VA
-import Database.PostgreSQL.Simple (SomePostgreSqlException, query_)
+import Database.PostgreSQL.Simple (FromRow, SomePostgreSqlException, query_)
 import Database.PostgreSQL.Simple.Types (Only (..), Query (Query), fromOnly)
 import Effectful (Eff, IOE, (:>))
 import Effectful.Error.Static (Error, throwError)
@@ -61,23 +60,19 @@ pivot' rows
        in (headers, V.fromList ngrouped, totalSum, rate)
 
 
--- Helper to convert from Double timestamp to Int timestamp tuples
-
 transform :: V.Vector Text -> V.Vector (Int, Text, Double) -> V.Vector (Maybe Double)
 transform fields tuples =
-  V.cons (Just timestamp) (V.map getValue fields)
+  V.cons (Just timestamp) (V.map (\field -> thd3 <$> V.find ((== field) . snd3) tuples) fields)
   where
-    getValue field = V.find (\(_, b, _) -> b == field) tuples >>= \(_, _, a) -> Just a
-    timestamp = fromIntegral $ maybe 0 fst3 (V.find (const True) tuples)
+    timestamp = fromIntegral $ maybe 0 fst3 (tuples V.!? 0)
 
 
 statsTriple :: V.Vector (Int, Text, Double) -> MetricsStats
 statsTriple v
-  | V.null v = MetricsStats 0 0 0 0 0 0 0
+  | V.null v = def
   | otherwise = MetricsStats mn mx tot cnt (tot / fromIntegral cnt) mode maxGroupSum
   where
-    -- Extract the Double values from each tuple
-    doubles = V.map thd3 v
+    d0 = thd3 $ V.head v
 
     (!mn, !mx, !tot, !cnt, !freq, !timestampMap) =
       V.foldl'
@@ -90,23 +85,13 @@ statsTriple v
             , M.insertWith (+) ts x tsMap
             )
         )
-        (V.head doubles, V.head doubles, 0, 0, M.empty, M.empty)
+        (d0, d0, 0, 0, M.empty, M.empty)
         v
 
-    -- Find the maximum of the grouped sums
-    maxGroupSum =
-      if M.null timestampMap
-        then 0
-        else L.maximum $ M.elems timestampMap
+    maxGroupSum = fromMaybe 0 $ viaNonEmpty (\(x :| xs) -> foldl' max x xs) (M.elems timestampMap)
 
-    mode =
-      fst
-        $ M.foldlWithKey'
-          ( \acc@(_, cnt') k c ->
-              if c > cnt' then (k, c) else acc
-          )
-          (V.head doubles, 0)
-          freq
+    -- first (smallest) value wins ties, hence the strict `>`
+    mode = fst $ M.foldlWithKey' (\acc@(_, cnt') k c -> if c > cnt' then (k, c) else acc) (d0, 0) freq
 
 
 type M = Maybe
@@ -118,15 +103,8 @@ sourceTable = \case
   _ -> "otel_logs_and_spans"
 
 
--- Helper function: converts Just "" to Nothing.
-nonNull :: Maybe Text -> Maybe Text
-nonNull Nothing = Nothing
-nonNull (Just "") = Nothing
-nonNull x = x
-
-
 queryMetrics :: (DB es, Effectful.Error.Static.Error ServerError :> es, Effectful.Reader.Static.Reader AuthContext :> es, Log :> es, Time.Time :> es, Tracing :> es) => M Text -> M DataType -> M Projects.ProjectId -> M Text -> M Text -> M Text -> M Text -> M Text -> M Text -> [(Text, Maybe Text)] -> Eff es MetricsData
-queryMetrics dbSource (maybeToMonoid -> respDataType) pidM (nonNull -> queryM) (nonNull -> querySQLM) (nonNull -> sinceM) (nonNull -> fromM) (nonNull -> toM) (nonNull -> sourceM) allParams = do
+queryMetrics dbSource (maybeToMonoid -> respDataType) pidM (Utils.nonEmptyT -> queryM) (Utils.nonEmptyT -> querySQLM) (Utils.nonEmptyT -> sinceM) (Utils.nonEmptyT -> fromM) (Utils.nonEmptyT -> toM) (Utils.nonEmptyT -> sourceM) allParams = do
   authCtx <- Effectful.Reader.Static.ask @AuthContext
   now <- Time.currentTime
   -- project_id is required for every query path; a missing one is a malformed request,
@@ -136,21 +114,19 @@ queryMetrics dbSource (maybeToMonoid -> respDataType) pidM (nonNull -> queryM) (
   let mappngSQL = variablePresets pid.toText fromD toD allParams now
       mappngKQL = variablePresetsKQL pid.toText fromD toD allParams now
   let parseQuery q = either (\err -> throwError err400{errBody = encodeUtf8 $ "Invalid query: " <> err}) pure (parseQueryToAST $ replacePlaceholders mappngKQL q)
+  let source = parseMaybe pSource =<< sourceM
+  queryAST <-
+    checkpoint (toAnnotation ("queryMetrics", queryM))
+      $ parseQuery
+      $ maybeToMonoid queryM
+  let sqlQueryCfg = (defSqlQueryCfg pid now source Nothing){dateRange = (fromD, toD)}
 
-  case (queryM, querySQLM) of
-    (_, Just querySQL) -> do
-      queryAST <-
-        checkpoint (toAnnotation ("queryMetrics", queryM))
-          $ parseQuery
-          $ maybeToMonoid queryM
-      let sqlQueryComponents =
-            (defSqlQueryCfg pid now (parseMaybe pSource =<< sourceM) Nothing)
-              { dateRange = (fromD, toD)
-              }
-      let (_, qc) = queryASTToComponents sqlQueryComponents queryAST
+  case querySQLM of
+    Just querySQL -> do
+      let (_, qc) = queryASTToComponents sqlQueryCfg queryAST
       let mappngSQL' = mappngSQL <> M.fromList [("query_ast_filters", maybe "" (" AND " <>) qc.whereClause)]
       let sqlQuery = replacePlaceholders mappngSQL' querySQL
-      let tbl = sourceTable (parseMaybe pSource =<< sourceM)
+      let tbl = sourceTable source
       convertTimestampsToMs
         <$> withChartSpan
           tbl
@@ -162,13 +138,7 @@ queryMetrics dbSource (maybeToMonoid -> respDataType) pidM (nonNull -> queryM) (
           sqlQuery
           (emptyMetricsFor now fromD toD)
           (runFetchMetrics respDataType sqlQuery now fromD toD authCtx dbSource)
-    _ -> do
-      queryAST <-
-        checkpoint (toAnnotation ("queryMetrics", queryM))
-          $ parseQuery
-          $ maybeToMonoid queryM
-      let source = parseMaybe pSource =<< sourceM
-      let sqlQueryCfg = (defSqlQueryCfg pid now source Nothing){dateRange = (fromD, toD)}
+    Nothing -> do
       -- Scalar aggregates (summarize with no `by` clause) produce a single
       -- float row; decoding them with the default DTMetric (timestamp-first
       -- pivot) raises a type error. Callers that don't pass data_type — the
@@ -179,11 +149,9 @@ queryMetrics dbSource (maybeToMonoid -> respDataType) pidM (nonNull -> queryM) (
 
 -- | A summarize with no @by@ clause at all — yields one scalar row.
 isScalarSummarize :: [Section] -> Bool
-isScalarSummarize = any isScalar
-  where
-    isScalar = \case
-      SummarizeCommand _ Nothing -> True
-      _ -> False
+isScalarSummarize = any \case
+  SummarizeCommand _ Nothing -> True
+  _ -> False
 
 
 -- | Execute query with caching support for timeseries queries
@@ -294,15 +262,6 @@ emptyMetricsFor now fromD toD =
     }
 
 
--- | Map common backend failure modes to a short user-facing label. Covers both
--- Postgres ("column \"x\" does not exist") and TimeFusion's wrapped form
--- ("External error: Kernel error: Predicate references unknown column: x")
--- since prod chart reads can hit either backend. Raw error stays in the OTEL
--- span + log line.
-sanitizeChartError :: SomePostgreSqlException -> Text
-sanitizeChartError = Utils.sanitizeBackendError . toText . displayException
-
-
 -- | Wrap a chart-data fetch with its OTEL span and turn any SQL failure into
 -- an error-tagged empty 'MetricsData' so the dashboard keeps rendering. The
 -- exception is rethrown through 'withSpan_' first, so the span gets
@@ -318,7 +277,9 @@ withChartSpan
   -> Eff es MetricsData
 withChartSpan tbl attrs sqlQuery fallback action =
   withSpan_ ("SELECT " <> tbl) attrs action `catch` \(e :: SomePostgreSqlException) -> do
-    let userMsg = sanitizeChartError e
+    -- sanitizeBackendError covers both Postgres ("column \"x\" does not exist") and
+    -- TimeFusion's wrapped form; the raw error stays on the span + log line.
+    let userMsg = Utils.sanitizeBackendError . toText $ displayException e
     -- TODO(otel-metrics): widget_sql_error{project_id, error_class=userMsg}
     Log.logAttention
       "widget SQL execution failed; rendering error overlay"
@@ -332,23 +293,20 @@ fetchMetricsData respDataType sqlQuery now fromD toD authCtx dbSource = do
         Just "postgres" -> authCtx.pool
         Just "timefusion" -> authCtx.timefusionPgPool
         _ -> if authCtx.env.enableTimefusionReads then authCtx.timefusionPgPool else authCtx.pool
-  let baseMetricsData =
-        def
-          { from = Just $ round . utcTimeToPOSIXSeconds $ fromMaybe (addUTCTime (-86400) now) fromD
-          , to = Just $ round . utcTimeToPOSIXSeconds $ fromMaybe now toD
-          }
+  let baseMetricsData = emptyMetricsFor now fromD toD
+  let runQ :: FromRow r => IO [r]
+      runQ = withResource pool \conn -> query_ conn (Query $ encodeUtf8 sqlQuery)
 
   try @SomePostgreSqlException $ checkpoint (toAnnotation (respDataType, sqlQuery)) $ case respDataType of
     DTFloat -> do
-      chartData <- withResource pool \conn -> query_ conn (Query $ encodeUtf8 sqlQuery) :: IO [Only (Maybe Double)]
+      chartData <- runQ :: IO [Only (Maybe Double)]
       pure
         baseMetricsData
           { dataFloat = listToMaybe chartData >>= fromOnly
           , rowsCount = 1
           }
     DTMetric -> do
-      chartData <- withResource pool $ \conn -> query_ conn (Query $ encodeUtf8 sqlQuery)
-      let chartsDataV = V.fromList chartData
+      chartsDataV <- V.fromList <$> runQ
       let (hdrs, groupedData, rowsCount, rpm) = pivot' chartsDataV
       pure
         baseMetricsData
@@ -359,19 +317,11 @@ fetchMetricsData respDataType sqlQuery now fromD toD authCtx dbSource = do
           , stats = Just $ statsTriple chartsDataV
           }
     DTText -> do
-      chartData <- withResource pool $ \conn -> query_ conn (Query $ encodeUtf8 sqlQuery)
-      pure
-        baseMetricsData
-          { dataText = V.fromList chartData
-          , rowsCount = fromIntegral $ length chartData
-          }
+      chartData <- V.fromList <$> runQ
+      pure baseMetricsData{dataText = chartData, rowsCount = fromIntegral $ V.length chartData}
     DTJson -> do
-      chartData <- withResource pool $ \conn -> query_ conn (Query $ encodeUtf8 sqlQuery)
-      pure
-        baseMetricsData
-          { dataJSON = V.fromList chartData
-          , rowsCount = fromIntegral $ length chartData
-          }
+      chartData <- V.fromList <$> runQ
+      pure baseMetricsData{dataJSON = chartData, rowsCount = fromIntegral $ V.length chartData}
 
 
 -- | Convert timestamps in MetricsData from seconds to milliseconds for ECharts

--- a/src/Pages/Charts/Types.hs
+++ b/src/Pages/Charts/Types.hs
@@ -2,20 +2,16 @@
 
 module Pages.Charts.Types (MetricsData (..), MetricsStats (..), DataType (..)) where
 
-import Control.Lens ((?~))
 import Data.Aeson qualified as AE
-import Data.Default
-import Data.OpenApi (NamedSchema (..), ToParamSchema (..), ToSchema (..), enum_, type_)
-import Data.OpenApi qualified as OpenApi
+import Data.Default (Default)
+import Data.OpenApi (ToParamSchema, ToSchema)
 import Data.Semigroup (Max (Max))
 import Data.Vector qualified as V
-import Deriving.Aeson qualified as DAE
 import Deriving.Aeson.Stock qualified as DAE
 import Language.Haskell.TH.Syntax qualified as THS
-import Pkg.DeriveUtils (SnakeSchema (..))
+import Pkg.DeriveUtils (SnakeSchema (..), WrappedEnumSC (..))
 import Relude
-import Servant (FromHttpApiData (..))
-import Utils (JSONHttpApiData (..))
+import Servant (FromHttpApiData)
 
 
 data MetricsStats = MetricsStats
@@ -56,23 +52,7 @@ data MetricsData = MetricsData
 
 
 data DataType = DTMetric | DTJson | DTFloat | DTText
-  deriving stock (Bounded, Enum, Eq, Generic, Ord, Show, THS.Lift)
+  deriving stock (Bounded, Enum, Eq, Generic, Ord, Read, Show, THS.Lift)
   deriving anyclass (NFData)
   deriving (Monoid, Semigroup) via (Max DataType)
-  deriving (AE.FromJSON, AE.ToJSON) via DAE.CustomJSON '[DAE.ConstructorTagModifier '[DAE.StripPrefix "DT", DAE.CamelToSnake]] DataType
-  deriving (FromHttpApiData) via Utils.JSONHttpApiData DataType
-
-
-instance ToSchema DataType where
-  declareNamedSchema _ =
-    pure
-      $ NamedSchema (Just "DataType")
-      $ mempty
-      & type_
-      ?~ OpenApi.OpenApiString
-        & enum_
-      ?~ [AE.toJSON @DataType v | v <- universe]
-
-
-instance ToParamSchema DataType where
-  toParamSchema _ = mempty & type_ ?~ OpenApi.OpenApiString
+  deriving (AE.FromJSON, AE.ToJSON, FromHttpApiData, ToParamSchema, ToSchema) via WrappedEnumSC 'Nothing "DT" DataType

--- a/src/Pages/CommandPalette.hs
+++ b/src/Pages/CommandPalette.hs
@@ -1,6 +1,7 @@
 module Pages.CommandPalette (paletteShell_, commandPaletteItemsH, commandPaletteRecentPostH, RecentForm (..)) where
 
 import Data.Effectful.Hasql qualified as Hasql
+import Data.List (lookup)
 import Data.Text qualified as T
 import Data.UUID (UUID)
 import Effectful (Eff)
@@ -15,11 +16,6 @@ import Servant (NoContent (..))
 import System.Types (ATAuthCtx, RespHeaders, addRespHeaders)
 import Utils (faSprite_)
 import Web.FormUrlEncoded (FromForm)
-
-
-data PaletteIssue = PaletteIssue {id :: UUID, title :: Text, seqNum :: Int}
-  deriving stock (Generic, Show)
-  deriving anyclass (HI.DecodeRow)
 
 
 data PaletteItem = PaletteItem {id :: UUID, title :: Text}
@@ -41,49 +37,14 @@ data RecentForm = RecentForm {label :: Text, url :: Text, itemType :: Text}
 commandPaletteItemsH :: Projects.ProjectId -> ATAuthCtx (RespHeaders (Html ()))
 commandPaletteItemsH pid = do
   sess <- Projects.getSession
-  let userId = sess.user.id
-  (recents, issues, monitors, dashboards) <- fetchPaletteData pid userId
+  (recents, issues, monitors, dashboards) <- fetchPaletteData pid sess.user.id
   addRespHeaders $ renderDynamicItems pid recents issues monitors dashboards
 
 
 commandPaletteRecentPostH :: Projects.ProjectId -> RecentForm -> ATAuthCtx (RespHeaders NoContent)
 commandPaletteRecentPostH pid form = do
   sess <- Projects.getSession
-  let userId = sess.user.id
-  recordRecent pid userId form
-  addRespHeaders NoContent
-
-
--- DB operations
-
-fetchPaletteData :: DB es => Projects.ProjectId -> Projects.UserId -> Eff es ([PaletteRecent], [PaletteIssue], [PaletteItem], [PaletteItem])
-fetchPaletteData pid userId = do
-  recents <-
-    Hasql.interp
-      [HI.sql|
-    SELECT item_type, label, url FROM apis.command_palette_recents
-    WHERE project_id = #{pid} AND user_id = #{userId} ORDER BY created_at DESC LIMIT 10 |]
-  issues <-
-    Hasql.interp
-      [HI.sql|
-    SELECT id, title, seq_num FROM apis.issues
-    WHERE project_id = #{pid} AND archived_at IS NULL ORDER BY created_at DESC LIMIT 50 |]
-  monitors <-
-    Hasql.interp
-      [HI.sql|
-    SELECT id, alert_config->>'title' as title FROM monitors.query_monitors
-    WHERE project_id = #{pid} AND deleted_at IS NULL ORDER BY created_at DESC LIMIT 50 |]
-  dashboards <-
-    Hasql.interp
-      [HI.sql|
-    SELECT id, title FROM projects.dashboards
-    WHERE project_id = #{pid} ORDER BY title |]
-  pure (recents, issues, monitors, dashboards)
-
-
-recordRecent :: DB es => Projects.ProjectId -> Projects.UserId -> RecentForm -> Eff es ()
-recordRecent pid userId form = do
-  let (fType, fLabel, fUrl) = (form.itemType, form.label, form.url)
+  let (userId, fType, fLabel, fUrl) = (sess.user.id, form.itemType, form.label, form.url)
   void
     $ Hasql.interpExecute
       [HI.sql|
@@ -98,6 +59,32 @@ recordRecent pid userId form = do
       SELECT id FROM apis.command_palette_recents
       WHERE project_id = #{pid} AND user_id = #{userId} ORDER BY created_at DESC OFFSET 20
     ) |]
+  addRespHeaders NoContent
+
+
+fetchPaletteData :: DB es => Projects.ProjectId -> Projects.UserId -> Eff es ([PaletteRecent], [PaletteItem], [PaletteItem], [PaletteItem])
+fetchPaletteData pid userId = do
+  recents <-
+    Hasql.interp
+      [HI.sql|
+    SELECT item_type, label, url FROM apis.command_palette_recents
+    WHERE project_id = #{pid} AND user_id = #{userId} ORDER BY created_at DESC LIMIT 10 |]
+  issues <-
+    Hasql.interp
+      [HI.sql|
+    SELECT id, title FROM apis.issues
+    WHERE project_id = #{pid} AND archived_at IS NULL ORDER BY created_at DESC LIMIT 50 |]
+  monitors <-
+    Hasql.interp
+      [HI.sql|
+    SELECT id, alert_config->>'title' as title FROM monitors.query_monitors
+    WHERE project_id = #{pid} AND deleted_at IS NULL ORDER BY created_at DESC LIMIT 50 |]
+  dashboards <-
+    Hasql.interp
+      [HI.sql|
+    SELECT id, title FROM projects.dashboards
+    WHERE project_id = #{pid} ORDER BY title |]
+  pure (recents, issues, monitors, dashboards)
 
 
 -- Rendering
@@ -123,7 +110,7 @@ paletteShell_ pid = do
         span_ [class_ "text-2xs font-medium text-white dark:text-white/70 uppercase tracking-wider"] "Quick Search"
         span_ [class_ "cmd-palette-count text-xs text-white/80 dark:text-white/50"] ""
       -- Panel
-      div_ [class_ "cmd-palette w-full max-w-lg bg-base-100 rounded-lg shadow-2xl border border-base-300 overflow-hidden", data_ "pid" pidTxt, data_ "current-category" "", drillInitScript] do
+      div_ [class_ "cmd-palette w-full max-w-lg bg-base-100 rounded-lg shadow-2xl border border-base-300 overflow-hidden", data_ "pid" pidTxt, data_ "current-category" "", [__|on click halt the event's bubbling|]] do
         -- Search input
         div_ [class_ "px-3 border-b border-base-300"] do
           input_
@@ -142,51 +129,27 @@ paletteShell_ pid = do
           -- Lazy-loaded dynamic items placeholder
           div_ [id_ "cmd-palette-dynamic", hxGet_ ("/p/" <> pidTxt <> "/command-palette"), hxTrigger_ "palette:open from:body", hxSwap_ "outerHTML", class_ "text-center text-xs text-textWeak py-2"] "Loading..."
           -- Direct page links (static, always present)
-          forM_ directPages \(path, icon, label) ->
-            cmdItem pidTxt "direct" path [] [] icon label "Page"
+          forM_ directPages \(path, icon, label) -> cmdItem pidTxt "direct" path [] icon label "Page"
           -- Logs shortcut
-          a_
-            [ class_ "cmd-item flex items-center gap-2 px-3 py-2 rounded text-sm cursor-pointer transition-colors"
-            , data_ "search" "search logs"
-            , data_ "cmd-type" "direct"
-            , href_ $ "/p/" <> pidTxt <> "/log_explorer"
-            , data_ "log-shortcut" "true"
-            ]
-            do
-              faSprite_ "explore" "regular" "w-3.5 h-3.5 text-textWeak shrink-0"
-              span_ [class_ "cmd-log-label truncate flex-1"] "Search logs for: \"\""
-              badge_ "Logs"
+          cmdLink_ "search logs" "direct" [href_ $ "/p/" <> pidTxt <> "/log_explorer", data_ "log-shortcut" "true"]
+            $ itemBody_ "explore" "cmd-log-label truncate flex-1" "Search logs for: \"\"" "Logs"
           -- Actions
-          cmdItem pidTxt "direct" "log_explorer#create-alert-toggle" [] [] "plus" "Create monitor" "Action"
-          cmdItem pidTxt "direct" "dashboards?new=true" [] [] "plus" "Create dashboard" "Action"
-          a_
-            [ class_ "cmd-item flex items-center gap-2 px-3 py-2 rounded text-sm cursor-pointer transition-colors"
-            , data_ "search" "switch project"
-            , data_ "cmd-type" "direct"
-            , href_ "/"
-            ]
-            do
-              faSprite_ "grid" "regular" "w-3.5 h-3.5 text-textWeak shrink-0"
-              span_ [class_ "truncate flex-1"] "Switch project"
-              badge_ "Action"
-          a_
-            [ class_ "cmd-item flex items-center gap-2 px-3 py-2 rounded text-sm cursor-pointer transition-colors"
-            , data_ "search" "copy current url"
-            , data_ "cmd-type" "direct"
-            , data_ "action" "copy-url"
+          cmdItem pidTxt "direct" "log_explorer#create-alert-toggle" [] "plus" "Create monitor" "Action"
+          cmdItem pidTxt "direct" "dashboards?new=true" [] "plus" "Create dashboard" "Action"
+          cmdLink_ "switch project" "direct" [href_ "/"] $ itemBody_ "grid" "truncate flex-1" "Switch project" "Action"
+          cmdLink_
+            "copy current url"
+            "direct"
+            [ data_ "action" "copy-url"
             , [__|on click js navigator.clipboard.writeText(window.location.href); end then add .hidden to #cmd-palette-backdrop|]
             ]
-            do
-              faSprite_ "copy" "regular" "w-3.5 h-3.5 text-textWeak shrink-0"
-              span_ [class_ "truncate flex-1"] "Copy current URL"
-              badge_ "Action"
+            $ itemBody_ "copy" "truncate flex-1" "Copy current URL" "Action"
           -- AI row (hidden initially)
           div_ [class_ "cmd-ai-row", style_ "display:none"]
-            $ a_
-              [ class_ "cmd-item flex items-center gap-2 px-3 py-2 rounded text-sm cursor-pointer transition-colors"
-              , data_ "search" ""
-              , data_ "cmd-type" "direct"
-              , data_ "ai-action" "true"
+            $ cmdLink_
+              ""
+              "direct"
+              [ data_ "ai-action" "true"
               , [__|on click
                   set :q to #cmd-palette-input.value
                   fetch `/p/${me.closest('.cmd-palette').dataset.pid}/log_explorer/ai_search` {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({input: :q})}
@@ -194,10 +157,7 @@ paletteShell_ pid = do
                   then set window.location to `/p/${me.closest('.cmd-palette').dataset.pid}/log_explorer?query=${encodeURIComponent(:r.query)}`
                |]
               ]
-              do
-                faSprite_ "sparkles" "regular" "w-3.5 h-3.5 text-textWeak shrink-0"
-                span_ [class_ "cmd-ai-label truncate flex-1"] "Ask AI: \"\""
-                badge_ "AI"
+            $ itemBody_ "sparkles" "cmd-ai-label truncate flex-1" "Ask AI: \"\"" "AI"
           -- Empty state
           div_
             [class_ "cmd-palette-empty px-3 py-8 text-center text-sm text-base-content/40", style_ "display:none"]
@@ -211,9 +171,14 @@ paletteShell_ pid = do
 
 
 -- | Dynamic items fragment — loaded lazily into the shell
-renderDynamicItems :: Projects.ProjectId -> [PaletteRecent] -> [PaletteIssue] -> [PaletteItem] -> [PaletteItem] -> Html ()
+renderDynamicItems :: Projects.ProjectId -> [PaletteRecent] -> [PaletteItem] -> [PaletteItem] -> [PaletteItem] -> Html ()
 renderDynamicItems pid recents issues monitors dashboards = do
   let pidTxt = pid.toText
+      section category icon label badge extras items = do
+        categoryItem category icon label (length items + length extras)
+        sequence_ extras
+        forM_ items \(path, title) ->
+          cmdItem pidTxt "child" path [data_ "cmd-category" category, style_ "display:none"] icon title badge
   div_
     [ id_ "cmd-palette-dynamic"
     , [__|init
@@ -230,23 +195,18 @@ renderDynamicItems pid recents issues monitors dashboards = do
     |]
     ]
     do
-      -- Recents
       unless (null recents)
-        $ div_ [class_ "cmd-section cmd-palette-recents"]
+        $ div_ [class_ "cmd-palette-recents"]
         $ forM_ recents (recentItem pidTxt)
-      -- Category: Dashboards
-      categoryItem pidTxt "dashboards" "dashboard" "Dashboards" (length dashboards + 1)
-      cmdItem pidTxt "child" "dashboards" [] [data_ "cmd-category" "dashboards", style_ "display:none"] "dashboard" "All Dashboards" "Page"
-      forM_ dashboards \d ->
-        cmdItem pidTxt "child" ("dashboards/" <> show d.id) [] [data_ "cmd-category" "dashboards", style_ "display:none"] "dashboard" (if T.null d.title then "Untitled Dashboard" else d.title) "Dashboard"
-      -- Category: Issues
-      categoryItem pidTxt "issues" "bug" "Issues" (length issues)
-      forM_ issues \i ->
-        cmdItem pidTxt "child" ("issues/" <> show i.id) [] [data_ "cmd-category" "issues", style_ "display:none"] "bug" i.title "Issue"
-      -- Category: Monitors
-      categoryItem pidTxt "monitors" "list-check" "Monitors" (length monitors)
-      forM_ monitors \m ->
-        cmdItem pidTxt "child" ("monitors?highlight=" <> show m.id) [] [data_ "cmd-category" "monitors", style_ "display:none"] "list-check" m.title "Monitor"
+      section
+        "dashboards"
+        "dashboard"
+        "Dashboards"
+        "Dashboard"
+        [cmdItem pidTxt "child" "dashboards" [data_ "cmd-category" "dashboards", style_ "display:none"] "dashboard" "All Dashboards" "Page"]
+        [("dashboards/" <> show d.id, if T.null d.title then "Untitled Dashboard" else d.title) | d <- dashboards]
+      section "issues" "bug" "Issues" "Issue" [] [("issues/" <> show i.id, i.title) | i <- issues]
+      section "monitors" "list-check" "Monitors" "Monitor" [] [("monitors?highlight=" <> show m.id, m.title) | m <- monitors]
 
 
 -- | Global Cmd+K listener + drill helpers — on a visible element so init runs
@@ -294,18 +254,13 @@ paletteGlobalScript =
           if (lbl) lbl.textContent = category.charAt(0).toUpperCase() + category.slice(1);
         }
         var input = palette.querySelector('#cmd-palette-input');
-        if (input) { input.value = ''; input.placeholder = 'Search ' + category + '\u2026'; input.focus(); }
+        if (input) { input.value = ''; input.placeholder = 'Search ' + category + '…'; input.focus(); }
         palette.querySelectorAll('a.cmd-item').forEach(function(el) { el.classList.remove('active'); });
         var first = palette.querySelector('a.cmd-item[data-cmd-category="' + category + '"]:not([style*="display: none"]):not([style*="display:none"])');
         if (first) first.classList.add('active');
       };
     end
   |]
-
-
--- | Prevents click events from bubbling through the palette panel
-drillInitScript :: Attribute
-drillInitScript = [__|on click halt the event's bubbling end|]
 
 
 -- Hyperscript for input filtering + keyboard nav
@@ -358,36 +313,27 @@ filterScript =
       end
       -- Reset active and highlight best match
       for item in <a.cmd-item/> in :palette remove .active from item end
-      set :first to the first <a.cmd-item:not([style*='display: none']):not([style*='display:none'])/> in :palette
-      if :first then add .active to :first end
+      set :visible to <a.cmd-item:not([style*='display: none']):not([style*='display:none'])/> in :palette
+      if :visible.length > 0 then add .active to :visible[0] end
       -- Update result count
       set :counter to the first <.cmd-palette-count/>
       set :total to :counter.dataset.total
-      set :visCount to <a.cmd-item:not([style*='display: none']):not([style*='display:none'])/> in :palette
-      if :q.length > 0 then put `${:visCount.length} of ${:total} items` into :counter
+      if :q.length > 0 then put `${:visible.length} of ${:total} items` into :counter
       else put `${:total} items` into :counter end
       -- AI row: show when query > 10 chars (root only)
       if :q.length > 10 and :cat === '' then show <.cmd-ai-row/> else hide <.cmd-ai-row/> end
       set :aiLabel to the first <.cmd-ai-label/>
       if :aiLabel then put `Ask AI: "${my value}"` into :aiLabel end
-      -- Log shortcut: update label
+      -- Log shortcut: label + href
       for el in <.cmd-log-label/> put `Search logs for: "${my value}"` into el end
-      set :ell to the first <.cmd-empty-log-label/>
-      if :ell then put `Search logs for: "${my value}"` into :ell end
-      set :eal to the first <.cmd-empty-ai-label/>
-      if :eal then put `Ask AI: "${my value}"` into :eal end
-      if :q.length > 10 then show <.cmd-empty-ai/> else hide <.cmd-empty-ai/> end
-      -- Update log shortcut hrefs
       for el in <[data-log-shortcut]/> set el.href to `/p/${el.closest('.cmd-palette').dataset.pid}/log_explorer?query=${encodeURIComponent(my value)}` end
       -- Empty state
-      set :allVisible to <a.cmd-item:not([style*='display: none']):not([style*='display:none'])/> in :palette
       set :empty to the first <.cmd-palette-empty/> in :palette
-      if :allVisible.length === 0 and :q.length > 0 then show :empty else hide :empty end
+      if :visible.length === 0 and :q.length > 0 then show :empty else hide :empty end
     end
     on keydown[key=='Escape']
       set :palette to closest .cmd-palette
-      set :cat to :palette.dataset.currentCategory
-      if :cat !== '' then
+      if :palette.dataset.currentCategory !== '' then
         call goBackToRoot(:palette)
         set me.placeholder to 'Search pages, issues, actions…'
       else
@@ -402,22 +348,10 @@ filterScript =
         call :a.click()
       end
     end
-    on keydown[key=='Backspace']
+    on keydown[key=='Backspace' or key=='ArrowLeft']
       if my value === '' then
         set :palette to closest .cmd-palette
-        set :cat to :palette.dataset.currentCategory
-        if :cat !== '' then
-          halt the event
-          call goBackToRoot(:palette)
-          set me.placeholder to 'Search pages, issues, actions…'
-        end
-      end
-    end
-    on keydown[key=='ArrowLeft']
-      if my value === '' then
-        set :palette to closest .cmd-palette
-        set :cat to :palette.dataset.currentCategory
-        if :cat !== '' then
+        if :palette.dataset.currentCategory !== '' then
           halt the event
           call goBackToRoot(:palette)
           set me.placeholder to 'Search pages, issues, actions…'
@@ -433,40 +367,16 @@ filterScript =
         end
       end
     end
-    on keydown[key=='ArrowDown'] halt the event
+    on keydown[key=='ArrowDown' or key=='ArrowUp'] halt the event
       set :all to <a.cmd-item:not([style*='display: none']):not([style*='display:none'])/> in closest .cmd-palette
       set :a to the first <a.active/> in closest .cmd-palette
-      if :a then
-        set :idx to -1
-        set :i to 0
-        for el in :all
-          if el === :a then set :idx to :i end
-          increment :i
-        end
-        if :idx >= 0 and :idx < :all.length - 1 then
-          remove .active from :a
-          add .active to :all[:idx + 1]
-          call :all[:idx + 1].scrollIntoView({block:'nearest'})
-        end
-      else
-        if :all.length > 0 then add .active to :all[0] end
-      end
-    end
-    on keydown[key=='ArrowUp'] halt the event
-      set :all to <a.cmd-item:not([style*='display: none']):not([style*='display:none'])/> in closest .cmd-palette
-      set :a to the first <a.active/> in closest .cmd-palette
-      if :a then
-        set :idx to -1
-        set :i to 0
-        for el in :all
-          if el === :a then set :idx to :i end
-          increment :i
-        end
-        if :idx > 0 then
-          remove .active from :a
-          add .active to :all[:idx - 1]
-          call :all[:idx - 1].scrollIntoView({block:'nearest'})
-        end
+      set :d to -1
+      if event.key === 'ArrowDown' then set :d to 1 end
+      set :next to :all.indexOf(:a) + :d
+      if :next >= 0 and :next < :all.length then
+        if :a then remove .active from :a end
+        add .active to :all[:next]
+        call :all[:next].scrollIntoView({block:'nearest'})
       end
     end
   |]
@@ -474,82 +384,62 @@ filterScript =
 
 -- Item helpers
 
--- | Shared recent-tracking hyperscript for items that record recent clicks
-recentClickScript :: Attribute
-recentClickScript =
-  [__|on click
-        set :ru to my.dataset.recentUrl
-        js(me) var p = new URLSearchParams(); p.set('label', me.dataset.recentLabel); p.set('url', me.getAttribute('href')); p.set('itemType', me.dataset.recentType); return p.toString(); end
-        then set :rb to it
-        fetch `${:ru}` {method:'POST', headers:{'Content-Type':'application/x-www-form-urlencoded'}, body: :rb}
-     |]
+-- | Records the click as a recent entry (fetch, not hx-post: htmx would cancel the anchor navigation)
+recentAttrs :: Text -> Text -> Text -> [Attribute]
+recentAttrs pidTxt label itemType =
+  [ data_ "recent-url" $ "/p/" <> pidTxt <> "/command-palette/recents"
+  , data_ "recent-label" label
+  , data_ "recent-type" itemType
+  , [__|on click
+          set :ru to my.dataset.recentUrl
+          js(me) var p = new URLSearchParams(); p.set('label', me.dataset.recentLabel); p.set('url', me.getAttribute('href')); p.set('itemType', me.dataset.recentType); return p.toString(); end
+          then set :rb to it
+          fetch `${:ru}` {method:'POST', headers:{'Content-Type':'application/x-www-form-urlencoded'}, body: :rb}
+       |]
+  ]
+
+
+cmdLink_ :: Text -> Text -> [Attribute] -> Html () -> Html ()
+cmdLink_ search cmdType attrs =
+  a_ $ [class_ "cmd-item flex items-center gap-2 px-3 py-2 rounded text-sm cursor-pointer transition-colors", data_ "search" search, data_ "cmd-type" cmdType] <> attrs
+
+
+itemBody_ :: Text -> Text -> Html () -> Text -> Html ()
+itemBody_ icon labelClass label badgeText = do
+  faSprite_ icon "regular" "w-3.5 h-3.5 text-textWeak shrink-0"
+  span_ [class_ labelClass] label
+  badge_ badgeText
 
 
 -- | Base item renderer — unifies direct, child, and action items
-cmdItem :: Text -> Text -> Text -> [Attribute] -> [Attribute] -> Text -> Text -> Text -> Html ()
-cmdItem pidTxt cmdType path recentAttrs extraAttrs icon label badgeText =
-  let url = "/p/" <> pidTxt <> "/" <> path
-      recentUrl = "/p/" <> pidTxt <> "/command-palette/recents"
-      baseAttrs =
-        [ class_ "cmd-item flex items-center gap-2 px-3 py-2 rounded text-sm cursor-pointer transition-colors"
-        , data_ "search" (T.toLower label)
-        , data_ "cmd-type" cmdType
-        , href_ url
-        ]
-      trackAttrs
-        | null recentAttrs =
-            [ data_ "recent-url" recentUrl
-            , data_ "recent-label" label
-            , data_ "recent-type" (T.toLower badgeText)
-            , recentClickScript
-            ]
-        | otherwise = recentAttrs
-   in a_ (baseAttrs <> trackAttrs <> extraAttrs) do
-        faSprite_ icon "regular" "w-3.5 h-3.5 text-textWeak shrink-0"
-        span_ [class_ "truncate flex-1"] $ toHtml label
-        badge_ badgeText
+cmdItem :: Text -> Text -> Text -> [Attribute] -> Text -> Text -> Text -> Html ()
+cmdItem pidTxt cmdType path extraAttrs icon label badgeText =
+  cmdLink_ (T.toLower label) cmdType (href_ ("/p/" <> pidTxt <> "/" <> path) : recentAttrs pidTxt label (T.toLower badgeText) <> extraAttrs)
+    $ itemBody_ icon "truncate flex-1" (toHtml label) badgeText
 
 
-categoryItem :: Text -> Text -> Text -> Text -> Int -> Html ()
-categoryItem pidTxt category icon label count =
-  a_
-    [ class_ "cmd-item flex items-center gap-2 px-3 py-2 rounded text-sm cursor-pointer transition-colors"
-    , data_ "search" (T.toLower label)
-    , data_ "cmd-type" "category"
-    , data_ "cmd-category" category
+categoryItem :: Text -> Text -> Text -> Int -> Html ()
+categoryItem category icon label count =
+  cmdLink_
+    (T.toLower label)
+    "category"
+    [ data_ "cmd-category" category
     , href_ "#"
     , [__|on click halt the event then call drillIntoCategory(closest .cmd-palette, my.dataset.cmdCategory)|]
     ]
     do
       faSprite_ icon "regular" "w-3.5 h-3.5 text-textWeak shrink-0"
       span_ [class_ "truncate flex-1"] $ toHtml label
-      span_ [class_ "badge badge-ghost badge-xs text-2xs tabular-nums"] $ toHtml (show count)
+      span_ [class_ "badge badge-ghost badge-xs text-2xs tabular-nums"] $ toHtml (show count :: Text)
       faSprite_ "chevron-right" "regular" "w-3 h-3 text-base-content/30 shrink-0"
 
 
 recentItem :: Text -> PaletteRecent -> Html ()
 recentItem pidTxt r =
-  let icon = case r.itemType of
-        "page" -> "file-lines"
-        "issue" -> "bug"
-        "monitor" -> "list-check"
-        "dashboard" -> "dashboard"
-        _ -> "clock"
-      recentUrl = "/p/" <> pidTxt <> "/command-palette/recents"
-   in a_
-        [ class_ "cmd-item flex items-center gap-2 px-3 py-2 rounded text-sm cursor-pointer transition-colors"
-        , data_ "search" (T.toLower r.label)
-        , data_ "cmd-type" "direct"
-        , href_ r.url
-        , data_ "recent-url" recentUrl
-        , data_ "recent-label" r.label
-        , data_ "recent-type" r.itemType
-        , recentClickScript
-        ]
-        do
-          faSprite_ icon "regular" "w-3.5 h-3.5 text-textWeak shrink-0"
-          span_ [class_ "truncate flex-1"] $ toHtml r.label
-          badge_ $ T.toTitle r.itemType
+  cmdLink_ (T.toLower r.label) "direct" (href_ r.url : recentAttrs pidTxt r.label r.itemType)
+    $ itemBody_ icon "truncate flex-1" (toHtml r.label) (T.toTitle r.itemType)
+  where
+    icon = fromMaybe "clock" $ lookup r.itemType [("page", "file-lines"), ("issue", "bug"), ("monitor", "list-check"), ("dashboard", "dashboard")]
 
 
 badge_ :: Monad m => Text -> HtmlT m ()

--- a/src/Pages/Components.hs
+++ b/src/Pages/Components.hs
@@ -14,7 +14,7 @@ import Models.Projects.Projects qualified as Projects
 import NeatInterpolation (text)
 import PyF qualified
 import Relude
-import Utils (LoadingSize (..), LoadingType (..), deleteParam, faSprite_, jsonValueToHtmlTree, loadingIndicator_, onpointerdown_)
+import Utils (LoadingSize (..), LoadingType (..), deleteParam, faSprite_, jsonValueToHtmlTree, loadingIndicator_)
 
 
 data EmptyStateSize = ESFull | ESCompact
@@ -54,7 +54,7 @@ emptyState_ cfg title subTxt =
         ESNone -> pass
         ESLink u txt ->
           unless (T.null txt)
-            $ a_ ([href_ u, class_ "btn text-sm w-max mx-auto btn-primary"] ++ if "https://" `T.isPrefixOf` u then [target_ "_blank", rel_ "noopener noreferrer"] else [])
+            $ a_ ([href_ u, class_ "btn text-sm w-max mx-auto btn-primary"] <> bool [] [target_ "_blank", rel_ "noopener noreferrer"] ("https://" `T.isPrefixOf` u))
             $ toHtml txt
         ESCustom h -> h
   where
@@ -120,7 +120,7 @@ drawer_ drawerId startOpen urlM content trigger = div_ [class_ "drawer drawer-en
 dateTime :: UTCTime -> Maybe UTCTime -> Html ()
 dateTime t endTM = do
   let utcOf = formatTime defaultTimeLocale "%Y-%m-%d %H:%M:%S UTC"
-      title = maybe (utcOf t) (\e -> utcOf t <> " — " <> utcOf e) endTM
+      title = utcOf t <> foldMap ((" — " <>) . utcOf) endTM
   span_
     [ class_ "flex items-center rounded-lg px-2 py-1.5 text-xs gap-2 border border-strokeWeak bg-fillWeaker text-textStrong whitespace-nowrap shrink-0"
     , Lucid.title_ (toText title)
@@ -152,10 +152,7 @@ localTimeFmt_ dfFmt ts =
 
 paymentPlanPicker :: Projects.ProjectId -> Text -> Text -> Text -> Bool -> Bool -> Bool -> Projects.BillingProvider -> Html ()
 paymentPlanPicker pid lemonUrl criticalUrl currentPlan freePricingEnabled basicAuthEnabled isOnboarding provider = do
-  let gridCols
-        | basicAuthEnabled = "grid-cols-1 md:grid-cols-2"
-        | freePricingEnabled = "grid-cols-1 md:grid-cols-3"
-        | otherwise = "grid-cols-1 md:grid-cols-2"
+  let gridCols = bool "grid-cols-1 md:grid-cols-2" "grid-cols-1 md:grid-cols-3" (freePricingEnabled && not basicAuthEnabled)
       useStripe = provider /= Projects.LemonSqueezyProvider
   div_ ([class_ "flex flex-col gap-8 w-full"] <> [hxVals_ "{\"isOnboarding\": true}" | isOnboarding]) do
     unless basicAuthEnabled $ div_ [class_ "flex flex-col gap-2 w-full"] do
@@ -166,15 +163,18 @@ paymentPlanPicker pid lemonUrl criticalUrl currentPlan freePricingEnabled basicA
     div_ [class_ "flex flex-col gap-8 mt-6 w-full"] do
       div_ [class_ $ "grid gap-8 w-full " <> gridCols] do
         let isCurrent p = not isOnboarding && currentPlan == p
-        when basicAuthEnabled $ openSourcePricing pid (isCurrent "Open Source")
-        when basicAuthEnabled enterprisePricing
-        when (freePricingEnabled && not basicAuthEnabled) $ freePricing pid (isCurrent "Free")
-        unless basicAuthEnabled $ popularPricing pid lemonUrl (isCurrent "Bring nothing") freePricingEnabled useStripe
-        unless basicAuthEnabled $ systemsPricing pid criticalUrl (isCurrent "Bring your own storage") useStripe
+        if basicAuthEnabled
+          then openSourcePricing pid (isCurrent "Open Source") >> enterprisePricing
+          else do
+            when freePricingEnabled $ freePricing pid (isCurrent "Free")
+            popularPricing pid lemonUrl (isCurrent "Bring nothing") freePricingEnabled useStripe
+            systemsPricing pid criticalUrl (isCurrent "Bring your own storage") useStripe
     unless useStripe
       $ script_ [src_ "https://assets.lemonsqueezy.com/lemon.js"] ("" :: Text)
-    script_
-      [text|
+    -- Guarded: #price_range/#price only exist when the usage slider is rendered.
+    unless basicAuthEnabled
+      $ script_
+        [text|
                const price_indicator = document.querySelector("#price_range");
                const priceContainer = document.querySelector("#price")
                const criticalContainer = document.querySelector("#critical_price")
@@ -191,16 +191,6 @@ paymentPlanPicker pid lemonUrl criticalUrl currentPlan freePricingEnabled basicA
                }
 
                price_indicator.addEventListener('input', priceChange)
-
-               function handlePaymentPlanSelect(event, id) {
-                event.stopPropagation()
-                const target = event.currentTarget
-                if(id === 'popularPlan') {
-                  window.paymentPlanUrl = "$lemonUrl"
-                } else if(id=== 'systemsPlan') {
-                  window.paymentPlanUrl = "$criticalUrl"
-                }
-               }
             |]
     unless useStripe
       $ script_
@@ -232,7 +222,7 @@ paymentPlanPicker pid lemonUrl criticalUrl currentPlan freePricingEnabled basicA
 
 pricingContent_ :: Text -> Text -> Html () -> Html () -> [Text] -> Html () -> Html ()
 pricingContent_ title subtitle priceEl ctaEl features featuresTitle = do
-  div_ [class_ "flex-col justify-start items-start gap-1 flex"] $ do
+  div_ [class_ "flex-col justify-start items-start gap-1 flex"] do
     div_ [class_ "text-xl font-semibold text-textStrong"] $ toHtml title
     div_ [class_ "text-textStrong text-sm"] $ toHtml subtitle
   div_ [class_ "flex items-center gap-1 mt-4"] priceEl
@@ -262,6 +252,20 @@ pricingBtnCls :: Bool -> Text -> Text
 pricingBtnCls isCurrent normalCls = "btn mb-6 mt-4 h-8 px-3 py-1 w-full text-sm font-semibold rounded-lg " <> if isCurrent then "bg-fillDisabled cursor-not-allowed border-0 text-textInverse-strong" else normalCls
 
 
+-- | Plan CTA: inert when already the current plan, else a Stripe checkout POST or a LemonSqueezy popup.
+pricingCta_ :: Projects.ProjectId -> Text -> Text -> Text -> Bool -> Bool -> Html ()
+pricingCta_ pid plan normalCls lemonUrl isCurrent useStripe =
+  div_ [[__|on click halt|]]
+    $ button_ ([class_ $ pricingBtnCls isCurrent normalCls, type_ "button"] <> attrs)
+    $ if isCurrent then "Current plan" else "Start 30 day free trial"
+  where
+    attrs :: [Attribute]
+    attrs
+      | isCurrent = []
+      | useStripe = [hxPost_ $ "/p/" <> pid.toText <> "/stripe_checkout", hxVals_ $ "{\"plan\": \"" <> plan <> "\"}", hxSwap_ "none"]
+      | otherwise = [term "_" $ "on click call window.payLemon(\"" <> plan <> "\", \"" <> lemonUrl <> "\")"]
+
+
 pricingBadge_ :: Html () -> Html () -> Html ()
 pricingBadge_ badge content = div_ [class_ "relative"] do
   content
@@ -272,7 +276,7 @@ pricingBadge_ badge content = div_ [class_ "relative"] do
 freePricing :: Projects.ProjectId -> Bool -> Html ()
 freePricing pid isCurrent =
   div_ (pricingPostAttrs pid "freePricing" "outline-strokeWeak" [])
-    $ div_ [class_ "flex flex-col gap-2 h-full relative", onpointerdown_ "handlePaymentPlanSelect(event, 'freePlan')", id_ "freePlan"] do
+    $ div_ [class_ "flex flex-col gap-2 h-full relative"] do
       div_ [class_ "pricing-gradient-slate"] pass
       pricingContent_
         "Free tier"
@@ -288,17 +292,13 @@ popularPricing pid lemonUrl isCurrent freeTierEnabled useStripe =
   div_ [class_ "relative"]
     $ div_ (pricingPostAttrs pid "GraduatedPricing" "outline-strokeWeak shadow-[0px_3px_3px_-1.5px_rgba(10,13,18,0.04)] shadow-[0px_8px_8px_-4px_rgba(10,13,18,0.03)] shadow-[0px_20px_24px_-4px_rgba(10,13,18,0.08)]" [hxVals_ "js:{orderIdM: document.querySelector('#popularPricing').value}"]) do
       div_ [class_ "pricing-gradient-slate-wide"] pass
-      div_ [class_ "relative flex flex-col gap-2 overflow-hidden", onpointerdown_ "handlePaymentPlanSelect(event, 'popularPlan')", id_ "popularPlan"] do
+      div_ [class_ "relative flex flex-col gap-2 overflow-hidden"] do
         input_ [type_ "hidden", class_ "orderId", id_ "popularPricing", name_ "ord", value_ ""]
-        let cta
-              | isCurrent = div_ [[__|on click halt|]] $ button_ [class_ $ pricingBtnCls True "", type_ "button"] "Current plan"
-              | useStripe = div_ [[__|on click halt|]] $ button_ [class_ $ pricingBtnCls False "btn-primary", hxPost_ ("/p/" <> pid.toText <> "/stripe_checkout"), hxVals_ "{\"plan\": \"GraduatedPricing\"}", hxSwap_ "none", type_ "button"] "Start 30 day free trial"
-              | otherwise = div_ [[__|on click halt|]] $ button_ [class_ $ pricingBtnCls False "btn-primary", term "_" [text|on click call window.payLemon("GraduatedPricing","$lemonUrl") |], type_ "button"] "Start 30 day free trial"
         pricingContent_
           "Bring nothing"
           "This plan can be adjusted"
           (priceDisplay_ [id_ "price"] "29" "/per month")
-          cta
+          (pricingCta_ pid "GraduatedPricing" "btn-primary" lemonUrl isCurrent useStripe)
           ["Fully managed cloud service", "Predictable usage-based pricing", "Intelligent incident alerts", "Query your data in english", "30 days data retention included"]
           (span_ [] $ when freeTierEnabled $ "Everything in " >> span_ [class_ "text-textBrand"] "free" >> " plus...")
 
@@ -307,18 +307,14 @@ systemsPricing :: Projects.ProjectId -> Text -> Bool -> Bool -> Html ()
 systemsPricing pid critical isCurrent useStripe =
   pricingBadge_ (span_ [class_ "text-sm font-medium leading-tight"] "🌟" >> span_ [class_ "leading-tight text-sm"] "MOST POPULAR")
     $ div_ (pricingPostAttrs pid "SystemsPricing" "outline-strokeBrand-strong" [hxVals_ "js:{orderIdM: document.querySelector('#systemsPricing').value}"])
-    $ div_ [class_ "flex flex-col gap-2", onpointerdown_ "handlePaymentPlanSelect(event, 'systemsPlan')", id_ "systemsPlan"] do
+    $ div_ [class_ "flex flex-col gap-2"] do
       input_ [type_ "hidden", class_ "orderId", id_ "systemsPricing", name_ "ord", value_ ""]
       div_ [class_ "pricing-gradient-brand-wide"] pass
-      let cta
-            | isCurrent = div_ [[__|on click halt|]] $ button_ [class_ $ pricingBtnCls True "", type_ "button"] "Current plan"
-            | useStripe = div_ [[__|on click halt|]] $ button_ [class_ $ pricingBtnCls False "bg-fillStrong text-textInverse-strong", hxPost_ ("/p/" <> pid.toText <> "/stripe_checkout"), hxVals_ "{\"plan\": \"SystemsPricing\"}", hxSwap_ "none", type_ "button"] "Start 30 day free trial"
-            | otherwise = div_ [[__|on click halt|]] $ button_ [class_ $ pricingBtnCls False "bg-fillStrong text-textInverse-strong", term "_" [text|on click call window.payLemon("SystemsPricing", "$critical") |], type_ "button"] "Start 30 day free trial"
       pricingContent_
         "Bring your own storage"
         "Business plan"
         (priceDisplay_ [id_ "critical_price"] "199" "/per month")
-        cta
+        (pricingCta_ pid "SystemsPricing" "bg-fillStrong text-textInverse-strong" critical isCurrent useStripe)
         ["Own and control all your data", "Save all your data to any S3-compatible bucket", "Unlimited data retention period", "Query years of data via monoscope", "No extra cost for data retention"]
         (span_ [] $ "Everything in " >> span_ [class_ "text-textBrand"] "bring nothing" >> " plus...")
 
@@ -354,32 +350,20 @@ enterprisePricing =
 
 included :: [Text] -> Html () -> Html ()
 included features title =
-  div_ [class_ "flex-col justify-start items-start gap-3 flex"] $ do
-    div_ [class_ "text-textStrong text-sm h-6 font-medium italic"] $ toHtml title
-    mapM_ featureRow features
-
-
-featureRow :: Text -> Html ()
-featureRow feature =
-  div_ [class_ "flex items-center gap-3"] $ do
-    faSprite_ "feature-check" "regular" "h-4 text-iconBrand shrink-0"
-    p_ [class_ "text-sm text-textStrong leading-tight"] (toHtml feature)
+  div_ [class_ "flex-col justify-start items-start gap-3 flex"] do
+    div_ [class_ "text-textStrong text-sm h-6 font-medium italic"] title
+    forM_ features \feature -> div_ [class_ "flex items-center gap-3"] do
+      faSprite_ "feature-check" "regular" "h-4 text-iconBrand shrink-0"
+      p_ [class_ "text-sm text-textStrong leading-tight"] $ toHtml feature
 
 
 navBar :: Html ()
-navBar = do
-  nav_ [id_ "main-navbar", class_ "fixed z-20 top-0 w-full w-full px-4 py-4 bg-bgOverlay flex flex-row justify-between"] do
-    div_ [class_ "flex justify-between items-center gap-4 w-[1000px] mx-auto"] do
-      a_ [href_ "https://monoscope.tech", class_ "flex items-center text-textWeak hover:text-textStrong"] do
-        -- Only show full logos (no mini version needed for navbar)
-        img_
-          [ class_ "h-12 dark:hidden"
-          , src_ "/public/assets/svgs/logo_black.svg"
-          ]
-        img_
-          [ class_ "h-12 hidden dark:block"
-          , src_ "/public/assets/svgs/logo_white.svg"
-          ]
+navBar =
+  nav_ [id_ "main-navbar", class_ "fixed z-20 top-0 w-full px-4 py-4 bg-bgOverlay flex flex-row justify-between"]
+    $ div_ [class_ "flex justify-between items-center gap-4 w-[1000px] mx-auto"]
+    $ a_ [href_ "https://monoscope.tech", class_ "flex items-center text-textWeak hover:text-textStrong"] do
+      img_ [class_ "h-12 dark:hidden", src_ "/public/assets/svgs/logo_black.svg"]
+      img_ [class_ "h-12 hidden dark:block", src_ "/public/assets/svgs/logo_white.svg"]
 
 
 modal_ :: T.Text -> Html () -> Html () -> Html ()
@@ -525,22 +509,13 @@ drawerLoadingSkeleton_ = div_ [class_ "flex w-full flex-col gap-5 pt-8", role_ "
 
 chartSkeleton_ :: Html ()
 chartSkeleton_ = div_ [class_ "h-64 w-full rounded-lg relative overflow-hidden bg-fillWeaker"] do
-  -- Y-axis hint
   div_ [class_ "absolute left-0 top-4 bottom-8 w-px bg-strokeWeak"] ""
-  -- X-axis hint
   div_ [class_ "absolute left-4 right-4 bottom-8 h-px bg-strokeWeak"] ""
-  -- Shimmer bars representing data
-  div_ [class_ "absolute left-8 right-4 top-8 bottom-12 flex items-end gap-2"] do
-    div_ [class_ "flex-1 h-3/5 skeleton-shimmer rounded-t", style_ "animation-delay: 0s"] ""
-    div_ [class_ "flex-1 h-2/5 skeleton-shimmer rounded-t", style_ "animation-delay: 0.1s"] ""
-    div_ [class_ "flex-1 h-4/5 skeleton-shimmer rounded-t", style_ "animation-delay: 0.2s"] ""
-    div_ [class_ "flex-1 h-1/2 skeleton-shimmer rounded-t", style_ "animation-delay: 0.3s"] ""
-    div_ [class_ "flex-1 h-3/4 skeleton-shimmer rounded-t", style_ "animation-delay: 0.4s"] ""
-    div_ [class_ "flex-1 h-2/5 skeleton-shimmer rounded-t", style_ "animation-delay: 0.5s"] ""
-  -- Y-axis labels hint
+  div_ [class_ "absolute left-8 right-4 top-8 bottom-12 flex items-end gap-2"]
+    $ forM_ (["h-3/5", "h-2/5", "h-4/5", "h-1/2", "h-3/4", "h-2/5"] `zip` ["0s", "0.1s", "0.2s", "0.3s", "0.4s", "0.5s"])
+    $ \(hCls, delay) -> div_ [class_ $ "flex-1 skeleton-shimmer rounded-t " <> hCls, style_ $ "animation-delay: " <> delay] ""
   div_ [class_ "absolute left-1 top-6 w-3 h-2 skeleton-shimmer rounded"] ""
   div_ [class_ "absolute left-1 top-1/2 w-4 h-2 skeleton-shimmer rounded"] ""
-  -- X-axis labels hint
   div_ [class_ "absolute left-8 bottom-3 w-6 h-2 skeleton-shimmer rounded"] ""
   div_ [class_ "absolute left-1/2 bottom-3 w-6 h-2 skeleton-shimmer rounded"] ""
   div_ [class_ "absolute right-4 bottom-3 w-6 h-2 skeleton-shimmer rounded"] ""
@@ -572,15 +547,18 @@ formField_ size cfg lbl name required customM =
       whenJust cfg.icon \ic -> faSprite_ ic "solid" "w-4 h-4 text-iconNeutral shrink-0"
       toHtml lbl
       when required $ span_ [class_ reqCls] "*"
-    case customM of
-      Just content -> content
-      Nothing -> case (cfg.inputType, cfg.suffix) of
-        ("textarea", _) -> textarea_ ([class_ textareaCls, name_ name, id_ name, placeholder_ cfg.placeholder] <> [required_ "true" | required] <> cfg.extraAttrs) $ toHtml cfg.value
-        (_, Just sfx) -> div_ [class_ "relative"] do
-          input_ $ [class_ $ inputCls <> " pr-14", value_ cfg.value, name_ name, id_ name, type_ cfg.inputType, placeholder_ cfg.placeholder] <> [required_ "true" | required] <> cfg.extraAttrs
-          span_ [class_ "absolute right-2 top-1/2 -translate-y-1/2 text-xs text-textWeak"] $ toHtml sfx
-        _ -> input_ $ [class_ inputCls, value_ cfg.value, name_ name, id_ name, type_ cfg.inputType, placeholder_ cfg.placeholder] <> [required_ "true" | required] <> cfg.extraAttrs
+    fromMaybe
+      ( case (cfg.inputType, cfg.suffix) of
+          ("textarea", _) -> textarea_ ([class_ textareaCls, name_ name, id_ name, placeholder_ cfg.placeholder] <> commonAttrs) $ toHtml cfg.value
+          (_, Just sfx) -> div_ [class_ "relative"] do
+            input_ $ [class_ $ inputCls <> " pr-14"] <> inputAttrs
+            span_ [class_ "absolute right-2 top-1/2 -translate-y-1/2 text-xs text-textWeak"] $ toHtml sfx
+          _ -> input_ $ [class_ inputCls] <> inputAttrs
+      )
+      customM
   where
+    commonAttrs = [required_ "true" | required] <> cfg.extraAttrs
+    inputAttrs = [value_ cfg.value, name_ name, id_ name, type_ cfg.inputType, placeholder_ cfg.placeholder] <> commonAttrs
     (wrapperCls, labelCls, inputCls, textareaCls, reqCls) = case size of
       FieldSm -> ("fieldset flex-1 min-w-0", "label text-xs text-textStrong", "input input-sm w-full", "textarea textarea-sm w-full leading-relaxed", "text-textError")
       FieldMd -> ("fieldset", "label flex w-full items-center gap-1 text-textStrong", "input w-full h-12", "textarea w-full", "text-textWeak")
@@ -633,14 +611,14 @@ panel_ cfg title content = case cfg.collapsible of
 
 
 formCheckbox_ :: Monad m => FieldSize -> Text -> Text -> [Attribute] -> HtmlT m ()
-formCheckbox_ FieldSm lbl name extraAttrs =
-  label_ [class_ "flex items-center gap-2 text-xs cursor-pointer"] do
+formCheckbox_ size lbl name extraAttrs =
+  label_ [class_ lblCls] do
     input_ $ [type_ "checkbox", class_ "checkbox checkbox-sm", name_ name] <> extraAttrs
-    span_ [] $ toHtml lbl
-formCheckbox_ FieldMd lbl name extraAttrs =
-  label_ [class_ "label cursor-pointer flex items-center gap-2"] do
-    input_ $ [type_ "checkbox", class_ "checkbox checkbox-sm", name_ name] <> extraAttrs
-    span_ [class_ "text-sm"] $ toHtml lbl
+    span_ [class_ spanCls] $ toHtml lbl
+  where
+    (lblCls, spanCls) = case size of
+      FieldSm -> ("flex items-center gap-2 text-xs cursor-pointer", "")
+      FieldMd -> ("label cursor-pointer flex items-center gap-2", "text-sm")
 
 
 tagInput_ :: Monad m => Text -> Text -> [Attribute] -> HtmlT m ()
@@ -662,7 +640,6 @@ connectionBadge_ status = span_ [class_ $ "badge badge-sm gap-1 " <> badgeCls] d
       "Active" -> ("badge-soft badge-success", Just "circle-check")
       "Connected" -> ("badge-soft badge-success", Just "circle-check")
       "Not connected" -> ("badge-soft badge-secondary", Just "circle-info")
-      "Configure" -> ("badge-soft badge-secondary", Nothing)
       _ -> ("badge-soft badge-secondary", Nothing)
 
 
@@ -759,7 +736,7 @@ confirmModal_ modalId title description confirmAttrs confirmText =
 colorChip_ :: Monad m => Text -> Text -> Text -> HtmlT m ()
 colorChip_ color icon label = span_ [class_ $ "inline-flex items-center gap-1.5 text-xs rounded-full px-2.5 py-1 " <> bool "text-textWeak bg-fillWeaker" color (color /= "")] do
   faSprite_ icon "regular" "h-3 w-3"
-  toHtml @Text label
+  toHtml label
 
 
 metadataChip_ :: Monad m => Text -> Text -> HtmlT m ()
@@ -860,7 +837,7 @@ sparkline_ buckets
           barW = max 2 (120 `div` n - gap)
           barsEnd = n * (barW + gap)
           topPad = h - barZone
-          peakIdx = maybe 0 fst $ viaNonEmpty head $ filter ((== peakVal) . snd) $ zip [0 ..] buckets
+          peakIdx = length $ takeWhile (/= peakVal) buckets
           lineX1 = peakIdx * (barW + gap) + barW
           lineX2 = barsEnd + 2
           w = lineX2 + labelW

--- a/src/Pages/Dashboards.hs
+++ b/src/Pages/Dashboards.hs
@@ -50,8 +50,7 @@ import Data.Effectful.UUID qualified as UUID
 import Data.Effectful.Wreq qualified as Wreq
 import Data.Generics.Labels ()
 import Data.HashMap.Lazy qualified as HM
-import Data.HashMap.Lazy qualified as M
-import Data.List qualified as L
+import Data.List (lookup)
 import Data.Map qualified as Map
 import Data.Text qualified as T
 import Data.Text.Display (display)
@@ -97,7 +96,6 @@ import Pkg.DeriveUtils (UUIDId (..), hashAssetFile)
 import Pkg.Parser (QueryComponents (..), SqlQueryCfg (..), constantToKQLList, constantToSQLList, defSqlQueryCfg, finalAlertQuery, fixedUTCTime, parseQueryToComponents, presetRollup)
 import Pkg.SchemaLearning.Catalog qualified as Catalog
 import Relude hiding (ask)
-import Relude.Unsafe qualified as Unsafe
 import Servant (NoContent (..), ServerError, err302, err404, errBody, errHeaders)
 import Servant.API (Header)
 import Servant.API.ResponseHeaders (Headers, addHeader)
@@ -122,8 +120,14 @@ dashboardHeadContent_ = do
 
 
 folderFromPath :: Maybe Text -> Text
-folderFromPath Nothing = ""
-folderFromPath (Just path) = let dir = takeDirectory (toString path) in if dir == "." then "" else toText dir <> "/"
+folderFromPath = maybe "" \path -> case takeDirectory (toString path) of
+  "." -> ""
+  dir -> toText dir <> "/"
+
+
+-- | Git file path for a dashboard: folder (trailing slash normalized) + generated filename.
+dashFilePath :: Text -> Text -> Text
+dashFilePath dir title = (if T.null dir || T.last dir == '/' then dir else dir <> "/") <> GitSync.titleToFilePath title
 
 
 normalizeWidgetId :: Text -> Text
@@ -144,8 +148,7 @@ syncDashboardFileInfo dashId = do
   forM_ dashM \dash -> forM_ dash.schema \_ -> do
     teams <- ManageMembers.getTeamsById dash.projectId dash.teams
     let schema = GitSync.buildSchemaWithMeta dash.schema dash.title (V.toList dash.tags) (map (.handle) teams)
-        existingDir = folderFromPath dash.filePath
-        filePath = existingDir <> GitSync.titleToFilePath dash.title
+        filePath = dashFilePath (folderFromPath dash.filePath) dash.title
         newSha = GitSync.computeContentSha $ GitSync.dashboardToYaml schema
     when (dash.fileSha /= Just newSha || dash.filePath /= Just filePath)
       $ void
@@ -181,11 +184,20 @@ instance ToHtml DashboardGet where
 
 dashboardPage_ :: Projects.ProjectId -> Dashboards.DashboardId -> Dashboards.Dashboard -> Dashboards.DashboardVM -> [(Text, Maybe Text)] -> Html ()
 dashboardPage_ pid dashId dash dashVM allParams = do
+  let pidText = pid.toText
+      dashIdText = dashId.toText
+      allTabs = fold dash.tabs
+      activeTabSlug = join (lookup activeTabSlugKey allParams)
+      activeTabInfo = activeTabSlug >>= findTabBySlug allTabs
+      activeTabIdx = maybe 0 fst activeTabInfo
+      -- Slug used for content/widget-order, falling back to the first tab when unset
+      renderTabSlug = dash.tabs *> (activeTabSlug <|> (slugify . (.name) <$> listToMaybe allTabs))
+      renderTab = renderTabSlug >>= findTabBySlug allTabs <&> snd
   -- Modal for renaming dashboard
   Components.modal_ "pageTitleModalId" ""
     $ form_
       [ class_ "flex flex-col p-3 gap-3"
-      , hxPatch_ ("/p/" <> pid.toText <> "/dashboards/" <> dashId.toText <> "/rename")
+      , hxPatch_ ("/p/" <> pidText <> "/dashboards/" <> dashIdText <> "/rename")
       , hxSwap_ "innerHTML"
       , hxTrigger_ "submit"
       , hxTarget_ "#pageTitleText"
@@ -196,50 +208,36 @@ dashboardPage_ pid dashId dash dashVM allParams = do
       Components.formActionsModal_ "pageTitleModalId" $ button_ [type_ "submit", class_ "btn btn-primary"] "Save"
 
   -- Modal for renaming tab (only shown for dashboards with tabs)
-  whenJust dash.tabs \tabs -> do
-    let activeTabSlug = join (L.lookup activeTabSlugKey allParams)
-        activeTabInfo = activeTabSlug >>= findTabBySlug tabs
-        activeTabName = maybe "" ((.name) . snd) activeTabInfo
-        currentTabSlug = fromMaybe "" activeTabSlug
+  whenJust dash.tabs \_ ->
     Components.modal_ "tabRenameModalId" ""
       $ form_
         [ class_ "flex flex-col p-3 gap-3"
-        , hxPatch_ ("/p/" <> pid.toText <> "/dashboards/" <> dashId.toText <> "/tab/" <> currentTabSlug <> "/rename")
+        , hxPatch_ ("/p/" <> pidText <> "/dashboards/" <> dashIdText <> "/tab/" <> fromMaybe "" activeTabSlug <> "/rename")
         , hxSwap_ "none"
         , hxTrigger_ "submit"
         ]
       $ do
-        formField_ FieldSm def{value = activeTabName, placeholder = "Enter tab name"} "Tab Name" "newName" False Nothing
+        formField_ FieldSm def{value = maybe "" ((.name) . snd) activeTabInfo, placeholder = "Enter tab name"} "Tab Name" "newName" False Nothing
         Components.formActionsModal_ "tabRenameModalId" $ button_ [type_ "submit", class_ "btn btn-primary"] "Save"
 
   -- Variable picker modal - auto-opens when required vars are unset (from tab.requires or variable.required)
-  whenJust dash.variables \variables -> do
-    let activeTabSlug' = join (L.lookup activeTabSlugKey allParams)
-        activeTab = activeTabSlug' >>= \slug -> dash.tabs >>= (`findTabBySlug` slug) <&> snd
-    whenJust (findVarToPrompt activeTab variables) \v -> variablePickerModal_ pid dashId activeTabSlug' allParams v False
+  whenJust dash.variables \variables ->
+    whenJust (findVarToPrompt (snd <$> activeTabInfo) variables) \v -> variablePickerModal_ pid dashId activeTabSlug allParams v False
 
   -- Render variables and tabs in the same container
   when (isJust dash.variables || isJust dash.tabs) $ div_ [class_ "flex bg-bgRaised backdrop-blur-xs max-md:px-2 px-4 py-1 max-md:py-0.5 gap-4 max-md:gap-2 items-center flex-wrap sticky top-0 z-10"] do
     -- Tabs section (on the left) - now using htmx for lazy loading
     whenJust dash.tabs \tabs -> do
-      -- Get active tab from path-based slug or fall back to first tab
-      let activeTabSlug = join (L.lookup activeTabSlugKey allParams)
-          activeTabIdx = case activeTabSlug of
-            Just slug -> maybe 0 fst (findTabBySlug tabs slug)
-            Nothing -> 0
-          baseTabUrl = "/p/" <> pid.toText <> "/dashboards/" <> dashId.toText <> "/tab/"
-          -- Build query string from current params (excluding internal keys and expand param)
-          queryStr = queryStringFrom $ filter (\(k, _) -> k `notElem` [activeTabSlugKey, "expand"]) allParams
+      -- Build query string from current params (excluding internal keys and expand param)
+      let queryStr = queryStringFrom $ filter (\(k, _) -> k `notElem` [activeTabSlugKey, "expand"]) allParams
       div_ [role_ "tablist", class_ "tabs tabs-box tabs-outline max-md:flex-nowrap max-md:overflow-x-auto max-md:scrollbar-none max-md:[mask-image:linear-gradient(to_right,black_85%,transparent)]", id_ "dashboard-tabs-container", term "preload" "mouseover"] do
         forM_ (zip [0 ..] tabs) \(idx, tab) -> do
-          let tabSlug = slugify tab.name
-              isActive = idx == activeTabIdx
-              tabUrl = baseTabUrl <> tabSlug
+          let tabUrl = "/p/" <> pidText <> "/dashboards/" <> dashIdText <> "/tab/" <> slugify tab.name <> queryStr
           a_
             [ role_ "tab"
-            , href_ $ tabUrl <> queryStr
-            , class_ $ "tab flex items-center gap-2 max-md:whitespace-nowrap" <> if isActive then " tab-active" else ""
-            , hxGet_ $ tabUrl <> queryStr
+            , href_ tabUrl
+            , class_ $ "tab flex items-center gap-2 max-md:whitespace-nowrap" <> memptyIfFalse (idx == activeTabIdx) " tab-active"
+            , hxGet_ tabUrl
             , hxTarget_ "#dashboard-tabs-content"
             , hxSelect_ "#dashboard-tabs-content"
             , term "hx-select-oob" "#dashboard-tabs-container:morph"
@@ -271,10 +269,8 @@ dashboardPage_ pid dashId dash dashVM allParams = do
                       . fromLazy
                       . AE.encode
                       . map \opt ->
-                        AE.object
-                          [ "value" AE..= (opt Unsafe.!! 0)
-                          , "name" AE..= fromMaybe (opt Unsafe.!! 0) (opt !!? 1)
-                          ]
+                        let v = maybeToMonoid (opt !!? 0)
+                         in AE.object ["value" AE..= v, "name" AE..= fromMaybe v (opt !!? 1)]
                   )
                   var.options
 
@@ -293,48 +289,37 @@ dashboardPage_ pid dashId dash dashVM allParams = do
               , value_ $ maybeToMonoid var.value
               ]
             <> memptyIfFalse (var.multi == Just True) [data_ "tagify-mode" "select"]
-  let pidText = pid.toText
-      dashIdText = dashId.toText
-      activeTabSlug = dash.tabs >>= \tabs -> join (L.lookup activeTabSlugKey allParams) <|> (slugify . (.name) <$> listToMaybe tabs)
-      widgetOrderUrl = "/p/" <> pidText <> "/dashboards/" <> dashIdText <> "/widgets_order" <> maybe "" ("?tab=" <>) activeTabSlug
-      constantsJson = decodeUtf8 $ AE.encode $ M.fromList [(k, fromMaybe "" v) | (k, v) <- allParams, "const-" `T.isPrefixOf` k]
+  let widgetOrderUrl = "/p/" <> pidText <> "/dashboards/" <> dashIdText <> "/widgets_order" <> maybe "" ("?tab=" <>) renderTabSlug
+      constantsJson = decodeUtf8 $ AE.encode $ HM.fromList [(k, fromMaybe "" v) | (k, v) <- allParams, "const-" `T.isPrefixOf` k]
 
   section_ [class_ "h-full"] $ div_ [class_ "mx-auto mb-20 pt-2 pb-6 max-md:pb-20 max-md:px-2 px-4 gap-3.5 w-full flex flex-col group/pg", id_ "dashboardPage", data_ "constants" constantsJson] do
     -- Only warn when a constant actually ran and returned zero rows (Just []).
     -- result == Nothing means the query was skipped (nothing references it) or
     -- failed (logged separately) — neither is a "no data" condition.
-    let emptyConstants = [c.key | c <- fromMaybe [] dash.constants, c.result == Just []]
+    let emptyConstants = [c.key | c <- fold dash.constants, c.result == Just []]
     unless (null emptyConstants) $ div_ [class_ "alert alert-warning text-sm"] do
       faSprite_ "circle-exclamation" "regular" "w-4 h-4"
       span_ $ toHtml $ "Constants with no data: " <> T.intercalate ", " emptyConstants
     div_ [class_ "dashboard-grid-wrapper relative min-h-[400px]"] do
       dashboardSkeleton_
       case dash.tabs of
-        Just tabs -> do
-          let activeTabIdx = case activeTabSlug of
-                Just slug -> maybe 0 fst (findTabBySlug tabs slug)
-                Nothing -> 0
+        Just tabs ->
           -- Tab system with htmx lazy loading - only render active tab content
-          div_ [class_ "dashboard-tabs-container", id_ "dashboard-tabs-content"] do
-            -- Only render the active tab's content (other tabs load via htmx)
-            case tabs !!? activeTabIdx of
-              Just activeTab -> do
-                tabContentPanel_ pid dashId.toText activeTabIdx activeTab.name activeTab.widgets True False
-                -- Variable picker modal inside content div so it's included in HTMX tab swaps
-                whenJust dash.variables \variables -> do
-                  let activeTab' = activeTabSlug >>= \slug -> fmap snd . findTabBySlug tabs $ slug
-                  whenJust (findVarToPrompt activeTab' variables) \v ->
-                    variablePickerModal_ pid dashId activeTabSlug allParams v False
-              Nothing -> pass
+          div_ [class_ "dashboard-tabs-container", id_ "dashboard-tabs-content"]
+            $ whenJust (tabs !!? activeTabIdx) \activeTab -> do
+              tabContentPanel_ pid dashIdText activeTabIdx activeTab.name activeTab.widgets False
+              -- Variable picker modal inside content div so it's included in HTMX tab swaps
+              whenJust dash.variables \variables ->
+                whenJust (findVarToPrompt renderTab variables) \v ->
+                  variablePickerModal_ pid dashId renderTabSlug allParams v False
+        -- Fall back to old behavior for dashboards without tabs
         Nothing -> do
-          -- Fall back to old behavior for dashboards without tabs
-          div_
-            [class_ "grid-stack -m-2"]
-            do
-              forM_ (dash :: Dashboards.Dashboard).widgets (\w -> toHtml (w{Widget._projectId = Just pid}))
-              when (null (dash :: Dashboards.Dashboard).widgets) $ label_ [id_ "add_a_widget_label", class_ "grid-stack-item pb-8 cursor-pointer bg-fillBrand-weak border-2 border-strokeBrand-strong border-dashed text-strokeSelected rounded-sm rounded-lg flex flex-col gap-3 items-center justify-center *:right-0!  *:bottom-0! ", term "gs-w" "3", term "gs-h" "2", Lucid.for_ "page-data-drawer"] do
-                faSprite_ "plus" "regular" "h-8 w-8"
-                span_ "Add a widget"
+          let rootWidgets = (dash :: Dashboards.Dashboard).widgets
+          div_ [class_ "grid-stack -m-2"] do
+            forM_ rootWidgets \w -> toHtml w{Widget._projectId = Just pid}
+            when (null rootWidgets) $ label_ [id_ "add_a_widget_label", class_ "grid-stack-item pb-8 cursor-pointer bg-fillBrand-weak border-2 border-strokeBrand-strong border-dashed text-strokeSelected rounded-sm rounded-lg flex flex-col gap-3 items-center justify-center *:right-0!  *:bottom-0! ", term "gs-w" "3", term "gs-h" "2", Lucid.for_ "page-data-drawer"] do
+              faSprite_ "plus" "regular" "h-8 w-8"
+              span_ "Add a widget"
 
     -- Add hidden element for the auto-refresh handler
     div_ [id_ "dashboard-refresh-handler", class_ "hidden"] ""
@@ -600,14 +585,24 @@ widgetOrderTriggerForm_ url isOob =
 
 
 loadDashboardFromVM :: [Dashboards.Dashboard] -> Dashboards.DashboardVM -> Maybe Dashboards.Dashboard
-loadDashboardFromVM templates dashVM = case dashVM.schema of
-  Just schema_ -> pure schema_
-  Nothing -> find (\d -> d.file == dashVM.baseTemplate) templates
+loadDashboardFromVM templates dashVM = dashVM.schema <|> find (\d -> d.file == dashVM.baseTemplate) templates
+
+
+-- | Flatten a secured-query result set into plain text rows.
+queryRowsToText :: V.Vector (V.Vector AE.Value) -> [[Text]]
+queryRowsToText = map (map valueToText . V.toList) . V.toList
+  where
+    valueToText = \case
+      AE.String t -> t
+      AE.Number n -> show n
+      AE.Bool b -> bool "false" "true" b
+      AE.Null -> ""
+      v -> decodeUtf8 $ AE.encode v
 
 
 -- Process a single dashboard variable recursively.
 processVariable :: Projects.ProjectId -> UTCTime -> (Maybe Text, Maybe Text, Maybe Text) -> [(Text, Maybe Text)] -> Dashboards.Variable -> ATAuthCtx Dashboards.Variable
-processVariable pid now timeRange@(sinceStr, fromDStr, toDStr) allParams variableBase = do
+processVariable pid now (sinceStr, fromDStr, toDStr) allParams variableBase = do
   let (fromD, toD, _) = TimePicker.parseTimeRange now (TimePicker.TimePicker sinceStr fromDStr toDStr)
       paramsMap = Map.fromList allParams
       variable' = Dashboards.replaceQueryVariables pid fromD toD allParams now variableBase
@@ -633,27 +628,16 @@ processVariable pid now timeRange@(sinceStr, fromDStr, toDStr) allParams variabl
       Dashboards.VTQuery | Just sqlQuery <- variable.sql -> do
         -- SECURITY: Use secured query execution with project_id filtering
         useTf <- (.env.enableTimefusionReads) <$> ask @AuthContext
-        result <- LogQueries.executeSecuredQuery useTf pid sqlQuery 1000
-        case result of
-          Right queryResults -> pure variable{Dashboards.options = Just $ map (map valueToText . V.toList) $ V.toList queryResults}
-          Left _ -> pure variable -- Return unchanged on error
+        LogQueries.executeSecuredQuery useTf pid sqlQuery 1000 <&> \case
+          Right queryResults -> variable{Dashboards.options = Just $ queryRowsToText queryResults}
+          Left _ -> variable -- Return unchanged on error
       _ -> pure variable
-  where
-    valueToText :: AE.Value -> Text
-    valueToText (AE.String t) = t
-    valueToText (AE.Number n) = show n
-    valueToText (AE.Bool b) = if b then "true" else "false"
-    valueToText AE.Null = ""
-    valueToText v = decodeUtf8 $ AE.encode v
 
 
 -- | Process all dashboard variables concurrently.
 processVariablesConcurrently :: Projects.ProjectId -> UTCTime -> (Maybe Text, Maybe Text, Maybe Text) -> [(Text, Maybe Text)] -> Dashboards.Dashboard -> ATAuthCtx Dashboards.Dashboard
-processVariablesConcurrently pid now timeParams allParams dash = case dash.variables of
-  Nothing -> pure dash
-  Just vars -> do
-    vars' <- pooledForConcurrently vars (processVariable pid now timeParams allParams)
-    pure $ dash & #variables ?~ vars'
+processVariablesConcurrently pid now timeParams allParams dash =
+  forOf (#variables . _Just) dash $ flip pooledForConcurrently (processVariable pid now timeParams allParams)
 
 
 -- | Get required variables without values (respecting dependsOn order)
@@ -680,7 +664,7 @@ variablePickerModal_ pid dashId activeTabSlug allParams var useOob = do
       tabPath = maybe "" ("/tab/" <>) activeTabSlug
       urlPrefix = "/p/" <> pid.toText <> "/dashboards/" <> dashId.toText <> tabPath <> queryBase <> (if T.null queryBase then "?" else "&") <> varKey <> "="
       oobAttr = if useOob then [id_ $ "varPicker-" <> var.key <> "-container", hxSwapOob_ "beforeend:body"] else []
-      opts = fromMaybe [] var.options
+      opts = fold var.options
       optCount = length opts
   div_ oobAttr do
     div_ [class_ "var-picker-backdrop fixed inset-0 flex flex-col items-center pt-[15vh] bg-black/40", style_ "z-index:99999", [__|on click if event.target is me remove me|]] do
@@ -738,7 +722,7 @@ variablePickerModal_ pid dashId activeTabSlug allParams var useOob = do
             ]
         div_ [class_ "max-h-80 overflow-y-auto p-1"] do
           forM_ (zip [0 :: Int ..] opts) \(idx, opt) -> do
-            let optVal = opt Unsafe.!! 0
+            let optVal = maybeToMonoid (opt !!? 0)
                 optLbl = fromMaybe optVal (opt !!? 1)
                 isCurrent = var.value == Just optVal
             a_
@@ -766,32 +750,23 @@ processConstant :: Projects.ProjectId -> UTCTime -> (Maybe Text, Maybe Text, May
 processConstant pid now (sinceStr, fromDStr, toDStr) allParams constantBase = do
   let (fromD, toD, _) = TimePicker.parseTimeRange now (TimePicker.TimePicker sinceStr fromDStr toDStr)
       constant = Dashboards.replaceConstantVariables pid fromD toD allParams now constantBase
-      runQuery :: forall a. Text -> ATAuthCtx a -> (a -> [[Text]]) -> ATAuthCtx Dashboards.Constant
+      runQuery :: forall a. Text -> ATAuthCtx (Either Text a) -> (a -> [[Text]]) -> ATAuthCtx Dashboards.Constant
       runQuery label action toResult = do
-        (res, duration) <- Log.timeAction $ try action
+        (res, duration) <- Log.timeAction action
         either
-          (\(err :: SomeException) -> Log.logWarn ("Dashboard constant " <> label <> " query failed") (constant.key, show err, duration) $> constant)
+          (\err -> Log.logWarn ("Dashboard constant " <> label <> " query failed") (constant.key, err, duration) $> constant)
           (\val -> Log.logDebug ("Dashboard constant " <> label <> " query completed") (constant.key, duration) $> constant{Dashboards.result = Just $ toResult val})
           res
   useTf <- (.env.enableTimefusionReads) <$> ask @AuthContext
   case (constant.sql, constant.query) of
-    (Just sqlQuery, _) -> do
-      -- SECURITY: Use secured query execution with project_id filtering
-      (res, duration) <- Log.timeAction $ LogQueries.executeSecuredQuery useTf pid sqlQuery 1000
-      case res of
-        Left err -> Log.logWarn "Dashboard constant SQL query failed" (constant.key, err, duration) $> constant
-        Right queryResults -> do
-          let toTextList = map (map valueToText . V.toList) $ V.toList queryResults
-          Log.logDebug "Dashboard constant SQL query completed" (constant.key, duration) $> constant{Dashboards.result = Just toTextList}
-    (Nothing, Just kqlQuery) -> runQuery "KQL" (Charts.queryMetrics Nothing (Just Charts.DTText) (Just pid) (Just kqlQuery) Nothing sinceStr fromDStr toDStr Nothing allParams) (map V.toList . V.toList . (.dataText))
+    -- SECURITY: Use secured query execution with project_id filtering
+    (Just sqlQuery, _) -> runQuery "SQL" (LogQueries.executeSecuredQuery useTf pid sqlQuery 1000) queryRowsToText
+    (Nothing, Just kqlQuery) ->
+      runQuery
+        "KQL"
+        (first (\(e :: SomeException) -> show e) <$> try (Charts.queryMetrics Nothing (Just Charts.DTText) (Just pid) (Just kqlQuery) Nothing sinceStr fromDStr toDStr Nothing allParams))
+        (map V.toList . V.toList . (.dataText))
     _ -> pure constant
-  where
-    valueToText :: AE.Value -> Text
-    valueToText (AE.String t) = t
-    valueToText (AE.Number n) = show n
-    valueToText (AE.Bool b) = if b then "true" else "false"
-    valueToText AE.Null = ""
-    valueToText v = decodeUtf8 $ AE.encode v
 
 
 -- Process a single widget recursively. Keeps sql/query with {{var-*}} templates intact
@@ -805,13 +780,9 @@ processWidget pid now timeRange allParams widgetBase = do
       then processEagerWidget pid now timeRange allParams widget
       else pure widget
 
-  -- Recursively process child widgets concurrently
-  case widget'.children of
-    Nothing -> pure widget'
-    Just childWidgets -> do
-      let addDashboardId child = child & #_dashboardId %~ (<|> widget'._dashboardId)
-      processedChildren <- pooledForConcurrently childWidgets (processWidget pid now timeRange allParams . addDashboardId)
-      pure $ widget' & #children ?~ processedChildren
+  -- Recursively process child widgets concurrently, inheriting the parent's dashboard id
+  forOf (#children . _Just) widget' \kids ->
+    pooledForConcurrently kids $ processWidget pid now timeRange allParams . (#_dashboardId %~ (<|> widget'._dashboardId))
 
 
 -- | Fetch widget data based on widget type (for stat and chart widgets)
@@ -826,15 +797,15 @@ fetchWidgetData pid (sinceStr, fromDStr, toDStr) allParams widget = case widget.
 
 
 processEagerWidget :: Projects.ProjectId -> UTCTime -> (Maybe Text, Maybe Text, Maybe Text) -> [(Text, Maybe Text)] -> Widget.Widget -> ATAuthCtx Widget.Widget
-processEagerWidget pid now (sinceStr, fromDStr, toDStr) allParams widget = case widget.wType of
+processEagerWidget pid now timeRange@(sinceStr, fromDStr, toDStr) allParams widget = case widget.wType of
   Widget.WTAnomalies -> do
-    (issues, _) <- Issues.selectIssues pid Nothing (Just False) (Just False) 2 0 Nothing Nothing "24h" [] []
+    (issues, _) <- Issues.selectIssues pid (Just False) (Just False) 2 0 Nothing Nothing "24h" [] []
     pure
       $ widget
       & #html
         ?~ renderText
           (div_ [class_ "flex flex-col gap-3 h-full w-full overflow-hidden"] $ forM_ issues $ AnomalyList.issueCardCompact_ pid now)
-  Widget.WTStat -> fetchWidgetData pid (sinceStr, fromDStr, toDStr) allParams widget
+  Widget.WTStat -> fetchWidgetData pid timeRange allParams widget
   Widget.WTTable -> do
     -- Fetch table data
     tableData <- Charts.queryMetrics widget.dbSource (Just Charts.DTText) (Just pid) widget.query widget.sql sinceStr fromDStr toDStr Nothing allParams
@@ -850,17 +821,17 @@ processEagerWidget pid now (sinceStr, fromDStr, toDStr) allParams widget = case 
       concurrently
         (Telemetry.getTraceShapes pid trIds)
         (Telemetry.getSpanRecordsByTraceIds pid trIds Nothing)
-    let grouped = M.fromListWith (++) [(trId, [(spanName, duration, events)]) | (trId, spanName, duration, events) <- shapeWithDuration]
+    let grouped = HM.fromListWith (++) [(trId, [(spanName, duration, events)]) | (trId, spanName, duration, events) <- shapeWithDuration]
         spanRecords = V.fromList $ mapMaybe Telemetry.convertOtelLogsAndSpansToSpanRecord spanRecords'
         serviceColors = getServiceColors ((\x -> getServiceName x.resource) <$> spanRecords)
         colorsJson = decodeUtf8 $ AE.encode $ AE.object [AEKey.fromText k AE..= v | (k, v) <- HM.toList serviceColors]
-        spansGrouped = M.fromListWith (++) [(sp.traceId, [sp]) | sp <- V.toList spanRecords]
+        spansGrouped = HM.fromListWith (++) [(sp.traceId, [sp]) | sp <- V.toList spanRecords]
 
     pure
       $ widget
       & #html
         ?~ renderText (Widget.renderTraceDataTable widget tracesD.dataText grouped spansGrouped colorsJson)
-  _ -> fetchWidgetData pid (sinceStr, fromDStr, toDStr) allParams widget
+  _ -> fetchWidgetData pid timeRange allParams widget
 
 
 -- | Populate widgets with their alert statuses
@@ -897,35 +868,34 @@ dashboardWidgetPutH pid dashId widgetIdM tabSlugM widget = do
   (_, dash) <- getDashAndVM dashId Nothing
   uid <- UUID.genUUID <&> UUID.toText
   let normalizedWidgetIdM = normalizeWidgetId <$> widgetIdM
-  let widgetUpdated = normalizeWidget widget normalizedWidgetIdM uid
-  let dash' = updateDashboardWidgets dash tabSlugM normalizedWidgetIdM widgetUpdated
+      widgetUpdated = normalizeWidget widget normalizedWidgetIdM uid
 
-  _ <- Dashboards.updateSchema dashId dash'
+  _ <- Dashboards.updateSchema dashId $ updateDashboardWidgets dash tabSlugM normalizedWidgetIdM widgetUpdated
   syncDashboardAndQueuePush pid dashId
   whenJust normalizedWidgetIdM \nwid -> syncWidgetAlert pid nwid widget
 
-  let successMsg = if isJust normalizedWidgetIdM then "Widget updated successfully" else "Widget added to dashboard successfully"
-  addSuccessToast successMsg Nothing
+  addSuccessToast (if isJust normalizedWidgetIdM then "Widget updated successfully" else "Widget added to dashboard successfully") Nothing
   addTriggerEvent "closeModal" ""
   addRespHeaders widgetUpdated
 
 
+-- | A newly created widget (no id yet) also drops any centered title.
 normalizeWidget :: Widget.Widget -> Maybe Text -> Text -> Widget.Widget
-normalizeWidget widget normalizedWidgetIdM generatedId = case normalizedWidgetIdM of
-  Just nwid -> widget{Widget.standalone = Nothing, Widget.naked = Nothing, Widget.id = Just nwid}
-  Nothing -> widget{Widget.standalone = Nothing, Widget.naked = Nothing, Widget.id = Just generatedId, Widget._centerTitle = Nothing}
+normalizeWidget widget normalizedWidgetIdM generatedId =
+  widget
+    { Widget.standalone = Nothing
+    , Widget.naked = Nothing
+    , Widget.id = Just $ fromMaybe generatedId normalizedWidgetIdM
+    , Widget._centerTitle = normalizedWidgetIdM *> widget._centerTitle
+    }
 
 
 updateDashboardWidgets :: Dashboards.Dashboard -> Maybe Text -> Maybe Text -> Widget.Widget -> Dashboards.Dashboard
 updateDashboardWidgets dash tabSlugM normalizedWidgetIdM widgetUpdated =
-  let updateWidgets ws = case normalizedWidgetIdM of
-        Just nwid ->
-          let updateWidget w =
-                if (w.id == Just nwid) || (maybeToMonoid (slugify <$> w.title) == nwid)
-                  then mergeWidgetPreservingQuery w widgetUpdated
-                  else w
-           in map updateWidget ws
-        Nothing -> ws <> [widgetUpdated]
+  let updateWidget nwid w
+        | w.id == Just nwid || maybeToMonoid (slugify <$> w.title) == nwid = mergeWidgetPreservingQuery w widgetUpdated
+        | otherwise = w
+      updateWidgets ws = maybe (ws <> [widgetUpdated]) (\nwid -> map (updateWidget nwid) ws) normalizedWidgetIdM
    in case (tabSlugM, dash.tabs) of
         (Just slug, Just _) -> updateTabBySlug slug (#widgets %~ updateWidgets) dash
         _ -> dash & #widgets %~ updateWidgets
@@ -979,7 +949,7 @@ dashboardWidgetReorderPatchH pid dashId tabSlugM widgetOrder = do
   (_, dash) <- getDashAndVM dashId Nothing
 
   let oldWidgets = case (tabSlugM, dash.tabs) of
-        (Just slug, Just tabs) -> maybe [] (.widgets) $ find (\t -> slugify t.name == slug) tabs
+        (Just slug, Just tabs) -> foldMap (.widgets) $ find (\t -> slugify t.name == slug) tabs
         _ -> dash.widgets
       oldWidgetIds = mapMaybe (.id) oldWidgets
       newWidgetIds = Map.keys widgetOrder
@@ -1013,7 +983,7 @@ reorderWidgets patch ws = mapMaybe findAndUpdate (Map.toList patch)
       orig <- Map.lookup wid widgetMap
       let newLayout =
             Just
-              $ maybe def Relude.id orig.layout
+              $ fromMaybe def orig.layout
               & #x .~ (item.x <|> (orig.layout >>= (.x)))
               & #y .~ (item.y <|> (orig.layout >>= (.y)))
               & #w .~ (item.w <|> (orig.layout >>= (.w)))
@@ -1025,7 +995,7 @@ reorderWidgets patch ws = mapMaybe findAndUpdate (Map.toList patch)
           }
 
     mkWidgetMap = Map.fromList . concatMap flatten
-    flatten w = (widgetId w, w) : maybe [] (concatMap flatten) w.children
+    flatten w = (widgetId w, w) : foldMap (concatMap flatten) w.children
     widgetId w = fromMaybe (maybeToMonoid $ slugify <$> w.title) w.id
 
 
@@ -1040,21 +1010,15 @@ getDashAndVM dashId fileM = do
   appCtx <- ask @AuthContext
   templates <- getDashboardTemplates appCtx.config.liveReloadDashboards
   dashVM <-
-    Dashboards.getDashboardById dashId >>= \case
-      Just v -> pure v
-      Nothing -> throwError $ err404{errBody = "Dashboard with ID not found. ID:" <> encodeUtf8 dashId.toText}
-
-  dash <- case fileM of
-    Just file -> Dashboards.readDashboardEndpoint file
-    Nothing -> pure $ fromMaybe def (loadDashboardFromVM templates dashVM)
-
+    Dashboards.getDashboardById dashId
+      `whenNothingM` throwError err404{errBody = "Dashboard with ID not found. ID:" <> encodeUtf8 dashId.toText}
+  dash <- maybe (pure $ fromMaybe def (loadDashboardFromVM templates dashVM)) Dashboards.readDashboardEndpoint fileM
   pure (dashVM, dash)
 
 
 dashboardGetH :: Projects.ProjectId -> Dashboards.DashboardId -> Maybe Text -> Maybe Text -> Maybe Text -> Maybe Text -> [(Text, Maybe Text)] -> ATAuthCtx (RespHeaders (PageCtx DashboardGet))
 dashboardGetH pid dashId fileM fromDStr toDStr sinceStr allParams = do
   (_, project, bw) <- mkPageCtx pid
-  appCtx <- ask @AuthContext
   now <- Time.currentTime
   let (_fromD, _toD, currentRange) = TimePicker.parseTimeRange now (TimePicker.TimePicker sinceStr fromDStr toDStr)
 
@@ -1070,18 +1034,10 @@ dashboardGetH pid dashId fileM fromDStr toDStr sinceStr allParams = do
       -- No tabs - render the dashboard normally (existing behavior for non-tabbed dashboards)
       let timeParams = (sinceStr, fromDStr, toDStr)
           paramsWithVarDefaults = addVariableDefaults allParams dash.variables
-      (processedConstants, allParamsWithConstants) <- processConstantsAndExtendParams pid now timeParams paramsWithVarDefaults (dashboardQueryText dash) (fromMaybe [] dash.constants)
+      (processedConstants, allParamsWithConstants) <- processConstantsAndExtendParams pid now timeParams paramsWithVarDefaults (dashboardQueryText dash) (fold dash.constants)
 
-      let dashWithConstants = dash & #constants ?~ processedConstants
-          processWidgetWithDashboardId = mkWidgetProcessor pid dashId now timeParams allParamsWithConstants
-
-      dash' <- processVariablesConcurrently pid now timeParams allParamsWithConstants dashWithConstants
-      -- Process widgets concurrently
-      processedWidgets <- pooledForConcurrently dash'.widgets processWidgetWithDashboardId
-      -- Populate alert statuses and PNG URLs for widgets
-      widgetsWithAlerts <- populateWidgetAlertStatuses processedWidgets
-      widgetsWithPngUrls <- populateWidgetPngUrls appCtx.env.apiKeyEncryptionSecretKey bw.config.hostUrl pid timeParams widgetsWithAlerts
-      let dash'' = dash' & #widgets .~ widgetsWithPngUrls
+      dash' <- processVariablesConcurrently pid now timeParams allParamsWithConstants (dash & #constants ?~ processedConstants)
+      dash'' <- (\ws -> dash' & #widgets .~ ws) <$> processDashWidgets pid dashId now timeParams allParamsWithConstants dash'.widgets
 
       freeTierStatus <- checkFreeTierStatus pid project.paymentPlan
 
@@ -1113,9 +1069,8 @@ numberedStep_ n title content = div_ [class_ "space-y-4"] do
 widgetViewerEditor_ :: Projects.ProjectId -> Text -> Maybe Dashboards.DashboardId -> Maybe Text -> Maybe (Text, Text) -> Maybe Widget.Widget -> Text -> Html ()
 widgetViewerEditor_ pid paymentPlan dashboardIdM tabSlugM currentRange existingWidgetM activeTab = div_ [class_ "group/wgtexp"] do
   let isNewWidget = isNothing existingWidgetM
-  let effectiveActiveTab = if isNewWidget then "edit" else activeTab
-
-  let defaultWidget =
+      effectiveActiveTab = if isNewWidget then "edit" else activeTab
+      defaultWidget =
         (def :: Widget.Widget)
           { Widget.wType = Widget.WTTimeseries
           , Widget.id = Just "newWidget"
@@ -1129,30 +1084,22 @@ widgetViewerEditor_ pid paymentPlan dashboardIdM tabSlugM currentRange existingW
           , Widget._dashboardId = dashboardIdM <&> (.toText)
           , Widget.layout = Just $ def{Widget.w = Just 3, Widget.h = Just 3}
           }
-      widgetToUse' = fromMaybe defaultWidget existingWidgetM
-      widgetToUse = (fromMaybe defaultWidget existingWidgetM){Widget.id = Just $ maybeToMonoid widgetToUse'.id <> "Expanded", Widget.standalone = Just True, Widget.naked = Just True}
-
-  -- Generate unique IDs for all elements based on widget ID to prevent conflicts
-  let wid = maybeToMonoid widgetToUse.id
+      widgetBase = fromMaybe defaultWidget existingWidgetM
+      widgetToUse = widgetBase{Widget.id = Just $ maybeToMonoid widgetBase.id <> "Expanded", Widget.standalone = Just True, Widget.naked = Just True}
+      -- Element ids are derived from the widget id to prevent conflicts
+      wid = maybeToMonoid widgetToUse.id
       sourceWid = normalizeWidgetId wid
       widPrefix = "id" <> T.take 8 wid
       widgetFormId = widPrefix <> "-widget-form"
       widgetPreviewId = widPrefix <> "-widget-preview"
       widgetTitleInputId = widPrefix <> "-widget-title-input"
-      -- queryBuilderId = widPrefix <> "-queryBuilder" -- removed unused variable
-      -- filterElementId = widPrefix <> "-filterElement" -- removed unused variable
-      -- widgetTypeNameId = widPrefix <> "-widgetType" -- removed unused variable
       drawerStateCheckbox = if isJust existingWidgetM then "global-data-drawer" else "page-data-drawer"
       stickySentinelId = widPrefix <> "-sticky-sentinel"
       stickyContainerId = widPrefix <> "-sticky-container"
-
-  let widgetJSON = Widget.encodeText widgetToUse
-  let formAction = case dashboardIdM of
-        Just dashId ->
-          let baseUrl = "/p/" <> pid.toText <> "/dashboards/" <> dashId.toText
-              params = catMaybes [("widget_id=" <>) . fromMaybe "" . (.id) <$> existingWidgetM, ("tab=" <>) <$> tabSlugM]
-           in baseUrl <> if null params then "" else "?" <> T.intercalate "&" params
-        Nothing -> ""
+      widgetJSON = Widget.encodeText widgetToUse
+      formAction = flip foldMap dashboardIdM \dashId ->
+        let params = catMaybes [("widget_id=" <>) . maybeToMonoid . (.id) <$> existingWidgetM, ("tab=" <>) <$> tabSlugM]
+         in "/p/" <> pid.toText <> "/dashboards/" <> dashId.toText <> memptyIfFalse (not (null params)) ("?" <> T.intercalate "&" params)
 
   form_
     [ class_ "hidden"
@@ -1297,9 +1244,7 @@ widgetViewerEditor_ pid paymentPlan dashboardIdM tabSlugM currentRange existingW
   -- Alerts tab content
   unless isNewWidget do
     let alertFormId = widPrefix <> "-alert-form"
-        alertEndpoint = case dashboardIdM of
-          Just dashId -> "/p/" <> pid.toText <> "/widgets/" <> sourceWid <> "/alert?dashboard_id=" <> dashId.toText
-          Nothing -> ""
+        alertEndpoint = flip foldMap dashboardIdM \dashId -> "/p/" <> pid.toText <> "/widgets/" <> sourceWid <> "/alert?dashboard_id=" <> dashId.toText
     div_ [class_ "group/walert hidden group-has-[.page-drawer-tab-alerts:checked]/wgtexp:block mt-6"] do
       widgetAlertConfig_ pid paymentPlan alertFormId alertEndpoint wid sourceWid widgetToUse
 
@@ -1335,14 +1280,11 @@ widgetAlertConfig_ _pid paymentPlan alertFormId alertEndpoint chartTargetId widg
       -- Thresholds section (shared component)
       Alerts.thresholdsSection_ (Just chartTargetId) widget.alertThreshold widget.warningThreshold False Nothing Nothing
       -- Widget-specific: Show threshold lines option
-      let isAlways = widget.showThresholdLines == Just "always" || isNothing widget.showThresholdLines
-          isOnBreach = widget.showThresholdLines == Just "on_breach"
-          isNever = widget.showThresholdLines == Just "never"
-      div_ [class_ "bg-bgBase rounded-xl border border-strokeWeak p-3"] do
-        Components.formSelectField_ Components.FieldSm "Show threshold lines on chart" "showThresholdLines" False do
-          option_ ([value_ "always"] <> [selected_ "" | isAlways]) "Always"
-          option_ ([value_ "on_breach"] <> [selected_ "" | isOnBreach]) "Only when breached"
-          option_ ([value_ "never"] <> [selected_ "" | isNever]) "Never"
+      let currentLines = fromMaybe "always" widget.showThresholdLines
+      div_ [class_ "bg-bgBase rounded-xl border border-strokeWeak p-3"]
+        $ Components.formSelectField_ Components.FieldSm "Show threshold lines on chart" "showThresholdLines" False
+        $ forM_ ([("always", "Always"), ("on_breach", "Only when breached"), ("never", "Never")] :: [(Text, Text)]) \(v, lbl) ->
+          option_ ([value_ v] <> [selected_ "" | v == currentLines]) $ toHtml lbl
 
       -- Notification Settings section (shared component) - empty teams, users can configure after creation
       Alerts.notificationSettingsSection_ Nothing Nothing Nothing True V.empty V.empty alertFormId Nothing
@@ -1389,11 +1331,10 @@ widgetAlertUpsertH pid _widgetIdPath dashboardIdM form = do
   _ <- Projects.sessionAndProject pid
   now <- Time.currentTime
 
-  -- Check if alert already exists for this widget
-  existingMonitor <- Monitors.queryMonitorByWidgetId form.widgetId
-  queryMonitorId <- case existingMonitor of
-    Just m -> pure m.id
-    Nothing -> liftIO $ Monitors.QueryMonitorId <$> UUID.nextRandom
+  -- Reuse the widget's existing monitor id when there is one
+  queryMonitorId <-
+    Monitors.queryMonitorByWidgetId form.widgetId
+      >>= maybe (liftIO $ Monitors.QueryMonitorId <$> UUID.nextRandom) (pure . (.id))
 
   -- Update widget's showThresholdLines in the dashboard
   whenJust dashboardIdM \dashId -> do
@@ -1458,13 +1399,6 @@ widgetAlertDeleteH pid widgetId = do
   addRespHeaders $ toHtml ("" :: Text)
 
 
--- visTypes is now imported from LogQueryBox to avoid circular dependencies
-
--- | Wrapper for the new widget editor
-newWidget_ :: Projects.ProjectId -> Text -> Dashboards.DashboardId -> Maybe Text -> Maybe (Text, Text) -> Html ()
-newWidget_ pid paymentPlan dashId tabSlugM currentRange = widgetViewerEditor_ pid paymentPlan (Just dashId) tabSlugM currentRange Nothing "edit"
-
-
 --------------------------------------------------------------------
 -- Dashboard List
 --
@@ -1477,7 +1411,6 @@ data DashboardsGetD = DashboardsGetD
   , teams :: V.Vector ManageMembers.Team
   , tableActions :: Maybe Table.TableHeaderActions
   , filters :: DashboardFilters
-  , availableTags :: [Text]
   , copyMode :: Maybe (Text, Dashboards.DashboardId) -- (widgetId, sourceDashboardId) for copy-to-dashboard mode
   , dashTemplates :: [Dashboards.Dashboard]
   , showNew :: Bool
@@ -1502,18 +1435,15 @@ renderDashboardListItem checked tmplClass title value description icon prview = 
       group-has-[input:checked]/it:bg-fillWeaker group-has-[input:checked]/it:border-strokeWeak dashboardListItem|]
   , term "data-title" title
   , term "data-description" $ maybeToMonoid description
-  , term "data-icon" $ fromMaybe "square-dashed" icon
   , term "data-preview" $ fromMaybe "/public/assets/svgs/screens/dashboard_blank.svg" prview
   , [__| on mouseover set #dItemPreview.src to my @data-preview
               then set #dItemTitle.innerText to my @data-title
               then set #dItemDescription.innerText to my @data-description
-              then set #dItemIcon.innerHTML to `<svg class='w-8 h-8'><use href='/public/assets/svgs/fa-sprites/regular.svg#${my @data-icon}'></use></svg>`
           on mouseout
               put (<.dashboardListItem:has(input:checked)/>) into checkedLabel
               set #dItemPreview.src to checkedLabel's @data-preview
               then set #dItemTitle.innerText to checkedLabel's @data-title
               then set #dItemDescription.innerText to checkedLabel's @data-description
-              then set #dItemIcon.innerHTML to `<svg class='w-8 h-8'><use href='/public/assets/svgs/fa-sprites/regular.svg#${checkedLabel's @data-icon}'></use></svg>`
               |]
   ]
   do
@@ -1524,8 +1454,7 @@ renderDashboardListItem checked tmplClass title value description icon prview = 
 
 
 starButton_ :: Projects.ProjectId -> Dashboards.DashboardId -> Bool -> Html ()
-starButton_ pid dashId isStarred = do
-  let starIconType = if isStarred then "solid" else "regular"
+starButton_ pid dashId isStarred =
   button_
     [ id_ $ "star-btn-" <> dashId.toText
     , class_ $ "leading-none cursor-pointer " <> if isStarred then "" else "opacity-0 group-hover/row:opacity-100"
@@ -1534,7 +1463,7 @@ starButton_ pid dashId isStarred = do
     , hxTarget_ $ "#star-btn-" <> dashId.toText
     , hxSwap_ "outerHTML"
     ]
-    $ faSprite_ "star" starIconType
+    $ faSprite_ "star" (if isStarred then "solid" else "regular")
     $ "w-4 h-4 "
     <> if isStarred then "text-iconWarning" else "text-iconNeutral"
 
@@ -1587,58 +1516,48 @@ dashboardsGet_ dg = do
 
   div_ [id_ "itemsListPage", class_ "mx-auto gap-8 w-full flex flex-col h-full overflow-hidden group/pg"] do
     let getTeams x = mapMaybe (\xx -> find (\t -> t.id == xx) dg.teams) (V.toList x.teams)
-
-    let getDashIcon dash = maybe "square-dashed" (\d -> fromMaybe "square-dashed" d.icon) (loadDashboardFromVM dg.dashTemplates dash)
+        getDashIcon dash = fromMaybe "square-dashed" (loadDashboardFromVM dg.dashTemplates dash >>= (.icon))
         getWidgetCount dash = maybe 0 (length . (.widgets)) (loadDashboardFromVM dg.dashTemplates dash)
-
-    let noBulkActions = dg.embedded || dg.hideActions || isJust dg.copyMode
+        noBulkActions = dg.embedded || dg.hideActions || isJust dg.copyMode
         inCopyMode = isJust dg.copyMode
+        baseUrl = "/p/" <> dg.projectId.toText <> "/dashboards"
 
-    let renderNameCol dash = do
-          let baseUrl = "/p/" <> dg.projectId.toText <> "/dashboards/" <> dash.id.toText
+        renderNameCol dash = do
+          let dashUrl = baseUrl <> "/" <> dash.id.toText
               folder = folderFromPath dash.filePath
           span_ [class_ "flex items-center gap-2"] do
             span_ [class_ "p-1 px-2 bg-fillWeak rounded-md", data_ "tippy-content" "Dashboard icon"] $ faSprite_ (getDashIcon dash) "regular" "w-3 h-3"
             unless (T.null folder) $ span_ [class_ "text-xs text-textWeak font-mono", data_ "tippy-content" "Folder path for git sync"] $ toHtml folder
             if inCopyMode
               then span_ [class_ "font-medium text-textStrong"] $ toHtml $ dashTitle dash.title
-              else a_ [href_ baseUrl, class_ "font-medium text-textStrong hover:text-textBrand hover:underline underline-offset-2"] $ toHtml $ dashTitle dash.title
+              else a_ [href_ dashUrl, class_ "font-medium text-textStrong hover:text-textBrand hover:underline underline-offset-2"] $ toHtml $ dashTitle dash.title
             unless inCopyMode $ starButton_ dg.projectId dash.id (isJust dash.starredSince)
           div_ [class_ "hidden max-md:flex items-center gap-2 mt-1 text-xs text-textWeak flex-wrap"] do
             span_ [class_ "tabular-nums"] $ toHtml $ toText $ formatTime defaultTimeLocale "%b %-e" dash.updatedAt
             forM_ (getTeams dash) \team -> span_ [class_ "badge badge-sm badge-neutral"] $ toHtml team.handle
             forM_ (V.toList dash.tags) $ span_ [class_ "badge badge-sm badge-neutral"] . toHtml
 
-    let renderModifiedCol dash = span_ [class_ "text-xs text-textWeak tabular-nums", data_ "tippy-content" "Last modified date"] $ Components.localTimeFmt_ "MMM d, h:mm aaa" dash.updatedAt
-
-    let renderTeamsCol dash = forM_ (getTeams dash) \team -> span_ [class_ "badge badge-sm badge-neutral mr-1"] $ toHtml team.handle
-
-    let baseUrl = "/p/" <> dg.projectId.toText <> "/dashboards"
-    let renderTagsCol dash = forM_ (V.toList dash.tags) \tag ->
+        renderModifiedCol dash = span_ [class_ "text-xs text-textWeak tabular-nums", data_ "tippy-content" "Last modified date"] $ Components.localTimeFmt_ "MMM d, h:mm aaa" dash.updatedAt
+        renderTeamsCol dash = forM_ (getTeams dash) \team -> span_ [class_ "badge badge-sm badge-neutral mr-1"] $ toHtml team.handle
+        renderTagsCol dash = forM_ (V.toList dash.tags) \tag ->
           if inCopyMode
             then span_ [class_ "badge badge-sm badge-neutral mr-1"] $ toHtml tag
             else a_ [class_ "badge badge-sm badge-neutral mr-1 cursor-pointer hover:badge-primary", hxGet_ $ baseUrl <> "?tag=" <> toUriStr tag, hxTarget_ "#dashboardsTableContainer", hxSelect_ "#dashboardsTableContainer", hxPushUrl_ "true", hxSwap_ "outerHTML"] $ toHtml tag
 
-    let renderWidgetsCol dash = do
+        renderWidgetsCol dash = do
           let count = getWidgetCount dash
           span_ [class_ "flex items-center gap-1.5 text-textWeak", data_ "tippy-content" $ show count <> " widget" <> if count == 1 then "" else "s"] do
             faSprite_ "grid" "regular" "w-3.5 h-3.5 text-iconNeutral"
             span_ [class_ "leading-none tabular-nums"] $ toHtml $ show count
 
-    let tableCols = case dg.copyMode of
-          Just _ ->
-            [ Table.col "Name" renderNameCol & Table.withAttrs [class_ "min-w-0"]
-            , Table.col "Teams" renderTeamsCol & Table.withAttrs [class_ "w-48 max-md:hidden"]
-            , Table.col "Tags" renderTagsCol & Table.withAttrs [class_ "w-48 max-md:hidden"]
-            , Table.col "Widgets" renderWidgetsCol & Table.withAttrs [class_ "w-24 max-md:hidden"]
-            ]
-          Nothing ->
-            [ Table.col "Name" renderNameCol & Table.withAttrs [class_ "min-w-0"] & Table.withSort "title"
-            , Table.col "Last Modified" renderModifiedCol & Table.withAttrs [class_ "w-44 max-md:hidden"] & Table.withSort "updated_at"
-            , Table.col "Teams" renderTeamsCol & Table.withAttrs [class_ "w-48 max-md:hidden"]
-            , Table.col "Tags" renderTagsCol & Table.withAttrs [class_ "w-48 max-md:hidden"]
-            , Table.col "Widgets" renderWidgetsCol & Table.withAttrs [class_ "w-24 max-md:hidden"]
-            ]
+    let nameCol = Table.col "Name" renderNameCol & Table.withAttrs [class_ "min-w-0"]
+        tableCols =
+          [if inCopyMode then nameCol else nameCol & Table.withSort "title"]
+            <> [Table.col "Last Modified" renderModifiedCol & Table.withAttrs [class_ "w-44 max-md:hidden"] & Table.withSort "updated_at" | not inCopyMode]
+            <> [ Table.col "Teams" renderTeamsCol & Table.withAttrs [class_ "w-48 max-md:hidden"]
+               , Table.col "Tags" renderTagsCol & Table.withAttrs [class_ "w-48 max-md:hidden"]
+               , Table.col "Widgets" renderWidgetsCol & Table.withAttrs [class_ "w-24 max-md:hidden"]
+               ]
 
     let table =
           Table
@@ -1663,7 +1582,7 @@ dashboardsGet_ dg = do
                           [ Table.BulkAction{icon = Just "plus", title = "Add teams", uri = "/p/" <> dg.projectId.toText <> "/dashboards/bulk_action/add_teams"}
                           , Table.BulkAction{icon = Just "trash", title = "Delete", uri = "/p/" <> dg.projectId.toText <> "/dashboards/bulk_action/delete"}
                           ]
-                  , Table.search = if dg.embedded || dg.hideActions || inCopyMode then Nothing else Just Table.ClientSide
+                  , Table.search = if noBulkActions then Nothing else Just Table.ClientSide
                   , Table.tableHeaderActions = dg.tableActions
                   , Table.header = if dg.embedded || null dg.filters.tag || inCopyMode then Nothing else Just $ activeFilters_ dg.projectId baseUrl dg.filters
                   , Table.zeroState = if dg.embedded then Nothing else Just Table.ZeroState{icon = "chart-area", title = "No dashboards yet", description = "Create your first dashboard to visualize your data", actionText = "Create Dashboard", destination = Left "newDashboardMdl"}
@@ -1724,7 +1643,7 @@ dashboardsGetH pid sortM embeddedM teamIdM copyWidgetIdM sourceDashIdM newM filt
     Nothing -> V.fromList <$> Dashboards.selectDashboardsSortedBy pid orderByClause
 
   -- Collect all available tags from all dashboards (before filtering)
-  let availableTags = L.nub $ concatMap (V.toList . (.tags)) (V.toList dashboards')
+  let availableTags = ordNub $ concatMap (V.toList . (.tags)) (V.toList dashboards')
 
   -- Apply tag filtering
   let dashboards = if null filters.tag then dashboards' else V.filter (\d -> any (`elem` filters.tag) (V.toList d.tags)) dashboards'
@@ -1732,14 +1651,14 @@ dashboardsGetH pid sortM embeddedM teamIdM copyWidgetIdM sourceDashIdM newM filt
   teams <- V.fromList <$> ManageMembers.getTeams pid
 
   -- Check if we're requesting in embedded mode (for modals, etc.)
-  let embedded = embeddedM == Just "true" || embeddedM == Just "1" || embeddedM == Just "yes"
+  let embedded = maybe False (`elem` ["true", "1", "yes"]) embeddedM
       isTeamView = isJust teamIdM
       copyMode = (,) <$> copyWidgetIdM <*> (UUIDId <$> sourceDashIdM)
 
   templates <- getDashboardTemplates bw.config.liveReloadDashboards
   if embedded || isTeamView
     then -- For embedded/team mode, use a minimal BWConfig that will still work with ToHtml instance
-      addRespHeaders $ DashboardsGetSlim DashboardsGetD{dashboards, projectId = pid, embedded, hideActions = isTeamView, teams, tableActions = Nothing, filters, availableTags, copyMode, dashTemplates = templates, showNew = False}
+      addRespHeaders $ DashboardsGetSlim DashboardsGetD{dashboards, projectId = pid, embedded, hideActions = isTeamView, teams, tableActions = Nothing, filters, copyMode, dashTemplates = templates, showNew = False}
     else do
       freeTierStatus <- checkFreeTierStatus pid project.paymentPlan
       let bwconf =
@@ -1763,7 +1682,7 @@ dashboardsGetH pid sortM embeddedM teamIdM copyWidgetIdM sourceDashIdM newM filt
                 , activeFilters = [("Tags", filters.tag) | not (null filters.tag)]
                 , headerExtra = Nothing
                 }
-      addRespHeaders $ DashboardsGet (PageCtx bwconf $ DashboardsGetD{dashboards, projectId = pid, embedded = False, hideActions = False, teams, tableActions, filters, availableTags, copyMode, dashTemplates = templates, showNew = isJust newM})
+      addRespHeaders $ DashboardsGet (PageCtx bwconf $ DashboardsGetD{dashboards, projectId = pid, embedded = False, hideActions = False, teams, tableActions, filters, copyMode, dashTemplates = templates, showNew = isJust newM})
 
 
 data DashboardRes = DashboardNoContent | DashboardPostError Text | DashboardRenameSuccess Text
@@ -1800,7 +1719,7 @@ dashboardsPostH pid form = do
       let dashM = find (\dashboard -> dashboard.file == Just form.file) templates
       let redirectURI = "/p/" <> pid.toText <> "/dashboards/" <> did.toText
           dir = fromMaybe "" form.fileDir
-          filePath = if T.null dir then Nothing else Just $ (if T.last dir == '/' then dir else dir <> "/") <> GitSync.titleToFilePath form.title
+          filePath = if T.null dir then Nothing else Just $ dashFilePath dir form.title
       let dbd =
             Dashboards.DashboardVM
               { id = did
@@ -1907,12 +1826,10 @@ dashboardRenamePatchH pid dashId form = do
     Just dashVM -> do
       _ <- Dashboards.updateTitle dashId form.title
 
-      whenJust dashVM.schema \_ ->
-        void $ Dashboards.updateSchema dashId (fromMaybe def dashVM.schema & #title ?~ form.title)
+      whenJust dashVM.schema \schema ->
+        void $ Dashboards.updateSchema dashId (schema & #title ?~ form.title)
 
-      -- Update file path: directory + auto-generated filename
-      let dir = fromMaybe "" form.fileDir
-          newPath = (if T.null dir || T.last dir == '/' then dir else dir <> "/") <> GitSync.titleToFilePath form.title
+      let newPath = dashFilePath (fromMaybe "" form.fileDir) form.title
       when (Just newPath /= dashVM.filePath)
         $ void
         $ GitSync.updateDashboardGitInfo dashId newPath ""
@@ -1964,15 +1881,11 @@ dashboardStarPostH :: Projects.ProjectId -> Dashboards.DashboardId -> ATAuthCtx 
 dashboardStarPostH pid dashId = do
   _ <- Projects.sessionAndProject pid
   now <- Time.currentTime
-  mDashboard <- Dashboards.getDashboardById dashId
-  case mDashboard of
-    Nothing -> throwError $ err404{errBody = "Dashboard not found"}
-    Just dashVM -> do
-      let newStarredSince = if isJust dashVM.starredSince then Nothing else Just now
-      _ <- Dashboards.updateStarredSince dashId newStarredSince
-      let msg = if isJust newStarredSince then "Dashboard starred" else "Dashboard unstarred"
-      addSuccessToast msg Nothing
-      addRespHeaders $ starButton_ pid dashId (isJust newStarredSince)
+  dashVM <- Dashboards.getDashboardById dashId `whenNothingM` throwError err404{errBody = "Dashboard not found"}
+  let newStarredSince = if isJust dashVM.starredSince then Nothing else Just now
+  _ <- Dashboards.updateStarredSince dashId newStarredSince
+  addSuccessToast (if isJust newStarredSince then "Dashboard starred" else "Dashboard unstarred") Nothing
+  addRespHeaders $ starButton_ pid dashId (isJust newStarredSince)
 
 
 -- | Handler for deleting a dashboard.
@@ -1981,15 +1894,11 @@ dashboardStarPostH pid dashId = do
 dashboardDeleteH :: Projects.ProjectId -> Dashboards.DashboardId -> ATAuthCtx (RespHeaders DashboardRes)
 dashboardDeleteH pid dashId = do
   _ <- Projects.sessionAndProject pid
-  mDashboard <- Dashboards.getDashboardById dashId
-  case mDashboard of
-    Nothing -> throwError $ err404{errBody = "Dashboard not found or does not belong to this project"}
-    Just _ -> do
-      _ <- Dashboards.deleteDashboard dashId
-      let redirectURI = "/p/" <> pid.toText <> "/dashboards"
-      redirectCS redirectURI
-      addSuccessToast "Dashboard was deleted successfully" Nothing
-      addRespHeaders DashboardNoContent
+  _ <- Dashboards.getDashboardById dashId `whenNothingM` throwError err404{errBody = "Dashboard not found or does not belong to this project"}
+  _ <- Dashboards.deleteDashboard dashId
+  redirectCS $ "/p/" <> pid.toText <> "/dashboards"
+  addSuccessToast "Dashboard was deleted successfully" Nothing
+  addRespHeaders DashboardNoContent
 
 
 data DashboardBulkActionForm = DashboardBulkActionForm
@@ -2070,19 +1979,14 @@ dashboardDuplicateWidgetPostH pid targetDashId widgetId sourceDashIdM = do
       -- Get target dashboard name for toast message (if cross-dashboard)
       targetDashNameM <-
         if isCrossDashboard
-          then do
-            (targetDashVM, _) <- getDashAndVM targetDashId Nothing
-            pure $ Just $ dashTitle targetDashVM.title
+          then Just . dashTitle . (.title) . fst <$> getDashAndVM targetDashId Nothing
           else pure Nothing
 
       let titleSuffix = bool " (Copy)" "" isCrossDashboard
           widgetCopy =
             widgetToDuplicate
               { Widget.id = Just newWidgetId
-              , Widget.title = case widgetToDuplicate.title of
-                  Nothing -> Just $ "Widget" <> titleSuffix
-                  Just "" -> Just $ "Widget" <> titleSuffix
-                  Just title -> Just (title <> titleSuffix)
+              , Widget.title = Just $ (case maybeToMonoid widgetToDuplicate.title of "" -> "Widget"; t -> t) <> titleSuffix
               , Widget._projectId = Just pid
               , Widget._dashboardId = Just targetDashId.toText
               , Widget.alertId = newAlertIdM
@@ -2091,31 +1995,23 @@ dashboardDuplicateWidgetPostH pid targetDashId widgetId sourceDashIdM = do
 
       -- Add widget to target dashboard (might be same as source)
       (_, targetDash) <- getDashAndVM targetDashId Nothing
-      let targetHasTabs = not (null (fromMaybe [] targetDash.tabs))
-          addedToTab = targetHasTabs && isJust (viaNonEmpty head (fromMaybe [] targetDash.tabs))
+      let targetTabs = fold targetDash.tabs
+          firstTabM = viaNonEmpty head targetTabs
 
       Log.logTrace "Widget duplication"
         $ AE.object
           [ "widgetId" AE..= widgetId
           , "targetDashboardId" AE..= targetDashId
-          , "addedToTab" AE..= addedToTab
-          , "targetTabCount" AE..= length (fromMaybe [] targetDash.tabs)
+          , "addedToTab" AE..= isJust firstTabM
+          , "targetTabCount" AE..= length targetTabs
           ]
 
-      let updatedDash =
-            if targetHasTabs
-              then case viaNonEmpty head (fromMaybe [] targetDash.tabs) of
-                Just firstTab -> updateTabBySlug (slugify firstTab.name) (#widgets %~ (<> [widgetCopy])) targetDash
-                Nothing -> targetDash & #widgets %~ (<> [widgetCopy])
-              else targetDash & #widgets %~ (<> [widgetCopy])
+      let updatedDash = maybe (targetDash & #widgets %~ (<> [widgetCopy])) (\t -> updateTabBySlug (slugify t.name) (#widgets %~ (<> [widgetCopy])) targetDash) firstTabM
       _ <- Dashboards.updateSchemaAndUpdatedAt targetDashId updatedDash now
       syncDashboardAndQueuePush pid targetDashId
 
       addWidgetJSON $ Widget.encodeText widgetCopy
-      let toastMsg = case targetDashNameM of
-            Just name -> "Widget copied to " <> name
-            Nothing -> "Widget duplicated successfully"
-      addSuccessToast toastMsg Nothing
+      addSuccessToast (maybe "Widget duplicated successfully" ("Widget copied to " <>) targetDashNameM) Nothing
       addRespHeaders widgetCopy
 
 
@@ -2126,12 +2022,10 @@ dashboardWidgetExpandGetH pid dashId widgetId = do
   now <- Time.currentTime
   let timeParams = (Nothing, Nothing, Nothing)
       paramsWithVarDefaults = addVariableDefaults [] dash.variables
-  (_, allParamsWithConstants) <- processConstantsAndExtendParams pid now timeParams paramsWithVarDefaults (dashboardQueryText dash) (fromMaybe [] dash.constants)
-  case snd <$> findWidgetInDashboard widgetId dash of
-    Nothing -> throwError $ err404{errBody = "Widget not found in dashboard"}
-    Just widgetToExpand -> do
-      processedWidget <- processWidget pid now timeParams allParamsWithConstants widgetToExpand
-      addRespHeaders $ widgetViewerEditor_ pid project.paymentPlan (Just dashId) Nothing Nothing (Just processedWidget) "edit"
+  (_, allParamsWithConstants) <- processConstantsAndExtendParams pid now timeParams paramsWithVarDefaults (dashboardQueryText dash) (fold dash.constants)
+  widgetToExpand <- (snd <$> findWidgetInDashboard widgetId dash) `whenNothing` throwError err404{errBody = "Widget not found in dashboard"}
+  processedWidget <- processWidget pid now timeParams allParamsWithConstants widgetToExpand
+  addRespHeaders $ widgetViewerEditor_ pid project.paymentPlan (Just dashId) Nothing Nothing (Just processedWidget) "edit"
 
 
 -- | SQL preview endpoint for debugging KQL queries (shows generated SQL)
@@ -2185,8 +2079,8 @@ findWidgetInDashboard wid dash = tabResult <|> rootResult
     match w = w.id == Just wid || maybeToMonoid (slugify <$> w.title) == wid
     -- Recursively search widget and its children
     findInWidget :: Widget.Widget -> Maybe Widget.Widget
-    findInWidget w = mfilter match (pure w) <|> asum (maybe [] (map findInWidget) w.children)
-    tabResult = listToMaybe [(Just $ slugify t.name, w') | t <- fromMaybe [] dash.tabs, w <- t.widgets, w' <- maybeToList (findInWidget w)]
+    findInWidget w = mfilter match (pure w) <|> asum (foldMap (map findInWidget) w.children)
+    tabResult = listToMaybe [(Just $ slugify t.name, w') | t <- fold dash.tabs, w <- t.widgets, w' <- maybeToList (findInWidget w)]
     rootResult = (Nothing,) <$> asum (map findInWidget dash.widgets)
 
 
@@ -2219,7 +2113,7 @@ addVariableDefaults :: [(Text, Maybe Text)] -> Maybe [Dashboards.Variable] -> [(
 addVariableDefaults params varsM = params <> defaults
   where
     paramsMap = Map.fromList params
-    defaults = [("var-" <> v.key, v.value) | v <- fromMaybe [] varsM, not (Map.member ("var-" <> v.key) paramsMap)]
+    defaults = [("var-" <> v.key, v.value) | v <- fold varsM, not (Map.member ("var-" <> v.key) paramsMap)]
 
 
 -- | All query text that can reference a @{{const-…}}@ placeholder, across a
@@ -2228,9 +2122,9 @@ addVariableDefaults params varsM = params <> defaults
 -- query (e.g. a top_resources GROUP BY full-day scan) on every page load.
 dashboardQueryText :: Dashboards.Dashboard -> Text
 dashboardQueryText dash =
-  T.concat $ concatMap widgetText (dash.widgets <> foldMap (.widgets) (fromMaybe [] dash.tabs)) <> foldMap varText (fromMaybe [] dash.variables)
+  T.concat $ concatMap widgetText (dash.widgets <> foldMap (.widgets) (fold dash.tabs)) <> foldMap varText (fold dash.variables)
   where
-    widgetText w = catMaybes [w.query, w.sql] <> concatMap widgetText (fromMaybe [] w.children)
+    widgetText w = catMaybes [w.query, w.sql] <> concatMap widgetText (fold w.children)
     varText v = catMaybes [v.sql, v.query]
 
 
@@ -2248,8 +2142,8 @@ processConstantsAndExtendParams pid now timeParams allParams haystack constants 
   pooledForConcurrently constants processOne <&> \pc ->
     ( pc
     , allParams
-        <> [("const-" <> c.key, Just $ constantToSQLList $ fromMaybe [] c.result) | c <- pc]
-        <> [("const-" <> c.key <> "-kql", Just $ constantToKQLList $ fromMaybe [] c.result) | c <- pc]
+        <> [("const-" <> c.key, Just $ constantToSQLList $ fold c.result) | c <- pc]
+        <> [("const-" <> c.key <> "-kql", Just $ constantToKQLList $ fold c.result) | c <- pc]
     )
   where
     processOne c
@@ -2257,18 +2151,21 @@ processConstantsAndExtendParams pid now timeParams allParams haystack constants 
       | otherwise = pure c -- unreferenced: emit empty-sentinel params without running the query
 
 
--- | Create a widget processor that adds dashboard ID to processed widgets.
--- Pre-computes replacement maps once for efficiency across all widgets.
-mkWidgetProcessor
+-- | Full render pipeline for a set of widgets: concurrent processing (tagged with
+-- the dashboard id), then alert statuses and PNG URLs.
+processDashWidgets
   :: Projects.ProjectId
   -> Dashboards.DashboardId
   -> UTCTime
   -> (Maybe Text, Maybe Text, Maybe Text)
   -> [(Text, Maybe Text)]
-  -> Widget.Widget
-  -> ATAuthCtx Widget.Widget
-mkWidgetProcessor pid dashId now timeParams paramsWithConstants =
-  fmap (#_dashboardId ?~ dashId.toText) . processWidget pid now timeParams paramsWithConstants
+  -> [Widget.Widget]
+  -> ATAuthCtx [Widget.Widget]
+processDashWidgets pid dashId now timeParams paramsWithConstants widgets = do
+  appCtx <- ask @AuthContext
+  pooledForConcurrently widgets (fmap (#_dashboardId ?~ dashId.toText) . processWidget pid now timeParams paramsWithConstants)
+    >>= populateWidgetAlertStatuses
+    >>= populateWidgetPngUrls appCtx.env.apiKeyEncryptionSecretKey appCtx.config.hostUrl pid timeParams
 
 
 -- | Handler for dashboard with tab in path: /p/{pid}/dashboards/{dash_id}/tab/{tab_slug}
@@ -2276,7 +2173,6 @@ mkWidgetProcessor pid dashId now timeParams paramsWithConstants =
 dashboardTabGetH :: Projects.ProjectId -> Dashboards.DashboardId -> Text -> Maybe Text -> Maybe Text -> Maybe Text -> Maybe Text -> [(Text, Maybe Text)] -> ATAuthCtx (RespHeaders (PageCtx DashboardGet))
 dashboardTabGetH pid dashId tabSlug fileM fromDStr toDStr sinceStr allParams = do
   (_, project, bw) <- mkPageCtx pid
-  appCtx <- ask @AuthContext
   now <- Time.currentTime
   let (_fromD, _toD, currentRange) = TimePicker.parseTimeRange now (TimePicker.TimePicker sinceStr fromDStr toDStr)
 
@@ -2290,27 +2186,16 @@ dashboardTabGetH pid dashId tabSlug fileM fromDStr toDStr sinceStr allParams = d
       paramsWithVarDefaults = addVariableDefaults allParams dash.variables
 
   -- Process constants and variables
-  (processedConstants, allParamsWithConstants) <- processConstantsAndExtendParams pid now timeParams paramsWithVarDefaults (dashboardQueryText dash) (fromMaybe [] dash.constants)
-  let dashWithConstants = dash & #constants ?~ processedConstants
-      processWidgetWithDashboardId = mkWidgetProcessor pid dashId now timeParams allParamsWithConstants
+  (processedConstants, allParamsWithConstants) <- processConstantsAndExtendParams pid now timeParams paramsWithVarDefaults (dashboardQueryText dash) (fold dash.constants)
+  dash' <- processVariablesConcurrently pid now timeParams allParamsWithConstants (dash & #constants ?~ processedConstants)
 
-  dash' <- processVariablesConcurrently pid now timeParams allParamsWithConstants dashWithConstants
-
-  -- Only process widgets for the ACTIVE tab (lazy loading - other tabs load via htmx)
+  -- Only process widgets for the ACTIVE tab (lazy loading - other tabs load via htmx).
   -- Note: We don't process dash.widgets here since this is a tab-based dashboard
-  dash'' <- case dash'.tabs of
-    Just tabs -> do
-      processedTabs <- forM (zip [0 ..] tabs) \(idx, tab) ->
-        if idx == activeTabIdx
-          then do
-            -- Process widgets concurrently for faster initial page load
-            processedWidgets <- pooledForConcurrently tab.widgets processWidgetWithDashboardId
-            widgetsWithAlerts <- populateWidgetAlertStatuses processedWidgets
-            widgetsWithPngUrls <- populateWidgetPngUrls appCtx.env.apiKeyEncryptionSecretKey bw.config.hostUrl pid timeParams widgetsWithAlerts
-            pure $ tab & #widgets .~ widgetsWithPngUrls
-          else pure tab -- Don't process widgets for inactive tabs
-      pure $ dash' & #tabs ?~ processedTabs
-    Nothing -> pure dash'
+  dash'' <- forOf (#tabs . _Just) dash' \tabs ->
+    forM (zip [0 ..] tabs) \(idx, tab) ->
+      if idx == activeTabIdx
+        then (\ws -> tab & #widgets .~ ws) <$> processDashWidgets pid dashId now timeParams allParamsWithConstants tab.widgets
+        else pure tab
 
   freeTierStatus <- checkFreeTierStatus pid project.paymentPlan
 
@@ -2341,43 +2226,31 @@ dashboardTabGetH pid dashId tabSlug fileM fromDStr toDStr sinceStr allParams = d
 dashboardTabContentGetH :: Projects.ProjectId -> Dashboards.DashboardId -> Text -> Maybe Text -> Maybe Text -> Maybe Text -> Maybe Text -> [(Text, Maybe Text)] -> ATAuthCtx (RespHeaders (Html ()))
 dashboardTabContentGetH pid dashId tabSlug fileM fromDStr toDStr sinceStr allParams = do
   _ <- Projects.sessionAndProject pid
-  appCtx <- ask @AuthContext
   now <- Time.currentTime
-  (_dashVM, dash) <- getDashAndVM dashId fileM
+  (_, dash) <- getDashAndVM dashId fileM
   let timeParams = (sinceStr, fromDStr, toDStr)
       paramsWithVarDefaults = addVariableDefaults allParams dash.variables
       -- Check if constants are already in params (passed from initial page load)
       hasConstants = any (\(k, _) -> "const-" `T.isPrefixOf` k) allParams
 
-  -- Find the tab by slug
-  case dash.tabs of
-    Nothing -> throwError $ err404{errBody = "Dashboard has no tabs"}
-    Just tabs -> case findTabBySlug tabs tabSlug of
-      Nothing -> throwError $ err404{errBody = "Tab not found: " <> encodeUtf8 tabSlug}
-      Just (idx, tab) -> do
-        -- Skip constant processing if already provided via params (avoids redundant SQL queries)
-        allParamsWithConstants <-
-          if hasConstants
-            then pure paramsWithVarDefaults
-            else snd <$> processConstantsAndExtendParams pid now timeParams paramsWithVarDefaults (dashboardQueryText dash) (fromMaybe [] dash.constants)
-        let processWidgetWithDashboardId = mkWidgetProcessor pid dashId now timeParams allParamsWithConstants
+  tabs <- dash.tabs `whenNothing` throwError err404{errBody = "Dashboard has no tabs"}
+  (idx, tab) <- findTabBySlug tabs tabSlug `whenNothing` throwError err404{errBody = "Tab not found: " <> encodeUtf8 tabSlug}
 
-        -- Process variables to check if tab requires one that's not set
-        dash' <- processVariablesConcurrently pid now timeParams allParamsWithConstants dash
-        let varToPrompt = findVarToPrompt (Just tab) (fromMaybe [] dash'.variables)
+  -- Skip constant processing if already provided via params (avoids redundant SQL queries)
+  allParamsWithConstants <-
+    if hasConstants
+      then pure paramsWithVarDefaults
+      else snd <$> processConstantsAndExtendParams pid now timeParams paramsWithVarDefaults (dashboardQueryText dash) (fold dash.constants)
 
-        -- Process widgets concurrently to speed up tabs with multiple eager widgets
-        processedWidgets <- pooledForConcurrently tab.widgets processWidgetWithDashboardId
-        widgetsWithAlerts <- populateWidgetAlertStatuses processedWidgets
-        widgetsWithPngUrls <- populateWidgetPngUrls appCtx.env.apiKeyEncryptionSecretKey appCtx.config.hostUrl pid timeParams widgetsWithAlerts
+  -- Process variables to check if tab requires one that's not set
+  dash' <- processVariablesConcurrently pid now timeParams allParamsWithConstants dash
+  widgetsWithPngUrls <- processDashWidgets pid dashId now timeParams allParamsWithConstants tab.widgets
 
-        -- Render tab content panel + OOB modal if variable needs prompting + OOB form URL update
-        let widgetOrderUrl = "/p/" <> pid.toText <> "/dashboards/" <> dashId.toText <> "/widgets_order?tab=" <> tabSlug
-        addRespHeaders $ do
-          tabContentPanel_ pid dashId.toText idx tab.name widgetsWithPngUrls True True
-          whenJust varToPrompt \v -> variablePickerModal_ pid dashId (Just tabSlug) allParamsWithConstants v True
-          -- OOB swap to update widget-order-trigger form's hx-patch URL for the current tab
-          widgetOrderTriggerForm_ widgetOrderUrl True
+  -- Render tab content panel + OOB modal if variable needs prompting + OOB form URL update
+  addRespHeaders do
+    tabContentPanel_ pid dashId.toText idx tab.name widgetsWithPngUrls True
+    whenJust (findVarToPrompt (Just tab) (fold dash'.variables)) \v -> variablePickerModal_ pid dashId (Just tabSlug) allParamsWithConstants v True
+    widgetOrderTriggerForm_ ("/p/" <> pid.toText <> "/dashboards/" <> dashId.toText <> "/widgets_order?tab=" <> tabSlug) True
 
 
 -- | Skeleton loader shown while GridStack initializes
@@ -2393,19 +2266,18 @@ dashboardSkeleton_ = div_ [class_ "dashboard-skeleton absolute inset-0 z-10 bg-b
     div_ [class_ "col-span-4 max-md:hidden h-24 rounded-lg skeleton-shimmer"] ""
 
 
--- | Render a single tab content panel
+-- | Render a single tab content panel.
 -- isPartial: True for HTMX partial loads (include OOB swap), False for full page loads
-tabContentPanel_ :: Projects.ProjectId -> Text -> Int -> Text -> [Widget.Widget] -> Bool -> Bool -> Html ()
-tabContentPanel_ pid dashboardId idx tabName widgets isActive isPartial = do
+tabContentPanel_ :: Projects.ProjectId -> Text -> Int -> Text -> [Widget.Widget] -> Bool -> Html ()
+tabContentPanel_ pid dashboardId idx tabName widgets isPartial = do
   when isPartial $ breadcrumbSuffixOob_ tabName
-  -- Tab content panel
   div_
-    [ class_ $ "tab-panel grid-stack -m-2" <> if isActive then "" else " hidden"
+    [ class_ "tab-panel grid-stack -m-2"
     , data_ "tab-index" (show idx)
     , id_ $ "tab-panel-" <> dashboardId <> "-" <> show idx
     ]
     do
-      forM_ widgets (\w -> toHtml (w{Widget._projectId = Just pid}))
+      forM_ widgets \w -> toHtml w{Widget._projectId = Just pid}
       when (null widgets) $ label_ [id_ $ "add_widget_tab_" <> show idx, class_ "grid-stack-item pb-8 cursor-pointer bg-fillBrand-weak border-2 border-strokeBrand-strong border-dashed text-strokeSelected rounded-sm rounded-lg flex flex-col gap-3 items-center justify-center", term "gs-w" "3", term "gs-h" "2", Lucid.for_ "page-data-drawer"] do
         faSprite_ "plus" "regular" "h-8 w-8"
         span_ "Add a widget"
@@ -2436,33 +2308,26 @@ instance ToHtml TabRenameRes where
 dashboardTabRenamePatchH :: Projects.ProjectId -> Dashboards.DashboardId -> Text -> TabRenameForm -> ATAuthCtx (RespHeaders TabRenameRes)
 dashboardTabRenamePatchH pid dashId tabSlug form = do
   _ <- Projects.sessionAndProject pid
-  (dashVM, dash) <- getDashAndVM dashId Nothing
+  (_, dash) <- getDashAndVM dashId Nothing
   now <- Time.currentTime
 
-  case dash.tabs of
-    Nothing -> throwError $ err404{errBody = "Dashboard has no tabs"}
-    Just tabs -> case findTabBySlug tabs tabSlug of
-      Nothing -> throwError $ err404{errBody = "Tab not found: " <> encodeUtf8 tabSlug}
-      Just (idx, _) -> do
-        let updatedTabs = tabs & ix idx . #name .~ form.newName
-            updatedDash = dash & #tabs ?~ updatedTabs
-            newSlug = slugify form.newName
+  tabs <- dash.tabs `whenNothing` throwError err404{errBody = "Dashboard has no tabs"}
+  (idx, _) <- findTabBySlug tabs tabSlug `whenNothing` throwError err404{errBody = "Tab not found: " <> encodeUtf8 tabSlug}
 
-        -- Update the dashboard schema
-        _ <- Dashboards.updateSchemaAndUpdatedAt dashId updatedDash now
-        syncDashboardAndQueuePush pid dashId
+  let newSlug = slugify form.newName
+  _ <- Dashboards.updateSchemaAndUpdatedAt dashId (dash & #tabs ?~ (tabs & ix idx . #name .~ form.newName)) now
+  syncDashboardAndQueuePush pid dashId
 
-        addSuccessToast "Tab renamed successfully" Nothing
-        -- Redirect to new tab URL after rename
-        redirectCS $ "/p/" <> pid.toText <> "/dashboards/" <> dashId.toText <> "/tab/" <> newSlug
-        addRespHeaders $ TabRenameRes{newName = form.newName, newSlug = newSlug}
+  addSuccessToast "Tab renamed successfully" Nothing
+  redirectCS $ "/p/" <> pid.toText <> "/dashboards/" <> dashId.toText <> "/tab/" <> newSlug
+  addRespHeaders TabRenameRes{newName = form.newName, newSlug}
 
 
 -- | Unified dashboard actions (add widget button, yaml drawer, context menu)
 dashboardActions_ :: Projects.ProjectId -> Text -> Dashboards.DashboardId -> Maybe Text -> Maybe (Text, Text) -> Html ()
 dashboardActions_ pid paymentPlan dashId tabSlugM currentRange = div_ [class_ "flex items-center"] do
   span_ [class_ "text-fillDisabled mr-2 max-md:hidden"] "|"
-  div_ [class_ "max-md:hidden"] $ Components.drawer_ "page-data-drawer" False Nothing (Just $ newWidget_ pid paymentPlan dashId tabSlugM currentRange) $ span_ [class_ "text-iconNeutral cursor-pointer p-2 hover:bg-fillWeak rounded-lg tap-target", Aria.label_ "Add a new widget", data_ "tippy-content" "Add a new widget"] $ faSprite_ "plus" "regular" "w-3 h-3"
+  div_ [class_ "max-md:hidden"] $ Components.drawer_ "page-data-drawer" False Nothing (Just $ widgetViewerEditor_ pid paymentPlan (Just dashId) tabSlugM currentRange Nothing "edit") $ span_ [class_ "text-iconNeutral cursor-pointer p-2 hover:bg-fillWeak rounded-lg tap-target", Aria.label_ "Add a new widget", data_ "tippy-content" "Add a new widget"] $ faSprite_ "plus" "regular" "w-3 h-3"
   div_ [class_ "max-md:hidden"] $ yamlEditorDrawer_ pid dashId
   let dashActionsPop = "dash-actions-" <> dashId.toText
   div_ [class_ "inline-block"] do

--- a/src/Pages/Dashboards.hs
+++ b/src/Pages/Dashboards.hs
@@ -614,7 +614,7 @@ processVariable pid now (sinceStr, fromDStr, toDStr) allParams variableBase = do
   facetOpts <- case variable.facetField of
     Just field -> do
       docM <- SchemaCatalog.getSummary pid
-      pure $ docM >>= \(d :: Catalog.SummaryDoc) -> HM.lookup field d.topValuesByField <&> \tk -> map ((: []) . fst) $ sortOn (Down . snd) $ HM.toList tk.top
+      pure $ docM >>= \(d :: Catalog.SummaryDoc) -> HM.lookup field d.topValuesByField <&> \tk -> map (one . fst) $ sortWith (Down . snd) $ HM.toList tk.top
     Nothing -> pure Nothing
   case facetOpts of
     Just opts | not (null opts) -> pure variable{Dashboards.options = Just opts}

--- a/src/Pages/Dashboards.hs
+++ b/src/Pages/Dashboards.hs
@@ -282,13 +282,14 @@ dashboardPage_ pid dashId dash dashVM allParams = do
               , data_ "tagify-whitelist" whitelist
               , data_ "tagify-enforce-whitelist" ""
               , data_ "tagify-text-prop" "name"
-              , data_ "tagify-mode" $ if var.multi == Just True then "" else "select"
               , data_ "tagify-query-sql" $ maybeToMonoid var.sql
               , data_ "tagify-query" $ maybeToMonoid var.query
               , data_ "tagify-reload-on-change" $ maybe "false" (T.toLower . show) var.reloadOnChange
               , value_ $ maybeToMonoid var.value
               ]
-            <> memptyIfFalse (var.multi == Just True) [data_ "tagify-mode" "select"]
+            -- Multi vars must carry NO tagify-mode attr (main.ts only sets options.mode
+            -- when present); a second data_ attr would be (<>)-merged by Lucid.
+            <> memptyIfFalse (var.multi /= Just True) [data_ "tagify-mode" "select"]
   let widgetOrderUrl = "/p/" <> pidText <> "/dashboards/" <> dashIdText <> "/widgets_order" <> maybe "" ("?tab=" <>) renderTabSlug
       constantsJson = decodeUtf8 $ AE.encode $ HM.fromList [(k, fromMaybe "" v) | (k, v) <- allParams, "const-" `T.isPrefixOf` k]
 

--- a/src/Pages/Endpoints.hs
+++ b/src/Pages/Endpoints.hs
@@ -3,6 +3,7 @@ module Pages.Endpoints (apiCatalogH, HostEventsVM (..), endpointListGetH, Catalo
 import Data.Aeson qualified as AE
 import Data.Cache qualified as Cache
 import Data.Default (def)
+import Data.List (lookup)
 import Data.Text qualified as T
 import Data.Time (UTCTime)
 import Data.Time.LocalTime (ZonedTime, zonedTimeToUTC)
@@ -33,24 +34,14 @@ apiCatalogH pid sortM timeFilter currentTabM periodM skipM filterTabM statsM = d
   (_, project, bw) <- mkPageCtx pid
 
   -- Legacy request_type=… kept alongside the unified ?filter=… for shared links.
-  let normTab t = if t `elem` ["Incoming", "Outgoing", "Archived"] then Just t else Nothing
+  let normTab = guarded (`elem` ["Incoming", "Outgoing", "Archived"])
       currentTab = fromMaybe "Incoming" $ asum $ map (>>= normTab) [filterTabM, currentTabM]
       currentSort = fromMaybe "-events" sortM
       filterV = fromMaybe "24H" timeFilter
       period = fromMaybe "24h" periodM
       showArchived = currentTab == "Archived"
-      outgoingM :: Maybe Bool
-      outgoingM = case currentTab of
-        "Outgoing" -> Just True
-        "Incoming" -> Just False
-        _ -> Nothing
-      -- Map new sort format to old format for DB query
-      sortV = case currentSort of
-        "-events" -> "events"
-        "+events" -> "events"
-        "-name" -> "name"
-        "+name" -> "name"
-        _ -> "events"
+      outgoingM = directionOf currentTab
+      sortV = bool "events" "name" (currentSort `elem` ["-name", "+name"])
 
   appCtx <- ask @AuthContext
   -- The host list is a cheap Postgres read; the per-host counts and sparkline scan a
@@ -80,6 +71,9 @@ apiCatalogH pid sortM timeFilter currentTabM periodM skipM filterTabM statsM = d
           then BulkAction{icon = Just "rotate-left", title = "Unarchive", uri = "/p/" <> pid.toText <> "/api_catalog/bulk_action/unarchive"}
           else BulkAction{icon = Just "archive", title = "Archive", uri = "/p/" <> pid.toText <> "/api_catalog/bulk_action/archive?request_type=" <> currentTab}
       hostsVM = V.fromList $ map (\events -> HostEventsVM{events, currTime, statsMode}) hostsAndEvents
+      cols = catalogColumns pid baseUrl period
+      hostRowId = Just \(vm :: HostEventsVM) -> vm.events.host
+      hostRowAttrs = Just $ const [class_ "group/row hover:bg-fillWeaker"]
       tableActions =
         TableHeaderActions
           { baseUrl
@@ -93,15 +87,15 @@ apiCatalogH pid sortM timeFilter currentTabM periodM skipM filterTabM statsM = d
           , activeFilters = []
           , headerExtra = Nothing
           }
-  let catalogTable =
+      catalogTable =
         Table
           { config = def{elemID = "apiCatalogForm", containerId = Just "apiCatalogContainer", addPadding = True, renderAsTable = True, bulkActionsInHeader = Just 0, refreshOnEvent = Just ("apiCatalogChanged", statsUrl), deferredUrl = statsUrl <$ guard (statsMode == Endpoints.ShellOnly)}
-          , columns = catalogColumns pid currentTab baseUrl period
+          , columns = cols
           , rows = hostsVM
           , features =
               def
-                { rowId = Just (.events.host)
-                , rowAttrs = Just $ const [class_ "group/row hover:bg-fillWeaker"]
+                { rowId = hostRowId
+                , rowAttrs = hostRowAttrs
                 , bulkActions = [bulkActionItem]
                 , search = Just ClientSide
                 , tableHeaderActions = Just tableActions
@@ -119,11 +113,10 @@ apiCatalogH pid sortM timeFilter currentTabM periodM skipM filterTabM statsM = d
                         }
                 }
           }
-
-  let bwconf =
+      bwconf =
         bw
           { pageTitle = "API Catalog"
-          , freeTierStatus = freeTierStatus
+          , freeTierStatus
           , navTabs =
               Just
                 $ toHtml
@@ -138,9 +131,9 @@ apiCatalogH pid sortM timeFilter currentTabM periodM skipM filterTabM statsM = d
                       ]
                   }
           }
-  case skipM of
-    Just _ -> addRespHeaders $ CatalogListRows $ TableRows{columns = catalogColumns pid currentTab baseUrl period, rows = hostsVM, emptyState = Nothing, renderAsTable = True, rowId = Just (.events.host), rowAttrs = Just $ const [class_ "group/row hover:bg-fillWeaker"], pagination = Nothing}
-    _ -> addRespHeaders $ CatalogListPage $ PageCtx bwconf catalogTable
+  addRespHeaders case skipM of
+    Just _ -> CatalogListRows TableRows{columns = cols, rows = hostsVM, emptyState = Nothing, renderAsTable = True, rowId = hostRowId, rowAttrs = hostRowAttrs, pagination = Nothing}
+    Nothing -> CatalogListPage $ PageCtx bwconf catalogTable
 
 
 -- | A catalog row: its traffic, the clock the "last seen" column renders against, and
@@ -152,9 +145,9 @@ data HostEventsVM = HostEventsVM
   }
 
 
-catalogColumns :: Projects.ProjectId -> Text -> Text -> Text -> [Column HostEventsVM]
-catalogColumns pid currentTab baseUrl period =
-  [ col "Dependency" (renderCatalogMainCol pid currentTab) & withAttrs [class_ "min-w-0 max-w-0 w-full"]
+catalogColumns :: Projects.ProjectId -> Text -> Text -> [Column HostEventsVM]
+catalogColumns pid baseUrl period =
+  [ col "Dependency" (renderCatalogMainCol pid) & withAttrs [class_ "min-w-0 max-w-0 w-full"]
   , col ("Events (" <> period <> ")") (\vm -> statCell_ vm.statsMode $ eventsCountCell_ (fromIntegral vm.events.eventCount)) & withAttrs [class_ "w-24 max-md:hidden"]
   , col "Last Seen" (\vm -> statCell_ vm.statsMode $ lastSeenCell_ vm.currTime vm.events.last_seen) & withAttrs [class_ "w-24 max-md:hidden"]
   , col "Activity" (\vm -> statCell_ vm.statsMode $ activityCell_ vm.events.activityBuckets) & withAttrs [class_ "w-40 max-md:hidden"] & withColHeaderExtra (periodToggle_ baseUrl "apiCatalogContainer" period)
@@ -165,8 +158,18 @@ logExplorerHref :: Projects.ProjectId -> Text -> Text
 logExplorerHref pid q = "/p/" <> pid.toText <> "/log_explorer?query=" <> toUriStr q
 
 
-servicesBadges_ :: Text -> Text -> (Text -> Text) -> [Text] -> Html ()
-servicesBadges_ sourceLabel kindVal badgeHref svcs =
+-- | Parse a request-direction tab label into the `outgoing` flag it filters on.
+directionOf :: Text -> Maybe Bool
+directionOf = (`lookup` [("Outgoing", True), ("Incoming", False)])
+
+
+-- | The two labels that vary by request direction: (kindVal, sourceLabel).
+directionLabels :: Bool -> (Text, Text)
+directionLabels outgoing = (bool "server" "client" outgoing, bool "Served by:" "Called by:" outgoing)
+
+
+servicesBadges_ :: Text -> (Text -> Text) -> [Text] -> Html ()
+servicesBadges_ sourceLabel badgeHref svcs =
   unless (null svcs) $ div_ [class_ "flex items-center gap-1 flex-wrap min-w-0"] do
     span_ [class_ "text-xs text-textWeak shrink-0"] $ toHtml sourceLabel
     forM_ svcs \svc ->
@@ -178,28 +181,22 @@ servicesBadges_ sourceLabel kindVal badgeHref svcs =
         $ toHtml svc
 
 
-renderCatalogMainCol :: Projects.ProjectId -> Text -> HostEventsVM -> Html ()
-renderCatalogMainCol pid _currentTab vm = do
+renderCatalogMainCol :: Projects.ProjectId -> HostEventsVM -> Html ()
+renderCatalogMainCol pid vm = do
   let he = vm.events
-  let svcs = V.toList he.services
       outgoing = he.outgoing
       reqTypeLabel = bool "Incoming" "Outgoing" outgoing :: Text
-      sourceLabel = bool "Served by:" "Called by:" outgoing
-      kindVal = bool "server" "client" outgoing
-      (arrowIcon, arrowClass, arrowTip) =
-        if outgoing
-          then ("arrow-up-right", "h-3 w-3 fill-iconBrand shrink-0", "Outgoing request" :: Text)
-          else ("arrow-down-left", "h-3 w-3 fill-iconNeutral shrink-0", "Incoming request" :: Text)
+      (kindVal, sourceLabel) = directionLabels outgoing
+      (arrowIcon, arrowClass) = bool ("arrow-down-left", "h-3 w-3 fill-iconNeutral shrink-0") ("arrow-up-right", "h-3 w-3 fill-iconBrand shrink-0") outgoing
   div_ [class_ "flex flex-col gap-1 min-w-0"] do
     div_ [class_ "flex items-center gap-2 min-w-0"] do
-      span_ [class_ "tooltip tooltip-right shrink-0 inline-flex", term "data-tip" arrowTip] $ faSprite_ arrowIcon "solid" arrowClass
+      span_ [class_ "tooltip tooltip-right shrink-0 inline-flex", term "data-tip" $ reqTypeLabel <> " request"] $ faSprite_ arrowIcon "solid" arrowClass
       a_ ([href_ $ "/p/" <> pid.toText <> "/endpoints?host=" <> he.host <> "&request_type=" <> reqTypeLabel, class_ "font-medium text-textStrong hover:text-textBrand transition-colors truncate min-w-0"] <> navTabAttrs) $ toHtml (T.replace "http://" "" $ T.replace "https://" "" he.host)
       a_ ([href_ $ logExplorerHref pid $ "attributes.net.host.name==\"" <> he.host <> "\"", class_ "shrink-0 text-xs text-textBrand hover:text-textStrong transition-colors"] <> navTabAttrs) "View logs"
     servicesBadges_
       sourceLabel
-      kindVal
       (\svc -> logExplorerHref pid $ "resource.service.name==\"" <> svc <> "\" AND kind==\"" <> kindVal <> "\"")
-      svcs
+      (V.toList he.services)
 
 
 data CatalogList = CatalogListPage (PageCtx (Table HostEventsVM)) | CatalogListRows (TableRows HostEventsVM)
@@ -227,26 +224,19 @@ endpointListGetH
   -> Maybe Text
   -> Maybe Text
   -> ATAuthCtx (RespHeaders EndpointRequestStatsVM)
-endpointListGetH pid pageM perPageM layoutM filterTM hostM currentTabM sortM periodM hxRequestM hxBoostedM hxCurrentURL loadMoreM searchM = do
+endpointListGetH pid pageM perPageM _layoutM filterTM hostM currentTabM sortM periodM _hxRequestM _hxBoostedM _hxCurrentURL loadMoreM searchM = do
   (_, project, bw) <- mkPageCtx pid
-  let (archived, currentFilterTab) = case filterTM of
-        Just "Archived" -> (True, "Archived")
-        _ -> (False, "Endpoints")
-
-  let host = maybeToMonoid $ hostM >>= \t -> if t == "" then Nothing else Just t
-      page = fromMaybe 0 $ readMaybe (toString $ fromMaybe "" pageM)
-      perPage = max 1 $ min 200 $ fromMaybe 25 $ readMaybe (toString $ fromMaybe "" perPageM)
-      hostParam = hostM >>= \h -> if h == "" then Nothing else Just h
-      isOutgoing = fromMaybe "Incoming" currentTabM == "Outgoing"
+  let archived = filterTM == Just "Archived"
+      currentFilterTab = bool "Endpoints" "Archived" archived
+      hostParam = guarded (/= "") =<< hostM
+      host = maybeToMonoid hostParam
+      page = fromMaybe 0 $ readMaybe . toString =<< pageM
+      perPage = max 1 $ min 200 $ fromMaybe 25 $ readMaybe . toString =<< perPageM
+      currentTab = fromMaybe "Incoming" currentTabM
+      isOutgoing = currentTab == "Outgoing"
       currentSort = fromMaybe "-events" sortM
       period = fromMaybe "24h" periodM
-      -- Map new sort format to old format for DB query
-      sortV = case currentSort of
-        "-events" -> Just "events"
-        "+events" -> Just "events"
-        "-name" -> Just "name"
-        "+name" -> Just "name"
-        _ -> Just "events"
+      sortV = Just $ bool "events" "name" (currentSort `elem` ["-name", "+name"])
   useTf <- (.env.enableTimefusionReads) <$> ask @AuthContext
   (endpointStats, totalCount) <-
     concurrently
@@ -254,13 +244,12 @@ endpointListGetH pid pageM perPageM layoutM filterTM hostM currentTabM sortM per
       (Endpoints.countEndpointsForHost pid isOutgoing archived hostParam searchM)
   freeTierStatus <- checkFreeTierStatus pid project.paymentPlan
 
-  let currentTab = fromMaybe "Incoming" currentTabM
-      baseUrl = [PyF.fmt|/p/{pid.toText}/endpoints?filter={currentFilterTab}&request_type={currentTab}&host={host}&sort={currentSort}&period={period}|]
-  let bwconf =
+  let baseUrl = [PyF.fmt|/p/{pid.toText}/endpoints?filter={currentFilterTab}&request_type={currentTab}&host={host}&sort={currentSort}&period={period}|]
+      bwconf =
         bw
           { prePageTitle = Just "API Catalog"
           , pageTitle = "Endpoints for " <> host
-          , freeTierStatus = freeTierStatus
+          , freeTierStatus
           , navTabs =
               Just
                 $ toHtml
@@ -276,7 +265,11 @@ endpointListGetH pid pageM perPageM layoutM filterTM hostM currentTabM sortM per
           }
 
   currTime <- Time.currentTime
-  let endpReqVM = V.map (EnpReqStatsVM False currTime period) endpointStats
+  let endpReqVM = V.map (EnpReqStatsVM currTime period) endpointStats
+      cols = endpointColumns pid baseUrl period currentTab
+      endpRowId = Just \(EnpReqStatsVM _ _ enp) -> enp.endpointHash
+      endpRowAttrs = Just $ const [class_ "group/row hover:bg-fillWeaker"]
+      pagination' = Just Pagination{currentPage = page, perPage, totalCount, baseUrl, targetId = "endpointsListContainer"}
       tableActions =
         TableHeaderActions
           { baseUrl
@@ -290,19 +283,19 @@ endpointListGetH pid pageM perPageM layoutM filterTM hostM currentTabM sortM per
           , activeFilters = []
           , headerExtra = Nothing
           }
-  let endpointsTable =
+      endpointsTable =
         Table
           { config = def{elemID = "endpointsForm", containerId = Just "endpointsListContainer", addPadding = True, renderAsTable = True, bulkActionsInHeader = Just 0, refreshOnEvent = Just ("endpointsListChanged", baseUrl)}
-          , columns = endpointColumns pid baseUrl period currentTab
+          , columns = cols
           , rows = endpReqVM
           , features =
               def
-                { rowId = Just \(EnpReqStatsVM _ _ _ enp) -> enp.endpointHash
-                , rowAttrs = Just $ const [class_ "group/row hover:bg-fillWeaker"]
+                { rowId = endpRowId
+                , rowAttrs = endpRowAttrs
                 , bulkActions = [BulkAction{icon = Just "archive", title = "Archive", uri = "/p/" <> pid.toText <> "/endpoints/bulk_action/archive"}]
                 , search = Just (ServerSide baseUrl)
                 , tableHeaderActions = Just tableActions
-                , pagination = Just Pagination{currentPage = page, perPage = perPage, totalCount = totalCount, baseUrl = baseUrl, targetId = "endpointsListContainer"}
+                , pagination = pagination'
                 , zeroState =
                     Just
                       $ ZeroState
@@ -312,27 +305,25 @@ endpointListGetH pid pageM perPageM layoutM filterTM hostM currentTabM sortM per
                         , actionText = "View SDK setup guides"
                         , destination = Right "https://monoscope.tech/docs/sdks/"
                         }
-                , header = Just $ div_ [class_ "mb-4"] $ case hostM of
-                    Just h -> span_ [] "Endpoints for: " >> span_ [class_ "text-textBrand font-bold"] (toHtml h)
-                    Nothing -> "Endpoints"
+                , header = Just $ div_ [class_ "mb-4"] $ maybe "Endpoints" (\h -> span_ [] "Endpoints for: " >> span_ [class_ "text-textBrand font-bold"] (toHtml h)) hostM
                 }
           }
-  let endpRowId = Just \(EnpReqStatsVM _ _ _ enp) -> enp.endpointHash
-      endpRowAttrs = Just $ const [class_ "group/row hover:bg-fillWeaker"]
-      rowsOnly = EndpointsListRows $ TableRows{columns = endpointColumns pid baseUrl period currentTab, rows = endpReqVM, emptyState = Nothing, renderAsTable = True, rowId = endpRowId, rowAttrs = endpRowAttrs, pagination = Just Pagination{currentPage = page, perPage = perPage, totalCount = totalCount, baseUrl = baseUrl, targetId = "endpointsListContainer"}}
-  addRespHeaders $ if isJust loadMoreM || isJust searchM then rowsOnly else EndpointsListPage $ PageCtx bwconf endpointsTable
+  addRespHeaders
+    $ if isJust loadMoreM || isJust searchM
+      then EndpointsListRows TableRows{columns = cols, rows = endpReqVM, emptyState = Nothing, renderAsTable = True, rowId = endpRowId, rowAttrs = endpRowAttrs, pagination = pagination'}
+      else EndpointsListPage $ PageCtx bwconf endpointsTable
 
 
-data EnpReqStatsVM = EnpReqStatsVM Bool UTCTime Text Endpoints.EndpointRequestStats
+data EnpReqStatsVM = EnpReqStatsVM UTCTime Text Endpoints.EndpointRequestStats
   deriving stock (Show)
 
 
 endpointColumns :: Projects.ProjectId -> Text -> Text -> Text -> [Column EnpReqStatsVM]
 endpointColumns pid baseUrl period currentTab =
   [ col "Endpoint" (renderEndpointMainCol pid currentTab) & withAttrs [class_ "min-w-0 max-w-0 w-full"]
-  , col ("Events (" <> period <> ")") (\(EnpReqStatsVM _ _ _ enp) -> eventsCountCell_ enp.totalRequests) & withAttrs [class_ "w-24 max-md:hidden"]
-  , col "Last Seen" (\(EnpReqStatsVM _ currTime _ enp) -> lastSeenCell_ currTime enp.lastSeen) & withAttrs [class_ "w-24 max-md:hidden"]
-  , col "Activity" (\(EnpReqStatsVM _ _ _ enp) -> activityCell_ enp.activityBuckets) & withAttrs [class_ "w-40 max-md:hidden"] & withColHeaderExtra (periodToggle_ baseUrl "endpointsListContainer" period)
+  , col ("Events (" <> period <> ")") (\(EnpReqStatsVM _ _ enp) -> eventsCountCell_ enp.totalRequests) & withAttrs [class_ "w-24 max-md:hidden"]
+  , col "Last Seen" (\(EnpReqStatsVM currTime _ enp) -> lastSeenCell_ currTime enp.lastSeen) & withAttrs [class_ "w-24 max-md:hidden"]
+  , col "Activity" (\(EnpReqStatsVM _ _ enp) -> activityCell_ enp.activityBuckets) & withAttrs [class_ "w-40 max-md:hidden"] & withColHeaderExtra (periodToggle_ baseUrl "endpointsListContainer" period)
   ]
 
 
@@ -347,12 +338,12 @@ statCell_ Endpoints.ShellOnly _ = span_ [class_ "block h-4 w-12 rounded bg-fillW
 
 eventsCountCell_ :: Int -> Html ()
 eventsCountCell_ n =
-  span_ [class_ $ "tabular-nums font-medium " <> style] $ toHtml $ formatWithCommas (fromIntegral n)
+  span_ [class_ $ "tabular-nums font-medium text-sm " <> color] $ toHtml $ formatWithCommas (fromIntegral n)
   where
-    style
-      | n >= 100 = "text-sm text-fillError-strong"
-      | n >= 10 = "text-sm text-fillWarning-strong"
-      | otherwise = "text-sm text-textStrong"
+    color
+      | n >= 100 = "text-fillError-strong"
+      | n >= 10 = "text-fillWarning-strong"
+      | otherwise = "text-textStrong"
 
 
 lastSeenCell_ :: UTCTime -> Maybe ZonedTime -> Html ()
@@ -366,13 +357,11 @@ activityCell_ = sparkline_ . V.toList
 
 
 renderEndpointMainCol :: Projects.ProjectId -> Text -> EnpReqStatsVM -> Html ()
-renderEndpointMainCol pid currentTab (EnpReqStatsVM _ _ _ enp) = do
+renderEndpointMainCol pid currentTab (EnpReqStatsVM _ _ enp) = do
   let outgoing = currentTab == "Outgoing"
       hostAttr = bool "attributes.net.host.name" "attributes.server.address" outgoing
-      kindVal = bool "server" "client" outgoing :: Text
-      sourceLabel = bool "Served by:" "Called by:" outgoing
+      (kindVal, sourceLabel) = directionLabels outgoing
       q = hostAttr <> "==\"" <> enp.host <> "\" AND kind==\"" <> kindVal <> "\" AND attributes.http.route==\"" <> enp.urlPath <> "\" AND attributes.http.request.method==\"" <> enp.method <> "\""
-      svcs = V.toList enp.services
   div_ [class_ "flex flex-col gap-1 min-w-0"] do
     div_ [class_ "flex items-center gap-2 min-w-0"] do
       a_ ([class_ "inline-flex items-center gap-1.5 font-medium text-textStrong hover:text-textBrand transition-colors truncate min-w-0", href_ ("/p/" <> pid.toText <> "/endpoints/details?var-endpointHash=" <> enp.endpointHash <> "&var-host=" <> enp.host)] <> navTabAttrs) $ do
@@ -381,9 +370,8 @@ renderEndpointMainCol pid currentTab (EnpReqStatsVM _ _ _ enp) = do
       a_ ([class_ "shrink-0 text-xs text-textBrand hover:text-textStrong transition-colors", href_ (logExplorerHref pid q)] <> navTabAttrs) "View logs"
     servicesBadges_
       sourceLabel
-      kindVal
       (\svc -> logExplorerHref pid $ "resource.service.name==\"" <> svc <> "\" AND kind==\"" <> kindVal <> "\" AND attributes.http.route==\"" <> enp.urlPath <> "\"")
-      svcs
+      (V.toList enp.services)
 
 
 data EndpointRequestStatsVM
@@ -421,46 +409,26 @@ apiCatalogBulkActionH pid action currentTabM items = do
   (sess, _project) <- Projects.sessionAndProject pid
   -- request_type=Incoming/Outgoing scopes the action; absent (e.g. on the
   -- Archived tab) means apply to whichever direction the host carries.
-  let outgoingM = case currentTabM of
-        Just "Outgoing" -> Just True
-        Just "Incoming" -> Just False
-        _ -> Nothing
+  let outgoingM = directionOf =<< currentTabM
       requested = length items.itemId
+      logCtx extra = AE.object $ ["project_id" AE..= pid.toText, "action" AE..= action, "requested_count" AE..= requested] <> extra
   if requested == 0
-    then do
-      addErrorToast "No hosts selected" Nothing
-      addRespHeaders CatalogBulkDone
+    then addErrorToast "No hosts selected" Nothing
     else do
       affected <- case action of
         "archive" -> Endpoints.archiveHosts pid outgoingM (Just sess.user.id) items.itemId
         "unarchive" -> Endpoints.unarchiveHosts pid outgoingM items.itemId
         _ -> throwError err400{errBody = "unhandled api_catalog bulk action: " <> encodeUtf8 action}
       let touched = fromIntegral affected :: Int
-          verb = action <> "d"
-          noun = if requested == 1 then "host" else "hosts"
+          noun = bool "hosts" "host" (requested == 1)
       if touched == 0
         then do
-          logAttention "api_catalog bulk action affected 0 rows"
-            $ AE.object
-              [ "project_id" AE..= pid.toText
-              , "action" AE..= action
-              , "requested_count" AE..= requested
-              , "outgoing" AE..= outgoingM
-              ]
+          logAttention "api_catalog bulk action affected 0 rows" $ logCtx ["outgoing" AE..= outgoingM]
           addErrorToast ("Could not " <> action <> " " <> noun) (Just "Already in that state, or rows were removed")
         else do
           when (touched < requested)
             $ logAttention "api_catalog bulk action partially applied"
-            $ AE.object
-              [ "project_id" AE..= pid.toText
-              , "action" AE..= action
-              , "requested_count" AE..= requested
-              , "affected_count" AE..= touched
-              ]
-          let summary =
-                if touched == requested
-                  then verb <> " " <> show touched <> " " <> noun
-                  else verb <> " " <> show touched <> " of " <> show requested <> " " <> noun
-          addSuccessToast summary Nothing
+            $ logCtx ["affected_count" AE..= touched]
+          addSuccessToast (action <> "d " <> show touched <> bool (" of " <> show requested) "" (touched == requested) <> " " <> noun) Nothing
           addTriggerEvent "apiCatalogChanged" AE.Null
-      addRespHeaders CatalogBulkDone
+  addRespHeaders CatalogBulkDone

--- a/src/Pages/GitSync.hs
+++ b/src/Pages/GitSync.hs
@@ -28,8 +28,8 @@ import Deriving.Aeson.Stock qualified as DAES
 import Effectful.Reader.Static (ask)
 import Lucid
 import Lucid.Htmx (hxDelete_, hxIndicator_, hxPost_, hxSwap_, hxTarget_)
+import Lucid.Hyperscript (__)
 import Models.Projects.Dashboards qualified as Dashboards
-import Models.Projects.GitSync qualified as GitHub
 import Models.Projects.GitSync qualified as GitSync
 import Models.Projects.Projects qualified as Projects
 import NeatInterpolation (text)
@@ -86,48 +86,36 @@ data GitSyncForm = GitSyncForm
   deriving anyclass (FromForm)
 
 
+statusResp :: Text -> AE.Value
+statusResp s = AE.object ["status" AE..= s]
+
+
+errResp :: Text -> AE.Value
+errResp msg = AE.object ["status" AE..= ("error" :: Text), "message" AE..= msg]
+
+
 githubWebhookPostH :: Maybe Text -> Maybe Text -> ByteString -> ATBaseCtx AE.Value
-githubWebhookPostH signatureM eventTypeM rawBody = do
-  case AE.eitherDecodeStrict rawBody of
-    Left err -> do
-      Log.logAttention "GitHub webhook invalid JSON payload" err
-      pure $ AE.object ["status" AE..= ("error" :: Text), "message" AE..= ("invalid JSON: " <> toText err)]
-    Right payload -> handlePayload signatureM eventTypeM rawBody payload
-
-
-handlePayload :: Maybe Text -> Maybe Text -> ByteString -> GitHubWebhookPayload -> ATBaseCtx AE.Value
-handlePayload signatureM eventTypeM rawBody payload = do
-  ctx <- ask @Config.AuthContext
-  case payload.repository of
-    Nothing -> do
-      Log.logAttention "GitHub webhook missing repository" ()
-      pure $ AE.object ["status" AE..= ("error" :: Text), "message" AE..= ("missing repository" :: Text)]
+githubWebhookPostH signatureM eventTypeM rawBody = case AE.eitherDecodeStrict @GitHubWebhookPayload rawBody of
+  Left err -> errResp ("invalid JSON: " <> toText err) <$ Log.logAttention "GitHub webhook invalid JSON payload" err
+  Right payload -> case payload.repository of
+    Nothing -> errResp "missing repository" <$ Log.logAttention "GitHub webhook missing repository" ()
     Just repo -> do
-      let ownerName = repo.owner.login
-          repoName = repo.name
+      let (ownerName, repoName) = (repo.owner.login, repo.name)
       syncM <- GitSync.getGitHubSyncByRepo ownerName repoName
       case syncM of
-        Nothing -> do
-          Log.logTrace "GitHub webhook for untracked repo" (ownerName, repoName)
-          pure $ AE.object ["status" AE..= ("ignored" :: Text)]
+        Nothing -> statusResp "ignored" <$ Log.logTrace "GitHub webhook for untracked repo" (ownerName, repoName)
         Just sync -> case validateWebhookSignature sync.webhookSecret signatureM rawBody of
-          Left err -> do
-            Log.logAttention "GitHub webhook signature validation failed" (ownerName, repoName, err)
-            pure $ AE.object ["status" AE..= ("error" :: Text), "message" AE..= err]
+          Left err -> errResp err <$ Log.logAttention "GitHub webhook signature validation failed" (ownerName, repoName, err)
           Right () -> do
             when (isNothing sync.webhookSecret) $ Log.logWarn "GitHub webhook accepted without secret validation" (ownerName, repoName)
             case eventTypeM of
               Just "push" -> do
+                ctx <- ask @Config.AuthContext
                 liftIO $ withResource ctx.jobsPool \conn ->
                   void $ createJob conn "background_jobs" $ BackgroundJobs.GitSyncFromRepo sync.projectId
-                Log.logTrace "Triggered git sync from webhook" (sync.projectId, ownerName, repoName)
-                pure $ AE.object ["status" AE..= ("ok" :: Text)]
-              Just event -> do
-                Log.logTrace "Ignoring GitHub event type" event
-                pure $ AE.object ["status" AE..= ("ignored" :: Text), "event" AE..= event]
-              Nothing -> do
-                Log.logInfo "GitHub webhook missing event type" ()
-                pure $ AE.object ["status" AE..= ("error" :: Text)]
+                statusResp "ok" <$ Log.logTrace "Triggered git sync from webhook" (sync.projectId, ownerName, repoName)
+              Just event -> AE.object ["status" AE..= ("ignored" :: Text), "event" AE..= event] <$ Log.logTrace "Ignoring GitHub event type" event
+              Nothing -> statusResp "error" <$ Log.logInfo "GitHub webhook missing event type" ()
 
 
 validateWebhookSignature :: Maybe Text -> Maybe Text -> ByteString -> Either Text ()
@@ -135,77 +123,55 @@ validateWebhookSignature Nothing _ _ = Right () -- No secret configured, skip va
 validateWebhookSignature _ Nothing _ = Left "signature required but not provided"
 validateWebhookSignature (Just secret) (Just sig) body =
   let expectedSig = "sha256=" <> decodeUtf8 (B16.encode $ BA.convert (HMAC.hmac (encodeUtf8 secret :: ByteString) body :: HMAC.HMAC SHA256))
-   in if BA.constEq (encodeUtf8 sig :: ByteString) (encodeUtf8 expectedSig :: ByteString) then Right () else Left "invalid signature"
+   in unless (BA.constEq (encodeUtf8 sig :: ByteString) (encodeUtf8 expectedSig :: ByteString)) $ Left "invalid signature"
 
 
 gitSyncSettingsGetH :: Projects.ProjectId -> ATAuthCtx (RespHeaders (Html ()))
 gitSyncSettingsGetH pid = do
   ctx <- ask @Config.AuthContext
   syncM <- GitSync.getGitHubSync pid
-  withSettingsPage pid "Integrations" \_ -> pure $ gitSyncSettingsPage ctx.env.hostUrl pid syncM
+  withSettingsPage pid "Integrations" \_ -> pure $ settingsSection_ do
+    settingsH2_ "GitHub Sync"
+    div_ [id_ "git-sync-content"] $ gitSyncSettingsView ctx.env.hostUrl pid syncM
 
 
 gitSyncSettingsPostH :: Projects.ProjectId -> GitSyncForm -> ATAuthCtx (RespHeaders (Html ()))
 gitSyncSettingsPostH pid form = do
   ctx <- ask @Config.AuthContext
   let encKey = encodeUtf8 ctx.config.apiKeyEncryptionSecretKey
-  -- Auto-detect branch if not specified or empty
-  branch <-
-    if T.null form.branch
-      then GitSync.detectDefaultBranch form.accessToken form.owner form.repo
-      else pure form.branch
+  branch <- if T.null form.branch then GitSync.detectDefaultBranch form.accessToken form.owner form.repo else pure form.branch
   existingM <- GitSync.getGitHubSync pid
   syncM <- case existingM of
-    Nothing -> do
-      result <- GitSync.insertGitHubSync encKey pid form.owner form.repo branch form.accessToken Nothing (fromMaybe "" form.pathPrefix)
-      Log.logTrace "Created GitHub sync config" (pid, form.owner, form.repo)
-      pure result
-    Just existing -> do
-      result <-
-        if T.null form.accessToken
-          then GitSync.updateGitHubSyncKeepToken existing.id form.owner form.repo branch True
-          else GitSync.updateGitHubSync encKey existing.id form.owner form.repo branch form.accessToken True
-      Log.logTrace "Updated GitHub sync config" (pid, form.owner, form.repo)
-      pure result
+    Nothing -> GitSync.insertGitHubSync encKey pid form.owner form.repo branch form.accessToken Nothing (fromMaybe "" form.pathPrefix)
+    Just existing
+      | T.null form.accessToken -> GitSync.updateGitHubSyncKeepToken existing.id form.owner form.repo branch True
+      | otherwise -> GitSync.updateGitHubSync encKey existing.id form.owner form.repo branch form.accessToken True
+  Log.logTrace (maybe "Created GitHub sync config" (const "Updated GitHub sync config") existingM) (pid, form.owner, form.repo)
   addRespHeaders $ gitSyncSettingsView ctx.env.hostUrl pid syncM
 
 
 gitSyncSettingsDeleteH :: Projects.ProjectId -> ATAuthCtx (RespHeaders (Html ()))
 gitSyncSettingsDeleteH pid = do
   ctx <- ask @Config.AuthContext
-  existingM <- GitSync.getGitHubSync pid
-  case existingM of
-    Nothing -> pass
-    Just existing -> do
-      _ <- GitSync.deleteGitHubSync existing.id
-      Log.logTrace "Deleted GitHub sync config" pid
+  whenJustM (GitSync.getGitHubSync pid) \existing -> do
+    _ <- GitSync.deleteGitHubSync existing.id
+    Log.logTrace "Deleted GitHub sync config" pid
   addRespHeaders $ gitSyncSettingsView ctx.env.hostUrl pid Nothing
 
 
-gitSyncSettingsPage :: Text -> Projects.ProjectId -> Maybe GitSync.GitHubSync -> Html ()
-gitSyncSettingsPage hostUrl pid syncM = settingsSection_ do
-  settingsH2_ "GitHub Sync"
-  div_ [id_ "git-sync-content"] $ gitSyncSettingsView hostUrl pid syncM
-
-
 gitSyncSettingsView :: Text -> Projects.ProjectId -> Maybe GitSync.GitHubSync -> Html ()
-gitSyncSettingsView hostUrl pid syncM = do
-  let webhookUrl = hostUrl <> "webhook/github"
-      actionUrl = "/p/" <> pid.toText <> "/settings/git-sync"
-      installUrl = "/p/" <> pid.toText <> "/settings/git-sync/install"
-      isViaApp = maybe False (isJust . (.installationId)) syncM
-  div_ [class_ "space-y-6"] do
-    case syncM of
-      Nothing -> notConnectedView pid actionUrl installUrl
-      Just sync -> connectedView hostUrl pid sync actionUrl webhookUrl isViaApp
+gitSyncSettingsView hostUrl pid syncM =
+  div_ [class_ "space-y-6"] $ maybe (notConnectedView actionUrl) (\sync -> connectedView sync actionUrl (hostUrl <> "webhook/github")) syncM
+  where
+    actionUrl = "/p/" <> pid.toText <> "/settings/git-sync"
 
 
-notConnectedView :: Projects.ProjectId -> Text -> Text -> Html ()
-notConnectedView pid actionUrl installUrl = do
+notConnectedView :: Text -> Html ()
+notConnectedView actionUrl = do
   -- GitHub App (primary)
   div_ [class_ "space-y-3"] do
     p_ [class_ "text-sm text-textWeak"] "Install the GitHub App to sync dashboards with your repository. Webhooks are configured automatically."
-    a_ [href_ installUrl, class_ "btn btn-sm btn-primary gap-2"] do
+    a_ [href_ (actionUrl <> "/install"), class_ "btn btn-sm btn-primary gap-2"] do
       faSprite_ "github" "regular" "w-3.5 h-3.5"
       "Install GitHub App"
 
@@ -230,9 +196,9 @@ notConnectedView pid actionUrl installUrl = do
           htmxIndicator_ "indicator" LdXS
 
 
-connectedView :: Text -> Projects.ProjectId -> GitSync.GitHubSync -> Text -> Text -> Bool -> Html ()
-connectedView hostUrl pid sync actionUrl webhookUrl isViaApp = do
-  -- Status line
+connectedView :: GitSync.GitHubSync -> Text -> Text -> Html ()
+connectedView sync actionUrl webhookUrl = do
+  let isViaApp = isJust sync.installationId
   headerRow_ [] do
     div_ [class_ "flex items-center gap-2 text-sm"] do
       faSprite_ "circle-check" "solid" "w-3.5 h-3.5 text-iconSuccess"
@@ -256,9 +222,17 @@ connectedView hostUrl pid sync actionUrl webhookUrl isViaApp = do
     div_ [class_ "pt-4 border-t border-strokeWeak space-y-2"] do
       headerRow_ [] do
         sectionLabel_ "Webhook URL"
-        button_ [type_ "button", class_ "btn btn-xs btn-ghost gap-1", onclick_ ("navigator.clipboard.writeText('" <> webhookUrl <> "'); this.querySelector('span').textContent='Copied!'; setTimeout(() => this.querySelector('span').textContent='Copy', 2000)")] do
-          faSprite_ "copy" "regular" "w-3 h-3"
-          span_ "Copy"
+        button_
+          [ type_ "button"
+          , class_ "btn btn-xs btn-ghost gap-1"
+          , term "data-url" webhookUrl
+          , [__| on click call navigator.clipboard.writeText(my @data-url)
+                   then put 'Copied!' into the first <span/> in me
+                   then wait 2s then put 'Copy' into the first <span/> in me |]
+          ]
+          do
+            faSprite_ "copy" "regular" "w-3 h-3"
+            span_ "Copy"
       div_ [class_ "bg-fillWeak rounded-lg px-3 py-1.5 font-mono text-xs text-textWeak break-all"] $ toHtml webhookUrl
       unless isViaApp $ p_ [class_ "text-xs text-textWeak"] "Add this to your repository for automatic syncing."
 
@@ -340,14 +314,10 @@ For automatic syncing when you push changes:
 queueGitSyncPush :: Projects.ProjectId -> Dashboards.DashboardId -> ATAuthCtx ()
 queueGitSyncPush pid dashboardId = do
   ctx <- ask @Config.AuthContext
-  syncM <- GitSync.getGitHubSync pid
-  case syncM of
-    Nothing -> pass
-    Just sync | not sync.syncEnabled -> pass
-    Just _ -> do
-      liftIO $ withResource ctx.jobsPool \conn ->
-        void $ createJob conn "background_jobs" $ BackgroundJobs.GitSyncPushDashboard pid (unUUIDId dashboardId)
-      Log.logTrace "Queued git sync push for dashboard" (pid, dashboardId)
+  whenJustM (GitSync.getGitHubSync pid) \sync -> when sync.syncEnabled do
+    liftIO $ withResource ctx.jobsPool \conn ->
+      void $ createJob conn "background_jobs" $ BackgroundJobs.GitSyncPushDashboard pid (unUUIDId dashboardId)
+    Log.logTrace "Queued git sync push for dashboard" (pid, dashboardId)
 
 
 -- | Form for selecting a repo from GitHub App installation
@@ -361,17 +331,19 @@ data RepoSelectForm = RepoSelectForm
   deriving anyclass (FromForm)
 
 
+-- | Meta-refresh redirect (no JS, escapes url properly) with a fallback link for no-refresh clients.
+redirectPage :: Text -> Text -> Html ()
+redirectPage msg url = div_ [class_ "p-8 text-center"] do
+  meta_ [httpEquiv_ "refresh", content_ ("0;url=" <> url)]
+  p_ [class_ "text-textWeak mb-4"] $ toHtml msg
+  a_ [href_ url, class_ "text-textBrand underline"] "Continue"
+
+
 -- | Redirect to GitHub App installation page
 githubAppInstallH :: Projects.ProjectId -> ATAuthCtx (RespHeaders (Html ()))
 githubAppInstallH pid = do
   ctx <- ask @Config.AuthContext
-  -- Store project ID in state parameter for callback
-  let stateParam = pid.toText
-      installUrl = "https://github.com/apps/" <> ctx.config.githubAppName <> "/installations/new?state=" <> stateParam
-  -- Return a redirect page
-  addRespHeaders $ div_ [class_ "p-8 text-center"] do
-    p_ [class_ "text-textWeak mb-4"] "Redirecting to GitHub..."
-    script_ $ "window.location.href = '" <> installUrl <> "';"
+  addRespHeaders $ redirectPage "Redirecting to GitHub..." $ "https://github.com/apps/" <> ctx.config.githubAppName <> "/installations/new?state=" <> pid.toText
 
 
 -- | Handle callback from GitHub after App installation
@@ -382,16 +354,9 @@ githubAppCallbackH instIdM _setupAction stateM = do
   let bwconf = (def :: BWConfig){sessM = Just sess, pageTitle = "GitHub Sync", config = ctx.config}
   case (instIdM, stateM >>= rightToMaybe . parseUrlPiece) of
     (Just instId, Just pid) -> do
-      -- Check if sync already exists for this project
       existingM <- GitSync.getGitHubSync pid
-      case existingM of
-        Just _ -> Log.logInfo "GitHub App already configured, updating installation" (pid, instId)
-        Nothing -> Log.logInfo "GitHub App installed, awaiting repo selection" (pid, instId)
-      -- Redirect to repo selection page
-      let reposUrl = "/p/" <> pid.toText <> "/settings/git-sync/repos?installationId=" <> show instId
-      addRespHeaders $ bodyWrapper bwconf $ div_ [class_ "p-8 text-center"] do
-        p_ [class_ "text-textWeak mb-4"] "GitHub App installed! Redirecting..."
-        script_ $ "window.location.href = '" <> reposUrl <> "';"
+      Log.logInfo (maybe "GitHub App installed, awaiting repo selection" (const "GitHub App already configured, updating installation") existingM) (pid, instId)
+      addRespHeaders $ bodyWrapper bwconf $ redirectPage "GitHub App installed! Redirecting..." $ "/p/" <> pid.toText <> "/settings/git-sync/repos?installationId=" <> show instId
     (Just instId, Nothing) -> do
       -- No state param - user installed directly from GitHub, show project selector
       Log.logInfo "GitHub callback without state, showing project selector" instId
@@ -425,24 +390,14 @@ githubAppReposH pid instIdParam = withSettingsPage pid "Integrations" \_ -> do
   ctx <- ask @Config.AuthContext
   syncM <- GitSync.getGitHubSync pid
   let instIdM = instIdParam <|> (syncM >>= (.installationId))
+      errBox err = div_ [class_ "text-textError p-4"] $ toHtml err
   content <- case instIdM of
-    Nothing -> pure $ div_ [class_ "text-textError p-4"] "No GitHub App installation found"
-    Just instId -> W.runHTTPWreq do
-      tokenResult <- GitHub.getInstallationToken ctx.config.githubAppId ctx.config.githubAppPrivateKey instId
-      case tokenResult of
-        Left err -> pure $ div_ [class_ "text-textError p-4"] $ toHtml $ "Failed to get token: " <> err
-        Right tok -> do
-          reposResult <- GitHub.listInstallationRepos tok.token
-          case reposResult of
-            Left err -> pure $ div_ [class_ "text-textError p-4"] $ toHtml $ "Failed to list repos: " <> err
-            Right repos -> pure $ repoSelectionView pid instId repos
-  pure $ repoSelectionPage content
-
-
--- | Page structure for repo selection
-repoSelectionPage :: Html () -> Html ()
-repoSelectionPage content = div_ [class_ "w-full h-full overflow-y-auto"] do
-  section_ [class_ "p-8 max-w-2xl mx-auto space-y-6"] do
+    Nothing -> pure $ errBox ("No GitHub App installation found" :: Text)
+    Just instId ->
+      W.runHTTPWreq $ either errBox (repoSelectionView pid instId) <$> runExceptT do
+        tok <- ExceptT $ first ("Failed to get token: " <>) <$> GitSync.getInstallationToken ctx.config.githubAppId ctx.config.githubAppPrivateKey instId
+        ExceptT $ first ("Failed to list repos: " <>) <$> GitSync.listInstallationRepos tok.token
+  pure $ div_ [class_ "w-full h-full overflow-y-auto"] $ section_ [class_ "p-8 max-w-2xl mx-auto space-y-6"] do
     div_ [class_ "mb-2"] do
       h2_ [class_ "text-textStrong text-xl font-semibold"] "GitHub Sync"
       p_ [class_ "text-textWeak text-sm mt-1"] "Select a repository to sync dashboards with."
@@ -450,7 +405,7 @@ repoSelectionPage content = div_ [class_ "w-full h-full overflow-y-auto"] do
 
 
 -- | View for selecting a repository
-repoSelectionView :: Projects.ProjectId -> Int64 -> [GitHub.GitHubRepo] -> Html ()
+repoSelectionView :: Projects.ProjectId -> Int64 -> [GitSync.GitHubRepo] -> Html ()
 repoSelectionView pid instId repos = div_ [class_ "space-y-4"] do
   h3_ [class_ "text-lg font-medium text-textStrong"] "Select Repository"
   p_ [class_ "text-sm text-textWeak"] "Choose which repository to sync dashboards with:"
@@ -471,19 +426,13 @@ repoSelectionView pid instId repos = div_ [class_ "space-y-4"] do
 githubAppSelectRepoH :: Projects.ProjectId -> RepoSelectForm -> ATAuthCtx (RespHeaders (Html ()))
 githubAppSelectRepoH pid form = do
   ctx <- ask @Config.AuthContext
-  syncM <- GitSync.getGitHubSync pid
-  -- Parse owner/repo from fullName
-  let (ownerVal, repoVal) = case T.splitOn "/" form.repoFullName of
-        [o, r] -> (o, r)
-        _ -> (form.repoFullName, "")
+  let (ownerVal, repoVal) = second (T.drop 1) $ T.breakOn "/" form.repoFullName
       prefix = fromMaybe "" form.pathPrefix
-  -- Insert or update the sync config
-  result <- case syncM of
-    Nothing -> GitSync.insertGitHubAppSync pid form.installationId ownerVal repoVal form.branch prefix
-    Just existing -> GitSync.updateGitHubSyncRepo existing.id ownerVal repoVal form.branch prefix
+  result <-
+    GitSync.getGitHubSync pid >>= \case
+      Nothing -> GitSync.insertGitHubAppSync pid form.installationId ownerVal repoVal form.branch prefix
+      Just existing -> GitSync.updateGitHubSyncRepo existing.id ownerVal repoVal form.branch prefix
   Log.logInfo "GitHub App repo selected" (pid, form.repoFullName)
-  -- Push all existing dashboards to the repo
   liftIO $ withResource ctx.jobsPool \conn ->
     void $ createJob conn "background_jobs" $ BackgroundJobs.GitSyncPushAllDashboards pid
-  -- Return updated settings view
   addRespHeaders $ gitSyncSettingsView ctx.env.hostUrl pid result

--- a/src/Pages/LogExplorer/Log.hs
+++ b/src/Pages/LogExplorer/Log.hs
@@ -61,7 +61,7 @@ import Models.Telemetry.Schema qualified as Schema
 import NeatInterpolation (text)
 import Numeric (showFFloat)
 import Pages.BodyWrapper (BWConfig (..), PageCtx (..), mkPageCtx, navTabAttrs, pageActions, pageTitle)
-import Pkg.Components.LogQueryBox (LogQueryBoxConfig (..), enrichSchemaWithFacets, logQueryBox_, queryLibrary_)
+import Pkg.Components.LogQueryBox (LogQueryBoxConfig (..), enrichSchemaWithFacets, logQueryBox_, queryLibraryDropdown_)
 import Pkg.Components.TimePicker qualified as Components
 import Pkg.Components.Widget (WidgetAxis (..), WidgetType (WTTimeseries, WTTimeseriesLine))
 import Pkg.Components.Widget qualified as Widget
@@ -73,7 +73,7 @@ import Servant qualified
 import System.Config (AuthContext (..), EnvConfig (..))
 import System.Types
 import Text.Megaparsec (parseMaybe)
-import Utils (FieldAction (..), FieldMenuCtx (..), LoadingSize (..), LoadingType (..), checkFreeTierStatus, faSprite_, fieldContextMenuItems_, fieldMenuPanel_, getDurationNSMS, getServiceColors, htmxOverlayIndicator_, levelFillColor, listToIndexHashMap, loadingIndicator_, lookupVecTextByKey, methodFillColor, popoverTrigger_, prettyPrintCount, sanitizeBackendError, serviceFillColor, statusFillColorText)
+import Utils (FieldAction (..), FieldMenuCtx (..), LoadingSize (..), LoadingType (..), checkFreeTierStatus, faSprite_, fieldContextMenuItems_, fieldMenuPanel_, getDurationNSMS, getServiceColors, htmxOverlayIndicator_, levelFillColor, listToIndexHashMap, loadingIndicator_, lookupVecTextByKey, methodFillColor, nonEmptyT, popoverTrigger_, prettyPrintCount, sanitizeBackendError, serviceFillColor, statusFillColorText)
 
 import Data.Time.Clock.POSIX (utcTimeToPOSIXSeconds)
 import Data.Time.Format.ISO8601 (iso8601ParseM, iso8601Show)
@@ -516,36 +516,30 @@ renderFacets facetSummary = do
                 div_ [class_ "hidden peer-checked/more:block space-y-1"] $ forM_ hiddenValues renderFacetValue
 
 
-keepNonEmpty :: Maybe Text -> Maybe Text
-keepNonEmpty Nothing = Nothing
-keepNonEmpty (Just "") = Nothing
-keepNonEmpty (Just a) = Just a
-
-
 -- | Core result builder shared by apiLogH and queryEvents. When @withChildren@
 -- is False, only matched rows are returned — no descendants, no synthesised
 -- orphan headers (trace-tree concerns the UI wants but the API/CLI usually doesn't).
 buildLogResult :: (DB es, Time.Time :> es) => Bool -> Projects.ProjectId -> UTCTime -> Maybe Text -> Maybe Text -> Maybe Text -> [Text] -> [Text] -> (V.Vector (V.Vector AE.Value), [Text], Int) -> Eff es LogResult
 buildLogResult withChildren pid now sinceM fromM toM addCols removeCols (requestVecs, colNames, resultCount') = do
   let colIdxMap = listToIndexHashMap colNames
-      reqLastCreatedAtM = (\r -> lookupVecTextByKey r colIdxMap "timestamp") =<< (requestVecs V.!? (V.length requestVecs - 1))
-      reqFirstCreatedAtM = (\r -> lookupVecTextByKey r colIdxMap "timestamp") =<< (requestVecs V.!? 0)
-      alreadyLoadedIds = V.mapMaybe (\v -> lookupVecTextByKey v colIdxMap "id") requestVecs
+      colOf k v = lookupVecTextByKey v colIdxMap k
+      reqLastCreatedAtM = colOf "timestamp" =<< (requestVecs V.!? (V.length requestVecs - 1))
+      reqFirstCreatedAtM = colOf "timestamp" =<< (requestVecs V.!? 0)
+      alreadyLoadedIds = V.mapMaybe (colOf "id") requestVecs
       (fromDD, toDD, _) = Components.parseTimeRange now (Components.TimePicker sinceM reqLastCreatedAtM reqFirstCreatedAtM)
   childSpansList <-
     if not withChildren || V.length requestVecs > 100
       then pure [] -- Skip expensive child span fetch for large result sets; traces load lazily on detail view
       else do
-        let allTraceIds = V.filter (not . T.null) $ V.catMaybes $ V.map (\v -> lookupVecTextByKey v colIdxMap "trace_id") requestVecs
-            traceIds = V.fromList $ take 50 $ nubOrd $ V.toList allTraceIds
+        let traceIds = V.fromList $ take 50 $ nubOrd $ V.toList $ V.mapMaybe (mfilter (not . T.null) . colOf "trace_id") requestVecs
             -- latency_breakdown is aliased from context___span_id (see Pkg.Parser).
-            seedSpanIds = V.mapMaybe (\v -> lookupVecTextByKey v colIdxMap "latency_breakdown") requestVecs
+            seedSpanIds = V.mapMaybe (colOf "latency_breakdown") requestVecs
         LogQueries.selectChildSpansAndLogs pid addCols traceIds seedSpanIds (fromDD, toDD) alreadyLoadedIds
   let synthRows = if withChildren then synthesizeOrphanHeaders colIdxMap requestVecs else V.empty
       requestVecsAug = synthRows <> requestVecs
       rawLogsData = requestVecsAug <> V.fromList childSpansList
       cols = nubOrd $ curateCols addCols removeCols colNames
-      colors = getServiceColors $ V.catMaybes $ V.map (\v -> lookupVecTextByKey v colIdxMap "span_name") rawLogsData
+      colors = getServiceColors $ V.mapMaybe (colOf "span_name") rawLogsData
       queryResultCount = V.length requestVecsAug
       (logsData, traces) = buildTraceTree colIdxMap queryResultCount rawLogsData
   pure
@@ -648,27 +642,17 @@ kqlError400 code msg fieldM suggestionM detailsM =
 extractMissingColumn :: Text -> Maybe Text
 extractMissingColumn t = tfMatch <|> pgMatch
   where
-    tfMatch =
-      let after = snd (T.breakOn "no field named " (T.toLower t))
-       in if T.null after
-            then Nothing
-            else
-              -- Re-slice from the original-case text so the column name keeps its casing.
-              let idx = T.length t - T.length after
-                  rest = T.drop (idx + T.length "no field named ") t
-                  col = T.strip $ T.takeWhile (\c -> c /= '.' && c /= ' ' && c /= '\n' && c /= '"' && c /= '`') rest
-               in if T.null col then Nothing else Just col
-    pgMatch =
-      let after = snd (T.breakOn "column " (T.toLower t))
-       in if T.null after || not ("does not exist" `T.isInfixOf` T.toLower t)
-            then Nothing
-            else
-              let idx = T.length t - T.length after
-                  rest = T.drop (idx + T.length "column ") t
-                  col = case T.stripPrefix "\"" rest of
-                    Just q -> T.takeWhile (/= '"') q
-                    Nothing -> T.takeWhile (\c -> c /= ' ' && c /= ',') rest
-               in if T.null col then Nothing else Just col
+    lower = T.toLower t
+    -- Match case-insensitively but re-slice from the original-case text so the
+    -- column name keeps its casing.
+    after needle =
+      let (pre, hit) = T.breakOn needle lower
+       in T.drop (T.length pre + T.length needle) t <$ guard (not (T.null hit))
+    tfMatch = after "no field named " >>= guarded (not . T.null) . T.strip . T.takeWhile (`notElem` ['.', ' ', '\n', '"', '`'])
+    pgMatch = do
+      guard $ "does not exist" `T.isInfixOf` lower
+      rest <- after "column "
+      guarded (not . T.null) $ maybe (T.takeWhile (`notElem` [' ', ',']) rest) (T.takeWhile (/= '"')) (T.stripPrefix "\"" rest)
 
 
 -- | Log Explorer page shell. Renders chrome only (query box, facets, widgets,
@@ -679,7 +663,7 @@ apiLogH pid queryM' cols' sinceM fromM toM sourceM targetSpansM targetEventM sho
   let source = fromMaybe "spans" sourceM
   (sess, project, bw) <- mkPageCtx pid
   let queryInput = maybeToMonoid queryM'
-  let parseError msg = addTriggerEvent "showParseError" (AE.toJSON msg) >> addErrorToast "Error Parsing Query" (Just msg) $> ([], Just msg)
+      parseError msg = addTriggerEvent "showParseError" (AE.toJSON msg) >> addErrorToast "Error Parsing Query" (Just msg) $> ([], Just msg)
   (queryAST, parseErrorMsg) <- case parseQueryToAST queryInput of
     Left err -> parseError err
     Right ast
@@ -694,9 +678,7 @@ apiLogH pid queryM' cols' sinceM fromM toM sourceM targetSpansM targetEventM sho
   authCtx <- Effectful.Reader.Static.ask @AuthContext
 
   -- An alert ID pre-fills the query box and selects the alert's viz type.
-  alertDM <- case alertM >>= UUID.fromText of
-    Just alertId -> Monitors.queryMonitorById (Monitors.QueryMonitorId alertId)
-    Nothing -> pure Nothing
+  alertDM <- lookupAlert alertM
   let effectiveVizType = vizTypeM <|> ((.visualizationType) <$> alertDM)
 
   -- Shell-side queries are just query library + free-tier. Facets lazy-load via
@@ -706,8 +688,8 @@ apiLogH pid queryM' cols' sinceM fromM toM sourceM targetSpansM targetEventM sho
   (queryLibE, freeTierStatusE) <- Ki.scoped \scope -> do
     let aw = Ki.atomically . Ki.await
     t1 <- forkWithCtx scope $ tryAny $ Projects.queryLibHistoryForUser pid sess.persistentSession.userId
-    t3 <- forkWithCtx scope $ tryAny $ checkFreeTierStatus pid project.paymentPlan
-    (,) <$> aw t1 <*> aw t3
+    t2 <- forkWithCtx scope $ tryAny $ checkFreeTierStatus pid project.paymentPlan
+    (,) <$> aw t1 <*> aw t2
 
   let logErr label res = whenLeft_ (void res) (Log.logAttention ("Log explorer " <> label <> " failed") . show @Text)
   logErr "queryLib" queryLibE
@@ -715,7 +697,7 @@ apiLogH pid queryM' cols' sinceM fromM toM sourceM targetSpansM targetEventM sho
 
   let queryLib = fromRight [] queryLibE
       freeTierStatus = fromRight def freeTierStatusE
-      (queryLibRecent, queryLibSaved) = bimap V.fromList V.fromList $ L.partition (\x -> Projects.QLTHistory == x.queryType) queryLib
+      (queryLibRecent, queryLibSaved) = partitionQueryLib queryLib
 
   -- Preload the data fetch from <head> so it overlaps shell render instead of
   -- starting only after the log-list web component boots. Point it at the endpoint
@@ -829,7 +811,7 @@ logExplorerDataH pid queryM' cols' cursorM' sinceM fromM toM sourceM targetSpans
         Right t -> pure (Nothing, t)
   -- UI always wants the trace-tree context; the API/CLI defaults off.
   lr <- buildLogResult True pid now sinceM fromM toM addCols removeCols tableData
-  let lastFM = lr.cursor >>= textToUTC <&> toText . iso8601Show . addUTCTime (-0.001)
+  let lastFM = lr.cursor >>= (iso8601ParseM . toString) <&> toText . iso8601Show . addUTCTime (-0.001)
   addRespHeaders
     (lr :: LogResult)
       { error = errM
@@ -907,9 +889,9 @@ saveQueryH pid form = do
   (sess, _) <- Projects.sessionAndProject pid
   let uid = sess.persistentSession.userId
       queryAST = fromRight [] $ parseQueryToAST (maybeToMonoid form.query)
-  if (isJust . keepNonEmpty) form.queryLibId && (isJust . keepNonEmpty) form.queryTitle
-    then Projects.queryLibTitleEdit pid uid (maybeToMonoid form.queryLibId) (maybeToMonoid form.queryTitle) >> addSuccessToast "Edited Query title successfully" Nothing
-    else Projects.queryLibInsert Projects.QLTSaved pid uid (toQText queryAST) queryAST form.queryTitle >> addSuccessToast "Saved to Query Library successfully" Nothing
+  case (,) <$> nonEmptyT form.queryLibId <*> nonEmptyT form.queryTitle of
+    Just (qId, title) -> Projects.queryLibTitleEdit pid uid qId title >> addSuccessToast "Edited Query title successfully" Nothing
+    Nothing -> Projects.queryLibInsert Projects.QLTSaved pid uid (toQText queryAST) queryAST form.queryTitle >> addSuccessToast "Saved to Query Library successfully" Nothing
   addTriggerEvent "closeModal" ""
   queryLibraryFragment pid uid
 
@@ -928,8 +910,13 @@ deleteQueryH pid qId = do
 queryLibraryFragment :: Projects.ProjectId -> Projects.UserId -> ATAuthCtx (RespHeaders QueryLibraryView)
 queryLibraryFragment pid uid = do
   queryLib <- Projects.queryLibHistoryForUser pid uid
-  let (recent, saved) = bimap V.fromList V.fromList $ L.partition (\x -> Projects.QLTHistory == x.queryType) queryLib
+  let (recent, saved) = partitionQueryLib queryLib
   addRespHeaders $ QueryLibraryView pid saved recent
+
+
+-- | Split a user's query-library items into (recent, saved) — history entries first.
+partitionQueryLib :: [Projects.QueryLibItem] -> (V.Vector Projects.QueryLibItem, V.Vector Projects.QueryLibItem)
+partitionQueryLib = bimap V.fromList V.fromList . L.partition (\x -> Projects.QLTHistory == x.queryType)
 
 
 -- | Lazily-loaded alert configuration form (HTMX partial). Kept off the shell's
@@ -937,15 +924,14 @@ queryLibraryFragment pid uid = do
 alertFormH :: Projects.ProjectId -> Maybe Text -> ATAuthCtx (RespHeaders (Html ()))
 alertFormH pid alertM = do
   (_, project) <- Projects.sessionAndProject pid
-  alertDM <- case alertM >>= UUID.fromText of
-    Just alertId -> Monitors.queryMonitorById (Monitors.QueryMonitorId alertId)
-    Nothing -> pure Nothing
+  alertDM <- lookupAlert alertM
   teams <- V.fromList <$> ManageMembers.getTeams pid
   addRespHeaders $ alertConfigurationForm_ project alertDM teams
 
 
-textToUTC :: Text -> Maybe UTCTime
-textToUTC = iso8601ParseM . toString
+-- | Resolve an @?alert=<uuid>@ query param to its monitor, if it parses and exists.
+lookupAlert :: DB es => Maybe Text -> Eff es (Maybe Monitors.QueryMonitor)
+lookupAlert = maybe (pure Nothing) (Monitors.queryMonitorById . Monitors.QueryMonitorId) . (>>= UUID.fromText)
 
 
 -- Widget definitions for log explorer charts
@@ -1000,11 +986,18 @@ fmtPct1 :: Double -> Text
 fmtPct1 x = toText (showFFloat (Just 1) x "") <> "%"
 
 
+-- | Wrapper classes for #page-summary-region contents. Both hide under the
+-- chart toggles; literal (not concatenated) so Tailwind's scanner sees them.
+summaryRegionCls, chartRegionCls :: Text
+summaryRegionCls = "mt-3 group-has-[.no-chart:checked]/pg:hidden group-has-[.toggle-chart:checked]/pg:hidden w-full flex flex-col gap-2"
+chartRegionCls = "timeline flex flex-row gap-4 mt-3 group-has-[.no-chart:checked]/pg:hidden group-has-[.toggle-chart:checked]/pg:hidden w-full min-h-36 max-md:min-h-28 aspect-[10/1] max-md:aspect-auto max-md:flex-col"
+
+
 -- | Shimmer placeholder mirroring 'sessionsHeader_' (6-KPI grid + over-time bar
 -- card) so the summary region keeps its height during the sessions-viz swap.
 sessionsSummarySkeleton_ :: Html ()
 sessionsSummarySkeleton_ =
-  div_ [class_ "mt-3 group-has-[.no-chart:checked]/pg:hidden group-has-[.toggle-chart:checked]/pg:hidden w-full flex flex-col gap-2", role_ "status", Aria.label_ "Loading session summary"] do
+  div_ [class_ summaryRegionCls, role_ "status", Aria.label_ "Loading session summary"] do
     div_ [class_ "grid grid-cols-6 max-md:grid-cols-3 gap-2"]
       $ replicateM_ 6
       $ div_ [class_ "surface-raised rounded-2xl px-3 py-2 flex flex-col gap-1"] do
@@ -1020,7 +1013,7 @@ sessionsSummarySkeleton_ =
 -- summary region) so its height is preserved during the swap back from sessions.
 chartSummarySkeleton_ :: Html ()
 chartSummarySkeleton_ =
-  div_ [class_ "timeline flex flex-row gap-4 mt-3 group-has-[.no-chart:checked]/pg:hidden group-has-[.toggle-chart:checked]/pg:hidden w-full min-h-36 max-md:min-h-28 aspect-[10/1] max-md:aspect-auto max-md:flex-col", role_ "status", Aria.label_ "Loading chart"] do
+  div_ [class_ chartRegionCls, role_ "status", Aria.label_ "Loading chart"] do
     div_ [class_ "flex-[3] min-w-0 rounded-2xl skeleton-shimmer"] ""
     div_ [class_ "flex-1 min-w-0 max-md:hidden rounded-2xl skeleton-shimmer"] ""
 
@@ -1050,16 +1043,18 @@ facetsSkeleton_ =
 
 
 -- | KPI card shared by the sessions/patterns summary headers.
-kpiCard_ :: Text -> Text -> Maybe Text -> Html ()
-kpiCard_ label value subM = div_ [class_ "surface-raised rounded-2xl px-3 py-2 flex flex-col gap-0.5 min-w-0"] do
+kpiCard_ :: (Text, Text, Maybe Text) -> Html ()
+kpiCard_ (label, value, subM) = div_ [class_ "surface-raised rounded-2xl px-3 py-2 flex flex-col gap-0.5 min-w-0"] do
   span_ [class_ "text-xs text-textWeak truncate"] $ toHtml label
   strong_ [class_ "text-textStrong text-xl font-bold tabular-nums leading-tight truncate"] $ toHtml value
   whenJust subM (span_ [class_ "text-xs text-textWeak tabular-nums truncate"] . toHtml)
 
 
--- | Legend swatch shared by the sessions/patterns over-time charts.
-legendSwatch_ :: Text -> Html () -> Html ()
-legendSwatch_ cls label = span_ [class_ "flex items-center gap-1"] (span_ [class_ $ "inline-block w-2 h-2 rounded-sm " <> cls] "" >> label)
+-- | Percent-of-tallest-bar normalizer for the over-time charts (0 when empty).
+barNorm :: [Int] -> [Int] -> Int -> Double
+barNorm clean err = \n -> if maxBar <= 0 then 0 else fromIntegral n / fromIntegral maxBar * 100
+  where
+    maxBar = foldl' max 0 (zipWith (+) clean err)
 
 
 -- | The stacked clean/errored rects inside one over-time bar.
@@ -1081,8 +1076,9 @@ summaryChartCard_ title noteM bucketStartEpoch bucketWidthSec barEls =
     div_ [class_ "flex items-center justify-between mb-1"] do
       span_ [class_ "text-xs text-textWeak"] $ toHtml title
       div_ [class_ "flex gap-3 text-xs text-textWeak"] do
-        legendSwatch_ "bg-fillBrand-strong/70" "Clean"
-        legendSwatch_ "bg-fillError-strong" "Errored"
+        let swatch cls label = span_ [class_ "flex items-center gap-1"] (span_ [class_ $ "inline-block w-2 h-2 rounded-sm " <> cls] "" >> label)
+        swatch "bg-fillBrand-strong/70" "Clean"
+        swatch "bg-fillError-strong" "Errored"
     if null barEls
       then div_ [class_ "h-12 flex items-center justify-center text-xs text-textWeak"] "No data in range"
       else do
@@ -1121,19 +1117,14 @@ patternsHeader_ rowsV totalPatterns baseHourEpoch = do
       rawClean = sumBk (filter (not . (.isError)) rows)
       rawErr = sumBk errRows
       active = [i | (i, t) <- zip [0 :: Int ..] (zipWith (+) rawClean rawErr), t > 0]
-      slice xs = case active of
-        [] -> []
-        _ -> take (L.maximum active - L.minimum active + 1) $ drop (L.minimum active) xs
+      window = viaNonEmpty (\a -> (L.minimum a, L.maximum a)) active
+      slice xs = maybe [] (\(lo, hi) -> take (hi - lo + 1) $ drop lo xs) window
       cleanBk = slice rawClean
       errBk = slice rawErr
       -- Bars keep their original hour index so the client maps bar i to the
       -- clock hour @baseHourEpoch + i*3600@.
-      shownIdx = case active of
-        [] -> []
-        _ -> [L.minimum active .. L.maximum active]
-      bars = zip3 shownIdx cleanBk errBk
-      maxBar = foldl' max 0 (zipWith (+) cleanBk errBk)
-      norm n = if maxBar <= 0 then 0 else (fromIntegral n / fromIntegral maxBar :: Double) * 100
+      bars = zip3 (maybe [] (uncurry enumFromTo) window) cleanBk errBk
+      norm = barNorm cleanBk errBk
       barEls =
         [ div_
             [ class_ "flex-1 h-full flex flex-col-reverse gap-[1px] min-w-[2px] group/bar"
@@ -1153,8 +1144,8 @@ patternsHeader_ rowsV totalPatterns baseHourEpoch = do
         , ("Noisiest", fmtPct1 topShare, Just "of events")
         ]
 
-  div_ [class_ "mt-3 group-has-[.no-chart:checked]/pg:hidden group-has-[.toggle-chart:checked]/pg:hidden w-full flex flex-col gap-2"] do
-    div_ [class_ "grid grid-cols-5 max-md:grid-cols-3 gap-2"] $ forM_ kpis \(label, value, subM) -> kpiCard_ label value subM
+  div_ [class_ summaryRegionCls] do
+    div_ [class_ "grid grid-cols-5 max-md:grid-cols-3 gap-2"] $ forM_ kpis kpiCard_
     -- Patterns volume is hourly (from the rollup), so a range under an hour
     -- resolves to a single full-width bar. Rather than hide the trend, the note
     -- rides on the container and the client appends it to the lone bar's tooltip
@@ -1171,10 +1162,11 @@ sessionsHeader_ summ = do
       p95Dur = toText $ getDurationNSMS (fromIntegral summ.p95DurationNs)
       totalEvt = fromIntegral summ.totalEvents :: Int
       bars = zip3 [0 :: Int ..] summ.clean summ.errored
-      maxBar = foldl' max 0 $ zipWith (+) summ.clean summ.errored
-      norm n = if maxBar <= 0 then 0 else (fromIntegral n / fromIntegral maxBar :: Double) * 100
+      norm = barNorm summ.clean summ.errored
       bucketFrom i = summ.bucketStartEpoch + i * summ.bucketWidthSec
-      -- The onclick filters the table to the bucket; the axis labels + time-range
+      -- The onclick filters the table to the bucket; window.__sessionsBucketFilter
+      -- is defined once in queryEditorInitializationCode so this header stays
+      -- script-free and can be injected via innerHTML. Axis labels + time-range
       -- tooltips are filled client-side by window.formatSummaryChart from the
       -- data-bucket-start/width on the container (see summaryChartCard_).
       barEls =
@@ -1191,7 +1183,7 @@ sessionsHeader_ summ = do
 
       kpis :: [(Text, Text, Maybe Text)]
       kpis =
-        [ ("Sessions" :: Text, prettyPrintCount total, Just $ prettyPrintCount (max 0 (total - errored)) <> " clean")
+        [ ("Sessions", prettyPrintCount total, Just $ prettyPrintCount (max 0 (total - errored)) <> " clean")
         , ("Errored", fmtPct1 errRate, Just $ prettyPrintCount errored <> " sessions")
         , ("Median duration", medDur, Just $ "p95 " <> p95Dur)
         , ("Median events", prettyPrintCount $ fromIntegral summ.medianEvents, Just $ prettyPrintCount totalEvt <> " total")
@@ -1199,32 +1191,21 @@ sessionsHeader_ summ = do
         , ("Services", prettyPrintCount $ fromIntegral summ.uniqueServices, Nothing)
         ]
 
-  div_ [class_ "mt-3 group-has-[.no-chart:checked]/pg:hidden group-has-[.toggle-chart:checked]/pg:hidden w-full flex flex-col gap-2"] do
-    div_ [class_ "grid grid-cols-6 max-md:grid-cols-3 gap-2"] $ forM_ kpis \(label, value, subM) -> kpiCard_ label value subM
+  div_ [class_ summaryRegionCls] do
+    div_ [class_ "grid grid-cols-6 max-md:grid-cols-3 gap-2"] $ forM_ kpis kpiCard_
     summaryChartCard_ "Sessions over time" Nothing summ.bucketStartEpoch summ.bucketWidthSec barEls
 
 
--- The bar's onclick calls window.__sessionsBucketFilter, defined once in
--- queryEditorInitializationCode (not here) so this header stays script-free
--- and can be injected via innerHTML from the sessions data response.
-
-data LogsGet
-  = LogPage (PageCtx ApiLogsPageData)
-  | LogsGetError (PageCtx Text)
-  | LogsGetErrorSimple Text
+newtype LogsGet = LogPage (PageCtx ApiLogsPageData)
 
 
 instance ToHtml LogsGet where
   toHtml (LogPage (PageCtx conf pa_dat)) = toHtml $ PageCtx conf $ apiLogsPage pa_dat
-  toHtml (LogsGetErrorSimple err) = span_ [class_ "text-textError"] $ toHtml err
-  toHtml (LogsGetError (PageCtx conf err)) = toHtml $ PageCtx conf err
   toHtmlRaw = toHtml
 
 
 instance AE.ToJSON LogsGet where
-  toJSON (LogsGetError _) = AE.object ["error" AE..= True, "message" AE..= ("Something went wrong" :: Text)]
-  toJSON (LogsGetErrorSimple msg) = AE.object ["error" AE..= True, "message" AE..= msg]
-  toJSON _ = AE.object ["error" AE..= True]
+  toJSON (LogPage _) = AE.object ["error" AE..= True]
 
 
 -- | HTMX fragment for the query-library popover, returned by the save/delete
@@ -1233,7 +1214,7 @@ data QueryLibraryView = QueryLibraryView Projects.ProjectId (V.Vector Projects.Q
 
 
 instance ToHtml QueryLibraryView where
-  toHtml (QueryLibraryView pid queryLibSaved queryLibRecent) = toHtml $ queryLibrary_ pid queryLibSaved queryLibRecent
+  toHtml (QueryLibraryView _pid queryLibSaved queryLibRecent) = toHtml $ queryLibraryDropdown_ queryLibSaved queryLibRecent
   toHtmlRaw = toHtml
 
 
@@ -1272,10 +1253,10 @@ instance AE.ToJSON PatternsView where
 
 -- | JSON payload for the sessions visualization endpoint. Reuses the logs
 -- column layout so the same rendering code applies; session-specific info is
--- packed into the summary column as badge elements.
--- | Sessions data payload. The optional 'SessionSummary' is present only on the
--- first page (skip=0); its rendered header HTML is delivered as @summaryHtml@ so
--- the client can inject #page-summary-region without a second scan/request.
+-- packed into the summary column as badge elements. The optional
+-- 'LogQueries.SessionSummary' is present only on the first page (skip=0); its
+-- rendered header HTML rides along as @summaryHtml@ so the client can inject
+-- #page-summary-region without a second scan/request.
 data SessionsView = SessionsView Int (V.Vector LogQueries.SessionRow) (Maybe LogQueries.SessionSummary)
 
 
@@ -1491,6 +1472,16 @@ apiLogsPage page = do
     countText = prettyPrintCount page.queryResultCount
     suffixText = if page.queryResultCount >= page.resultCount then " rows" else "+ rows"
 
+    -- Show/hide-filters label; @attrs@ must not carry a class_ (Lucid concatenates
+    -- duplicate class attributes with no separator).
+    filtersLabel_ :: [Attribute] -> Html () -> Html ()
+    filtersLabel_ attrs trailing = label_ ([class_ "gap-1 flex items-center cursor-pointer text-textWeak"] <> attrs) do
+      faSprite_ "side-chevron-left-in-box" "regular" "w-4 h-4 group-has-[.toggle-filters:checked]/pg:rotate-180 text-iconNeutral"
+      span_ [class_ "hidden group-has-[.toggle-filters:checked]/pg:block"] "Show"
+      span_ [class_ "group-has-[.toggle-filters:checked]/pg:hidden"] "Hide"
+      "filters"
+      trailing
+
     -- data-fullscreen=details|trace drives layout via tailwind.css; single-valued so
     -- "at most one fullscreen mode" holds by construction.
     sectionWrapper_ =
@@ -1553,11 +1544,7 @@ apiLogsPage page = do
           , alert = isJust page.alert
           , patternSelected = page.targetPattern
           , mobileExtra = Just do
-              label_ [class_ "gap-1 flex items-center cursor-pointer text-textWeak", Lucid.for_ "toggle-filters"] do
-                faSprite_ "side-chevron-left-in-box" "regular" "w-4 h-4 group-has-[.toggle-filters:checked]/pg:rotate-180 text-iconNeutral"
-                span_ [class_ "hidden group-has-[.toggle-filters:checked]/pg:block"] "Show"
-                span_ [class_ "group-has-[.toggle-filters:checked]/pg:hidden"] "Hide"
-                "filters"
+              filtersLabel_ [Lucid.for_ "toggle-filters"] pass
               span_ [class_ "text-strokeWeak text-xs"] "·"
               rowCountDisplay_ "mobile" countText suffixText
           , parseError = page.parseError
@@ -1571,7 +1558,7 @@ apiLogsPage page = do
       div_ [id_ "page-summary-region"]
         $ if page.vizType == Just "sessions" || page.vizType == Just "patterns"
           then sessionsSummarySkeleton_
-          else div_ [class_ "timeline flex flex-row gap-4 mt-3 group-has-[.no-chart:checked]/pg:hidden group-has-[.toggle-chart:checked]/pg:hidden w-full min-h-36 max-md:min-h-28 aspect-[10/1] max-md:aspect-auto max-md:flex-col"] do
+          else div_ [class_ chartRegionCls] do
             Widget.widget_ page.chartWidget
             div_ [class_ "flex-1 min-w-0 max-md:hidden"] $ Widget.widget_ page.latencyWidget
 
@@ -1606,9 +1593,7 @@ apiLogsPage page = do
                     if the event's key is 'Escape'
                       set my value to '' then trigger keyup
                     else
-                      show <div.facet-section-group/> in #{@data-filterParent} when its textContent.toLowerCase() contains my value.toLowerCase()
-                      show <div.facet-section/> in #{@data-filterParent} when its textContent.toLowerCase() contains my value.toLowerCase()
-                      show <div.facet-value/> in #{@data-filterParent} when its textContent.toLowerCase() contains my value.toLowerCase()
+                      show <div.facet-section-group, div.facet-section, div.facet-value/> in #{@data-filterParent} when its textContent.toLowerCase() contains my value.toLowerCase()
                   |]
             ]
         -- Facet values (~680KB) are lazy-loaded via HTMX on first intersect so
@@ -1632,12 +1617,8 @@ apiLogsPage page = do
 
     -- Filters toggle and row count, shown above the viz widget / trace / virtual table.
     rowCountHeader = div_ [class_ "flex gap-2 py-1 text-sm z-10 w-max bg-bgBase -mb-6 group-has-[#viz-patterns:checked]/pg:mb-0"] do
-      label_ [class_ "gap-1 flex items-center cursor-pointer text-textWeak"] do
-        faSprite_ "side-chevron-left-in-box" "regular" "w-4 h-4 group-has-[.toggle-filters:checked]/pg:rotate-180 text-iconNeutral"
-        span_ [class_ "hidden group-has-[.toggle-filters:checked]/pg:block"] "Show"
-        span_ [class_ "group-has-[.toggle-filters:checked]/pg:hidden"] "Hide"
-        "filters"
-        input_
+      filtersLabel_ []
+        $ input_
           [ type_ "checkbox"
           , class_ "toggle-filters hidden"
           , id_ "toggle-filters"
@@ -1783,32 +1764,31 @@ apiLogsPage page = do
 -- (@kind=pattern@), plus a @hasMore@ flag for pagination.
 apiLogExpandH :: Projects.ProjectId -> Maybe Text -> Maybe Text -> Maybe Int -> Maybe Text -> Maybe Text -> Maybe Text -> Maybe Text -> ATAuthCtx (RespHeaders AE.Value)
 apiLogExpandH pid kindM keyM skipM queryM sinceM fromM toM = do
-  _ <- Projects.sessionAndProject pid
-  when (T.null $ maybeToMonoid keyM) $ throwError Servant.err400{Servant.errBody = "Missing key"}
-  expandKind <- case kindM of
-    Just "session" -> pure $ LogQueries.ExpandSession (maybeToMonoid keyM)
-    Just "pattern" -> pure $ LogQueries.ExpandPattern (maybeToMonoid keyM)
+  (authCtx, _, fromD, toD) <- logDataEnv pid sinceM fromM toM
+  let key = maybeToMonoid keyM
+  when (T.null key) $ throwError Servant.err400{Servant.errBody = "Missing key"}
+  -- Sessions render a trace tree (hence the child-span fetch and larger page);
+  -- patterns just show flat examples.
+  (expandKind, limitN) <- case kindM of
+    Just "session" -> pure (LogQueries.ExpandSession key, 100 :: Int)
+    Just "pattern" -> pure (LogQueries.ExpandPattern key, 20)
     _ -> throwError Servant.err400{Servant.errBody = "kind must be session or pattern"}
-
-  let isSession = case expandKind of LogQueries.ExpandSession _ -> True; LogQueries.ExpandPattern _ -> False
-      limitN = (if isSession then 100 else 20) :: Int
 
   queryAST <-
     either (\err -> throwError Servant.err400{Servant.errBody = encodeUtf8 $ "Invalid query: " <> err}) pure (parseQueryToAST (maybeToMonoid queryM))
 
-  now <- Time.currentTime
-  let (fromD, toD, _) = Components.parseTimeRange now (Components.TimePicker sinceM fromM toM)
-  authCtx <- Effectful.Reader.Static.ask @AuthContext
   (rows, cols) <- LogQueries.fetchEventExamples authCtx.env.enableTimefusionReads pid queryAST (fromD, toD) expandKind (fromMaybe 0 skipM) (limitN + 1)
 
   let hasMore = V.length rows > limitN
       shown = if hasMore then V.take limitN rows else rows
       colIdxMap = listToIndexHashMap cols
-      alreadyLoadedIds = V.mapMaybe (\v -> lookupVecTextByKey v colIdxMap "id") shown
-  -- Only fetch child spans for sessions (trace tree view); patterns just show flat examples
-  let traceIds = V.fromList $ take 100 $ nubOrd $ mapMaybe (mfilter (not . T.null) . (\v -> lookupVecTextByKey v colIdxMap "trace_id")) $ V.toList shown
-      seedSpanIds = V.mapMaybe (\v -> lookupVecTextByKey v colIdxMap "latency_breakdown") shown
-  childSpansList <- bool (pure []) (LogQueries.selectChildSpansAndLogs pid [] traceIds seedSpanIds (fromD, toD) alreadyLoadedIds) isSession
+      colOf k v = lookupVecTextByKey v colIdxMap k
+      alreadyLoadedIds = V.mapMaybe (colOf "id") shown
+      traceIds = V.fromList $ take 100 $ nubOrd $ mapMaybe (mfilter (not . T.null) . colOf "trace_id") $ V.toList shown
+      seedSpanIds = V.mapMaybe (colOf "latency_breakdown") shown
+  childSpansList <- case expandKind of
+    LogQueries.ExpandSession _ -> LogQueries.selectChildSpansAndLogs pid [] traceIds seedSpanIds (fromD, toD) alreadyLoadedIds
+    LogQueries.ExpandPattern _ -> pure []
   let rawLogsData = shown <> V.fromList childSpansList
       (logsData, traces) = buildTraceTree colIdxMap (V.length shown) rawLogsData
 

--- a/src/Pages/LogExplorer/Log.hs
+++ b/src/Pages/LogExplorer/Log.hs
@@ -70,7 +70,7 @@ import Pkg.Parser (defaultQueryLimit, pSource, parseQueryToAST, toQText)
 import Pkg.Parser.Stats (Section (TakeCommand))
 import Pkg.SchemaLearning.Catalog (FacetData (..), FacetSummary (..), FacetValue (..))
 import Relude hiding (ask)
-import Relude.Extra.Foldable1 (minimum1)
+import Relude.Extra.Foldable1 (maximum1, minimum1)
 import Servant qualified
 import System.Config (AuthContext (..), EnvConfig (..))
 import System.Types
@@ -1119,7 +1119,7 @@ patternsHeader_ rowsV totalPatterns baseHourEpoch = do
       rawClean = sumBk (filter (not . (.isError)) rows)
       rawErr = sumBk errRows
       active = [i | (i, t) <- zip [0 :: Int ..] (zipWith (+) rawClean rawErr), t > 0]
-      window = viaNonEmpty (\a -> (L.minimum a, L.maximum a)) active
+      window = viaNonEmpty (\a -> (minimum1 a, maximum1 a)) active
       slice xs = maybe [] (\(lo, hi) -> take (hi - lo + 1) $ drop lo xs) window
       cleanBk = slice rawClean
       errBk = slice rawErr

--- a/src/Pages/LogExplorer/Log.hs
+++ b/src/Pages/LogExplorer/Log.hs
@@ -23,6 +23,7 @@ module Pages.LogExplorer.Log (
   logQueryBox_,
   TraceTreeEntry (..),
   buildTraceTree,
+  synthesizeOrphanHeaders,
   fmtPct1,
   -- Sidebar facet definitions — exported for high-level tests.
   Facet (..),
@@ -69,6 +70,7 @@ import Pkg.Parser (defaultQueryLimit, pSource, parseQueryToAST, toQText)
 import Pkg.Parser.Stats (Section (TakeCommand))
 import Pkg.SchemaLearning.Catalog (FacetData (..), FacetSummary (..), FacetValue (..))
 import Relude hiding (ask)
+import Relude.Extra.Foldable1 (minimum1)
 import Servant qualified
 import System.Config (AuthContext (..), EnvConfig (..))
 import System.Types
@@ -306,7 +308,7 @@ synthesizeOrphanHeaders colIdxMap rows = V.fromList [synthRow t p ks | ((t, p), 
     firstText k = fromMaybe "" . asum . map (textAt k)
     synthRow tid pid ks =
       let spans' = mapMaybe (\r -> (,) <$> numAt "start_time_ns" r <*> numAt "duration" r) ks
-          startNs = foldr (min . fst) 0 spans'
+          startNs = maybe 0 minimum1 $ nonEmpty $ map fst spans'
           endNs = foldr (max . uncurry (+)) startNs spans'
           label = "Upstream span missing \x2014 " <> T.take 8 pid
           -- 'text-textWeak' style matches renderer's WEAK_TEXT_STYLES lookup; italic +

--- a/src/Pages/LogExplorer/Log.hs
+++ b/src/Pages/LogExplorer/Log.hs
@@ -579,7 +579,7 @@ queryEvents pid queryM sinceM fromM toM sourceM limitM withChildrenM includeAttr
       -- trace-tree rows include synth headers + descendants.
       hasKqlLimit = any (\case TakeCommand{} -> True; _ -> False) queryAST
       queryAST' = if hasKqlLimit then queryAST else queryAST <> [TakeCommand (min defaultQueryLimit (fromMaybe 100 limitM))]
-  result <- LogQueries.selectLogTable pid queryAST' (toQText queryAST') Nothing (fromD, toD) (if fromMaybe False includeAttributesM then ["attributes"] else []) (parseMaybe pSource =<< sourceM) Nothing
+  result <- LogQueries.selectLogTable pid queryAST' (toQText queryAST') Nothing (fromD, toD) ["attributes" | fromMaybe False includeAttributesM] (parseMaybe pSource =<< sourceM) Nothing
   case result of
     Left err -> throwError $ translateQueryError err
     -- Default to exact-match (no trace expansion); UI passes True via apiLogH.
@@ -1457,7 +1457,7 @@ apiLogsPage :: ApiLogsPageData -> Html ()
 apiLogsPage page = do
   sectionWrapper_ do
     template_ [id_ "loader-tmp"] $ loadingIndicator_ LdMD LdDots
-    template_ [id_ "trace-loading-skeleton"] $ traceLoadingSkeleton_
+    template_ [id_ "trace-loading-skeleton"] traceLoadingSkeleton_
     div_ [class_ "fixed z-[9999] hidden right-0 w-max h-max border rounded top-32 bg-bgBase shadow-lg", id_ "sessionPlayerWrapper"] do
       termRaw "session-replay" [id_ "sessionReplay", class_ "shrink-1 flex flex-col", term "projectId" page.pid.toText, term "containerId" "sessionPlayerWrapper"] ("" :: Text)
     shareLogModal

--- a/src/Pages/LogExplorer/LogItem.hs
+++ b/src/Pages/LogExplorer/LogItem.hs
@@ -15,7 +15,6 @@ import Control.Lens (filtered, has, (^..), (^?), _Just)
 import Data.Aeson qualified as AE
 import Data.Aeson.KeyMap qualified as KEM
 import Data.Aeson.Lens (key, _Array, _String)
-import Data.Char (isSpace)
 import Data.Default (def)
 import Data.Effectful.Hasql qualified as Hasql
 import Data.Foldable.WithIndex (ifor_)
@@ -47,7 +46,7 @@ getServiceName rs = fromMaybe "Unknown" $ (Map.lookup "service" =<< rs) >>= (^? 
 
 
 getServiceColor :: Text -> HashMap Text Text -> Text
-getServiceColor s serviceColors = fromMaybe "bg-fillNeutral-strong" $ HM.lookup s serviceColors
+getServiceColor = HM.findWithDefault "bg-fillNeutral-strong"
 
 
 getRequestDetails :: Maybe (Map Text AE.Value) -> Maybe (Text, Text, Text, Int)
@@ -62,7 +61,11 @@ getRequestDetails spanRecord = do
     txt k = fromMaybe "" $ atMapText k spanRecord
     query = txt "db.query"
     status pfx = fromMaybe 0 $ Telemetry.atMapInt (pfx <> ".status_code") spanRecord
-    url pfx = viaNonEmpty head $ Relude.filter (not . T.null) [txt (pfx <> "." <> k) | k <- ["route", "path", "url", "target"]]
+    url pfx = viaNonEmpty head $ filter (not . T.null) [txt (pfx <> "." <> k) | k <- ["route", "path", "url", "target"]]
+
+
+isHttpSpan :: Telemetry.OtelLogsAndSpans -> Bool
+isHttpSpan r = any (\(t, _, _, _) -> t == "HTTP") (getRequestDetails (unAesonTextMaybe r.attributes))
 
 
 -- | Exception events (event_name == "exception") within a span's events array.
@@ -116,12 +119,11 @@ anchorSdkSpan lookupParent lookupSdk record
   | record.name `elem` map Just Telemetry.sdkSpanNames = do
       parentM <- maybe (pure Nothing) lookupParent (record.parent_id >>= guarded (not . T.null))
       pure $ case parentM of
-        Just parent | isHttpRec parent -> (parent, Just record)
+        Just parent | isHttpSpan parent -> (parent, Just record)
         _ -> (record, Nothing)
-  | isHttpRec record && not hasBodies = (record,) <$> lookupSdk
+  | isHttpSpan record && not hasBodies = (record,) <$> lookupSdk
   | otherwise = pure (record, Nothing)
   where
-    isHttpRec r = any (\(t, _, _, _) -> t == "HTTP") (getRequestDetails (unAesonTextMaybe r.attributes))
     hasBodies = any (\k -> has (_Just . key k) (unAesonTextMaybe record.body)) ["request_body", "response_body"]
 
 
@@ -129,6 +131,12 @@ data ApiItemDetailed
   = SpanItemExpanded Projects.ProjectId Telemetry.OtelLogsAndSpans (Maybe Telemetry.OtelLogsAndSpans) (Maybe Text)
   | LogItemExpanded Projects.ProjectId Telemetry.OtelLogsAndSpans (Maybe Text)
   | ItemDetailedNotFound Text
+
+
+-- | Dismissing the panel: the trace overlay owns it via the global handler, the log-explorer
+-- shell via the event contract — both are wired on every close affordance.
+closeDetailAttrs :: [Attribute]
+closeDetailAttrs = [onclick_ "window.closeTraceDetails(this)", [__|on click send closeDetailPanel to closest <.details-panel/>|]]
 
 
 instance ToHtml ApiItemDetailed where
@@ -139,12 +147,9 @@ instance ToHtml ApiItemDetailed where
     where
       closeBtn =
         button_
-          [ class_ "btn btn-sm btn-ghost text-sm"
-          , Aria.label_ "Close details panel"
-          , term "data-share-hide" "1"
-          , onclick_ "window.closeTraceDetails(this)"
-          , [__|on click send closeDetailPanel to closest <.details-panel/>|]
-          ]
+          ( [class_ "btn btn-sm btn-ghost text-sm", Aria.label_ "Close details panel", term "data-share-hide" "1"]
+              <> closeDetailAttrs
+          )
           "Close"
   toHtmlRaw = toHtml
 
@@ -154,7 +159,7 @@ spanBadge pid path val fieldKey =
   div_
     [ class_ "relative min-w-0"
     , term "data-field-path" path
-    , term "data-field-value" $ "\"" <> T.dropAround isSpace (fromMaybe val (viaNonEmpty last (T.splitOn ":" val))) <> "\""
+    , term "data-field-value" $ "\"" <> T.strip (T.takeWhileEnd (/= ':') val) <> "\""
     ]
     $ button_
       [ class_ "relative cursor-pointer flex gap-2 items-center text-textStrong bg-fillWeaker border border-strokeWeak text-xs rounded-lg whitespace-nowrap px-2 py-1 max-w-64"
@@ -176,12 +181,12 @@ expandedItemView pid item aptSp selectedTabM = do
   -- Row #1 (both views): back-to-logs (mobile only), timestamp, close.
   div_ [class_ "sticky top-[-1px] z-10 flex items-center gap-2 bg-bgBase border-b border-l border-strokeWeak max-md:border-l-0 px-2 py-1"] do
     button_
-      [ class_ "hidden max-md:flex cursor-pointer items-center gap-1.5 text-sm font-medium text-textBrand"
-      , Aria.label_ "Close details"
-      , term "data-share-hide" "1"
-      , onclick_ "window.closeTraceDetails(this)"
-      , [__|on click send closeDetailPanel to closest <.details-panel/>|]
-      ]
+      ( [ class_ "hidden max-md:flex cursor-pointer items-center gap-1.5 text-sm font-medium text-textBrand"
+        , Aria.label_ "Close details"
+        , term "data-share-hide" "1"
+        ]
+          <> closeDetailAttrs
+      )
       (faSprite_ "chevron-left" "regular" "w-3.5 h-3.5" >> "Back to logs")
     div_ [class_ "flex gap-2 items-center shrink-0 ml-auto"] do
       dateTime (if isLog then item.timestamp else item.start_time) Nothing
@@ -197,12 +202,12 @@ expandedItemView pid item aptSp selectedTabM = do
             faSprite_ "expand" "regular" "w-3.5 h-3.5 text-iconNeutral [#apiLogsPage[data-fullscreen=details]_&]:hidden!"
             faSprite_ "compress" "regular" "hidden! w-3.5 h-3.5 text-iconNeutral [#apiLogsPage[data-fullscreen=details]_&]:block!"
         button_
-          [ class_ "cursor-pointer detail-close-btn rounded-md p-1 hover:bg-fillWeak transition-colors"
-          , Aria.label_ "Close item details"
-          , term "data-tippy-content" "Close · Esc"
-          , onclick_ "window.closeTraceDetails(this)"
-          , [__|on click send closeDetailPanel to closest <.details-panel/>|]
-          ]
+          ( [ class_ "cursor-pointer detail-close-btn rounded-md p-1 hover:bg-fillWeak transition-colors"
+            , Aria.label_ "Close item details"
+            , term "data-tippy-content" "Close · Esc"
+            ]
+              <> closeDetailAttrs
+          )
           $ faSprite_ "xmark" "regular" "w-3 h-3 text-iconNeutral"
   div_ [class_ $ "w-full pl-3 pr-1 pb-2 relative border-l border-strokeWeak max-md:border-l-0 max-md:px-0 " <> if isLog then " flex flex-col gap-2" else " pb-[50px]"] do
     div_ [id_ "copy_share_link"] pass
@@ -211,20 +216,20 @@ expandedItemView pid item aptSp selectedTabM = do
     headerBlock
     div_ [class_ "w-full mt-3 group/dtab"] do
       div_ [class_ "flex", [__|on click halt the event's bubbling|]] do
-        forM_ tabs \t -> lazyDetailTab_ t (t.marker == activeMarker)
+        traverse_ lazyDetailTab_ tabs
         div_ [class_ "w-full border-b-2 border-b-strokeWeak"] pass
       div_ [class_ "mt-2 py-1 text-textWeak", id_ "trace-details-content"] $ traverse_ (.panel) activeTabs
   where
     isLog = item.kind == Just "log"
     isAlert = item.kind == Just "alert"
-    isHttp = case if isLog then Nothing else getRequestDetails (unAesonTextMaybe item.attributes) of Just ("HTTP", _, _, _) -> True; _ -> False
+    isHttp = not isLog && isHttpSpan item
     createdAt = formatUTC item.timestamp
     dgrp = "dtab-" <> item.id
     detailUrl = "/p/" <> pid.toText <> "/log_explorer/" <> item.id <> "/" <> createdAt <> "/detailed"
     activeMarker = fromMaybe (case tabs of [] -> "tab-raw"; t : _ -> t.marker) selectedTabM
     activeTabs = filter ((== activeMarker) . (.marker)) tabs
-    lazyDetailTab_ t active = label_ [class_ $ "cursor-pointer border-b-2 border-b-strokeWeak px-4 py-1.5 text-sm has-[:focus-visible]:ring-2 has-[:focus-visible]:ring-strokeBrand-strong has-[:focus-visible]:rounded-sm has-[:checked]:font-bold has-[:checked]:border-strokeBrand-strong has-[:checked]:text-textBrand " <> t.cls] do
-      input_ $ [type_ "radio", name_ dgrp, class_ $ "sr-only " <> t.marker, hxGet_ (detailUrl <> "?tab=" <> t.marker), hxTarget_ "#trace-details-content", hxSelect_ "#trace-details-content", hxSwap_ "outerHTML", hxTrigger_ "change"] <> [checked_ | active]
+    lazyDetailTab_ t = label_ [class_ $ "cursor-pointer border-b-2 border-b-strokeWeak px-4 py-1.5 text-sm has-[:focus-visible]:ring-2 has-[:focus-visible]:ring-strokeBrand-strong has-[:focus-visible]:rounded-sm has-[:checked]:font-bold has-[:checked]:border-strokeBrand-strong has-[:checked]:text-textBrand " <> t.cls] do
+      input_ $ [type_ "radio", name_ dgrp, class_ $ "sr-only " <> t.marker, hxGet_ (detailUrl <> "?tab=" <> t.marker), hxTarget_ "#trace-details-content", hxSelect_ "#trace-details-content", hxSwap_ "outerHTML", hxTrigger_ "change"] <> [checked_ | t.marker == activeMarker]
       t.label
     events = fromMaybe AE.Null (unAesonTextMaybe item.events)
     spanErrors = if isLog then [] else getSpanErrors events
@@ -246,7 +251,7 @@ expandedItemView pid item aptSp selectedTabM = do
 
     actionRow = do
       when isHttp
-        $ button_ [class_ "action-btn", onclick_ "window.buildCurlRequest(event)", term "data-reqjson" (decodeUtf8 $ AE.encode $ AE.toJSON item)]
+        $ button_ [class_ "action-btn", onclick_ "window.buildCurlRequest(event)", term "data-reqjson" (decodeUtf8 $ AE.encode item)]
         $ actionBtnBody "copy" "Copy as curl"
       whenJust (item.context >>= (.trace_id) >>= guarded (not . T.null)) \trId ->
         button_
@@ -295,15 +300,11 @@ expandedItemView pid item aptSp selectedTabM = do
             (not isLog)
             "tab-logs"
             "flex items-center gap-1"
-            (badge "Logs" "badge badge-ghost badge-sm" (numberOfEvents events))
+            (badge "Logs" "badge badge-ghost badge-sm" (maybe 0 length (events ^? _Array)))
             (jsonTab_ "group-has-[.tab-logs:checked]/dtab:block" "logs-content" "events" events Nothing)
         , tab True "tab-raw" "whitespace-nowrap" "Raw data" (jsonTab_ "group-has-[.tab-raw:checked]/dtab:block" "m-raw-content" "raw" (AE.toJSON item) Nothing)
         ]
       where
-        numberOfEvents :: AE.Value -> Int
-        numberOfEvents (AE.Array obj) = length obj
-        numberOfEvents _ = 0
-
         tab shown m c l p = DetailTab m c l p <$ guard shown
         badge l c n = toHtml @Text l >> div_ [class_ c] (show n)
         attPanel = tabPanel_ "group-has-[.tab-att:checked]/dtab:block" "att-content" $ case unAesonTextMaybe item.attributes of
@@ -312,8 +313,8 @@ expandedItemView pid item aptSp selectedTabM = do
         reqPanel = tabPanel_ "group-has-[.tab-req:checked]/dtab:block" "request-content" $ div_ [id_ "http-content-container", class_ "group/htab flex flex-col gap-3 mt-2"] do
           let cSp = fromMaybe item aptSp
               bodyField k = fromMaybe (AE.object []) $ unAesonTextMaybe cSp.body >>= (^? key k)
-              httpSub = foldlM (\acc k -> case acc of AE.Object o -> KEM.lookup k o; _ -> Nothing) (AE.Object $ maybe mempty (\case AE.Object o -> o; _ -> mempty) (unAesonTextMaybe cSp.attributes >>= Map.lookup "http"))
-              hp = fromMaybe AE.Null . httpSub
+              httpAttrs = fromMaybe AE.Null $ unAesonTextMaybe cSp.attributes >>= Map.lookup "http"
+              hp ks = fromMaybe AE.Null $ foldlM (\v k -> v ^? key k) httpAttrs ks
               notEmpty v = v `notElem` ([AE.Null, AE.object [], AE.Array mempty, AE.String ""] :: [AE.Value])
               -- Default to the first sub-tab that has content (Request Details always does).
               defaultTab =
@@ -344,7 +345,6 @@ expandedItemView pid item aptSp selectedTabM = do
               \(visCls, eid, nm, val, filt) -> jsonTab_ visCls eid nm val filt
 
 
--- Helper functions
 renderErrors :: [AE.Value] -> Html ()
 renderErrors errs =
   div_ [class_ "flex flex-col mt-4 gap-3 w-full"] $ ifor_ errs \idx err ->

--- a/src/Pages/Monitors.hs
+++ b/src/Pages/Monitors.hs
@@ -25,7 +25,6 @@ module Pages.Monitors (
 )
 where
 
-import Control.Lens (view, _2, _3)
 import Data.Aeson qualified as AE
 import Data.CaseInsensitive qualified as CI
 import Data.Default (def)
@@ -50,13 +49,11 @@ import Models.Apis.Integrations qualified as Slack
 import Models.Apis.Monitors qualified as Monitors
 import Models.Projects.ProjectMembers (Team (discord_channels, slack_channels))
 import Models.Projects.ProjectMembers qualified as ManageMembers
-import Models.Projects.ProjectMembers qualified as ProjectMembers
 import Models.Projects.Projects qualified as Projects
 import NeatInterpolation (text)
 import Pages.BodyWrapper (BWConfig (..), PageCtx (..), mkPageCtx, navTabAttrs)
 import Pages.Bots.Discord qualified as Discord
 import Pages.Bots.Slack qualified as Slack
-import Pages.Bots.Slack qualified as SlackP
 import Pages.Bots.Utils (Channel (channelId, channelName))
 import Pages.Components (FieldCfg (..), FieldSize (..), PanelCfg (..), formCheckbox_, formField_, formSelectField_, metadataChip_, panel_, tagInput_)
 import Pages.Projects (TBulkActionForm (..))
@@ -119,9 +116,7 @@ convertToQueryMonitor projectId now queryMonitorId alertForm =
       (_, qc) = fromRight' $ parseQueryToComponents sqlQueryCfg alertForm.query
       warningThresholdD = readMaybe . toString =<< alertForm.warningThreshold
 
-      checkInterval = case alertForm.frequency of
-        Just freq -> max 1 $ fromMaybe 5 $ readMaybe $ toString $ T.dropEnd 1 freq
-        Nothing -> 5
+      checkInterval = maybe 5 (max 1 . fromMaybe 5 . readMaybe . toString . T.dropEnd 1) alertForm.frequency
       timeWindowMins = maybe 60 parseIntervalToMins alertForm.timeWindow
 
       isThresholdAlert = alertForm.conditionType == Just "threshold_exceeded"
@@ -177,9 +172,6 @@ convertToQueryMonitor projectId now queryMonitorId alertForm =
 
 parseIntervalToMins :: Text -> Int
 parseIntervalToMins = \case
-  "10m" -> 10
-  "20m" -> 20
-  "30m" -> 30
   "1h" -> 60
   "6h" -> 360
   "24h" -> 1440
@@ -198,22 +190,15 @@ alertUpsertPostH :: Projects.ProjectId -> AlertUpsertForm -> ATAuthCtx (RespHead
 alertUpsertPostH pid form = do
   _ <- Projects.sessionAndProject pid
   let alertId = form.alertId >>= UUID.fromText
-  queryMonitorId <- liftIO $ case alertId of
-    Just alertId' -> pure (Monitors.QueryMonitorId alertId')
-    Nothing -> Monitors.QueryMonitorId <$> UUID.nextRandom
+  queryMonitorId <- Monitors.QueryMonitorId <$> maybe (liftIO UUID.nextRandom) pure alertId
   now <- Time.currentTime
 
   -- For widget-tied alerts, preserve the query from the widget (can't edit directly)
-  existingMonitor <- case alertId of
-    Just _ -> Monitors.queryMonitorById queryMonitorId
-    Nothing -> pure Nothing
+  existingMonitor <- if isJust alertId then Monitors.queryMonitorById queryMonitorId else pure Nothing
 
   let baseMonitor = convertToQueryMonitor pid now queryMonitorId form
       queryMonitor = case existingMonitor of
-        Just existing
-          | isJust existing.widgetId ->
-              let Monitors.QueryMonitor{id = monitorId, ..} = baseMonitor
-               in Monitors.QueryMonitor{id = monitorId, logQuery = existing.logQuery, logQueryAsSql = existing.logQueryAsSql, ..}
+        Just existing | isJust existing.widgetId -> baseMonitor{Monitors.logQuery = existing.logQuery, Monitors.logQueryAsSql = existing.logQueryAsSql}
         _ -> baseMonitor
 
   _ <- Monitors.queryMonitorUpsert queryMonitor
@@ -250,16 +235,12 @@ data Alert
   = AlertListGet (V.Vector Monitors.QueryMonitor)
   | AlertSingle Projects.ProjectId (Maybe Monitors.QueryMonitor)
   | AlertNoContent Text
-  | AlertRedirect Text
-  | AlertPage (PageCtx (Html ()))
 
 
 instance ToHtml Alert where
   toHtml (AlertListGet monitors) = toHtml $ queryMonitors_ monitors
   toHtml (AlertSingle pid monitor) = toHtml $ alertSingleComp pid monitor
   toHtml (AlertNoContent msg) = toHtml msg
-  toHtml (AlertRedirect url) = script_ $ "window.location.href = '" <> url <> "';"
-  toHtml (AlertPage page) = toHtml page
   toHtmlRaw = toHtml
 
 
@@ -279,43 +260,27 @@ queryMonitors_ monitors = do
       th_ ""
     tbody_ do
       V.forM_ monitors \monitor -> tr_ do
-        let editAction =
-              [__|
-on click
-if ('URLSearchParams' in window)
-    make a URLSearchParams from window.location.search called :searchParams
-    call :searchParams.set("foo", "bar")
-    set :newRelativePathQuery to window.location.pathname + '?' + :searchParams.toString()
-    call history.pushState(null, '', newRelativePathQuery)
-end
-            |]
         let editURI = "/p/" <> monitor.projectId.toText <> "/monitors/alerts/" <> monitor.id.toText
+            isWidget = isJust monitor.widgetId
+            isDeactivated = isJust monitor.deactivatedAt
+            sourceLabel = do
+              faSprite_ (bool "file-lines" "chart-simple" isWidget) "regular" "w-3.5 h-3.5 text-iconNeutral"
+              bool "Log Explorer" "Widget" isWidget
         td_
-          [ class_ $ if isJust monitor.deactivatedAt then "line-through" else ""
+          [ class_ $ bool "" "line-through" isDeactivated
           , hxTarget_ "#alertsListContainer"
           , hxGet_ editURI
-          , editAction
           ]
           $ toHtml monitor.alertConfig.title
-        td_ [class_ "text-sm text-textWeak"] do
-          case monitor.widgetId of
-            Just wid -> case monitor.dashboardId of
-              Just dashId ->
-                a_ [class_ "flex items-center gap-1 hover:text-textStrong", href_ $ "/p/" <> monitor.projectId.toText <> "/dashboards/" <> UUID.toText dashId <> "#" <> wid] do
-                  faSprite_ "chart-simple" "regular" "w-3.5 h-3.5 text-iconNeutral"
-                  "Widget"
-              Nothing -> span_ [class_ "flex items-center gap-1"] do
-                faSprite_ "chart-simple" "regular" "w-3.5 h-3.5 text-iconNeutral"
-                "Widget"
-            Nothing -> span_ [class_ "flex items-center gap-1"] do
-              faSprite_ "file-lines" "regular" "w-3.5 h-3.5 text-iconNeutral"
-              "Log Explorer"
+        td_ [class_ "text-sm text-textWeak"]
+          $ case (,) <$> monitor.widgetId <*> monitor.dashboardId of
+            Just (wid, dashId) -> a_ [class_ "flex items-center gap-1 hover:text-textStrong", href_ $ "/p/" <> monitor.projectId.toText <> "/dashboards/" <> UUID.toText dashId <> "#" <> wid] sourceLabel
+            Nothing -> span_ [class_ "flex items-center gap-1"] sourceLabel
         td_ [class_ "flex items-center gap-1"] do
           a_
             [ class_ "btn btn-ghost btn-xs btn-square text-iconNeutral"
             , hxTarget_ "#alertsListContainer"
             , hxGet_ editURI
-            , editAction
             , Aria.label_ "Edit"
             ]
             $ faSprite_ "pen-to-square" "regular" "w-3.5 h-3.5"
@@ -323,9 +288,9 @@ end
             [ class_ "btn btn-ghost btn-xs btn-square text-iconNeutral"
             , hxTarget_ "#alertsListContainer"
             , hxPost_ $ "/p/" <> monitor.projectId.toText <> "/monitors/alerts/" <> monitor.id.toText <> "/toggle_active"
-            , Aria.label_ $ if isJust monitor.deactivatedAt then "Reactivate" else "Delete"
+            , Aria.label_ $ bool "Delete" "Reactivate" isDeactivated
             ]
-            $ faSprite_ (if isJust monitor.deactivatedAt then "arrow-rotate-left" else "trash") "regular" "w-3.5 h-3.5"
+            $ faSprite_ (bool "trash" "arrow-rotate-left" isDeactivated) "regular" "w-3.5 h-3.5"
 
 
 alertTeamDeleteH :: Projects.ProjectId -> Monitors.QueryMonitorId -> UUID.UUID -> ATAuthCtx (RespHeaders Alert)
@@ -353,15 +318,15 @@ monitorScheduleSection_ paymentPlan defaultFrequency defaultTimeWindow condition
          in option_ attrs ("every " <> toHtml l)
       mkTimeOpt (m, l) = option_ ([value_ (show m <> "m")] <> [selected_ "" | m == defaultTimeWindow]) ("the last " <> toHtml l)
       isThresholdType = conditionType == Just "threshold_exceeded" || isNothing conditionType
-      chartUpdateAttrM = case chartTargetIdM of
-        Just chartId -> Just $ term "_" [text|on change set chart to document.getElementById('${chartId}') if chart exists then call chart.updateRollup(my.value) end|]
-        Nothing -> Just [__|on change set qb to document.querySelector('query-builder') if qb exists then call qb.updateBinInQuery('timestamp', my.value) end|]
+      chartUpdateAttr = case chartTargetIdM of
+        Just chartId -> term "_" [text|on change set chart to document.getElementById('${chartId}') if chart exists then call chart.updateRollup(my.value) end|]
+        Nothing -> [__|on change set qb to document.querySelector('query-builder') if qb exists then call qb.updateBinInQuery('timestamp', my.value) end|]
   panel_ def{icon = Just "clock", collapsible = Just True} "Monitor Schedule" do
     when isFree $ p_ [class_ "text-xs text-textWeak mt-1"] "Free plan: hourly minimum frequency. Upgrade for faster checks."
     div_ [class_ "flex gap-2 py-2"] do
       formSelectField_ FieldSm "Execute the query" "frequency" False $ forM_ timeOpts mkFreqOpt
       formField_ FieldSm def "Include rows from" "timeWindow" False
-        $ Just (select_ ([class_ "select select-bordered select-sm w-full", name_ "timeWindow", id_ "timeWindow"] <> maybeToList chartUpdateAttrM) $ forM_ timeOpts mkTimeOpt)
+        $ Just (select_ [class_ "select select-bordered select-sm w-full", name_ "timeWindow", id_ "timeWindow", chartUpdateAttr] $ forM_ timeOpts mkTimeOpt)
       formField_ FieldSm def "Notify me when" "conditionType" False
         $ Just
         $ select_ [name_ "conditionType", class_ "select select-bordered select-sm w-full", id_ "condType", [__|on change if my value == 'threshold_exceeded' then set #thresholds.open to true else set #thresholds.open to false end|]] do
@@ -391,7 +356,7 @@ thresholdsSection_ chartTargetIdM alertThresholdM warningThresholdM triggerLessT
         formField_ FieldSm def{inputType = "number", dot = Just "bg-fillWarning-strong", suffix = Just "events", placeholder = "Same as trigger", value = showVal warningRecoveryM} "Warning recovery" "warningRecoveryThreshold" False Nothing
 
 
-notificationSettingsSection_ :: Maybe Text -> Maybe Text -> Maybe Text -> Bool -> V.Vector ProjectMembers.Team -> V.Vector UUID.UUID -> Text -> Maybe Monitors.QueryMonitor -> Html ()
+notificationSettingsSection_ :: Maybe Text -> Maybe Text -> Maybe Text -> Bool -> V.Vector ManageMembers.Team -> V.Vector UUID.UUID -> Text -> Maybe Monitors.QueryMonitor -> Html ()
 notificationSettingsSection_ severityM subjectM messageM emailAll allTeams selectedTeamIds formId monitorM = do
   let defaultSeverity = fromMaybe "Error" severityM
       defaultSubject = fromMaybe "Alert triggered" subjectM
@@ -473,21 +438,17 @@ alertBulkActionH :: Projects.ProjectId -> Text -> TBulkActionForm -> ATAuthCtx (
 alertBulkActionH pid action form = do
   _ <- Projects.sessionAndProject pid
   let monitorIds = Monitors.QueryMonitorId <$> form.itemId
-  unless (null monitorIds) $ case action of
-    "deactivate" -> void $ Monitors.monitorDeactivateByIds monitorIds
-    "reactivate" -> void $ Monitors.monitorReactivateByIds monitorIds
-    "mute" -> void $ Monitors.monitorMuteByIds Nothing monitorIds
-    "unmute" -> void $ Monitors.monitorUnmuteByIds monitorIds
-    "resolve" -> void $ Monitors.monitorResolveByIds monitorIds
-    "delete" -> void $ Monitors.monitorSoftDeleteByIds monitorIds
-    _ -> pass
-  let filterTab = case action of
-        "deactivate" -> "Inactive"
-        "reactivate" -> "Active"
-        "delete" -> "Active"
-        _ -> "Active"
-  unless (null monitorIds) $ addTriggerEvent "monitorsListChanged" AE.Null
-  unifiedMonitorsGetH pid (Just filterTab) Nothing
+  unless (null monitorIds) do
+    case action of
+      "deactivate" -> void $ Monitors.monitorDeactivateByIds monitorIds
+      "reactivate" -> void $ Monitors.monitorReactivateByIds monitorIds
+      "mute" -> void $ Monitors.monitorMuteByIds Nothing monitorIds
+      "unmute" -> void $ Monitors.monitorUnmuteByIds monitorIds
+      "resolve" -> void $ Monitors.monitorResolveByIds monitorIds
+      "delete" -> void $ Monitors.monitorSoftDeleteByIds monitorIds
+      _ -> pass
+    addTriggerEvent "monitorsListChanged" AE.Null
+  unifiedMonitorsGetH pid (Just $ bool "Active" "Inactive" (action == "deactivate")) Nothing
 
 
 unifiedMonitorsGetH
@@ -501,25 +462,16 @@ unifiedMonitorsGetH pid filterTM sinceM = do
 
   let filterType = fromMaybe "Active" filterTM
 
-  allAlertsList <- Monitors.queryMonitorsAll pid
+  allAlerts <- V.fromList <$> Monitors.queryMonitorsAll pid
   teamMap <- buildTeamMap pid
-  let allAlerts = V.fromList allAlertsList
-      activeAlerts = V.filter (isNothing . (.deactivatedAt)) allAlerts
-      inactiveAlerts = V.filter (isJust . (.deactivatedAt)) allAlerts
-
-  alerts <- case filterType of
-    "Active" -> pure activeAlerts
-    _ -> pure inactiveAlerts
-
-  let sortKey i = (view _3 $ statusInfo i.currentStatus, isNothing i.mutedUntil)
-      allItems = V.fromList $ sortOn sortKey $ V.toList $ V.map (toUnifiedMonitorItem teamMap pid currTime) alerts
-
-  let totalInactive = V.length inactiveAlerts
-
   freeTierStatus <- checkFreeTierStatus pid project.paymentPlan
 
-  let currentURL = "/p/" <> pid.toText <> "/monitors?"
-  let monitorsTable =
+  let (activeAlerts, inactiveAlerts) = V.partition (isNothing . (.deactivatedAt)) allAlerts
+      alerts = bool inactiveAlerts activeAlerts (filterType == "Active")
+      sortKey i = ((statusInfo i.currentStatus).rank, isNothing i.mutedUntil)
+      allItems = V.fromList $ sortOn sortKey $ V.toList $ V.map (toUnifiedMonitorItem teamMap pid currTime) alerts
+      currentURL = "/p/" <> pid.toText <> "/monitors?"
+      monitorsTable =
         Table
           { config = def{elemID = "monitorsListForm", containerId = Just "monitorsListContainer", addPadding = True, renderAsTable = True, bulkActionsInHeader = Just 0, refreshOnEvent = Just ("monitorsListChanged", currentURL <> "filter=" <> filterType)}
           , columns =
@@ -548,8 +500,7 @@ unifiedMonitorsGetH pid filterTM sinceM = do
                         }
                 }
           }
-
-  let bwconf =
+      bwconf =
         bw
           { pageTitle = "Monitors"
           , menuItem = Just "Monitors"
@@ -569,7 +520,7 @@ unifiedMonitorsGetH pid filterTM sinceM = do
                   , clientSide = False
                   , options =
                       [ TabFilterOpt{name = "Active", count = Just $ V.length activeAlerts, targetId = Nothing}
-                      , TabFilterOpt{name = "Inactive", count = Just totalInactive, targetId = Nothing}
+                      , TabFilterOpt{name = "Inactive", count = Just $ V.length inactiveAlerts, targetId = Nothing}
                       ]
                   }
           }
@@ -580,7 +531,7 @@ unifiedMonitorsGetH pid filterTM sinceM = do
 renderNameCol :: UnifiedMonitorItem -> Html ()
 renderNameCol item = do
   let base = monitorBase item
-      (dotColor, displayName, _) = statusInfo item.currentStatus
+      si = statusInfo item.currentStatus
       isMuted = isJust item.mutedUntil
       isActive = item.status == "Active"
       inlineBtn tip icon hxAction extraAttrs =
@@ -595,17 +546,18 @@ renderNameCol item = do
         inlineBtn "Delete" "trash" (hxDelete_ $ base <> "/alerts/" <> item.monitorId) [hxConfirm_ "Are you sure you want to delete this monitor?"]
   div_ [class_ "flex flex-col gap-1 py-0.5"] do
     div_ [class_ "flex items-center gap-2"] do
-      span_ [class_ $ "inline-block w-2 h-2 rounded-full shrink-0 " <> dotColor <> bool "" " alert-dot" (item.currentStatus == Monitors.MSAlerting), term "data-tippy-content" $ bool "Inactive" "Active" isActive] ""
-      a_ ([href_ $ base <> "/" <> item.monitorId <> "/overview", class_ "text-sm font-medium text-textStrong hover:text-textBrand transition-colors truncate"] <> navTabAttrs) $ toHtml $ if T.null item.title then "(Untitled)" else item.title
-      when (item.currentStatus /= Monitors.MSNormal) $ statusBadge_ False displayName
+      span_ [class_ $ "inline-block w-2 h-2 rounded-full shrink-0 " <> si.dotColor <> bool "" " alert-dot" (item.currentStatus == Monitors.MSAlerting), term "data-tippy-content" $ bool "Inactive" "Active" isActive] ""
+      a_ ([href_ $ base <> "/" <> item.monitorId <> "/overview", class_ "text-sm font-medium text-textStrong hover:text-textBrand transition-colors truncate"] <> navTabAttrs) $ toHtml $ bool item.title "(Untitled)" (T.null item.title)
+      when (item.currentStatus /= Monitors.MSNormal) $ statusBadge_ False si.statusLabel
       whenJust item.mutedUntil \until' ->
         let muteLabel = mutedLabel item.now until'
          in span_ [class_ "badge badge-sm badge-ghost gap-1 shrink-0", term "data-tippy-content" muteLabel] do
               faSprite_ "bell-slash" "regular" "h-3 w-3"
               toHtml muteLabel
       div_ [class_ "flex gap-1 items-center shrink-0 opacity-0 max-md:hidden group-hover/row:opacity-100 has-[:focus-within]:opacity-100 transition-opacity"] actionBtns
-    div_ [class_ "flex items-center gap-1.5"] do
-      span_ [class_ "text-xs text-textStrong/70 font-mono max-md:line-clamp-1 line-clamp-2 bg-fillWeaker border border-strokeWeak rounded px-1.5 py-0.5", term "data-tippy-content" item.details.query] $ toHtml item.details.query
+    div_ [class_ "flex items-center gap-1.5"]
+      $ span_ [class_ "text-xs text-textStrong/70 font-mono max-md:line-clamp-1 line-clamp-2 bg-fillWeaker border border-strokeWeak rounded px-1.5 py-0.5", term "data-tippy-content" item.details.query]
+      $ toHtml item.details.query
     div_ [class_ "hidden max-md:flex items-center justify-between gap-2"] do
       div_ [class_ "flex items-center gap-x-1.5 gap-y-0.5 text-xs text-textWeak flex-wrap min-w-0"] do
         span_ [class_ "tabular-nums"] $ toHtml item.schedule
@@ -661,11 +613,14 @@ monitorBase :: UnifiedMonitorItem -> Text
 monitorBase item = "/p/" <> item.projectId <> "/monitors"
 
 
-statusInfo :: Monitors.MonitorStatus -> (Text, Text, Int)
+data StatusInfo = StatusInfo {dotColor :: Text, statusLabel :: Text, rank :: Int, textColor :: Text}
+
+
+statusInfo :: Monitors.MonitorStatus -> StatusInfo
 statusInfo = \case
-  Monitors.MSAlerting -> ("bg-fillError-strong", "Alerting", 0)
-  Monitors.MSWarning -> ("bg-fillWarning-strong", "Warning", 1)
-  Monitors.MSNormal -> ("bg-fillSuccess-strong", "Normal", 2)
+  Monitors.MSAlerting -> StatusInfo "bg-fillError-strong" "Alerting" 0 "text-textError"
+  Monitors.MSWarning -> StatusInfo "bg-fillWarning-strong" "Warning" 1 "text-textWarning"
+  Monitors.MSNormal -> StatusInfo "bg-fillSuccess-strong" "Normal" 2 "text-textSuccess"
 
 
 bulkActionsFor :: Text -> Projects.ProjectId -> [BulkAction]
@@ -701,13 +656,8 @@ monitorActionH action msg pid monitorId = do
 
 
 alertMuteH :: Projects.ProjectId -> Monitors.QueryMonitorId -> Maybe Int -> ATAuthCtx (RespHeaders (Html ()))
-alertMuteH pid monitorId durationMinsM = do
-  _ <- Projects.sessionAndProject pid
-  void $ Monitors.monitorMuteByIds durationMinsM [monitorId]
-  let msg = maybe "Monitor muted indefinitely" (const "Monitor muted") durationMinsM
-  addSuccessToast msg Nothing
-  redirectCS $ "/p/" <> pid.toText <> "/monitors"
-  addRespHeaders ""
+alertMuteH pid monitorId durationMinsM =
+  monitorActionH (Monitors.monitorMuteByIds durationMinsM) (maybe "Monitor muted indefinitely" (const "Monitor muted") durationMinsM) pid monitorId
 
 
 alertUnmuteH, alertResolveH, alertDeleteH :: Projects.ProjectId -> Monitors.QueryMonitorId -> ATAuthCtx (RespHeaders (Html ()))
@@ -751,7 +701,7 @@ toUnifiedMonitorItem teamMap pid currTime alert =
           { query = alert.logQuery
           , alertThreshold = alert.alertThreshold
           , warningThreshold = alert.warningThreshold
-          , triggerDirection = if alert.triggerLessThan then "below" else "above"
+          , triggerDirection = bool "above" "below" alert.triggerLessThan
           , visualizationType = alert.visualizationType
           }
     , teamBadges = mapMaybe (\tid -> (UUID.toText tid,) <$> Map.lookup tid teamMap) $ V.toList alert.teams
@@ -772,8 +722,8 @@ statusBadge_ isLarge status = do
         "Pending" -> ("badge-ghost", "clock")
         "NoData" -> ("badge-ghost", "circle-question")
         _ -> ("badge-ghost", "circle")
-      sizeClass = if isLarge then "" else "badge-sm"
-      iconSize = if isLarge then "h-4 w-4" else "h-3 w-3"
+      sizeClass = bool "badge-sm" "" isLarge
+      iconSize = bool "h-3 w-3" "h-4 w-4" isLarge
   span_ [class_ $ "badge gap-1 " <> sizeClass <> " " <> badgeClass <> bool "" " alert-badge" (status `elem` ["Alerting", "alert"])] do
     faSprite_ icon "regular" iconSize
     toHtml status
@@ -782,12 +732,10 @@ statusBadge_ isLarge status = do
 -- | Rewrite @bin_auto@ to a fixed @<mins>m@ interval via the KQL AST so the monitor
 -- overview chart bins match the evaluation window rather than the viewer's time range.
 -- Falls back to the original query on parse failure or when @mins <= 0@.
-rewriteBinAutoMins :: Int -> Text -> (Text, Maybe Text)
+rewriteBinAutoMins :: Int -> Text -> Text
 rewriteBinAutoMins mins q
-  | mins <= 0 = (q, Nothing)
-  | otherwise = case parseQueryToAST q of
-      Right ast -> (toQText (rewriteBinAutoToFixed (show mins <> "m") ast), Nothing)
-      Left err -> (q, Just err)
+  | mins <= 0 = q
+  | otherwise = either (const q) (toQText . rewriteBinAutoToFixed (show mins <> "m")) $ parseQueryToAST q
 
 
 unifiedMonitorOverviewH :: Projects.ProjectId -> Text -> ATAuthCtx (RespHeaders (PageCtx (Html ())))
@@ -798,10 +746,7 @@ unifiedMonitorOverviewH pid monitorId = do
   (freeTierStatus, alertM) <-
     concurrently
       (checkFreeTierStatus pid project.paymentPlan)
-      ( case UUID.fromText monitorId of
-          Just uuid -> Monitors.queryMonitorById (Monitors.QueryMonitorId uuid)
-          Nothing -> pure Nothing
-      )
+      (maybe (pure Nothing) (Monitors.queryMonitorById . Monitors.QueryMonitorId) (UUID.fromText monitorId))
 
   let baseBwconf =
         bw
@@ -820,14 +765,8 @@ unifiedMonitorOverviewH pid monitorId = do
           (concurrently (Slack.getProjectSlackData pid) (Slack.getDiscordDataByProjectId pid))
       (channels, discordChannels) <-
         concurrently
-          ( case slackDataM of
-              Just slackData -> maybe [] (fromMaybe [] . (.channels)) <$> SlackP.getSlackChannels slackData.botToken slackData.teamId
-              Nothing -> return []
-          )
-          ( case discordDataM of
-              Just discordData -> Discord.getDiscordChannels appCtx.env.discordBotToken discordData.guildId
-              Nothing -> return []
-          )
+          (maybe (pure []) (\sd -> maybe [] (fromMaybe [] . (.channels)) <$> Slack.getSlackChannels sd.botToken sd.teamId) slackDataM)
+          (maybe (pure []) (Discord.getDiscordChannels appCtx.env.discordBotToken . (.guildId)) discordDataM)
       let muteBase = "/p/" <> pid.toText <> "/monitors/alerts/" <> alert.id.toText
           isInactive = isJust alert.deactivatedAt
           deactLabel = bool "Deactivate" "Activate" isInactive
@@ -874,8 +813,8 @@ unifiedMonitorOverviewH pid monitorId = do
                     faSprite_ "pen-to-square" "regular" "h-4 w-4"
                     span_ [class_ "max-md:hidden"] "Edit monitor"
               }
-      let findChannel xx x = fromMaybe x (find (\c -> c.channelId == x) xx >>= (\a -> Just a.channelName))
-      let teams' = (\x -> x{slack_channels = findChannel channels <$> x.slack_channels, discord_channels = (\xx -> fromMaybe xx (find (\c -> c.channelId == xx) discordChannels >>= (\a -> Just a.channelName))) <$> x.discord_channels}) <$> teams
+      let nameOf cs x = maybe x (.channelName) $ find ((== x) . (.channelId)) cs
+          teams' = (\t -> t{slack_channels = nameOf channels <$> t.slack_channels, discord_channels = nameOf discordChannels <$> t.discord_channels}) <$> teams
       addRespHeaders $ PageCtx bwconf $ unifiedOverviewPage pid alert currTime (V.fromList teams') slackDataM discordDataM
     _ -> addRespHeaders $ PageCtx baseBwconf $ div_ [class_ "p-6 text-center"] "Monitor not found"
 
@@ -906,7 +845,7 @@ unifiedOverviewPage pid alert currTime teams slackDataM discordDataM = do
           Widget.widget_
             $ (def :: Widget)
               { Widget.wType = Widget.mapChatTypeToWidgetType alert.visualizationType
-              , Widget.query = Just (fst $ rewriteBinAutoMins alert.timeWindowMins alert.logQuery)
+              , Widget.query = Just (rewriteBinAutoMins alert.timeWindowMins alert.logQuery)
               , Widget.title = Just "Query Results"
               , Widget.standalone = Just True
               , Widget._projectId = Just pid
@@ -919,37 +858,24 @@ unifiedOverviewPage pid alert currTime teams slackDataM discordDataM = do
 
     tabbedSection_ "monitor-tabs" [("Execution History", monitorHistoryTab_ pid alert.id), ("Notification Channels", alertNotificationsTab_ alert teams)]
   where
-    displayName = bool (view _2 $ statusInfo alert.currentStatus) "Inactive" (isJust alert.deactivatedAt)
+    displayName = bool (statusInfo alert.currentStatus).statusLabel "Inactive" (isJust alert.deactivatedAt)
 
 
 tabbedSection_ :: Text -> [(Text, Html ())] -> Html ()
 tabbedSection_ containerId tabs = do
   div_ [role_ "tablist", class_ "w-full", id_ containerId] do
     div_ [class_ "w-full flex border-b border-strokeWeak"] do
-      forM_ (zip [0 ..] tabs) $ \(idx, (label, _)) -> do
+      forM_ (zip [0 :: Int ..] tabs) \(idx, (label, _)) -> do
         let tabId = containerId <> "-tab-" <> show idx
         button_
-          [ class_ $ "cursor-pointer shrink-0 tab-btn tab-box text-sm font-medium px-3 py-2.5 text-textWeak border-b-2 border-b-transparent" <> if idx == 0 then " t-tab-active" else ""
+          [ class_ $ "cursor-pointer shrink-0 tab-btn tab-box text-sm font-medium px-3 py-2.5 text-textWeak border-b-2 border-b-transparent" <> bool "" " t-tab-active" (idx == 0)
           , role_ "tab"
           , term "aria-label" label
-          , onclick_ $ "navigateTab(this, '#" <> tabId <> "', '#" <> containerId <> "')"
+          , term "_" [text|on click set tl to #${containerId} then remove .t-tab-active from <.t-tab-active/> in tl then add .t-tab-active to me then add .hidden to <.t-tab-content/> in tl then remove .hidden from #${tabId}|]
           ]
           $ toHtml label
-    forM_ (zip [0 ..] tabs) $ \(idx, (_, content)) -> do
-      let tabId = containerId <> "-tab-" <> show idx
-      div_ [role_ "tabpanel", class_ $ "overflow-y-auto t-tab-content" <> if idx /= 0 then " hidden" else "", id_ tabId] do
-        content
-
-  script_
-    [text|
-    function navigateTab(tab, contentId, containerId) {
-        const container = document.querySelector(containerId);
-        container.querySelectorAll('.t-tab-active').forEach(t => t.classList.remove('t-tab-active'));
-        tab.classList.add('t-tab-active');
-        container.querySelectorAll('.t-tab-content').forEach(c => c.classList.add('hidden'));
-        document.querySelector(contentId).classList.remove('hidden');
-      }
-    |]
+    forM_ (zip [0 :: Int ..] tabs) \(idx, (_, content)) ->
+      div_ [role_ "tabpanel", class_ $ "overflow-y-auto t-tab-content" <> bool " hidden" "" (idx == 0), id_ $ containerId <> "-tab-" <> show idx] content
 
 
 monitorHistoryTab_ :: Projects.ProjectId -> Monitors.QueryMonitorId -> Html ()
@@ -969,9 +895,10 @@ alertSidebar_ displayName alert currTime = do
         span_ [class_ $ statusColor <> " tabular-nums text-xl font-bold"] $ toHtml $ formatWithCommas alert.currentValue
       mobileRow_ "Trigger" $ span_ [class_ "tabular-nums"] $ toHtml $ direction <> " " <> formatWithCommas alert.alertThreshold
       whenJust alert.warningThreshold \w -> mobileRow_ "Warning" $ span_ [class_ "tabular-nums text-textWarning"] $ toHtml $ direction <> " " <> formatWithCommas w
-      div_ [class_ "px-3 py-1.5 flex flex-col gap-1 cursor-pointer", onclick_ "this.querySelector('pre').classList.toggle('line-clamp-1')"] do
-        _ <- span_ [class_ "text-xs text-textWeak"] "Query \x203a"
-        pre_ [class_ "text-xs font-mono text-textStrong/70 whitespace-pre-wrap break-all line-clamp-1"] $ toHtml alert.logQuery
+      label_ [class_ "px-3 py-1.5 flex flex-col gap-1 cursor-pointer"] do
+        input_ [type_ "checkbox", class_ "peer sr-only"]
+        span_ [class_ "text-xs text-textWeak"] "Query \x203a"
+        pre_ [class_ "text-xs font-mono text-textStrong/70 whitespace-pre-wrap break-all line-clamp-1 peer-checked:line-clamp-none"] $ toHtml alert.logQuery
       mobileRow_ "Last eval" $ span_ [] $ toHtml $ toText (prettyTimeAuto currTime alert.lastEvaluated)
       mobileRow_ "Last triggered" $ span_ [class_ "text-textWeak"] $ toHtml $ maybe "Never" (toText . prettyTimeAuto currTime) alert.alertLastTriggered
     div_ [class_ "max-md:hidden divide-y divide-strokeWeak"] do
@@ -991,15 +918,14 @@ alertSidebar_ displayName alert currTime = do
         whenJust alert.stopAfterCount \count -> span_ [class_ "text-textWeak"] $ toHtml $ "Stop after: " <> show @Text count
   where
     direction = bool ">" "<" alert.triggerLessThan
-    statusColor = case alert.currentStatus of
-      Monitors.MSAlerting -> "text-textError"
-      Monitors.MSWarning -> "text-textWarning"
-      Monitors.MSNormal -> "text-textSuccess"
+    statusColor = (statusInfo alert.currentStatus).textColor
+    mobileRow_ :: Html () -> Html () -> Html ()
     mobileRow_ label val = div_ [class_ "px-3 py-1.5 flex items-center justify-between gap-2"] do
-      _ <- span_ [class_ "text-xs text-textWeak shrink-0"] label
+      span_ [class_ "text-xs text-textWeak shrink-0"] label
       val
+    sidebarItem_ :: Html () -> Html () -> Html ()
     sidebarItem_ label val = div_ [class_ "p-3 flex flex-col gap-1"] do
-      _ <- span_ [class_ "text-xs font-medium text-textWeak uppercase tracking-wider"] label
+      span_ [class_ "text-xs font-medium text-textWeak uppercase tracking-wider"] label
       val
 
 
@@ -1008,14 +934,13 @@ alertNotificationsTab_ alert teams = do
   div_ [class_ "pt-6 pb-3"] do
     div_ [class_ "mb-6"] do
       h4_ [class_ "text-base font-medium text-textStrong mb-2 flex items-center"] $ faSprite_ "users" "regular" "h-4 w-4 mr-2" >> "Teams"
-      when (null teams) $ do
-        div_ [class_ "text-sm text-textWeak"] "No teams configured for this monitor."
-        div_ [class_ "pt-2 flex items-center gap-1"] do
-          span_ [class_ "text-sm text-textWeak"] "Project level notification integrations will be used."
-          a_ [href_ $ "/p/" <> alert.projectId.toText <> "/settings/integrations", class_ "text-sm text-textBrand hover:underline"] "Configure integrations"
-      unless (V.null teams)
-        $ div_ [class_ "flex flex-wrap gap-4 mb-4"]
-        $ forM_ teams \team ->
+      if V.null teams
+        then do
+          div_ [class_ "text-sm text-textWeak"] "No teams configured for this monitor."
+          div_ [class_ "pt-2 flex items-center gap-1"] do
+            span_ [class_ "text-sm text-textWeak"] "Project level notification integrations will be used."
+            a_ [href_ $ "/p/" <> alert.projectId.toText <> "/settings/integrations", class_ "text-sm text-textBrand hover:underline"] "Configure integrations"
+        else div_ [class_ "flex flex-wrap gap-4 mb-4"] $ forM_ teams \team ->
           div_ [class_ "flex flex-col border rounded-lg gap-4 border-strokeWeak p-6 relative w-96", id_ team.handle] do
             button_
               [ type_ "button"
@@ -1025,18 +950,14 @@ alertNotificationsTab_ alert teams = do
               , hxTarget_ $ "#" <> team.handle
               , hxSwap_ "outerHTML"
               ]
-              do
-                faSprite_ "trash" "regular" "h-3 w-3"
+              $ faSprite_ "trash" "regular" "h-3 w-3"
             span_ [class_ "text-sm font-medium"] $ toHtml team.name
-            forM_ team.notify_emails $ \email ->
-              div_ [class_ "flex items-center gap-2"] do
-                span_ [class_ "text-sm text-textWeak"] $ faSprite_ "envelope" "regular" "h-3 w-3 mr-2 text-iconNeutral" >> toHtml email
-            forM_ team.slack_channels $ \channel ->
-              div_ [class_ "flex items-center gap-2"] do
-                span_ [class_ "text-sm text-textWeak"] $ faSprite_ "slack" "solid" "h-3 w-3 mr-2 text-iconNeutral" >> toHtml ("#" <> channel)
-            forM_ team.discord_channels $ \channel ->
-              div_ [class_ "flex items-center gap-2"] do
-                span_ [class_ "text-sm text-textWeak"] $ faSprite_ "discord" "brand" "h-3 w-3 mr-2 text-iconNeutral" >> toHtml ("#" <> channel)
+            forM_ ([("envelope", "regular", team.notify_emails), ("slack", "solid", ("#" <>) <$> team.slack_channels), ("discord", "brand", ("#" <>) <$> team.discord_channels)] :: [(Text, Text, V.Vector Text)]) \(icon, style, entries) ->
+              forM_ entries \entry ->
+                div_ [class_ "flex items-center gap-2"]
+                  $ span_ [class_ "text-sm text-textWeak"]
+                  $ faSprite_ icon style "h-3 w-3 mr-2 text-iconNeutral"
+                  >> toHtml entry
 
     div_ [class_ "pt-6 pb-3"] do
       h4_ [class_ "font-medium text-textStrong mb-2"] "Notification Template"

--- a/src/Pages/Onboarding.hs
+++ b/src/Pages/Onboarding.hs
@@ -282,7 +282,7 @@ onboardingInfoPostH pid form = do
   addRespHeaders $ OnboardingInfoPost ()
 
 
--- | Merge new answers into a project's existing questions blob; existing keys win.
+-- | Merge new answers into a project's existing questions blob; new answers win on conflict.
 mergeQuestions :: Maybe AE.Value -> [(AE.Key, AE.Value)] -> HI.AsJsonb AE.Value
 mergeQuestions old kvs =
   HI.AsJsonb $ AE.Object $ KM.fromList kvs <> case old of

--- a/src/Pages/Onboarding.hs
+++ b/src/Pages/Onboarding.hs
@@ -1,5 +1,3 @@
-{-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
-
 module Pages.Onboarding (
   onboardingGetH,
   onboardingInfoPostH,
@@ -32,7 +30,7 @@ import Data.Effectful.Wreq qualified as W (get, responseBody)
 import Data.Text qualified as T
 import Data.Tuple.Extra (thd3)
 import Data.Vector qualified as V (Vector, fromList, toList)
-import Effectful (Eff, (:>))
+import Effectful (Eff, IOE, (:>))
 import Effectful.Reader.Static (ask)
 import Effectful.State.Static.Local qualified as State
 import Hasql.Interpolate qualified as HI
@@ -49,7 +47,6 @@ import Pages.BodyWrapper (BWConfig (..), PageCtx (..), mkPageCtx)
 import Pages.Components
 import Pkg.DeriveUtils (hashAssetFile)
 import Relude hiding (ask)
-import Relude.Unsafe qualified as Unsafe
 import System.Config (AuthContext (..), EnvConfig (..))
 import System.Types (ATAuthCtx, HXRedirectDest, RespHeaders, TriggerEvents, XWidgetJSON, addErrorToast, addRespHeaders, redirectCS)
 import Utils (LoadingSize (..), LoadingType (..), faSprite_, insertIfNotExist, loadingIndicator_, lookupValueText, onpointerdown_)
@@ -61,57 +58,33 @@ onboardingGetH :: Projects.ProjectId -> Maybe Text -> ATAuthCtx (RespHeaders Onb
 onboardingGetH pid onboardingStepM = do
   (sess, project, bw) <- mkPageCtx pid
   appCtx <- ask @AuthContext
-  let bodyConfig = bw{currProject = Nothing}
-      questions = fromMaybe (AE.Object []) project.questions
+  let questions = fromMaybe (AE.Object []) project.questions
       onboardingStep = fromMaybe "Info" onboardingStepM
   stepData <- case onboardingStep of
     "Complete" -> pure $ CompleteStep pid
     "Survey" -> do
       let host = fromMaybe "" $ lookupValueText questions "location"
           func = case questions of
-            (AE.Object q) ->
-              let fun = case KM.lookup "functionality" q of
-                    Just (AE.Array f) ->
-                      ( \case
-                          AE.String s -> s
-                          _ -> ""
-                      )
-                        <$> V.toList f
-                    _ -> []
-               in fun
+            AE.Object q | Just (AE.Array f) <- KM.lookup "functionality" q -> (\case AE.String s -> s; _ -> "") <$> V.toList f
             _ -> []
       pure $ SurveyStep pid host func
     "NotifChannel" -> do
-      slack <- getProjectSlackData pid
-      discord <- getDiscordDataByProjectId pid
+      hasSlack <- isJust <$> getProjectSlackData pid
+      hasDiscord <- isJust <$> getDiscordDataByProjectId pid
       everyoneTeamM <- ProjectMembers.getEveryoneTeam pid
       let phone = fromMaybe "" $ everyoneTeamM >>= viaNonEmpty head . V.toList . (.phone_numbers)
-          emails = maybe mempty (.notify_emails) everyoneTeamM
-          hasDiscord = isJust discord
-          hasSlack = isJust slack
-          slackRedirectUri = appCtx.env.slackRedirectUri
-          discordRedirectUri = appCtx.env.discordRedirectUri
-          slackUrl = "https://slack.com/oauth/v2/authorize?client_id=" <> appCtx.config.slackClientId <> "&scope=chat:write,commands,incoming-webhook,files:write,app_mentions:read,channels:read,groups:read,channels:history,groups:history,im:history,mpim:history,chat:write.public&user_scope=&redirect_uri=" <> slackRedirectUri <> "&state=" <> pid.toText <> "__onboarding"
-          discordUrl = "https://discord.com/oauth2/authorize?response_type=code&client_id=" <> appCtx.config.discordClientId <> "&permissions=277025392640&integration_type=0&scope=bot+applications.commands" <> "&state=" <> pid.toText <> "__onboarding" <> "&redirect_uri=" <> discordRedirectUri
-      pure $ NotifChannelStep pid slackUrl discordUrl phone emails hasSlack hasDiscord
-    "Integration" -> do
-      apiKey <- ProjectApiKeys.projectApiKeysByProjectId pid
-      let key = maybe "<API_KEY>" (.keyPrefix) (listToMaybe apiKey)
-      pure $ IntegrationStep pid key
+          slackUrl = "https://slack.com/oauth/v2/authorize?client_id=" <> appCtx.config.slackClientId <> "&scope=chat:write,commands,incoming-webhook,files:write,app_mentions:read,channels:read,groups:read,channels:history,groups:history,im:history,mpim:history,chat:write.public&user_scope=&redirect_uri=" <> appCtx.env.slackRedirectUri <> "&state=" <> pid.toText <> "__onboarding"
+          discordUrl = "https://discord.com/oauth2/authorize?response_type=code&client_id=" <> appCtx.config.discordClientId <> "&permissions=277025392640&integration_type=0&scope=bot+applications.commands&state=" <> pid.toText <> "__onboarding&redirect_uri=" <> appCtx.env.discordRedirectUri
+      pure $ NotifChannelStep pid slackUrl discordUrl phone (maybe mempty (.notify_emails) everyoneTeamM) hasSlack hasDiscord
+    "Integration" -> IntegrationStep pid . maybe "<API_KEY>" (.keyPrefix) . listToMaybe <$> ProjectApiKeys.projectApiKeysByProjectId pid
     "Pricing" -> do
-      let lemonUrl = appCtx.config.lemonSqueezyUrl <> "&checkout[custom][project_id]=" <> pid.toText
-          critical = appCtx.config.lemonSqueezyCriticalUrl <> "&checkout[custom][project_id]=" <> pid.toText
-          paymentPlan = project.paymentPlan
-      pure $ PricingStep pid lemonUrl critical paymentPlan appCtx.config.enableFreetier appCtx.config.basicAuthEnabled
+      let checkout u = u <> "&checkout[custom][project_id]=" <> pid.toText
+      pure $ PricingStep pid (checkout appCtx.config.lemonSqueezyUrl) (checkout appCtx.config.lemonSqueezyCriticalUrl) project.paymentPlan appCtx.config.enableFreetier appCtx.config.basicAuthEnabled
     _ -> do
-      let firstName = sess.user.firstName
-          lastName = sess.user.lastName
-          (companyName, companySize, foundUsfrom) = (fromMaybe "" $ lookupValueText questions "companyName", fromMaybe "" $ lookupValueText questions "companySize", fromMaybe "" $ lookupValueText questions "foundUsFrom")
-      pure $ InfoStep pid firstName lastName companyName companySize foundUsfrom
-  addRespHeaders $ OnboardingGet $ PageCtx bodyConfig stepData
+      let q k = fromMaybe "" $ lookupValueText questions k
+      pure $ InfoStep pid sess.user.firstName sess.user.lastName (q "companyName") (q "companySize") (q "foundUsFrom")
+  addRespHeaders $ OnboardingGet $ PageCtx bw{currProject = Nothing} stepData
 
-
--- addRespHeaders $ PageCtx bodyConfig $ div_ [class_ "container"] $ "Hello world"
 
 data OnboardingInfoForm = OnboardingInfoForm
   { firstName :: Text
@@ -145,7 +118,6 @@ data NotifChannelForm = NotifChannelForm
   deriving anyclass (AE.FromJSON, AE.ToJSON, FromForm)
 
 
--- | Data type representing different onboarding steps
 data OnboardingStepData
   = InfoStep
       { stepPid :: Projects.ProjectId
@@ -188,7 +160,6 @@ data OnboardingStepData
   deriving anyclass (AE.ToJSON)
 
 
--- | Response type for onboarding GET handler
 newtype OnboardingGet = OnboardingGet (PageCtx OnboardingStepData)
   deriving stock (Generic, Show)
 
@@ -206,7 +177,6 @@ instance ToHtml OnboardingGet where
   toHtmlRaw = toHtml
 
 
--- | Response type for onboarding info POST handler (redirects to next step)
 newtype OnboardingInfoPost = OnboardingInfoPost ()
   deriving stock (Generic, Show)
 
@@ -216,7 +186,6 @@ instance ToHtml OnboardingInfoPost where
   toHtmlRaw = toHtml
 
 
--- | Response type for onboarding configuration POST handler (redirects to next step)
 newtype OnboardingConfPost = OnboardingConfPost ()
   deriving stock (Generic, Show)
 
@@ -226,7 +195,6 @@ instance ToHtml OnboardingConfPost where
   toHtmlRaw = toHtml
 
 
--- | Response type for phone/emails POST handler
 data OnboardingPhoneEmailsPost = OnboardingPhoneEmailsPost
   { projectId :: Projects.ProjectId
   , emails :: V.Vector Text
@@ -242,26 +210,22 @@ instance ToHtml OnboardingPhoneEmailsPost where
 
 onboardingStepSkipped :: Projects.ProjectId -> Maybe Text -> ATAuthCtx (RespHeaders (Html ()))
 onboardingStepSkipped pid stepM = do
-  (sess, project) <- Projects.sessionAndProject pid
-  case stepM of
-    Just step -> do
-      let stepsCompleted = project.onboardingStepsCompleted
-          newCompleted = insertIfNotExist step stepsCompleted
-      _ <- Hasql.interpExecute [HI.sql| update projects.projects set onboarding_steps_completed=#{newCompleted} where id=#{pid} |]
-
-      redirectCS $ "/p/" <> pid.toText <> "/onboarding?step=" <> getNextStep step
-      addRespHeaders ""
-    _ -> do
-      redirectCS $ "/p/" <> pid.toText <> "/onboarding?step=Info"
-      addRespHeaders ""
+  (_, project) <- Projects.sessionAndProject pid
+  whenJust stepM $ markStepCompleted pid project.onboardingStepsCompleted
+  redirectCS $ "/p/" <> pid.toText <> "/onboarding?step=" <> maybe "Info" getNextStep stepM
+  addRespHeaders ""
 
 
 dismissChecklistH :: Projects.ProjectId -> ATAuthCtx (RespHeaders (Html ()))
 dismissChecklistH pid = do
   (_, project) <- Projects.sessionAndProject pid
-  let newCompleted = insertIfNotExist "checklist_dismissed" project.onboardingStepsCompleted
-  Hasql.interpExecute_ [HI.sql| UPDATE projects.projects SET onboarding_steps_completed=#{newCompleted} WHERE id=#{pid} |]
+  markStepCompleted pid project.onboardingStepsCompleted "checklist_dismissed"
   addRespHeaders ""
+
+
+markStepCompleted :: (Hasql.Hasql :> es, IOE :> es) => Projects.ProjectId -> V.Vector Text -> Text -> Eff es ()
+markStepCompleted pid stepsCompleted step =
+  Hasql.interpExecute_ [HI.sql| update projects.projects set onboarding_steps_completed=#{insertIfNotExist step stepsCompleted} where id=#{pid} |]
 
 
 getNextStep :: Text -> Text
@@ -271,39 +235,26 @@ getNextStep _ = "Info"
 
 phoneEmailPostH :: Projects.ProjectId -> NotifChannelForm -> ATAuthCtx (RespHeaders OnboardingPhoneEmailsPost)
 phoneEmailPostH pid form = do
-  (sess, project) <- Projects.sessionAndProject pid
+  (_, project) <- Projects.sessionAndProject pid
   appCtx <- ask @AuthContext
-  let envCfg = appCtx.config
-      phone = form.phoneNumber
-      emails = form.emails
-      stepsCompleted = project.onboardingStepsCompleted
-      newCompleted = insertIfNotExist "NotifChannel" stepsCompleted
-      emailsVec = V.fromList emails
-  projectMembers <- Projects.usersByProjectId pid
-  let emails' = (\u -> CI.original u.email) <$> projectMembers
-  _ <- Hasql.interpExecute [HI.sql| update projects.projects set onboarding_steps_completed=#{newCompleted} where id=#{pid} |]
-  ProjectMembers.setEveryoneTeamEmails pid emailsVec
-  when (phone /= "") $ ProjectMembers.setEveryoneTeamPhones pid (V.fromList [phone])
-  addRespHeaders $ OnboardingPhoneEmailsPost pid (V.fromList $ ordNub $ emails <> emails') envCfg.enableFreetier
+  memberEmails <- map (CI.original . (.email)) <$> Projects.usersByProjectId pid
+  markStepCompleted pid project.onboardingStepsCompleted "NotifChannel"
+  ProjectMembers.setEveryoneTeamEmails pid (V.fromList form.emails)
+  unless (T.null form.phoneNumber) $ ProjectMembers.setEveryoneTeamPhones pid (V.fromList [form.phoneNumber])
+  addRespHeaders $ OnboardingPhoneEmailsPost pid (V.fromList $ ordNub $ form.emails <> memberEmails) appCtx.config.enableFreetier
 
 
 checkIntegrationGet :: Projects.ProjectId -> Maybe Text -> ATAuthCtx (RespHeaders (Html ()))
 checkIntegrationGet pid languageM = do
-  (sess, project) <- Projects.sessionAndProject pid
-  let stepsCompleted = project.onboardingStepsCompleted
-      newCompleted = insertIfNotExist "Integration" stepsCompleted
+  (_, project) <- Projects.sessionAndProject pid
   v :: Maybe Text <- Hasql.interpOne [HI.sql|SELECT context___span_id FROM otel_logs_and_spans WHERE project_id = #{pid.toText} LIMIT 1|]
-  if isJust v
-    then do
-      _ <- Hasql.interpExecute [HI.sql|update projects.projects set onboarding_steps_completed=#{newCompleted} where id=#{pid}|]
+  case v of
+    Nothing -> addErrorToast "No events found yet" Nothing >> addRespHeaders ""
+    Just _ -> do
+      markStepCompleted pid project.onboardingStepsCompleted "Integration"
       case languageM of
-        Just lg -> addRespHeaders verifiedCheck
-        _ -> do
-          redirectCS $ "/p/" <> pid.toText <> "/onboarding?step=Pricing"
-          addRespHeaders ""
-    else do
-      addErrorToast "No events found yet" Nothing
-      addRespHeaders ""
+        Just _ -> addRespHeaders verifiedCheck
+        Nothing -> redirectCS ("/p/" <> pid.toText <> "/onboarding?step=Pricing") >> addRespHeaders ""
 
 
 verifiedCheck :: Html ()
@@ -315,43 +266,36 @@ verifiedCheck = div_ [class_ "flex items-center gap-2 text-textSuccess"] do
 onboardingInfoPostH :: Projects.ProjectId -> OnboardingInfoForm -> ATAuthCtx (RespHeaders OnboardingInfoPost)
 onboardingInfoPostH pid form = do
   (sess, project) <- Projects.sessionAndProject pid
-  let firstName = form.firstName
-      lastName = form.lastName
-  let infoJson =
-        KM.fromList
+  let jsonBytes =
+        mergeQuestions
+          project.questions
           [ ("companyName", AE.toJSON form.companyName)
           , ("companySize", AE.toJSON form.companySize)
           , ("foundUsFrom", AE.toJSON form.whereDidYouHearAboutUs)
           ]
-      questions = case project.questions of
-        Just (AE.Object o) -> AE.Object $ infoJson <> o
-        _ -> AE.Object infoJson
-      jsonBytes = HI.AsJsonb questions
-      stepsCompleted = project.onboardingStepsCompleted
-      newCompleted = insertIfNotExist "Info" stepsCompleted
-  let companyName = form.companyName
+      newCompleted = insertIfNotExist "Info" project.onboardingStepsCompleted
+      OnboardingInfoForm{firstName, lastName, companyName} = form
       userId = sess.user.id
-  _ <- Hasql.interpExecute [HI.sql| update projects.projects set title=#{companyName},questions=#{jsonBytes},onboarding_steps_completed=#{newCompleted} where id=#{pid} |]
-  _ <- Hasql.interpExecute [HI.sql| update users.users set first_name=#{firstName}, last_name=#{lastName} where id=#{userId} |]
+  Hasql.interpExecute_ [HI.sql| update projects.projects set title=#{companyName},questions=#{jsonBytes},onboarding_steps_completed=#{newCompleted} where id=#{pid} |]
+  Hasql.interpExecute_ [HI.sql| update users.users set first_name=#{firstName}, last_name=#{lastName} where id=#{userId} |]
   redirectCS $ "/p/" <> pid.toText <> "/onboarding?step=Survey"
   addRespHeaders $ OnboardingInfoPost ()
 
 
+-- | Merge new answers into a project's existing questions blob; existing keys win.
+mergeQuestions :: Maybe AE.Value -> [(AE.Key, AE.Value)] -> HI.AsJsonb AE.Value
+mergeQuestions old kvs =
+  HI.AsJsonb $ AE.Object $ KM.fromList kvs <> case old of
+    Just (AE.Object o) -> o
+    _ -> mempty
+
+
 onboardingConfPostH :: Projects.ProjectId -> OnboardingConfForm -> ATAuthCtx (RespHeaders OnboardingConfPost)
 onboardingConfPostH pid form = do
-  (sess, project) <- Projects.sessionAndProject pid
-  let infoJson =
-        KM.fromList
-          [ ("functionality", AE.toJSON form.functionality)
-          , ("location", AE.toJSON form.location)
-          ]
-      questions = case project.questions of
-        Just (AE.Object o) -> AE.Object $ infoJson <> o
-        _ -> AE.Object infoJson
-      jsonBytes = HI.AsJsonb questions
-      stepsCompleted = project.onboardingStepsCompleted
-      newCompleted = insertIfNotExist "Survey" stepsCompleted
-  _ <- Hasql.interpExecute [HI.sql| update projects.projects set questions=#{jsonBytes}, onboarding_steps_completed=#{newCompleted} where id=#{pid} |]
+  (_, project) <- Projects.sessionAndProject pid
+  let jsonBytes = mergeQuestions project.questions [("functionality", AE.toJSON form.functionality), ("location", AE.toJSON form.location)]
+      newCompleted = insertIfNotExist "Survey" project.onboardingStepsCompleted
+  Hasql.interpExecute_ [HI.sql| update projects.projects set questions=#{jsonBytes}, onboarding_steps_completed=#{newCompleted} where id=#{pid} |]
   redirectCS $ "/p/" <> pid.toText <> "/onboarding?step=NotifChannel"
   addRespHeaders $ OnboardingConfPost ()
 
@@ -497,7 +441,7 @@ integrationGroups =
   ]
 
 
--- IMPORtANT: DO NOT DELETE. Needed for the tailwindcss to generate classes.
+-- IMPORTANT: DO NOT DELETE. Needed for the tailwindcss to generate classes.
 -- [class_ "group-has-[#check-js:checked]/pg:block group-has-[#check-go:checked]/pg:block group-has-[#check-elixir:checked]/pg:block group-has-[#check-py:checked]/pg:block group-has-[#check-java:checked]/pg:block"]
 -- [class_ "group-has-[#check-php:checked]/pg:block group-has-[#check-cs:checked]/pg:block"]
 -- [class_ "group-has-[#check-linux:checked]/pg:block group-has-[#check-docker:checked]/pg:block group-has-[#check-kubernetes:checked]/pg:block group-has-[#check-kafka:checked]/pg:block"]
@@ -525,13 +469,12 @@ integrationsPage pid apikey =
             button_
               [ class_ "px-4 py-2 bg-fillBrand-strong rounded-xl text-textInverse-strong flex items-center gap-1 hover:bg-fillBrand-strong/90 cursor-pointer"
               , type_ "button"
-              , onpointerdown_ "navigator.clipboard.writeText(document.getElementById('api-key-display').textContent); this.innerHTML = '<span>Copied!</span><svg class=\"h-4 w-4\" xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\"><path d=\"M5 13l4 4L19 7\"></path></svg>';"
+              , onpointerdown_ "navigator.clipboard.writeText(document.getElementById('api-key-display').textContent); this.innerHTML = 'Copied!';"
               ]
               do
                 span_ "Copy"
                 faSprite_ "copy" "regular" "h-4 w-4"
 
-        -- Quick Test suggestion banner
         div_ [class_ "mb-4 px-4 bg-gradient-to-r from-fillInfo-weak to-transparent border-l-4 border-strokeInfo rounded-lg"] do
           p_ [class_ "text-sm text-textStrong"] do
             "Want to test quickly? "
@@ -542,89 +485,54 @@ integrationsPage pid apikey =
               "Use telemetrygen"
             " to send sample data in seconds"
 
-        -- Display integration groups
         forM_ integrationGroups \(groupName, langsList) -> div_ [class_ "mb-4 md:mb-6"] do
           div_ [class_ "text-textWeak text-lg md:text-xl mb-2"] $ toHtml groupName
           div_ [class_ "grid grid-cols-2 gap-2"]
             $ forM_ langsList \(lang, langName, _) ->
               languageItem pid langName lang
 
-        -- Inline CTA on desktop (mobile uses sticky bar)
-        div_ [class_ "max-md:hidden flex items-center gap-4 py-8"] do
-          button_ [class_ "btn-primary px-8 py-3 text-xl rounded-xl cursor-pointer flex items-center", hxGet_ $ "/p/" <> pid.toText <> "/onboarding/integration-check", hxSwap_ "none", hxIndicator_ "#loadingIndicator"] "Confirm & Proceed"
-          a_
-            [ class_ "px-4 py-3 flex items-center underline text-textBrand text-xl cursor-pointer"
-            , type_ "button"
-            , hxPost_ $ "/p/" <> pid.toText <> "/onboarding/skip?step=Integration"
-            ]
-            "Skip"
-      -- Sticky CTA bar for mobile
-      div_ [class_ "md:hidden fixed bottom-0 left-0 right-0 bg-bgRaised border-t border-strokeWeak pl-4 pr-18 py-3 flex items-center gap-3 z-30"] do
-        button_ [class_ "btn-primary px-6 py-2.5 text-base rounded-xl cursor-pointer flex-1 flex items-center justify-center", hxGet_ $ "/p/" <> pid.toText <> "/onboarding/integration-check", hxSwap_ "none", hxIndicator_ "#loadingIndicator"] "Confirm & Proceed"
-        a_
-          [ class_ "px-3 py-2.5 flex items-center underline text-textBrand text-base cursor-pointer"
-          , type_ "button"
-          , hxPost_ $ "/p/" <> pid.toText <> "/onboarding/skip?step=Integration"
-          ]
-          "Skip"
+        integrationCta_ pid "max-md:hidden flex items-center gap-4 py-8" "btn-primary px-8 py-3 text-xl rounded-xl cursor-pointer flex items-center" "px-4 py-3 flex items-center underline text-textBrand text-xl cursor-pointer"
+      integrationCta_ pid "md:hidden fixed bottom-0 left-0 right-0 bg-bgRaised border-t border-strokeWeak pl-4 pr-18 py-3 flex items-center gap-3 z-30" "btn-primary px-6 py-2.5 text-base rounded-xl cursor-pointer flex-1 flex items-center justify-center" "px-3 py-2.5 flex items-center underline text-textBrand text-base cursor-pointer"
 
     div_ [class_ "w-full md:w-1/2 md:h-full overflow-hidden md:border-l border-weak", id_ "docs-panel"] do
       div_ [class_ "md:hidden sticky top-0 z-20 bg-bgBase border-b border-strokeWeak p-3 hidden", id_ "docs-panel-back"] do
         button_
           [ class_ "flex items-center gap-2 text-textBrand cursor-pointer"
           , type_ "button"
-          , onclick_ "event.preventDefault();event.stopPropagation();document.getElementById('docs-panel').classList.remove('open');this.parentElement.classList.add('hidden');"
+          , [__|on click remove .open from #docs-panel|]
           ]
           do
             faSprite_ "arrow-left" "regular" "h-4 w-4"
             span_ "Back to selection"
       div_ [class_ "md:h-full flex flex-col"] do
         div_ [class_ "w-full md:h-full overflow-y-auto rounded-2xl blue-gradient-box bg-bgBase"] do
-          -- Welcome content shown when no integration is selected (hidden on mobile)
           div_ [class_ "max-md:hidden p-12 text-center group-has-[.checkbox:checked]/pg:hidden flex items-center justify-center h-full"] do
             div_ [class_ "flex flex-col w-full items-center gap-8"] do
-              -- Icon/graphic
               div_ [class_ "p-6 bg-fillWeak rounded-full"] do
                 faSprite_ "brackets-curly" "regular" "h-16 w-16 text-iconBrand"
 
-              -- Welcome text
               h2_ [class_ "text-3xl text-textStrong"] "👈 Select your stack on the left to begin"
               p_ [class_ "text-lg text-textWeak max-w-md leading-relaxed"] do
                 "You can also check out our youtube videos for more interactive walkthroughs."
 
-                -- YouTube video embeds
-                div_ [class_ "grid grid-cols-2 gap-4 w-full"] do
-                  -- Video 1
-                  div_ [class_ "relative overflow-hidden rounded-lg border border-weak", style_ "padding-bottom: 56.25%;"] do
-                    iframe_
-                      [ class_ "absolute top-0 left-0 w-full h-full"
-                      , src_ "https://www.youtube.com/embed/Q-tGuIkDmyk?si=BIHn2vN1m9gDs_9v"
-                      , title_ "YouTube video player"
-                      , term "frameborder" "0"
-                      , term "allow" "accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-                      , term "referrerpolicy" "strict-origin-when-cross-origin"
-                      , term "allowfullscreen" ""
-                      ]
-                      ""
-
-                  -- Video 2 (replace VIDEO_ID_2 with actual ID)
-                  div_ [class_ "relative overflow-hidden rounded-lg border border-weak", style_ "padding-bottom: 56.25%;"] do
-                    iframe_
-                      [ class_ "absolute top-0 left-0 w-full h-full"
-                      , src_ "https://www.youtube.com/embed/OALS4ckfOdI"
-                      , title_ "YouTube video player"
-                      , term "frameborder" "0"
-                      , term "allow" "accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-                      , term "referrerpolicy" "strict-origin-when-cross-origin"
-                      , term "allowfullscreen" ""
-                      ]
-                      ""
+                div_ [class_ "grid grid-cols-2 gap-4 w-full"]
+                  $ forM_ ["Q-tGuIkDmyk?si=BIHn2vN1m9gDs_9v", "OALS4ckfOdI"] \vid ->
+                    div_ [class_ "relative overflow-hidden rounded-lg border border-weak", style_ "padding-bottom: 56.25%;"]
+                      $ iframe_
+                        [ class_ "absolute top-0 left-0 w-full h-full"
+                        , src_ $ "https://www.youtube.com/embed/" <> vid
+                        , title_ "YouTube video player"
+                        , term "frameborder" "0"
+                        , term "allow" "accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+                        , term "referrerpolicy" "strict-origin-when-cross-origin"
+                        , term "allowfullscreen" ""
+                        ]
+                        ""
 
                 div_ [class_ "text-center mt-3"]
                   $ a_ [href_ "https://www.youtube.com/@monoscope", target_ "_blank", class_ "text-textBrand hover:underline text-sm font-medium"] do
                     "Watch more tutorials →"
 
-          -- Display guides for all integration options
           forM_ integrationGroups \(_, integrations) -> do
             forM_ integrations \(lang, langName, frameworks) ->
               div_ [class_ $ "p-4 lang-guide hidden group-has-[#check-" <> lang <> ":checked]/pg:block", id_ $ lang <> "_main"] do
@@ -654,7 +562,7 @@ integrationsPage pid apikey =
                     $ loadingIndicator_ LdMD LdDots
                   div_
                     [ id_ $ "fw-content-" <> lang
-                    , hxGet_ $ "/proxy/docs/sdks/" <> thd3 (frameworks Unsafe.!! 0)
+                    , hxGet_ $ "/proxy/docs/sdks/" <> foldMap thd3 (listToMaybe frameworks)
                     , hxTrigger_ "load"
                     , hxSwap_ "innerHTML"
                     , hxSelect_ "#mainArticle"
@@ -662,7 +570,6 @@ integrationsPage pid apikey =
                     ]
                     ""
 
-    -- Telemetrygen modal
     modalWith_ "telemetrygen-modal" def{boxClass = "max-w-2xl", hideClose = True} Nothing do
       h3_ [class_ "text-lg font-bold text-textStrong flex items-center gap-2 mb-4"] do
         faSprite_ "flask-vial" "regular" "h-5 w-5"
@@ -671,7 +578,6 @@ integrationsPage pid apikey =
       p_ [class_ "text-textWeak mb-6 leading-relaxed"] "Use the Monoscope CLI to send test traces and verify your setup is working. No extra tools needed."
 
       div_ [class_ "space-y-4"] do
-        -- Step 1: Install CLI (if needed)
         div_ [class_ "p-4 bg-fillWeak rounded-lg"] do
           div_ [class_ "text-textStrong font-medium mb-2 flex items-center gap-2"] do
             span_ [class_ "inline-flex items-center justify-center w-6 h-6 rounded-full bg-fillBrand-weak text-textBrand text-sm font-bold"] "1"
@@ -680,7 +586,6 @@ integrationsPage pid apikey =
             [class_ "bg-bgBase p-3 rounded monospace text-sm overflow-x-auto border border-strokeWeak"]
             "curl https://monoscope.tech/install.sh | sh && monoscope auth login"
 
-        -- Step 2: Run command
         div_ [class_ "p-4 bg-fillWeak rounded-lg"] do
           div_ [class_ "text-textStrong font-medium mb-2 flex items-center gap-2"] do
             span_ [class_ "inline-flex items-center justify-center w-6 h-6 rounded-full bg-fillBrand-weak text-textBrand text-sm font-bold"] "2"
@@ -699,7 +604,6 @@ integrationsPage pid apikey =
                 span_ "Copy"
                 faSprite_ "copy" "regular" "h-3 w-3"
 
-      -- Success message
       div_ [class_ "mt-6 p-4 bg-fillSuccess-weak border border-strokeSuccess-weak rounded-lg flex items-start gap-3"] do
         faSprite_ "circle-check" "regular" "h-5 w-5 text-iconSuccess flex-shrink-0 mt-0.5"
         div_ do
@@ -708,10 +612,10 @@ integrationsPage pid apikey =
 
       div_ [class_ "modal-action"] $ label_ [Lucid.for_ "telemetrygen-modal", class_ "btn"] "Close"
 
-    -- Mobile overlay for docs panel
+    -- Mobile docs-panel overlay + the AI menu injected into proxied docs content
     style_
       $ unlines
-        [ "@media(max-width:767px){#docs-panel{display:none}#docs-panel.open{display:flex;flex-direction:column;position:fixed;inset:0;z-index:50;background:var(--color-bgBase);overflow-y:auto}}"
+        [ "@media(max-width:767px){#docs-panel{display:none}#docs-panel.open{display:flex;flex-direction:column;position:fixed;inset:0;z-index:50;background:var(--color-bgBase);overflow-y:auto}#docs-panel.open #docs-panel-back{display:block}}"
         , ".ai-menu-wrap{position:relative}"
         , ".ai-menu{position:absolute;right:0;top:100%;z-index:50;min-width:260px;margin-top:6px;background:var(--color-bgRaised);border:1px solid var(--color-strokeWeak);border-radius:12px;box-shadow:0 8px 24px rgba(0,0,0,0.12);padding:6px;opacity:0;transform:scale(0.95) translateY(-4px);pointer-events:none;transition:opacity 150ms ease,transform 150ms ease}"
         , ".ai-menu.open{opacity:1;transform:scale(1) translateY(0);pointer-events:auto}"
@@ -727,7 +631,6 @@ integrationsPage pid apikey =
         , ".ai-menu-item.copied svg:first-child{display:none}"
         ]
 
-    -- Highlight.js for syntax highlighting (v11.11.1)
     link_ [rel_ "stylesheet", href_ $(hashAssetFile "/public/assets/deps/highlightjs/atom-one-dark.min.css")]
     script_ [src_ $(hashAssetFile "/public/assets/deps/highlightjs/highlight.min.js")] ("" :: Text)
     script_ [src_ $(hashAssetFile "/public/assets/deps/highlightjs/javascript.min.js")] ("" :: Text)
@@ -742,12 +645,10 @@ integrationsPage pid apikey =
     script_ [src_ $(hashAssetFile "/public/assets/deps/highlightjs/yaml.min.js")] ("" :: Text)
     script_ [src_ $(hashAssetFile "/public/assets/deps/highlightjs/json.min.js")] ("" :: Text)
 
-    -- Initialize highlight.js after HTMX loads content
     script_
       [text|
-        // Initialize highlight.js
         hljs.highlightAll();
-        
+
         function initAIMenu(container) {
           var trigger = container.querySelector('#ai-menu-trigger');
           var menu = container.querySelector('#ai-menu');
@@ -769,25 +670,22 @@ integrationsPage pid apikey =
             if (!menu.contains(e.target) && e.target !== trigger) menu.classList.remove('open');
           });
           document.addEventListener('keydown', function(e) { if (e.key === 'Escape') menu.classList.remove('open'); });
-          var copyPage = menu.querySelector('[data-action="copy-page"]');
-          if (copyPage) copyPage.onclick = function() {
+          function pageMarkdown() {
             var clone = container.cloneNode(true);
             clone.querySelectorAll('.ai-menu-wrap, .code-header').forEach(function(el) { el.remove(); });
-            var text = '# ' + pageTitle + '\n\nSource: ' + pageUrl + '\n\n' + clone.innerText;
-            navigator.clipboard.writeText(text).then(function() { showCopied(menu, 'copy-page'); });
+            return '# ' + pageTitle + '\n\nSource: ' + pageUrl + '\n\n' + clone.innerText;
+          }
+          var copyPage = menu.querySelector('[data-action="copy-page"]');
+          if (copyPage) copyPage.onclick = function() {
+            navigator.clipboard.writeText(pageMarkdown()).then(function() {
+              copyPage.classList.add('copied');
+              setTimeout(function() { copyPage.classList.remove('copied'); }, 2000);
+            });
           };
           var viewMd = menu.querySelector('[data-action="view-markdown"]');
           if (viewMd) viewMd.onclick = function() {
-            var clone = container.cloneNode(true);
-            clone.querySelectorAll('.ai-menu-wrap, .code-header').forEach(function(el) { el.remove(); });
-            var text = '# ' + pageTitle + '\n\nSource: ' + pageUrl + '\n\n' + clone.innerText;
-            window.open(URL.createObjectURL(new Blob([text], { type: 'text/plain' })), '_blank');
+            window.open(URL.createObjectURL(new Blob([pageMarkdown()], { type: 'text/plain' })), '_blank');
           };
-          function showCopied(m, action) {
-            var item = m.querySelector('[data-action="' + action + '"]');
-            item.classList.add('copied');
-            setTimeout(function() { item.classList.remove('copied'); }, 2000);
-          }
         }
 
         // Re-highlight after HTMX swaps content
@@ -804,6 +702,13 @@ integrationsPage pid apikey =
       |]
 
 
+-- | "Confirm & Proceed" + "Skip" pair; classes differ between the desktop inline and mobile sticky bars.
+integrationCta_ :: Projects.ProjectId -> Text -> Text -> Text -> Html ()
+integrationCta_ pid wrapCls btnCls skipCls = div_ [class_ wrapCls] do
+  button_ [class_ btnCls, hxGet_ $ "/p/" <> pid.toText <> "/onboarding/integration-check", hxSwap_ "none", hxIndicator_ "#loadingIndicator"] "Confirm & Proceed"
+  a_ [class_ skipCls, type_ "button", hxPost_ $ "/p/" <> pid.toText <> "/onboarding/skip?step=Integration"] "Skip"
+
+
 languageItem :: Projects.ProjectId -> Text -> Text -> Html ()
 languageItem pid lang ext = do
   label_
@@ -815,7 +720,7 @@ languageItem pid lang ext = do
         , class_ "checkbox shrink-0"
         , id_ $ "check-" <> ext
         , value_ ext
-        , onchange_ $ "if(this.checked) { var dp=document.getElementById('docs-panel'); if(window.innerWidth<768){dp.classList.add('open');document.getElementById('docs-panel-back').classList.remove('hidden');requestAnimationFrame(function(){dp.scrollTop=0;});} else {requestAnimationFrame(function(){document.getElementById('" <> ext <> "_main').scrollIntoView({behavior:'smooth'});});} }"
+        , onchange_ $ "if(this.checked){var dp=document.getElementById('docs-panel');if(window.innerWidth<768){dp.classList.add('open');requestAnimationFrame(function(){dp.scrollTop=0});}else{requestAnimationFrame(function(){document.getElementById('" <> ext <> "_main').scrollIntoView({behavior:'smooth'})});}}"
         ]
       div_ [class_ "flex w-full items-center justify-between overflow-hidden"] do
         div_ [class_ "flex items-center gap-2 text-sm min-w-0"] do
@@ -834,32 +739,20 @@ languageItem pid lang ext = do
               faSprite_ "spinner" "regular" "h-4 w-4 animate-spin shrink-0"
 
 
--- Helper function to render connection status button
-connectionStatusButton :: Bool -> Text -> Html ()
-connectionStatusButton isConnected connectUrl
-  | isConnected = button_ [class_ "text-textSuccess "] "Connected"
-  | otherwise =
-      a_
-        [ target_ "_blank"
-        , class_ "border px-3 h-8 flex items-center shadow-xs border-[var(--brand-color)] rounded-lg text-textBrand "
-        , href_ connectUrl
-        ]
-        "Connect"
-
-
--- Helper function to render integration card
 integrationCard :: Text -> Text -> Bool -> Text -> Html ()
 integrationCard serviceName iconPath isConnected connectUrl = do
   div_ [class_ "px-3 py-2 rounded-xl border border-strokeWeak bg-fillWeak justify-between items-center flex"] $ do
     div_ [class_ "items-center gap-1.5 flex overflow-hidden"] $ do
       img_ [src_ iconPath]
       span_ [class_ "text-center text-textStrong text-xl"] $ toHtml serviceName
-    connectionStatusButton isConnected connectUrl
+    if isConnected
+      then button_ [class_ "text-textSuccess "] "Connected"
+      else a_ [target_ "_blank", class_ "border px-3 h-8 flex items-center shadow-xs border-[var(--brand-color)] rounded-lg text-textBrand ", href_ connectUrl] "Connect"
 
 
-onboardingStepWrapper_ :: Text -> Int -> Text -> Text -> Html () -> Html ()
-onboardingStepWrapper_ extraCls step title prevUrl content =
-  div_ [class_ $ "w-full max-w-xl mx-auto mt-20 md:mt-[156px] px-4 md:px-0 " <> extraCls]
+onboardingStepWrapper_ :: Int -> Text -> Text -> Html () -> Html ()
+onboardingStepWrapper_ step title prevUrl content =
+  div_ [class_ "w-full max-w-xl mx-auto mt-20 md:mt-[156px] px-4 md:px-0"]
     $ div_ [class_ "flex-col gap-4 flex w-full"] do
       stepIndicator step title prevUrl
       content
@@ -911,7 +804,7 @@ notifChannelsWithUrls slackUrl discordUrl pid phone emails hasDiscord hasSlack =
 
 onboardingInfoBody :: Projects.ProjectId -> Text -> Text -> Text -> Text -> Text -> Html ()
 onboardingInfoBody pid firstName lastName cName cSize fUsFrm = do
-  onboardingStepWrapper_ "" 1 "Tell us a little bit about you" ""
+  onboardingStepWrapper_ 1 "Tell us a little bit about you" ""
     $ form_ [class_ "flex-col w-full gap-8 flex", hxPost_ $ "/p/" <> pid.toText <> "/onboarding/info", hxIndicator_ "#loadingIndicator"]
     $ do
       div_ [class_ "flex-col w-full gap-4 mt-4 flex"] $ do
@@ -928,7 +821,7 @@ onboardingInfoBody pid firstName lastName cName cSize fUsFrm = do
 
 onboardingConfigBody :: Projects.ProjectId -> Text -> [Text] -> Html ()
 onboardingConfigBody pid loca func = do
-  onboardingStepWrapper_ "" 2 "Let's configure your project" ("/p/" <> pid.toText <> "/onboarding?step=Info")
+  onboardingStepWrapper_ 2 "Let's configure your project" ("/p/" <> pid.toText <> "/onboarding?step=Info")
     $ form_ [class_ "flex-col w-full gap-8 flex", hxPost_ $ "/p/" <> pid.toText <> "/onboarding/survey", hxIndicator_ "#loadingIndicator"]
     $ do
       div_ [class_ "flex-col w-full gap-14 mt-4 flex"] $ do
@@ -972,8 +865,8 @@ inviteTeamMemberModal pid emails enableFreetier = do
             , hxIndicator_ "#loadingIndicator"
             ]
             $ do
-              inviteMemberItem "hidden"
-              forM_ emails inviteMemberItem
+              inviteMemberItem Nothing
+              forM_ emails (inviteMemberItem . Just)
       div_ [class_ "modal-action w-full flex items-center justify-start gap-4"] do
         button_ [class_ "btn-primary px-8 py-2 text-lg rounded-xl cursor-pointer flex items-center", type_ "button", onpointerdown_ "htmx.trigger('#members-container', 'submit')"] "Proceed"
         label_ [Lucid.for_ "inviteModal", class_ "text-textWeak text-sm underline cursor-pointer"] "Close"
@@ -987,6 +880,8 @@ functionalities =
   , ("changeTracking", "API (Breaking) Change Tracking")
   , ("customDashboards", "Custom Dashboards")
   ]
+
+
 locations :: [(Text, Text)]
 locations =
   [ ("usa", "USA")
@@ -995,14 +890,14 @@ locations =
   ]
 
 
-inviteMemberItem :: Text -> Html ()
-inviteMemberItem email = do
-  let hide = email == "hidden"
-  div_ (class_ ("flex  py-1 w-full justify-between items-center border-b border-strokeWeak " <> if hide then "hidden" else "") : [id_ "member-template" | hide]) do
+-- | 'Nothing' renders the hidden @#member-template@ that appendMember() clones.
+inviteMemberItem :: Maybe Text -> Html ()
+inviteMemberItem emailM = do
+  let (email, isTemplate) = (fromMaybe "" emailM, isNothing emailM)
+  div_ (class_ ("flex  py-1 w-full justify-between items-center border-b border-strokeWeak " <> bool "" "hidden" isTemplate) : [id_ "member-template" | isTemplate]) do
     div_ [class_ "pr-6 py-1  w-full justify-start items-center inline-flex"] do
-      input_ ([type_ "hidden", value_ email] ++ [name_ "emails" | not hide])
-      span_ [class_ "text-textStrong text-sm font-normal"]
-        $ toHtml email
+      input_ ([type_ "hidden", value_ email] <> [name_ "emails" | not isTemplate])
+      span_ [class_ "text-textStrong text-sm font-normal"] $ toHtml email
     select_ [name_ "permissions", class_ "select select-xs"] do
       option_ [class_ "text-textWeak", value_ "admin"] "Admin"
       option_ [class_ "text-textWeak", value_ "edit"] "Can Edit"
@@ -1018,8 +913,7 @@ inviteMemberItem email = do
 createBinaryField :: Text -> Text -> [Text] -> (Text, Text) -> Html ()
 createBinaryField kind name selectedValues (value, label) = do
   div_ [class_ " items-center gap-3 inline-flex"] $ do
-    let checked = value `elem` selectedValues
-    input_ $ [class_ "w-6 h-6 rounded-sm", type_ kind, name_ name, value_ value, id_ value] <> [required_ "required" | kind == "radio"] <> [checked_ | checked]
+    input_ $ [class_ "w-6 h-6 rounded-sm", type_ kind, name_ name, value_ value, id_ value] <> [required_ "required" | kind == "radio"] <> [checked_ | value `elem` selectedValues]
     label_ [class_ " text-textStrong text-sm", Lucid.for_ value] $ toHtml label
 
 
@@ -1063,12 +957,5 @@ universalIndicator =
 -- This bypasses CORS restrictions by fetching the content server-side
 proxyLandingH :: (HTTP :> es, State.State HXRedirectDest :> es, State.State TriggerEvents :> es, State.State XWidgetJSON :> es) => [Text] -> Eff es (RespHeaders Text)
 proxyLandingH path = do
-  let baseUrl = "https://monoscope.tech/"
-      fullUrl = baseUrl <> T.intercalate "/" path
-
-  response <- W.get (toString fullUrl)
-
-  let content = fromMaybe "" $ response L.^? W.responseBody
-      textContent = decodeUtf8 content
-      textContent' = T.replace "href=\"/" "href=\"https://monoscope.tech/" textContent
-  addRespHeaders textContent'
+  response <- W.get $ toString $ "https://monoscope.tech/" <> T.intercalate "/" path
+  addRespHeaders $ T.replace "href=\"/" "href=\"https://monoscope.tech/" $ decodeUtf8 $ fromMaybe "" $ response L.^? W.responseBody

--- a/src/Pages/Projects.hs
+++ b/src/Pages/Projects.hs
@@ -46,7 +46,6 @@ where
 import BackgroundJobs qualified
 import Control.Lens ((^.))
 import Data.Aeson qualified as AE
-import Data.CaseInsensitive (original)
 import Data.CaseInsensitive qualified as CI
 import Data.Char (isAlphaNum, isDigit, isLower)
 import Data.Default (Default (..))
@@ -94,7 +93,6 @@ import Pkg.DeriveUtils (UUIDId (..))
 import Pkg.EmailTemplates qualified as ET
 import Pkg.Mail (addConvertKitUserOrganization, sendRenderedEmail)
 import Relude hiding (ask, asks)
-import Relude.Unsafe qualified as Unsafe
 import Servant (addHeader)
 import Servant.API (Header)
 import Servant.API.ResponseHeaders (Headers)
@@ -186,9 +184,10 @@ projectCard_ project = do
           faSprite_ "arrow-right" "regular" "h-4 w-4 text-iconNeutral opacity-0 group-hover:opacity-100 transition-opacity ml-2 mt-1"
 
         div_ [class_ "flex items-center justify-between text-sm text-textWeak"] do
+          let created = fmt @Text $ dateDashF project.createdAt
           div_ [class_ "flex items-center gap-1"] do
             faSprite_ "calendar" "regular" "h-3.5 w-3.5"
-            time_ [datetime_ $ fmt $ dateDashF project.createdAt] $ toHtml @Text $ fmt $ dateDashF project.createdAt
+            time_ [datetime_ created] $ toHtml created
 
           unless (V.null project.usersDisplayImages)
             $ div_ [class_ "flex -space-x-2"] do
@@ -235,20 +234,8 @@ data CreateProjectForm = CreateProjectForm
 
 integrationsSettingsGetH :: Projects.ProjectId -> ATAuthCtx (RespHeaders (Html ()))
 integrationsSettingsGetH pid = do
-  (sess, project, bw) <- mkPageCtx pid
+  (_, _, bw) <- mkPageCtx pid
   appCtx <- ask @AuthContext
-  let createProj =
-        CreateProjectForm
-          { title = project.title
-          , description = project.description
-          , emails = []
-          , permissions = []
-          , timeZone = project.timeZone
-          , errorAlerts = if project.errorAlerts then Just "on" else Nothing
-          , endpointAlerts = if project.endpointAlerts then Just "on" else Nothing
-          , weeklyNotifs = if project.weeklyNotif then Just "on" else Nothing
-          , dailyNotifs = if project.dailyNotif then Just "on" else Nothing
-          }
   slackInfo <- getProjectSlackData pid
   discordInfo <- getDiscordDataByProjectId pid
   channels <- resolveSlackChannels slackInfo
@@ -259,8 +246,7 @@ integrationsSettingsGetH pid = do
   whenJust slackInfo \s -> void $ ProjectMembers.addSlackChannelToEveryoneTeam pid s.channelId
   everyoneTeamM <- ProjectMembers.getEveryoneTeam pid
   let pagerdutyKey = listToMaybe . V.toList . (.pagerduty_services) =<< everyoneTeamM
-      hasDiscord = isJust discordInfo
-  let existingSlackChannels = maybe V.empty (.slack_channels) everyoneTeamM
+      existingSlackChannels = maybe V.empty (.slack_channels) everyoneTeamM
       knownChannelIds = S.fromList $ map BotUtils.channelId channels
       -- Seed extras with the stored default channel name (captured at OAuth time),
       -- since the bot often can't query conversations.info for it later.
@@ -268,30 +254,24 @@ integrationsSettingsGetH pid = do
       seededExtras = maybeToList $ mfilter (\c -> not $ S.member (BotUtils.channelId c) knownChannelIds) defaultChannel
       seededIds = S.fromList $ map BotUtils.channelId seededExtras
       missingIds = filter (\c -> not (S.member c knownChannelIds) && not (S.member c seededIds)) $ V.toList existingSlackChannels
-  fetchedExtras <- case slackInfo of
-    Just d -> catMaybes <$> traverse (SlackP.getSlackChannelInfo d.botToken) missingIds
-    Nothing -> pure []
+  fetchedExtras <- maybe (pure []) (\d -> catMaybes <$> traverse (SlackP.getSlackChannelInfo d.botToken) missingIds) slackInfo
   let extraSlackChannels = seededExtras <> fetchedExtras
-
-  let bwconf = bw{pageTitle = "Integrations", isSettingsPage = True}
+      bwconf = bw{pageTitle = "Integrations", isSettingsPage = True}
   addRespHeaders
     $ bodyWrapper bwconf
     $ integrationsBody
       IntegrationsConfig
-        { session = sess.persistentSession
-        , projectId = pid
+        { projectId = pid
         , envConfig = appCtx.env
-        , isUpdate = True
-        , createForm = createProj
         , disabledChannels = maybe V.empty (.disabled_channels) everyoneTeamM
         , phones = maybe V.empty (.phone_numbers) everyoneTeamM
         , emails = maybe V.empty (.notify_emails) everyoneTeamM
         , slackData = slackInfo
-        , pagerdutyKey = pagerdutyKey
-        , discordConnected = hasDiscord
+        , pagerdutyKey
+        , discordConnected = isJust discordInfo
         , slackChannels = channels
-        , extraSlackChannels = extraSlackChannels
-        , existingSlackChannels = existingSlackChannels
+        , extraSlackChannels
+        , existingSlackChannels
         , everyoneTeamId = (.id) <$> everyoneTeamM
         }
 
@@ -312,11 +292,8 @@ allChannels = ["email", "slack", "discord", "phone", "pagerduty"]
 
 updateNotificationsChannel :: Projects.ProjectId -> NotifListForm -> ATAuthCtx (RespHeaders (Html ()))
 updateNotificationsChannel pid NotifListForm{enabledChannels, phones, emails, slackChannels} = do
-  validationResult <- validateNotificationChannels pid enabledChannels phones
-  case validationResult of
-    Left errorMessage -> do
-      addErrorToast errorMessage Nothing
-      integrationsSettingsGetH pid
+  validateNotificationChannels pid enabledChannels phones >>= \case
+    Left errorMessage -> addErrorToast errorMessage Nothing
     Right () -> do
       projectM <- Projects.projectById pid
       slackInfoM <- getProjectSlackData pid
@@ -332,8 +309,8 @@ updateNotificationsChannel pid NotifListForm{enabledChannels, phones, emails, sl
         -- channel; drop any where Slack says not_in_channel / channel_not_found
         -- / etc. so we don't persist unreachable routes that fail every alert.
         (unreachable, reachableAdds) <- case (,) <$> projectM <*> slackInfoM of
-          Just (project, slackInfo) -> do
-            results <- forM addedChannels \cid -> do
+          Just (project, slackInfo) ->
+            partitionEithers <$> forM addedChannels \cid -> do
               -- OAuth-default channel: probe via the channel-bound webhook URL
               -- (works for private channels; no bot membership needed).
               -- Other channels: probe via chat.postMessage (needs bot membership).
@@ -347,28 +324,24 @@ updateNotificationsChannel pid NotifListForm{enabledChannels, phones, emails, sl
                 Left err -> do
                   SlackP.logWelcomeMessageFailure cid err
                   pure (Left cid)
-            pure $ partitionEithers results
           Nothing -> do
             unless (null addedChannels)
               $ addErrorToast "Slack workspace is not linked to this project; new channels were not saved." Nothing
             pure (addedChannels, [])
 
-        let finalSlack = V.fromList $ ordNub $ V.toList team.slack_channels <> reachableAdds
-            disabled = V.fromList $ filter (`notElem` enabledChannels) allChannels
-            teamDetails =
-              (ProjectMembers.teamToDetails team)
-                { ProjectMembers.slackChannels = finalSlack
-                , ProjectMembers.notifyEmails = V.fromList emails
-                , ProjectMembers.phoneNumbers = V.fromList phones
-                , ProjectMembers.disabledChannels = disabled
-                }
-                :: ProjectMembers.TeamDetails
-        void $ ProjectMembers.updateTeam pid team.id teamDetails
+        void
+          $ ProjectMembers.updateTeam pid team.id
+          $ (ProjectMembers.teamToDetails team)
+            { ProjectMembers.slackChannels = V.fromList $ ordNub $ V.toList team.slack_channels <> reachableAdds
+            , ProjectMembers.notifyEmails = V.fromList emails
+            , ProjectMembers.phoneNumbers = V.fromList phones
+            , ProjectMembers.disabledChannels = V.fromList $ filter (`notElem` enabledChannels) allChannels
+            }
 
         unless (null unreachable)
           $ addErrorToast ("Could not reach Slack channel(s): " <> T.intercalate ", " unreachable <> ". Invite Monoscope to each channel and try again.") Nothing
       addSuccessToast "Updated Notification Channels Successfully" Nothing
-      integrationsSettingsGetH pid
+  integrationsSettingsGetH pid
 
 
 validateNotificationChannels :: Projects.ProjectId -> [Text] -> [Text] -> ATAuthCtx (Either Text ())
@@ -415,28 +388,29 @@ newtype PagerdutyConnectForm = PagerdutyConnectForm {integrationKey :: Text}
   deriving anyclass (FromForm)
 
 
+-- | Audit an integration connect/disconnect for @name@ against the current session.
+logIntegrationAudit :: Projects.ProjectId -> Projects.AuditEvent -> Text -> ATAuthCtx ()
+logIntegrationAudit pid event name = do
+  sess <- Projects.getSession
+  Projects.logAuditS pid event sess $ Just $ AE.object ["integration" AE..= name]
+
+
 pagerdutyConnectH :: Projects.ProjectId -> PagerdutyConnectForm -> ATAuthCtx (RespHeaders (Html ()))
 pagerdutyConnectH pid form = do
   let key = T.strip form.integrationKey
-  if T.length key < 20 || T.null key
-    then addErrorToast "PagerDuty integration key is too short" Nothing >> integrationsSettingsGetH pid
+  if T.length key < 20
+    then addErrorToast "PagerDuty integration key is too short" Nothing
     else do
       void $ ProjectMembers.addPagerdutyServiceToEveryoneTeam pid key
-      sess <- Projects.getSession
-      Projects.logAuditS pid Projects.AEIntegrationConnected sess
-        $ Just
-        $ AE.object ["integration" AE..= ("pagerduty" :: Text)]
+      logIntegrationAudit pid Projects.AEIntegrationConnected "pagerduty"
       addSuccessToast "PagerDuty connected" Nothing
-      integrationsSettingsGetH pid
+  integrationsSettingsGetH pid
 
 
 pagerdutyDisconnectH :: Projects.ProjectId -> ATAuthCtx (RespHeaders (Html ()))
 pagerdutyDisconnectH pid = do
   ProjectMembers.removePagerdutyServicesFromEveryoneTeam pid
-  sess <- Projects.getSession
-  Projects.logAuditS pid Projects.AEIntegrationDisconnected sess
-    $ Just
-    $ AE.object ["integration" AE..= ("pagerduty" :: Text)]
+  logIntegrationAudit pid Projects.AEIntegrationDisconnected "pagerduty"
   addSuccessToast "PagerDuty disconnected" Nothing
   integrationsSettingsGetH pid
 
@@ -447,21 +421,15 @@ slackDisconnectH pid = do
   if deleted > 0
     then do
       void $ ProjectMembers.removeSlackChannelsFromEveryoneTeam pid
-      sess <- Projects.getSession
-      Projects.logAuditS pid Projects.AEIntegrationDisconnected sess
-        $ Just
-        $ AE.object ["integration" AE..= ("slack" :: Text)]
+      logIntegrationAudit pid Projects.AEIntegrationDisconnected "slack"
       addSuccessToast "Slack disconnected" Nothing
     else addErrorToast "Failed to disconnect Slack" Nothing
   integrationsSettingsGetH pid
 
 
 data IntegrationsConfig = IntegrationsConfig
-  { session :: Projects.PersistentSession
-  , projectId :: Projects.ProjectId
+  { projectId :: Projects.ProjectId
   , envConfig :: EnvConfig
-  , isUpdate :: Bool
-  , createForm :: CreateProjectForm
   , disabledChannels :: V.Vector Text
   , phones :: V.Vector Text
   , emails :: V.Vector Text
@@ -501,7 +469,7 @@ integrationsBody IntegrationsConfig{..} = do
               , ("slack", "Slack", isJust slackData, faSprite_ "slack" "solid" "h-4 w-4", renderSlackIntegration envConfig pid slackData slackChannels extraSlackChannels existingSlackChannels)
               , ("discord", "Discord", discordConnected, faSprite_ "discord" "solid" "h-4 w-4", renderDiscordIntegration envConfig pid)
               , ("phone", "WhatsApp", not $ V.null phones, faSprite_ "whatsapp" "solid" "h-4 w-4", renderWhatsappIntegration tgs)
-              , ("pagerduty", "PagerDuty", isJust pagerdutyKey, faSprite_ "pager" "solid" "h-4 w-4", renderPagerdutyIntegration projectId.toText pagerdutyKey)
+              , ("pagerduty", "PagerDuty", isJust pagerdutyKey, faSprite_ "pager" "solid" "h-4 w-4", renderPagerdutyIntegration pid (isJust pagerdutyKey))
               ]
                 :: [(Text, Text, Bool, Html (), Html ())]
 
@@ -517,7 +485,7 @@ integrationsBody IntegrationsConfig{..} = do
             , hxTarget_ "#integrations-form-section"
             , hxSelect_ "#integrations-form-section"
             , hxSwap_ "outerHTML swap:0.3s"
-            , [__| on change from closest <div/> put .btn-primary into my.className then put 'btn btn-sm btn-primary' into my.className end |]
+            , [__| on change from closest <div/> put 'btn btn-sm btn-primary' into my.className |]
             ]
             "Save"
 
@@ -549,7 +517,7 @@ renderInlineTestButton pid channel teamIdM =
 renderNotificationOption :: Text -> Maybe UUID.UUID -> Text -> Text -> Bool -> Bool -> Html () -> Html () -> Html ()
 renderNotificationOption pid teamIdM title value isChecked isConfigured icon extraContent = do
   let isActive = isChecked && isConfigured
-  div_ [class_ ""] do
+  div_ [] do
     -- Compact row: icon, name, test, toggle
     div_ [class_ "flex items-center gap-3 p-3"] do
       div_ [class_ "flex items-center justify-center shrink-0 w-7 h-7 rounded-md", class_ $ if isActive then "bg-fillBrand-weak" else "bg-fillWeak"] icon
@@ -618,8 +586,8 @@ renderDiscordIntegration envCfg pid = do
     "Add to Discord"
 
 
-renderPagerdutyIntegration :: Text -> Maybe Text -> Html ()
-renderPagerdutyIntegration pid = div_ [id_ "pagerduty-integration"] . maybe disconnectedUI (const connectedUI)
+renderPagerdutyIntegration :: Text -> Bool -> Html ()
+renderPagerdutyIntegration pid = div_ [id_ "pagerduty-integration"] . bool disconnectedUI connectedUI
   where
     connectedUI = do
       div_ [class_ "flex items-center gap-2"] do
@@ -651,31 +619,22 @@ manageMembersPostH pid onboardingM form = do
   projMembers <- ProjectMembers.selectActiveProjectMembers pid
   let usersAndPermissions = filter (\(x, _) -> not (T.null x)) $ zip (form.emails <&> T.strip) form.permissions & uniq
   let uAndPOldAndChanged =
-        mapMaybe
-          ( \(email, permission) -> do
-              let projMembersM = projMembers & find (\a -> original a.email == email && a.permission /= permission)
-              projMembersM >>= (\projMember -> Just (projMember.id, permission))
-          )
-          usersAndPermissions
+        usersAndPermissions
+          & mapMaybe \(email, permission) ->
+            (,permission) . (.id) <$> find (\a -> CI.original a.email == email && a.permission /= permission) projMembers
 
-  let uAndPNew = filter (\(email, _) -> not $ any (\a -> original a.email == email) projMembers) usersAndPermissions
+  let uAndPNew = filter (\(email, _) -> not $ any (\a -> CI.original a.email == email) projMembers) usersAndPermissions
 
   let deletedUAndP =
         projMembers
-          & filter (\pm -> not $ any (\(email, _) -> original pm.email == email) usersAndPermissions)
+          & filter (\pm -> not $ any (\(email, _) -> CI.original pm.email == email) usersAndPermissions)
           & filter (\a -> a.userId /= currUserId)
           & map (.id)
 
   newProjectMembers <- forM uAndPNew \(email, permission) -> do
-    userId' <- do
-      userIdM' <- Projects.userIdByEmail email
-      case userIdM' of
-        Nothing -> do
-          idM' <- Projects.createEmptyUser email
-          case idM' of
-            Nothing -> error "duplicate email in createEmptyUser"
-            Just idX -> pure idX
-        Just idX -> pure idX
+    userId' <-
+      Projects.userIdByEmail email
+        >>= maybe (Projects.createEmptyUser email >>= maybe (error "duplicate email in createEmptyUser") pure) pure
 
     when (userId' /= currUserId)
       $ void
@@ -683,11 +642,11 @@ manageMembersPostH pid onboardingM form = do
       $ withResource appCtx.pool \conn -> createJob conn "background_jobs" $ BackgroundJobs.InviteUserToProject currUserId pid email project.title
     pure (email, permission, userId')
 
-  let projectMembers =
-        newProjectMembers
-          & filter (\(_, _, id') -> id' /= currUserId)
-          & map (\(email, permission, id') -> ProjectMembers.CreateProjectMembers pid id' permission)
-  _ <- ProjectMembers.insertProjectMembers projectMembers
+  _ <-
+    ProjectMembers.insertProjectMembers
+      $ newProjectMembers
+      & filter (\(_, _, id') -> id' /= currUserId)
+      & map \(_, permission, id') -> ProjectMembers.CreateProjectMembers pid id' permission
 
   unless (null uAndPOldAndChanged)
     $ void
@@ -703,15 +662,16 @@ manageMembersPostH pid onboardingM form = do
 
   projMembersLatest <- V.fromList <$> ProjectMembers.selectAllProjectMembers pid
   teamsCount <- length <$> ProjectMembers.getTeamsVM pid
-  if isJust onboardingM
-    then do
-      redirectCS $ "/p/" <> pid.toText <> "/onboarding?step=Integration"
-      addRespHeaders $ ManageMembersPost (pid, projMembersLatest, project.paymentPlan, teamsCount)
-    else do
-      if Projects.isFreeTier project.paymentPlan && not (null uAndPNew)
-        then addSuccessToast "Members invited! Upgrade to enable team access." Nothing
-        else addSuccessToast "Updated Members List Successfully" Nothing
-      addRespHeaders $ ManageMembersPost (pid, projMembersLatest, project.paymentPlan, teamsCount)
+  case onboardingM of
+    Just _ -> redirectCS $ "/p/" <> pid.toText <> "/onboarding?step=Integration"
+    Nothing ->
+      addSuccessToast
+        ( if Projects.isFreeTier project.paymentPlan && not (null uAndPNew)
+            then "Members invited! Upgrade to enable team access."
+            else "Updated Members List Successfully"
+        )
+        Nothing
+  addRespHeaders $ ManageMembersPost (pid, projMembersLatest, project.paymentPlan, teamsCount)
 
 
 data TeamForm = TeamForm
@@ -769,7 +729,7 @@ manageTeamPostH pid form tmView = do
       _ <- ProjectMembers.updateTeam pid tid teamDetails
       addSuccessToast "Team updated successfully" Nothing
       addTriggerEvent "closeModal" ""
-      maybe (redirectCS $ "/p/" <> pid.toText <> "/manage_teams") (\_ -> redirectCS $ "/p/" <> pid.toText <> "/team/" <> form.teamHandle) tmView
+      redirectCS $ "/p/" <> pid.toText <> maybe "/manage_teams" (const $ "/team/" <> form.teamHandle) tmView
       addRespHeaders $ ManageTeamsPostError ""
     (_, _, _, Nothing) -> do
       createdM <- ProjectMembers.createTeam pid (Just currUserId) teamDetails
@@ -791,13 +751,11 @@ newtype TBulkActionForm = TBulkActionForm
 
 manageTeamBulkActionH :: Projects.ProjectId -> Text -> TBulkActionForm -> Maybe Text -> ATAuthCtx (RespHeaders ManageTeams)
 manageTeamBulkActionH pid action TBulkActionForm{itemId} listViewM = do
-  (sess, project) <- Projects.sessionAndProject pid
-  appCtx <- ask @AuthContext
+  (sess, _) <- Projects.sessionAndProject pid
   case action of
     "delete" -> do
       teamVm <- ProjectMembers.getTeamsById pid $ V.fromList itemId
-      let canDelete = all (\team -> Just sess.user.id == team.created_by) teamVm
-      if canDelete
+      if all (\team -> Just sess.user.id == team.created_by) teamVm
         then do
           _ <- ProjectMembers.deleteTeams pid $ V.fromList itemId
           when (isNothing listViewM)
@@ -820,7 +778,7 @@ data ManageTeams
 instance ToHtml ManageTeams where
   toHtml (ManageTeamsGet (PageCtx bwconf (pid, members, slackChannels, discordChannels, teams))) = toHtml $ PageCtx bwconf $ manageTeamsPage pid members slackChannels discordChannels teams
   toHtml (ManageTeamsGet' (pid, members, slackChannels, discordChannels, teams)) = toHtml $ manageTeamsPage pid members slackChannels discordChannels teams
-  toHtml (ManageTeamsPostError msg) = span_ [] ""
+  toHtml (ManageTeamsPostError _) = span_ [] ""
   toHtml ManageTeamsDelete = toHtml ""
   toHtml (ManageTeamGet (PageCtx bwconf (pid, team, members, slackChannels, discordChannels))) = toHtml $ PageCtx bwconf $ teamPage pid team members slackChannels discordChannels
   toHtml (ManageTeamGet' (pid, team, members, slackChannels, discordChannels)) = toHtml $ teamPage pid team members slackChannels discordChannels
@@ -834,19 +792,25 @@ manageTeamsGetH pid layoutM = do
   (projMembers, channels, discordChannels) <- teamPageData pid
   teams <- V.fromList <$> ProjectMembers.getTeamsVM pid
   let bwconf = bw{pageTitle = "Team", isSettingsPage = True}
-  case layoutM of
-    Just _ -> do
-      addRespHeaders $ ManageTeamsGet' (pid, projMembers, channels, discordChannels, teams)
-    _ -> do
-      addRespHeaders $ ManageTeamsGet (PageCtx bwconf (pid, projMembers, channels, discordChannels, teams))
+      payload = (pid, projMembers, channels, discordChannels, teams)
+  addRespHeaders $ maybe (ManageTeamsGet $ PageCtx bwconf payload) (const $ ManageTeamsGet' payload) layoutM
+
+
+encodeChannels :: [BotUtils.Channel] -> Text
+encodeChannels = decodeUtf8 . AE.encode . map \x -> AE.object ["name" AE..= ("#" <> x.channelName), "value" AE..= x.channelId]
+
+
+-- | Tagify whitelists for the team modal: (members by user id, members by email).
+memberWhitelists :: V.Vector ProjectMembers.ProjectMemberVM -> (Text, Text)
+memberWhitelists projMembers =
+  ( decodeUtf8 $ AE.encode $ (\x -> AE.object ["name" AE..= (x.first_name <> " " <> x.last_name), "email" AE..= x.email, "value" AE..= x.userId]) <$> projMembers
+  , decodeUtf8 $ AE.encode $ (\x -> AE.object ["name" AE..= x.email, "value" AE..= x.email]) <$> projMembers
+  )
 
 
 manageTeamsPage :: Projects.ProjectId -> V.Vector ProjectMembers.ProjectMemberVM -> [BotUtils.Channel] -> [BotUtils.Channel] -> V.Vector ProjectMembers.TeamVM -> Html ()
-encodeChannels :: [BotUtils.Channel] -> Text
-encodeChannels = decodeUtf8 . AE.encode . map \x -> AE.object ["name" AE..= ("#" <> x.channelName), "value" AE..= x.channelId]
 manageTeamsPage pid projMembers channels discordChannels teams = do
-  let whiteList = decodeUtf8 $ AE.encode $ (\x -> AE.object ["name" AE..= (x.first_name <> " " <> x.last_name), "email" AE..= x.email, "value" AE..= x.userId]) <$> projMembers
-      emailWhiteList = decodeUtf8 $ AE.encode $ (\x -> AE.object ["name" AE..= x.email, "value" AE..= x.email]) <$> projMembers
+  let (whiteList, emailWhiteList) = memberWhitelists projMembers
       (channelWhiteList, discordWhiteList) = (encodeChannels channels, encodeChannels discordChannels)
   div_ [class_ "w-full h-full overflow-y-auto"] $ section_ [class_ "py-6 px-4 sm:py-8 sm:px-8 lg:px-12 space-y-6"] do
     div_ [class_ "flex justify-between items-center max-w-2xl"] do
@@ -858,24 +822,24 @@ manageTeamsPage pid projMembers channels discordChannels teams = do
       then div_ [class_ "py-12 text-center surface-raised rounded-2xl max-w-2xl"] do
         div_ [class_ "text-sm text-textStrong font-medium"] "No teams yet"
         div_ [class_ "text-xs text-textWeak mt-1"] "Create a team to route alerts to the right people."
-      else do
-        let renderTeamNameCol team = nameCell pid team.name team.description team.handle team.is_everyone
-            renderModifiedCol team = span_ [class_ "monospace text-textWeak text-xs whitespace-nowrap"] $ toHtml $ toText $ formatTime defaultTimeLocale "%b %-e" team.updated_at
-            renderMembersCol team = memberCell team.members
-            renderNotificationsCol = notifsCell
-            tableCols = [Table.col "Name" renderTeamNameCol, Table.col "Members" renderMembersCol, Table.col "Notifications" renderNotificationsCol, Table.col "Modified" renderModifiedCol]
-            table =
-              Table
-                { config = def{Table.elemID = "teams_table", Table.renderAsTable = True}
-                , columns = tableCols
-                , rows = teams
-                , features =
-                    def
-                      { Table.rowAttrs = Just $ const [class_ "group/row hover:bg-fillWeaker"]
-                      , Table.search = if V.length teams >= 5 then Just Table.ClientSide else Nothing
-                      }
-                }
-        div_ [class_ "w-full"] $ toHtml table
+      else
+        div_ [class_ "w-full"]
+          $ toHtml
+            Table
+              { config = def{Table.elemID = "teams_table", Table.renderAsTable = True}
+              , columns =
+                  [ Table.col "Name" \team -> nameCell pid team.name team.description team.handle team.is_everyone
+                  , Table.col "Members" $ memberCell . (.members)
+                  , Table.col "Notifications" notifsCell
+                  , Table.col "Modified" \team -> span_ [class_ "monospace text-textWeak text-xs whitespace-nowrap"] $ toHtml $ toText $ formatTime defaultTimeLocale "%b %-e" team.updated_at
+                  ]
+              , rows = teams
+              , features =
+                  def
+                    { Table.rowAttrs = Just $ const [class_ "group/row hover:bg-fillWeaker"]
+                    , Table.search = if V.length teams >= 5 then Just Table.ClientSide else Nothing
+                    }
+              }
 
 
 nameCell :: Projects.ProjectId -> Text -> Text -> Text -> Bool -> Html ()
@@ -917,18 +881,14 @@ teamGetH pid handle layoutM = do
                       faSprite_ "pen-to-square" "regular" "h-4 w-4"
                       "Edit"
               }
-      case layoutM of
-        Just _ -> addRespHeaders $ ManageTeamGet' (pid, team, projMembers, channels, discordChannels)
-        _ -> addRespHeaders $ ManageTeamGet (PageCtx bwconf (pid, team, projMembers, channels, discordChannels))
-    Nothing -> do
-      let bwconf = bw{pageTitle = "Team details"}
-      addRespHeaders $ ManageTeamGetError (PageCtx bwconf (pid, handle))
+      let payload = (pid, team, projMembers, channels, discordChannels)
+      addRespHeaders $ maybe (ManageTeamGet $ PageCtx bwconf payload) (const $ ManageTeamGet' payload) layoutM
+    Nothing -> addRespHeaders $ ManageTeamGetError $ PageCtx bw{pageTitle = "Team details"} (pid, handle)
 
 
 teamPage :: Projects.ProjectId -> ProjectMembers.TeamVM -> V.Vector ProjectMembers.ProjectMemberVM -> [BotUtils.Channel] -> [BotUtils.Channel] -> Html ()
 teamPage pid team projMembers slackChannels discordChannels = do
-  let whiteList = decodeUtf8 $ AE.encode $ (\x -> AE.object ["name" AE..= (x.first_name <> " " <> x.last_name), "email" AE..= x.email, "value" AE..= x.userId]) <$> projMembers
-      emailWhiteList = decodeUtf8 $ AE.encode $ (\x -> AE.object ["name" AE..= x.email, "value" AE..= x.email]) <$> projMembers
+  let (whiteList, emailWhiteList) = memberWhitelists projMembers
       (channelWhiteList, discordWhiteList) = (encodeChannels slackChannels, encodeChannels discordChannels)
       isEveryone = team.is_everyone
       notifRow_ icon iconType lbl vals inherited = div_ [class_ "flex items-start gap-3 py-2.5"] do
@@ -944,7 +904,7 @@ teamPage pid team projMembers slackChannels discordChannels = do
           _ <- span_ [class_ "flex items-center gap-2 text-sm font-semibold text-textStrong"] (faSprite_ icon "regular" "h-4 w-4" >> toHtml title)
           label_ [class_ "input input-sm w-64 bg-fillWeak border-0"] do
             faSprite_ "magnifying-glass" "regular" "h-3.5 w-3.5 text-iconNeutral"
-            input_ [type_ "text", placeholder_ searchPh, class_ "", makeAttribute "_" $ "on input show <tr/> in #" <> secId <> " when its textContent.toLowerCase() contains my value.toLowerCase()"]
+            input_ [type_ "text", placeholder_ searchPh, makeAttribute "_" $ "on input show <tr/> in #" <> secId <> " when its textContent.toLowerCase() contains my value.toLowerCase()"]
         div_ [class_ "w-full max-h-96 overflow-y-auto", id_ secId] do
           unless (T.null url) $ a_ [hxGet_ url, hxTrigger_ "intersect once", hxTarget_ $ "#" <> secId, hxSwap_ "outerHTML"] ""
           emptyState_ def{icon = Just icon, size = ESCompact} ("No " <> T.toLower title <> " linked") ""
@@ -968,7 +928,7 @@ teamPage pid team projMembers slackChannels discordChannels = do
             div_ [class_ "flex gap-2"] $ span_ [class_ "text-textWeak w-16"] "Handle" >> span_ [class_ "text-textStrong"] (toHtml $ "@" <> team.handle)
             unless (T.null team.description) $ div_ [class_ "flex gap-2"] $ span_ [class_ "text-textWeak w-16"] "About" >> span_ [class_ "text-textStrong"] (toHtml team.description)
         let memberRow_ avatar name email = div_ [class_ "flex items-center gap-3 py-2.5"] $ img_ [src_ avatar, class_ "w-8 h-8 rounded-full border border-strokeWeak", term "loading" "lazy", term "decoding" "async"] >> div_ [] (div_ [class_ "text-sm font-medium text-textStrong"] (toHtml name) >> div_ [class_ "text-xs text-textWeak"] (toHtml email))
-            members = if isEveryone then (\m -> ("/api/avatar/" <> m.userId.toText, m.first_name <> " " <> m.last_name, original m.email)) <$> projMembers else (\m -> (m.memberAvatar, m.memberName, m.memberEmail)) <$> team.members
+            members = if isEveryone then (\m -> ("/api/avatar/" <> m.userId.toText, m.first_name <> " " <> m.last_name, CI.original m.email)) <$> projMembers else (\m -> (m.memberAvatar, m.memberName, m.memberEmail)) <$> team.members
         panel_ def{raised = True, icon = Just "users", subtitle = Just $ " (" <> show (V.length members) <> ")"} "Members" do
           div_ [class_ "divide-y divide-strokeWeak -mx-4"] $ forM_ members \(avatar, name, email) -> div_ [class_ "px-4"] $ memberRow_ avatar name email
         panel_ def{raised = True, icon = Just "bell"} "Notifications" $ div_ [class_ "divide-y divide-strokeWeak -mx-4"] do
@@ -991,7 +951,7 @@ teamPage pid team projMembers slackChannels discordChannels = do
                     input_ [type_ "hidden", name_ "channel", value_ "all"]
                     input_ [type_ "hidden", name_ "teamId", value_ $ UUID.toText team.id]
                     input_ [type_ "hidden", name_ "issueType", value_ "runtime_exception"]
-                    button_ ([type_ "submit", class_ "btn btn-xs btn-primary tap-target", [__| on htmx:afterRequest from closest <form/> trigger testSent on body |]] <> bool [] [disabled_ ""] (not hasAnyChannel)) do
+                    button_ ([type_ "submit", class_ "btn btn-xs btn-primary tap-target", [__| on htmx:afterRequest from closest <form/> trigger testSent on body |]] <> [disabled_ "" | not hasAnyChannel]) do
                       faSprite_ "flask-vial" "regular" "h-3.5 w-3.5"
                       " Send Test"
               div_ [id_ $ "team-test-history-" <> UUID.toText team.id, hxGet_ ("/p/" <> pid.toText <> "/settings/integrations/history"), hxTrigger_ "testSent from:body", hxSwap_ "innerHTML", class_ "mt-3"] mempty
@@ -1086,7 +1046,7 @@ manageMembersBody pid projMembers paymentPlan teamsCount =
         div_ [class_ "space-y-3"] do
           headerRow_ [] do
             h3_ [class_ "text-sm font-medium text-textStrong"] $ toHtml $ "Members (" <> show (V.length projMembers) <> ")"
-            when (V.length projMembers > 0) $ button_ [class_ "btn btn-sm btn-outline gap-1.5", disabled_ "true", id_ "saveMembersBtn", dirtyFormSaveAttr_] do
+            unless (V.null projMembers) $ button_ [class_ "btn btn-sm btn-outline gap-1.5", disabled_ "true", id_ "saveMembersBtn", dirtyFormSaveAttr_] do
               faSprite_ "check" "regular" "w-3 h-3"; "Save changes"
           div_ [class_ "divide-y divide-strokeWeak rounded-xl border border-strokeWeak overflow-hidden"]
             $ if V.null projMembers
@@ -1118,11 +1078,10 @@ memberRowWithStatus pid idx prM = do
 
 deleteMemberH :: Projects.ProjectId -> RealUUID.UUID -> ATAuthCtx (RespHeaders (Html ()))
 deleteMemberH pid memberId = do
-  (sess, project) <- Projects.sessionAndProject pid
+  (sess, _) <- Projects.sessionAndProject pid
   let currUserId = sess.persistentSession.userId
   projMembers <- ProjectMembers.selectActiveProjectMembers pid
-  let memberM = find (\m -> m.id == memberId) projMembers
-  case memberM of
+  case find (\m -> m.id == memberId) projMembers of
     Nothing -> toastError "Member not found" mempty
     Just member ->
       if member.userId == currUserId
@@ -1138,11 +1097,11 @@ deleteMemberH pid memberId = do
 
 manageSubGetH :: Projects.ProjectId -> ATAuthCtx (RespHeaders (Html ()))
 manageSubGetH pid = do
-  (sess, project) <- Projects.sessionAndProject pid
+  (_, project) <- Projects.sessionAndProject pid
   appCtx <- ask @AuthContext
   let envCfg = appCtx.config
   case Projects.projectProvider project of
-    Projects.StripeProvider -> do
+    Projects.StripeProvider ->
       case project.customerId <|> project.orderId of
         Just customerId | not (T.null customerId) -> do
           let returnUrl = envCfg.hostUrl <> "p/" <> pid.toText <> "/manage_billing"
@@ -1152,9 +1111,7 @@ manageSubGetH pid = do
             Nothing -> toastError "Failed to create billing portal" mempty
         _ -> toastError "Customer ID not found" mempty
     Projects.LemonSqueezyProvider -> do
-      sub <- case project.subId of
-        Nothing -> pure Nothing
-        Just sid -> lsGet @SubPortalDataVals envCfg.lemonSqueezyApiKey ("https://api.lemonsqueezy.com/v1/subscriptions/" <> sid)
+      sub <- maybe (pure Nothing) (lsGet @SubPortalDataVals envCfg.lemonSqueezyApiKey . ("https://api.lemonsqueezy.com/v1/subscriptions/" <>)) project.subId
       case sub of
         Nothing -> toastError "Subscription ID not found" mempty
         Just s -> redirectCS s.dataVal.attributes.urls.customerPortal >> addRespHeaders mempty
@@ -1264,26 +1221,20 @@ projectOnboardingH = do
   let envCfg = appCtx.config
   sess <- Projects.getSession
   projects <- Projects.selectProjectsForUser sess.persistentSession.userId
-  let projectM = find (\pr -> Projects.isOnboarding pr.paymentPlan) projects
-      bwconf = (def :: BWConfig){sessM = Just sess, currProject = Nothing, pageTitle = "New Project", config = appCtx.config}
-  case projectM of
-    Just p -> do
-      let h = "/p/" <> p.id.toText <> "/onboarding"
-      pure $ addHeader h $ PageCtx bwconf ""
-    _ -> do
+  let bwconf = (def :: BWConfig){sessM = Just sess, currProject = Nothing, pageTitle = "New Project", config = appCtx.config}
+  pid <- case find (\pr -> Projects.isOnboarding pr.paymentPlan) projects of
+    Just p -> pure p.id
+    Nothing -> do
       pid <- UUIDId <$> UUID.genUUID
-      let pr = Projects.CreateProject{id = pid, title = "Onboarding Project", description = "", paymentPlan = "ONBOARDING", timeZone = "", subId = Nothing, firstSubItemId = Nothing, orderId = Nothing, weeklyNotif = True, dailyNotif = True, endpointAlerts = True, errorAlerts = True}
-      _ <- Projects.insertProject pr
+      _ <- Projects.insertProject Projects.CreateProject{id = pid, title = "Onboarding Project", description = "", paymentPlan = "ONBOARDING", timeZone = "", subId = Nothing, firstSubItemId = Nothing, orderId = Nothing, weeklyNotif = True, dailyNotif = True, endpointAlerts = True, errorAlerts = True}
       _ <- ProjectMembers.createEveryoneTeam pid sess.user.id
       projectKeyUUID <- UUID.genUUID
-      let encryptedKeyB64 = ProjectApiKeys.encodeApiKeyB64 envCfg.apiKeyEncryptionSecretKey projectKeyUUID
-      pApiKey <- ProjectApiKeys.newProjectApiKeys pid projectKeyUUID "Default API Key" encryptedKeyB64
+      pApiKey <- ProjectApiKeys.newProjectApiKeys pid projectKeyUUID "Default API Key" $ ProjectApiKeys.encodeApiKeyB64 envCfg.apiKeyEncryptionSecretKey projectKeyUUID
       _ <- ProjectApiKeys.insertProjectApiKey pApiKey
-      let projectMember = ProjectMembers.CreateProjectMembers pid sess.user.id ProjectMembers.PAdmin
-      _ <- ProjectMembers.insertProjectMembers [projectMember]
+      _ <- ProjectMembers.insertProjectMembers [ProjectMembers.CreateProjectMembers pid sess.user.id ProjectMembers.PAdmin]
       Projects.logAuditS pid Projects.AEProjectCreated sess Nothing
-      let h = "/p/" <> pid.toText <> "/onboarding"
-      pure $ addHeader h $ PageCtx bwconf ""
+      pure pid
+  pure $ addHeader ("/p/" <> pid.toText <> "/onboarding") $ PageCtx bwconf ""
 
 
 data CreateProjectResp = CreateProjectResp
@@ -1313,7 +1264,7 @@ instance HasField "unwrapCreateProjectResp" CreateProject (Maybe CreateProjectRe
 
 instance ToHtml CreateProject where
   toHtml (CreateProject (PageCtx bwconf (sess, pid, config, paymentPlan, isUpdate, prf, pref, pro))) = toHtml $ PageCtx bwconf $ createProjectBody sess pid config paymentPlan prf pref pro
-  toHtml (PostNoContent message) = span_ [class_ ""] $ toHtml message
+  toHtml (PostNoContent message) = span_ [] $ toHtml message
   toHtml (ProjectPost cpr) = toHtml $ createProjectBody cpr.sess cpr.pid cpr.env cpr.paymentPlan cpr.form cpr.formError cpr.pro
   toHtmlRaw = toHtml
 
@@ -1322,17 +1273,18 @@ projectSettingsGetH :: Projects.ProjectId -> ATAuthCtx (RespHeaders CreateProjec
 projectSettingsGetH pid = do
   (sess, project, bw) <- mkPageCtx pid
   appCtx <- ask @AuthContext
-  let createProj =
+  let onFlag = bool Nothing (Just "on")
+      createProj =
         CreateProjectForm
           { title = project.title
           , description = project.description
           , emails = []
           , permissions = []
           , timeZone = project.timeZone
-          , weeklyNotifs = if project.weeklyNotif then Just "on" else Nothing
-          , dailyNotifs = if project.dailyNotif then Just "on" else Nothing
-          , errorAlerts = if project.errorAlerts then Just "on" else Nothing
-          , endpointAlerts = if project.endpointAlerts then Just "on" else Nothing
+          , weeklyNotifs = onFlag project.weeklyNotif
+          , dailyNotifs = onFlag project.dailyNotif
+          , errorAlerts = onFlag project.errorAlerts
+          , endpointAlerts = onFlag project.endpointAlerts
           }
 
   let bwconf = bw{pageTitle = "Project", isSettingsPage = True}
@@ -1344,9 +1296,7 @@ deleteProjectGetH pid = do
   sess <- Projects.getSession
   appCtx <- ask @AuthContext
   if isDemoAndNotSudo pid sess.user.isSudo
-    then do
-      addSuccessToast "Can't perform this action on the demon project" Nothing
-      addRespHeaders $ PostNoContent ""
+    then addSuccessToast "Can't perform this action on the demon project" Nothing
     else do
       _ <- Projects.deleteProject pid
       _ <- liftIO $ withResource appCtx.pool \conn ->
@@ -1354,7 +1304,7 @@ deleteProjectGetH pid = do
       Projects.logAuditS pid Projects.AEProjectDeleted sess Nothing
       addSuccessToast "Deleted Project Successfully" Nothing
       redirectCS "/"
-      addRespHeaders $ PostNoContent ""
+  addRespHeaders $ PostNoContent ""
 
 
 createProjectPostH :: Projects.ProjectId -> CreateProjectForm -> ATAuthCtx (RespHeaders CreateProject)
@@ -1383,12 +1333,6 @@ data SubDataVals = SubDataVals
   deriving (AE.FromJSON, AE.ToJSON) via DAE.CustomJSON '[DAE.FieldLabelModifier '[DAE.CamelToSnake]] SubDataVals
 
 
-getSubscriptionId :: HTTP :> es => Maybe Text -> Text -> Eff es (Maybe (LSData [SubDataVals]))
-getSubscriptionId orderId apiKey = case orderId of
-  Nothing -> pure Nothing
-  Just ordId -> lsGet apiKey ("https://api.lemonsqueezy.com/v1/orders/" <> ordId <> "/subscriptions")
-
-
 data PricingUpdateForm = PricingUpdateForm
   { orderIdM :: Maybe Text
   , plan :: Maybe Text
@@ -1404,8 +1348,7 @@ pricingUpdateH pid PricingUpdateForm{orderIdM, plan, isOnboarding} = do
   appCtx <- ask @AuthContext
   let envCfg = appCtx.config
       apiKey = envCfg.lemonSqueezyApiKey
-      steps = project.onboardingStepsCompleted
-      newStepsComp = insertIfNotExist "Pricing" steps
+      newStepsComp = insertIfNotExist "Pricing" project.onboardingStepsCompleted
       updatePricing name sid fid oid = Projects.updateProjectPricing pid name sid fid oid newStepsComp
       handleOnboarding name = when (Projects.isOnboarding project.paymentPlan) $ do
         _ <- liftIO $ withResource appCtx.pool \conn -> do
@@ -1422,7 +1365,9 @@ pricingUpdateH pid PricingUpdateForm{orderIdM, plan, isOnboarding} = do
         Projects.logAuditS pid Projects.AEPlanChanged sess
           $ Just
           $ AE.object ["plan" AE..= name]
-      notifyPlanChange email = sendRenderedEmail (CI.original email)
+      mailAllUsers (subj, html) = do
+        users <- Projects.usersByProjectId pid
+        forM_ users \u -> sendRenderedEmail (CI.original u.email) subj (ET.renderEmail subj html)
   case plan of
     Just "Open Source" | envCfg.basicAuthEnabled -> do
       _ <- updatePricing "Open Source" "" "" ""
@@ -1431,36 +1376,29 @@ pricingUpdateH pid PricingUpdateForm{orderIdM, plan, isOnboarding} = do
       void $ ProjectMembers.activateAllMembers pid
     _ -> case orderIdM of
       Just orderId ->
-        getSubscriptionId (Just orderId) apiKey >>= \case
-          Just sub | not (null sub.dataVal) -> do
-            let target = sub.dataVal Unsafe.!! 0
-                subId = show target.attributes.firstSubscriptionItem.subscriptionId
+        lsGet @[SubDataVals] apiKey ("https://api.lemonsqueezy.com/v1/orders/" <> orderId <> "/subscriptions") >>= \case
+          Just sub | Just target <- viaNonEmpty head sub.dataVal -> do
+            let subId = show target.attributes.firstSubscriptionItem.subscriptionId
                 firstSubId = show target.attributes.firstSubscriptionItem.id
                 productName = target.attributes.productName
             _ <- updatePricing productName subId firstSubId orderId
             auditPlan productName
             handleOnboarding productName
             void $ ProjectMembers.activateAllMembers pid
-            let (subj, html) = ET.planUpgradedEmail project.title productName billingUrl
-            users <- Projects.usersByProjectId pid
-            forM_ users \u -> notifyPlanChange u.email subj (ET.renderEmail subj html)
+            mailAllUsers $ ET.planUpgradedEmail project.title productName billingUrl
           _ -> addErrorToast "Something went wrong while fetching subscription id" Nothing
       Nothing -> do
         _ <- updatePricing "Free" "" "" ""
         auditPlan ("Free" :: Text)
         handleOnboarding "Free"
         void $ ProjectMembers.deactivateNonOwnerMembers pid
-        let (subj, html) = ET.planDowngradedEmail project.title "was cancelled" billingUrl
-        users <- Projects.usersByProjectId pid
-        forM_ users \u -> notifyPlanChange u.email subj (ET.renderEmail subj html)
+        mailAllUsers $ ET.planDowngradedEmail project.title "was cancelled" billingUrl
   if Projects.isOnboarding project.paymentPlan || isOnboarding == Just True
-    then do
-      redirectCS $ "/p/" <> pid.toText <> "/"
-      addRespHeaders mempty
+    then redirectCS $ "/p/" <> pid.toText <> "/"
     else do
       addTriggerEvent "closeModal" ""
       addSuccessToast "Pricing updated successfully" Nothing
-      addRespHeaders mempty
+  addRespHeaders mempty
 
 
 processProjectPostForm :: Valor.Valid CreateProjectForm -> Projects.ProjectId -> ATAuthCtx (RespHeaders CreateProject)
@@ -1471,14 +1409,12 @@ processProjectPostForm cpRaw pid = do
 
   let cp = Valor.unValid cpRaw
   if isDemoAndNotSudo pid sess.user.isSudo
-    then do
-      addErrorToast "Can't perform this action on the demo project" Nothing
-      addRespHeaders $ ProjectPost (CreateProjectResp sess.persistentSession pid envCfg "" cp (def @CreateProjectFormError) project)
+    then addErrorToast "Can't perform this action on the demo project" Nothing
     else do
       _ <- Projects.updateProject (createProjectFormToModel pid project.subId project.firstSubItemId project.orderId project.paymentPlan cp)
       Projects.logAuditS pid Projects.AEProjectUpdated sess Nothing
       addSuccessToast "Updated Project Successfully" Nothing
-      addRespHeaders $ ProjectPost (CreateProjectResp sess.persistentSession pid envCfg "" cp (def @CreateProjectFormError) project)
+  addRespHeaders $ ProjectPost (CreateProjectResp sess.persistentSession pid envCfg "" cp (def @CreateProjectFormError) project)
 
 
 createProjectBody :: Projects.PersistentSession -> Projects.ProjectId -> EnvConfig -> Text -> CreateProjectForm -> CreateProjectFormError -> Projects.Project -> Html ()
@@ -1505,7 +1441,7 @@ createProjectBody sess pid envCfg paymentPlan cp cpe proj = do
 
         -- Alert configuration
         div_ [class_ "border-t border-strokeWeak pt-1"]
-          $ alertConfiguration (isJust cp.endpointAlerts) (isJust cp.errorAlerts) (isJust cp.weeklyNotifs) (isJust cp.dailyNotifs)
+          $ alertConfiguration cp
 
         -- Save button: muted until form is dirty
         div_ [class_ "flex justify-end pt-2"] do
@@ -1550,24 +1486,27 @@ createProjectBody sess pid envCfg paymentPlan cp cpe proj = do
       "Delete project"
 
 
-alertConfiguration :: Bool -> Bool -> Bool -> Bool -> Html ()
-alertConfiguration newEndpointsAlerts errorAlerts weeklyReportsAlerts dailyReportsAlerts =
+alertConfiguration :: CreateProjectForm -> Html ()
+alertConfiguration cp =
   div_ do
     div_ [class_ "flex items-center gap-2 mb-3"] do
       iconBadgeXs_ NeutralBadge "bell"
       span_ [class_ "text-sm font-semibold text-textStrong"] "Notifications"
-    div_ [class_ "divide-y divide-strokeWeak"] do
-      switchRow "New endpoint alerts" "endpointAlerts" "Get notified when new API endpoints are detected" newEndpointsAlerts
-      switchRow "Runtime error alerts" "errorAlerts" "Receive immediate notifications for system errors" errorAlerts
-      switchRow "Weekly reports" "weeklyNotifs" "Get a summary of your project activity every week" weeklyReportsAlerts
-      switchRow "Daily reports" "dailyNotifs" "Receive daily summaries of your project metrics" dailyReportsAlerts
-  where
-    switchRow lbl forId descr checked =
-      div_ [class_ "flex items-center justify-between py-3 first:pt-0 last:pb-0"] do
-        div_ [class_ "space-y-0.5"] do
-          label_ [Lucid.for_ forId, class_ "text-sm font-medium text-textStrong cursor-pointer"] $ toHtml lbl
-          p_ [class_ "text-xs text-textWeak"] $ toHtml descr
-        input_ $ [type_ "checkbox", id_ forId, class_ "toggle toggle-sm", name_ forId] ++ [checked_ | checked]
+    div_ [class_ "divide-y divide-strokeWeak"]
+      $ forM_
+        ( [ ("New endpoint alerts", "endpointAlerts", "Get notified when new API endpoints are detected", isJust cp.endpointAlerts)
+          , ("Runtime error alerts", "errorAlerts", "Receive immediate notifications for system errors", isJust cp.errorAlerts)
+          , ("Weekly reports", "weeklyNotifs", "Get a summary of your project activity every week", isJust cp.weeklyNotifs)
+          , ("Daily reports", "dailyNotifs", "Receive daily summaries of your project metrics", isJust cp.dailyNotifs)
+          ]
+            :: [(Text, Text, Text, Bool)]
+        )
+        \(lbl, forId, descr, checked) ->
+          div_ [class_ "flex items-center justify-between py-3 first:pt-0 last:pb-0"] do
+            div_ [class_ "space-y-0.5"] do
+              label_ [Lucid.for_ forId, class_ "text-sm font-medium text-textStrong cursor-pointer"] $ toHtml lbl
+              p_ [class_ "text-xs text-textWeak"] $ toHtml descr
+            input_ $ [type_ "checkbox", id_ forId, class_ "toggle toggle-sm", name_ forId] <> [checked_ | checked]
 
 
 -- Main Modal Component

--- a/src/Pages/Replay.hs
+++ b/src/Pages/Replay.hs
@@ -60,20 +60,13 @@ data ReplayPost = ReplayPost
   deriving anyclass (AE.FromJSON, ToSchema)
 
 
--- Helper function to publish to Pub/Sub using the queue service
-publishReplayEvent :: ReplayPost -> Projects.ProjectId -> ATBaseCtx (Either Text ())
-publishReplayEvent replayData pid = do
-  ctx <- Effectful.Reader.Static.ask @AuthContext
-  let messagePayload = AE.object ["events" AE..= replayData.events, "sessionId" AE..= replayData.sessionId, "projectId" AE..= pid, "timestamp" AE..= replayData.timestamp, "userId" AE..= replayData.userId, "userEmail" AE..= replayData.userEmail, "userName" AE..= replayData.userName]
-      attributes = HM.fromList [("eventType", "replay")]
-  case ctx.config.rrwebTopics of
-    [] -> pure $ Left "No rrweb pubsub topics configured"
-    (topicName : _) -> first ("Failed to publish replay event: " <>) <$> runSharedProducer ctx (publishJSONToKafka topicName messagePayload attributes)
-
-
 replayPostH :: Projects.ProjectId -> ReplayPost -> ATBaseCtx AE.Value
 replayPostH pid body = do
-  pubResult <- publishReplayEvent body pid
+  ctx <- Effectful.Reader.Static.ask @AuthContext
+  let messagePayload = AE.object ["events" AE..= body.events, "sessionId" AE..= body.sessionId, "projectId" AE..= pid, "timestamp" AE..= body.timestamp, "userId" AE..= body.userId, "userEmail" AE..= body.userEmail, "userName" AE..= body.userName]
+  pubResult <- case ctx.config.rrwebTopics of
+    [] -> pure $ Left "No rrweb pubsub topics configured"
+    (topicName : _) -> first ("Failed to publish replay event: " <>) <$> runSharedProducer ctx (publishJSONToKafka topicName messagePayload (HM.fromList [("eventType", "replay")]))
   pure $ AE.object $ ["sessionId" AE..= body.sessionId] <> case pubResult of
     Left errMsg -> ["status" AE..= ("warning" :: Text), "message" AE..= errMsg]
     Right () -> ["status" AE..= ("ok" :: Text)]
@@ -292,7 +285,7 @@ skipStringBody =
 -- per-message handoff so finished messages are GC-eligible immediately.
 -- Drop counts feed `OtlpServer.bumpErrorCounter` so they roll up in the same
 -- minute-cadence summary as wire/UTF-8 parse errors — no per-event log spam.
--- | Replay doesn't dual-write so it can't surface a 'Telemetry.WriteFailure'.
+-- Replay doesn't dual-write so it can't surface a 'Telemetry.WriteFailure'.
 -- Oversize + decode-failed messages are returned as 'PoisonMsg' so Pkg.Queue
 -- can DLQ their raw bytes before committing offsets (no silent drop). S3/Minio
 -- transport errors still propagate as exceptions through the outer tryAny.
@@ -304,21 +297,20 @@ processReplayEvents msgs _attrs = do
       (oversized, valid) = partition (\(_, b) -> BS.length b > maxReplayMessageBytes) msgs
       oversizePoison = [(ackId, body, "replay:oversize_message") | (ackId, body) <- oversized]
   traverse_ (\_ -> Metrics.bumpErrorCounter "replay:oversize_message") oversized
-  (acks, decodePoison) <- mconcat <$> mapM (handleChunk envCfg ctx.jobsPool) (chunksByBytes replayBatchByteBudget (BS.length . snd) valid)
+  (acks, decodePoison) <- foldMapM (handleChunk envCfg ctx.jobsPool) (chunksByBytes replayBatchByteBudget (BS.length . snd) valid)
   pure $ Right (acks, oversizePoison <> decodePoison)
   where
     -- Returns @(acks, poison)@ for one chunk so the caller can DLQ poison and
     -- ack only the successfully-saved + DLQ'd ackIds.
-    handleChunk envCfg jobsPool chunk =
-      mconcat <$> forM chunk \(!ackId, !body) ->
-        case splitReplayPayload (stripJsonNullEscapes body) of
-          Left err -> do
-            Metrics.bumpErrorCounter "replay:decode_error"
-            pure ([], [(ackId, body, "replay:decode_error: " <> toText err)])
-          Right payload ->
-            saveReplayMinio envCfg jobsPool ackId payload <&> \case
-              Just acked -> ([acked], [])
-              Nothing -> ([], [])
+    handleChunk envCfg jobsPool = foldMapM \(!ackId, !body) ->
+      case splitReplayPayload (stripJsonNullEscapes body) of
+        Left err -> do
+          Metrics.bumpErrorCounter "replay:decode_error"
+          pure ([], [(ackId, body, "replay:decode_error: " <> toText err)])
+        Right payload ->
+          saveReplayMinio envCfg jobsPool ackId payload <&> \case
+            Just acked -> ([acked], [])
+            Nothing -> ([], [])
 
 
 -- | True if the Minio error represents a missing object (safe to treat as empty).
@@ -332,14 +324,6 @@ isNoSuchKey (MErrService NoSuchKey) = True
 isNoSuchKey _ = False
 
 
-toObjKey :: Text -> Minio.Object
-toObjKey = fromString . toString
-
-
-mergedKeyFor :: UUID.UUID -> Minio.Object
-mergedKeyFor sid = toObjKey (UUID.toText sid <> "/merged.json.gz")
-
-
 sessionLogCtx :: Projects.ProjectId -> UUID.UUID -> HashMap Text Text
 sessionLogCtx pid sid = HM.fromList [("session_id", UUID.toText sid), ("project_id", pid.toText)]
 
@@ -348,6 +332,14 @@ sessionLogCtx pid sid = HM.fromList [("session_id", UUID.toText sid), ("project_
 -- "error" key. Used so call sites stop repeating the displayException dance.
 withError :: Exception e => e -> HashMap Text Text -> HashMap Text Text
 withError e = HM.insert "error" (toText $ displayException e)
+
+
+-- | Enqueue a BgJobs job. The payload is hand-rolled to mirror the derived
+-- Generic ToJSON shape because BackgroundJobs imports this module, so we can't
+-- import its job sum type here.
+enqueueBgJob :: IOE :> es => Pool Connection -> Text -> [AE.Value] -> Eff es ()
+enqueueBgJob pool tag contents =
+  liftIO $ withResource pool \c -> void $ createJob c "background_jobs" (AE.object ["tag" AE..= tag, "contents" AE..= contents])
 
 
 markMerged :: DB es => Projects.ProjectId -> UUID.UUID -> UTCTime -> Eff es ()
@@ -477,7 +469,7 @@ projectMinioConn envCfg p =
           p.s3Bucket
       creds = Minio.CredentialValue (fromString $ toString acc) (fromString $ toString sec) Nothing
       info = if T.null endpoint then Minio.awsCI else fromString $ toString endpoint
-      conn = Minio.setCreds creds (Minio.setRegion (fromString $ toString region) info)
+      conn = Minio.setCreds creds (Minio.setRegion region info)
    in (conn, bucket)
 
 
@@ -494,7 +486,7 @@ fetchIndividualsRaw
   -> Eff es ([(Double, BL.ByteString)], Bool, Int)
 fetchIndividualsRaw conn bucket fileKeys logCtx = do
   perKey <- liftIO $ forM fileKeys $ \k ->
-    Minio.runMinio conn (fetchRawForMerge bucket (toObjKey k) False) <&> (k,)
+    Minio.runMinio conn (fetchRawForMerge bucket k False) <&> (k,)
   let (raws, decodeErrs, transportErrs, missing) = foldr classify ([], [], [], []) perKey
       classify (_, Right (Right r)) (rs, ds, ts, ms) = (r : rs, ds, ts, ms)
       classify (k, Right (Left de)) (rs, ds, ts, ms) = (rs, (k, de) : ds, ts, ms)
@@ -526,27 +518,24 @@ getSessionEvents conn pid bucket sessionId = do
       noEvents reason = do
         Log.logAttention "No replay events found anywhere for session" (HM.insert "reason" reason logCtx)
         pure $ Left notFoundErr
+      legacyFailed e = Left transientMsg <$ Log.logError "Failed to load legacy replay blob" (HM.insert "error" e logCtx)
       -- Ancient single-object sessions (pre file_keys migration): fetch raw.
       legacy reason = do
         Log.logInfo "Falling back to legacy replay blob" (HM.insert "reason" reason logCtx)
-        legacyRes <- liftIO $ Minio.runMinio conn $ fetchRawForMerge bucket (toObjKey (sessionStr <> ".json")) False
+        legacyRes <- liftIO $ Minio.runMinio conn $ fetchRawForMerge bucket (sessionStr <> ".json") False
         case legacyRes of
-          Left err | isNoSuchKey err -> noEvents "legacy_blob_missing"
-          Left err -> do
-            Log.logError "Failed to load legacy replay blob" (withError err logCtx)
-            pure $ Left transientMsg
-          Right (Left e) -> do
-            Log.logError "Failed to load legacy replay blob" (HM.insert "error" (toText e) logCtx)
-            pure $ Left transientMsg
+          Left err
+            | isNoSuchKey err -> noEvents "legacy_blob_missing"
+            | otherwise -> legacyFailed (toText $ displayException err)
+          Right (Left e) -> legacyFailed (toText e)
           Right (Right (_, raw))
             | isEmptyJsonArray raw -> noEvents "legacy_blob_missing"
             | otherwise -> pure $ Right (raw, False)
   -- Shards (incl. the legacy monolith, registered as a shard) and the unmerged
   -- individual tail both come from the DB — never from listing S3 (minio-hs can't
   -- list R2). Fetch each key by getObject, gzip-decoding by suffix.
-  shardKeys <- sessionShardKeys pid sessionId
-  fileKeys <- sessionFileKeys pid sessionId
-  shardRes <- liftIO $ forM shardKeys $ \sk -> Minio.runMinio conn (fetchRawForMerge bucket (toObjKey sk) (".gz" `T.isSuffixOf` sk))
+  (shardKeys, fileKeys) <- sessionKeys pid sessionId
+  shardRes <- liftIO $ forM shardKeys $ \sk -> Minio.runMinio conn (fetchRawForMerge bucket sk (".gz" `T.isSuffixOf` sk))
   let shardRaws = [r | Right (Right r) <- shardRes]
       shardDecodeErrs = [e | Right (Left e) <- shardRes] -- corrupt shard bytes
       shardTransportErrs = [e | Left e <- shardRes, not (isNoSuchKey e)] -- transient (NoSuchKey = concurrent seal, tolerate)
@@ -575,21 +564,19 @@ getSessionEvents conn pid bucket sessionId = do
         pure $ Left notFoundErr
 
 
--- | Lookup the tracked object keys for an unmerged replay session.
--- Empty list if the row doesn't exist (new session) or has a NULL/empty column.
+-- | Tracked object keys for a session as @(sealed shards, unmerged tail)@, both
+-- empty if the row doesn't exist (new session) or the columns are NULL. Always
+-- read from Postgres, never listed from S3 (minio-hs can't list R2); each shard
+-- key embeds its first-event ts so readers order shards without opening a blob.
+sessionKeys :: DB es => Projects.ProjectId -> UUID.UUID -> Eff es ([Text], [Text])
+sessionKeys pid sessionId = do
+  rows :: [(V.Vector Text, V.Vector Text)] <-
+    Hasql.interp [HI.sql| SELECT COALESCE(shard_keys, '{}'::text[]), COALESCE(file_keys, '{}'::text[]) FROM projects.replay_sessions WHERE session_id = #{sessionId} AND project_id = #{pid} LIMIT 1 |]
+  pure $ maybe ([], []) (bimap V.toList V.toList) (listToMaybe rows)
+
+
 sessionFileKeys :: DB es => Projects.ProjectId -> UUID.UUID -> Eff es [Text]
-sessionFileKeys pid sessionId = do
-  rows :: [V.Vector Text] <- Hasql.interp [HI.sql| SELECT COALESCE(file_keys, '{}'::text[]) FROM projects.replay_sessions WHERE session_id = #{sessionId} AND project_id = #{pid} LIMIT 1 |]
-  pure $ maybe [] V.toList (listToMaybe rows)
-
-
--- | Sealed shard object keys for a session, tracked in Postgres (never listed
--- from S3 — minio-hs can't list R2). Each key embeds the shard's first-event ts
--- so the read/manifest path orders them without opening a blob.
-sessionShardKeys :: DB es => Projects.ProjectId -> UUID.UUID -> Eff es [Text]
-sessionShardKeys pid sessionId = do
-  rows :: [V.Vector Text] <- Hasql.interp [HI.sql| SELECT COALESCE(shard_keys, '{}'::text[]) FROM projects.replay_sessions WHERE session_id = #{sessionId} AND project_id = #{pid} LIMIT 1 |]
-  pure $ maybe [] V.toList (listToMaybe rows)
+sessionFileKeys pid = fmap snd . sessionKeys pid
 
 
 -- | Identity + timing metadata for a session, surfaced in the player header.
@@ -603,11 +590,15 @@ data SessionMeta = SessionMeta
   deriving anyclass (AE.ToJSON, HI.DecodeRow)
 
 
-sessionMetadata :: DB es => Projects.ProjectId -> UUID.UUID -> Eff es (Maybe SessionMeta)
-sessionMetadata pid sessionId = do
-  rows :: [SessionMeta] <-
-    Hasql.interp [HI.sql| SELECT user_id, user_email, user_name, last_event_at FROM projects.replay_sessions WHERE session_id = #{sessionId} AND project_id = #{pid} LIMIT 1 |]
-  pure $ listToMaybe rows
+-- | Never fatal: a lookup failure logs and yields Nothing so the player still
+-- renders without identity.
+sessionMetadata :: (DB es, Log :> es) => Projects.ProjectId -> UUID.UUID -> HashMap Text Text -> Eff es (Maybe SessionMeta)
+sessionMetadata pid sessionId logCtx = do
+  r <- tryAny do
+    rows :: [SessionMeta] <-
+      Hasql.interp [HI.sql| SELECT user_id, user_email, user_name, last_event_at FROM projects.replay_sessions WHERE session_id = #{sessionId} AND project_id = #{pid} LIMIT 1 |]
+    pure $ listToMaybe rows
+  either (\err -> Nothing <$ Log.logAttention "sessionMetadata lookup failed; continuing without identity" (withError err logCtx)) pure r
 
 
 -- | One event's `timestamp` field (0 if absent / not an object). Sorts files by
@@ -645,17 +636,17 @@ instance AE.ToJSON ReplaySessionResp where
   toEncoding r =
     AE.pairs
       $ AEE.pair "events" (AE.toEncoding r.events)
-      <> maybe mempty ("partial" AE..=) r.partial
-      <> maybe mempty ("error" AE..=) r.errorMsg
+      <> foldMap ("partial" AE..=) r.partial
+      <> foldMap ("error" AE..=) r.errorMsg
       <> foldMap metaSeries r.meta
     where
       metaSeries m = "userId" AE..= m.userId <> "userEmail" AE..= m.userEmail <> "userName" AE..= m.userName <> "lastEventAt" AE..= m.lastEventAt
   toJSON r =
     AE.object
       $ ["events" AE..= r.events]
-      <> maybe [] (\p -> ["partial" AE..= p]) r.partial
-      <> maybe [] (\e -> ["error" AE..= e]) r.errorMsg
-      <> maybe [] (\m -> ["userId" AE..= m.userId, "userEmail" AE..= m.userEmail, "userName" AE..= m.userName, "lastEventAt" AE..= m.lastEventAt]) r.meta
+      <> foldMap (\p -> ["partial" AE..= p]) r.partial
+      <> foldMap (\e -> ["error" AE..= e]) r.errorMsg
+      <> foldMap (\m -> ["userId" AE..= m.userId, "userEmail" AE..= m.userEmail, "userName" AE..= m.userName, "lastEventAt" AE..= m.lastEventAt]) r.meta
 
 
 mergeFileCountThreshold :: Int
@@ -687,11 +678,11 @@ saveReplayMinio envCfg jobsPool ackId payload = do
               (conn, bucket) = projectMinioConn envCfg p
               timeStr = toText $ formatTime defaultTimeLocale "%Y%m%dT%H%M%S%q" now
               objKeyText = session <> "/" <> timeStr <> ".json"
-              objKey = toObjKey objKeyText
               body = payload.eventsBytes
-              bodySize = fromIntegral (BS.length body)
-          res <- liftIO $ Minio.runMinio conn $ do
-            Minio.putObject bucket objKey (CC.sourceLazy (BL.fromStrict body)) (Just bodySize) Minio.defaultPutObjectOptions
+          res <-
+            liftIO
+              $ Minio.runMinio conn
+              $ Minio.putObject bucket objKeyText (CC.sourceLazy (BL.fromStrict body)) (Just $ fromIntegral $ BS.length body) Minio.defaultPutObjectOptions
           case res of
             Right _ -> do
               let ReplayPayload{sessionId, projectId, userId, userEmail, userName} = payload
@@ -715,12 +706,8 @@ saveReplayMinio envCfg jobsPool ackId payload = do
               -- with N events past 14/28/42/... fires at most one merge per
               -- threshold-window, rather than one per save (which under high
               -- event rates piled up dozens of duplicate merges per session).
-              when (fileCount >= mergeFileCountThreshold && fileCount `mod` mergeFileCountThreshold == 0) $ do
-                -- Hand-rolled payload mirrors the derived Generic ToJSON shape for BgJobs;
-                -- cannot import BackgroundJobs here (BackgroundJobs imports Pages.Replay).
-                let jobPayload = AE.object ["tag" AE..= ("MergeReplaySession" :: Text), "contents" AE..= ([AE.toJSON payload.projectId, AE.toJSON payload.sessionId] :: [AE.Value])]
-                liftIO $ withResource jobsPool \conn' ->
-                  void $ createJob conn' "background_jobs" jobPayload
+              when (fileCount >= mergeFileCountThreshold && fileCount `mod` mergeFileCountThreshold == 0)
+                $ enqueueBgJob jobsPool "MergeReplaySession" [AE.toJSON payload.projectId, AE.toJSON payload.sessionId]
               pure $ Just ackId
             Left err -> do
               Log.logAttention "Failed to save replay events to MinIO" (withError err $ HM.fromList [("session", session), ("projectId", payload.projectId.toText)])
@@ -747,11 +734,7 @@ fetchReplaySession p sessionId = do
       (conn, bucket) = projectMinioConn ctx.config p
       sessionStr = UUID.toText sessionId
       summaryCtx = HM.fromList [("session", sessionStr), ("projectId", pid.toText)]
-  meta <-
-    tryAny (sessionMetadata pid sessionId)
-      >>= either
-        (\err -> Nothing <$ Log.logAttention "sessionMetadata lookup failed; continuing without identity" (withError err summaryCtx))
-        pure
+  meta <- sessionMetadata pid sessionId summaryCtx
   let emptyResp userMsg = ReplaySessionResp{events = RawJson "[]", partial = Nothing, errorMsg = Just userMsg, meta}
   result <- tryAny $ getSessionEvents conn pid bucket sessionId
   case result of
@@ -802,11 +785,8 @@ buildReplayManifest :: (DB es, Log :> es) => Projects.Project -> UUID.UUID -> Ef
 buildReplayManifest p sessionId = do
   let pid = p.id
       summaryCtx = HM.fromList [("session", UUID.toText sessionId), ("projectId", pid.toText)]
-  meta <-
-    tryAny (sessionMetadata pid sessionId)
-      >>= either (\err -> Nothing <$ Log.logAttention "sessionMetadata lookup failed; continuing without identity" (withError err summaryCtx)) pure
-  shardKeys <- sessionShardKeys pid sessionId
-  tailKeys <- sessionFileKeys pid sessionId
+  meta <- sessionMetadata pid sessionId summaryCtx
+  (shardKeys, tailKeys) <- sessionKeys pid sessionId
   -- Order shards by embedded first-event ts (the legacy monolith key doesn't
   -- parse → 0 → sorts first, which is correct: it's the oldest). gzip by suffix.
   let shardSegs = sortOn (.firstTs) [ReplaySegment{key = k, firstTs = fromIntegral (maybe 0 snd (parseShardKey k)), gzipped = ".gz" `T.isSuffixOf` k} | k <- shardKeys]
@@ -837,7 +817,7 @@ fetchReplayShard p sessionId mkey = do
       scoped k = (sidText <> "/") `T.isPrefixOf` k || k == sidText <> ".json"
   case mkey of
     Just k | scoped k -> do
-      res <- liftIO $ Minio.runMinio conn $ fetchRawObject bucket (toObjKey k) (".gz" `T.isSuffixOf` k)
+      res <- liftIO $ Minio.runMinio conn $ fetchRawObject bucket k (".gz" `T.isSuffixOf` k)
       case res of
         Right raw -> pure $ RawJson raw
         -- NoSuchKey = a concurrent seal/merge already removed this source; tolerate
@@ -881,8 +861,8 @@ compressAndMergeReplaySessions = do
       Log.logAttention "Replay session merge threw; continuing batch" (withError err (sessionLogCtx projectId sessionId))
 
 
--- | Look up a project + its S3 settings + tracked file keys and merge them into merged.json.gz.
--- Runs the extra DB finalization step after the S3 merge succeeds.
+-- | Look up a project + its S3 settings + tracked file keys and seal them into
+-- gzip shards. Runs the extra DB finalization step after the S3 merge succeeds.
 mergeOneSessionByKeys
   :: Projects.ProjectId
   -> UUID.UUID
@@ -907,7 +887,7 @@ mergeOneSessionByKeys pid sessionId logSuffix afterMerge = do
     mergeUnderLease p = do
       ctx <- Effectful.Reader.Static.ask @AuthContext
       let (s3Conn, bucket) = projectMinioConn ctx.config p
-      allFileKeys <- sessionFileKeys pid sessionId
+      (existingShards, allFileKeys) <- sessionKeys pid sessionId
       let fileKeys = take maxFilesPerMerge allFileKeys
       if null fileKeys
         then do
@@ -919,7 +899,6 @@ mergeOneSessionByKeys pid sessionId logSuffix afterMerge = do
           Log.logInfo "Replay session merge skipped (no tracked file keys)" ("session_id", UUID.toText sessionId)
         else do
           -- Next append index from the DB shard count (no S3 listing).
-          existingShards <- sessionShardKeys pid sessionId
           let startIdx = 1 + foldl' max 0 (mapMaybe (fmap fst . parseShardKey) existingShards)
           result <- liftIO $ try @MergeError $ mergeOneSession s3Conn bucket sessionId startIdx fileKeys
           case result of
@@ -966,10 +945,8 @@ mergeOneSessionByKeys pid sessionId logSuffix afterMerge = do
                   -- We capped the merge at `maxFilesPerMerge`; re-enqueue while
                   -- there's backlog so a session that fell behind drains in
                   -- bounded-heap chunks instead of waiting for the 30-min cron.
-                  when (length allFileKeys > maxFilesPerMerge) $ do
-                    let jobPayload = AE.object ["tag" AE..= ("MergeReplaySession" :: Text), "contents" AE..= ([AE.toJSON pid, AE.toJSON sessionId] :: [AE.Value])]
-                    liftIO $ withResource ctx.jobsPool \conn' ->
-                      void $ createJob conn' "background_jobs" jobPayload
+                  when (length allFileKeys > maxFilesPerMerge)
+                    $ enqueueBgJob ctx.jobsPool "MergeReplaySession" [AE.toJSON pid, AE.toJSON sessionId]
 
 
 -- | Uncompressed-bytes budget per sealed shard. A merge accumulates raw event
@@ -993,7 +970,7 @@ shardSealBytes = 12 * 1024 * 1024
 -- Just (7,1700000000000)
 shardKeyFor :: UUID.UUID -> Int -> Integer -> Minio.Object
 shardKeyFor sid idx firstTsMs =
-  toObjKey $ UUID.toText sid <> "/shard-" <> T.justifyRight 6 '0' (show idx) <> "-" <> show firstTsMs <> ".json.gz"
+  UUID.toText sid <> "/shard-" <> T.justifyRight 6 '0' (show idx) <> "-" <> show firstTsMs <> ".json.gz"
 
 
 -- | Parse a shard object key into (index, firstTsMs). `<sid>/shard-<idx>-<ts>.json.gz`;
@@ -1009,7 +986,7 @@ shardKeyFor sid idx firstTsMs =
 -- Nothing
 parseShardKey :: Text -> Maybe (Int, Integer)
 parseShardKey key = do
-  name <- T.stripSuffix ".json.gz" =<< listToMaybe (reverse (T.splitOn "/" key))
+  name <- T.stripSuffix ".json.gz" (T.takeWhileEnd (/= '/') key)
   rest <- T.stripPrefix "shard-" name
   case T.splitOn "-" rest of
     [idxT, tsT] -> (,) <$> readMaybe (toString idxT) <*> readMaybe (toString tsT)
@@ -1031,7 +1008,7 @@ mergeOneSession conn bucket sessionId startIdx fileKeys = reverse <$> go startId
     -- buf :: [(firstTs, raw, sourceKey)] for the current shard; sealed :: sealed keys (newest first)
     go idx [] buf _ sealed = seal idx buf sealed
     go idx (k : ks) buf !bufBytes sealed = do
-      res <- Minio.runMinio conn (fetchRawForMerge bucket (toObjKey k) False)
+      res <- Minio.runMinio conn (fetchRawForMerge bucket k False)
       case res of
         Left me | isNoSuchKey me -> go idx ks buf bufBytes sealed
         Left me -> throwIO (MergeFetchFailed me)
@@ -1051,7 +1028,7 @@ mergeOneSession conn bucket sessionId startIdx fileKeys = reverse <$> go startId
           shardKey = shardKeyFor sessionId idx (round (firstTs :: Double))
       putRes <- Minio.runMinio conn $ do
         Minio.putObject bucket shardKey (CC.sourceLazy compressed) (Just (BL.length compressed)) Minio.defaultPutObjectOptions
-        forM_ [toObjKey k | (_, _, k) <- sorted] (Minio.removeObject bucket)
+        forM_ [k | (_, _, k) <- sorted] (Minio.removeObject bucket)
       whenLeft_ putRes (throwIO . MergePutFailed)
       pure (shardKey : sealed)
 
@@ -1093,9 +1070,9 @@ expireOldReplayData = do
     projectM <- Projects.projectById pid
     whenJust projectM $ \p -> do
       let (conn, bucket) = projectMinioConn ctx.config p
-          -- shard_keys covers sealed shards + the legacy monolith; mergedKeyFor kept
+          -- shard_keys covers sealed shards + the legacy monolith; the merged key is kept
           -- as a belt-and-suspenders for any session not yet reflected in shard_keys.
-          keyObjs = mergedKeyFor sid : map toObjKey (V.toList shardKeys <> V.toList fileKeys)
+          keyObjs = (UUID.toText sid <> "/merged.json.gz") : V.toList shardKeys <> V.toList fileKeys
           logCtx = sessionLogCtx pid sid
       -- Separate `runMinio` per key so one transport error doesn't abort siblings;
       -- mirrors the `fetchIndividuals` pattern elsewhere in this module.
@@ -1111,8 +1088,4 @@ expireOldReplayData = do
           Hasql.interpExecute_
             [HI.sql| DELETE FROM projects.replay_sessions WHERE session_id = #{sid} AND project_id = #{pid} |]
           Log.logInfo "Expired replay session" logCtx
-  when (length rows >= expireReplayBatchSize) $ do
-    -- See MergeReplaySession note: cannot import BackgroundJobs (circular).
-    let payload = AE.object ["tag" AE..= ("ExpireReplayData" :: Text), "contents" AE..= ([] :: [AE.Value])]
-    liftIO $ withResource ctx.jobsPool \c ->
-      void $ createJob c "background_jobs" payload
+  when (length rows >= expireReplayBatchSize) $ enqueueBgJob ctx.jobsPool "ExpireReplayData" []

--- a/src/Pages/Reports.hs
+++ b/src/Pages/Reports.hs
@@ -11,12 +11,12 @@ module Pages.Reports (
   computeDurationChanges,
   EndpointStatsTuple,
   anomalyTypeCounts,
+  pctChange,
   eventsWidget,
   errorsWidget,
 )
 where
 
-import Control.Lens (view, _2, _3)
 import Data.Aeson qualified as AE
 import Data.Default (def)
 import Data.Map.Lazy qualified as Map
@@ -43,6 +43,7 @@ import Pkg.Components.Widget qualified as Widget
 import Pkg.EmailTemplates qualified as ET
 import Relude hiding (ask)
 import System.Config (AuthContext (..), EnvConfig (..))
+import System.Logging qualified as Log
 import System.Types (ATAuthCtx, RespHeaders, addRespHeaders, addSuccessToast)
 import Utils (FreeTierStatus, LoadingSize (..), LoadingType (..), checkFreeTierStatus, faSprite_, formatUTCMicros, loadingIndicatorWith_)
 
@@ -136,41 +137,43 @@ buildReportJson' totalEvents totalErrors eventsChange errorsChange spanTypeStats
       }
 
 
--- | Moved from BackgroundJobs
 type EndpointStatsTuple = (Text, Text, Text, Int64, Int64)
+
+
+-- | Percent change of @cur@ over @prev@, rounded to 2dp; 0 when there's no baseline.
+pctChange :: Integral a => a -> a -> Double
+pctChange cur prev
+  | prev == 0 = 0
+  | otherwise = fromIntegral (round (ratio * 10000) :: Int) / 100
+  where
+    ratio = fromIntegral (cur - prev) / fromIntegral prev :: Double
 
 
 getSpanTypeStats :: V.Vector (Text, Int, Int) -> V.Vector (Text, Int, Int) -> V.Vector (Text, Int, Double, Int, Double)
 getSpanTypeStats current prev =
-  let spanTypes = ordNub $ V.toList (V.map (\(t, _, _) -> t) current <> V.map (\(t, _, _) -> t) prev)
-      getStats t =
-        let evtCount = maybe 0 (\(_, c, _) -> c) (V.find (\(st, _, _) -> st == t) current)
-            prevEvtCount = maybe 0 (\(_, c, _) -> c) (V.find (\(st, _, _) -> st == t) prev)
-            evtChange' = if prevEvtCount == 0 then 0.00 :: Double else fromIntegral (evtCount - prevEvtCount) / fromIntegral prevEvtCount * 100
-            evtChange = fromIntegral (round (evtChange' * 100)) / 100
-            avgDuration = maybe 0 (\(_, _, d) -> d) (V.find (\(st, _, _) -> st == t) current)
-            prevAvgDuration = maybe 0 (\(_, _, d) -> d) (V.find (\(st, _, _) -> st == t) prev)
-            durationChange' = if prevAvgDuration == 0 then 0.00 :: Double else fromIntegral (avgDuration - prevAvgDuration) / fromIntegral prevAvgDuration * 100
-            durationChange = fromIntegral (round (durationChange' * 100)) / 100
-         in (t, evtCount, evtChange, avgDuration, durationChange)
-   in V.fromList (map getStats spanTypes)
+  V.fromList
+    [ (t, c, pctChange c pc, d, pctChange d pd)
+    | t <- ordNub [st | (st, _, _) <- V.toList current <> V.toList prev]
+    , let (c, d) = Map.findWithDefault (0, 0) t curMap
+    , let (pc, pd) = Map.findWithDefault (0, 0) t prevMap
+    ]
+  where
+    -- first row wins on duplicate span types, matching the pre-map lookup
+    toMap v = Map.fromListWith (\_ old -> old) [(t, (c, d)) | (t, c, d) <- V.toList v]
+    curMap = toMap current
+    prevMap = toMap prev
 
 
 computeDurationChanges :: V.Vector EndpointStatsTuple -> V.Vector EndpointStatsTuple -> V.Vector (Text, Text, Text, Int64, Double, Int64, Double)
-computeDurationChanges current prev =
-  let prevMap :: Map.Map (Text, Text, Text) Int64
-      prevMap = Map.fromList [((h, m, u), dur) | (h, m, u, dur, _req) <- V.toList prev]
-      prevMapReq :: Map.Map (Text, Text, Text) Int64
-      prevMapReq = Map.fromList [((h, m, u), req) | (h, m, u, _dur, req) <- V.toList prev]
-      compute (h, m, u, dur, req) =
-        let change = case Map.lookup (h, m, u) prevMap of
-              Just prevDur | prevDur > 0 -> Just $ (fromIntegral (dur - prevDur) / fromIntegral prevDur) * 100
-              _ -> Nothing
-            reqChange = case Map.lookup (h, m, u) prevMapReq of
-              Just prevReq | prevReq > 0 -> Just $ (fromIntegral (req - prevReq) / fromIntegral prevReq) * 100
-              _ -> Nothing
-         in (h, m, u, dur, maybe 100.00 (\x -> fromIntegral (round (x * 100)) / 100) change, req, maybe 100.00 (\x -> fromIntegral (round (x * 100)) / 100) reqChange)
-   in V.map compute current
+computeDurationChanges current prev = V.map compute current
+  where
+    prevMap :: Map.Map (Text, Text, Text) (Int64, Int64)
+    prevMap = Map.fromList [((h, m, u), (dur, req)) | (h, m, u, dur, req) <- V.toList prev]
+    -- no positive baseline reads as "all new": 100%
+    change cur = maybe 100 (\p -> if p > 0 then pctChange cur p else 100)
+    compute (h, m, u, dur, req) =
+      let pv = Map.lookup (h, m, u) prevMap
+       in (h, m, u, dur, change dur (fst <$> pv), req, change req (snd <$> pv))
 
 
 -- | Shared email rendering: builds WeeklyReportData from inputs, generates chart URLs, renders email
@@ -220,7 +223,7 @@ renderWeeklyEmail reportUrl project pid userName startTime endTime totalEvents t
 -- | Reconstruct the email HTML from a stored Report's reportJson. Returns (dateLabel, emailHtml)
 reportToEmailHtml :: Issues.Report -> Projects.Project -> Text -> ATAuthCtx (Text, Text)
 reportToEmailHtml report project userName = case AE.fromJSON @ReportData report.reportJson of
-  AE.Error _ -> pure ("", "Error: Could not parse report data")
+  AE.Error err -> ("", "Error: Could not parse report data") <$ Log.logAttention "Unparseable stored report json" (report.id.toText, toText err)
   AE.Success rd -> do
     let anomalies' = V.fromList rd.issues
         performance = V.fromList $ (\ep -> (ep.host, ep.method, ep.urlPath, fromIntegral ep.averageDuration :: Int64, ep.durationDiffPct, fromIntegral ep.requestCount :: Int64, ep.requestDiffPct)) <$> rd.endpoints
@@ -252,22 +255,20 @@ buildLiveReportEmailHtml pid project userName = do
               )
           )
           ( concurrently
-              (Issues.selectIssues pid Nothing (Just False) Nothing 100 0 (Just (startTime, currentTime)) Nothing "7d" [] [])
+              (Issues.selectIssues pid (Just False) Nothing 100 0 (Just (startTime, currentTime)) Nothing "7d" [] [])
               (concurrently (LogPatterns.getLogPatterns pid 10 0) (LogQueries.getLastSevenDaysTotalRequest pid))
           )
       )
-  let totalErrors = sum $ map (view _2) stats
-      totalEvents = sum $ map (view _3) stats
-      totalErrorsPrev = sum $ map (view _2) statsPrev
-      totalEventsPrev = sum $ map (view _3) statsPrev
-      pctChange cur prev = if prev == 0 then 0.0 else fromIntegral (round ((fromIntegral (cur - prev) / fromIntegral prev * 100 :: Double) * 100)) / 100
-      eventsChangePct = pctChange totalEvents totalEventsPrev :: Double
-      errorsChangePct = pctChange totalErrors totalErrorsPrev :: Double
+  let totals xs = (sum [e | (_, e, _) <- xs], sum [v | (_, _, v) <- xs])
+      (totalErrors, totalEvents) = totals stats
+      (totalErrorsPrev, totalEventsPrev) = totals statsPrev
+      eventsChangePct = pctChange totalEvents totalEventsPrev
+      errorsChangePct = pctChange totalErrors totalErrorsPrev
       slowQueries = V.fromList slowQueriesL
       performance = computeDurationChanges endpointStats endpointStatsPrev
       anomalies' = V.fromList $ Issues.toIssueSummary <$> anomalies
       topPatterns = V.fromList $ patterns <&> \p -> (p.logPattern, p.occurrenceCount, LogPatterns.sourceFieldLabel p.sourceField)
-  let reportUrl = "/p/" <> pid.toText <> "/reports"
+      reportUrl = "/p/" <> pid.toText <> "/reports"
       freeTierExceeded = Projects.isFreeTier project.paymentPlan && totalRequest > 5000
   renderWeeklyEmail reportUrl project pid userName startTime currentTime totalEvents totalErrors eventsChangePct errorsChangePct anomalies' performance slowQueries topPatterns freeTierExceeded
 
@@ -289,9 +290,8 @@ instance ToHtml ReportsPost where
 
 
 wrapSingleResponse :: BWConfig -> FreeTierStatus -> Text -> Maybe Text -> (Text, Text, Text) -> ATAuthCtx (RespHeaders ReportsGet)
-wrapSingleResponse bw freeTierStatus pageTitle hxRequestM content = case hxRequestM of
-  Just _ -> addRespHeaders $ ReportsGetSingle' content
-  _ -> addRespHeaders $ ReportsGetSingle $ PageCtx bw{pageTitle, freeTierStatus} content
+wrapSingleResponse bw freeTierStatus pageTitle hxRequestM content =
+  addRespHeaders $ maybe (ReportsGetSingle $ PageCtx bw{pageTitle, freeTierStatus} content) (const $ ReportsGetSingle' content) hxRequestM
 
 
 singleReportGetH :: Projects.ProjectId -> Issues.ReportId -> Maybe Text -> ATAuthCtx (RespHeaders ReportsGet)
@@ -319,11 +319,8 @@ reportsLiveGetH pid hxRequestM = do
 reportsGetH :: Projects.ProjectId -> Maybe Text -> Maybe Text -> Maybe Text -> ATAuthCtx (RespHeaders ReportsGet)
 reportsGetH pid page hxRequest hxBoosted = do
   (_, project, bw) <- mkPageCtx pid
-  let p = toString (fromMaybe "0" page)
-  let pg = fromMaybe 0 (readMaybe p :: Maybe Int)
-
-  reportsList <- Issues.reportHistoryByProject pid pg
-  let reports = V.fromList reportsList
+  let pg = fromMaybe 0 (readMaybe . toString =<< page) :: Int
+  reports <- V.fromList <$> Issues.reportHistoryByProject pid pg
   freeTierStatus <- checkFreeTierStatus pid project.paymentPlan
   let nextUrl =
         if V.length reports < 20
@@ -331,27 +328,25 @@ reportsGetH pid page hxRequest hxBoosted = do
           else Just $ "/p/" <> pid.toText <> "/reports?page=" <> show (pg + 1)
   case (hxRequest, hxBoosted) of
     (Just "true", Nothing) -> addRespHeaders $ ReportsGetList pid reports nextUrl
-    _ -> do
-      let bwconf = bw{pageTitle = "Reports", freeTierStatus = freeTierStatus}
-      addRespHeaders $ ReportsGetMain $ PageCtx bwconf (pid, reports, nextUrl, project.dailyNotif, project.weeklyNotif)
+    _ -> addRespHeaders $ ReportsGetMain $ PageCtx bw{pageTitle = "Reports", freeTierStatus} (pid, reports, nextUrl)
 
 
--- | (reportType, dateLabel, emailHtml)
 data ReportsGet
-  = ReportsGetMain (PageCtx (Projects.ProjectId, V.Vector Issues.ReportListItem, Maybe Text, Bool, Bool))
+  = ReportsGetMain (PageCtx (Projects.ProjectId, V.Vector Issues.ReportListItem, Maybe Text))
   | ReportsGetList Projects.ProjectId (V.Vector Issues.ReportListItem) (Maybe Text)
   | ReportsGetSingle (PageCtx (Text, Text, Text))
   | ReportsGetSingle' (Text, Text, Text)
 
 
 instance ToHtml ReportsGet where
-  toHtml (ReportsGetMain (PageCtx conf (pid, reports, next, daily, weekly))) = toHtml $ PageCtx conf $ reportsPage pid reports next daily weekly
+  toHtml (ReportsGetMain (PageCtx conf (pid, reports, next))) = toHtml $ PageCtx conf $ reportsPage pid reports next
   toHtml (ReportsGetList pid reports next) = toHtml $ reportListItems pid reports next
   toHtml (ReportsGetSingle (PageCtx conf content)) = toHtml $ PageCtx conf $ singleReportPage content
   toHtml (ReportsGetSingle' content) = toHtml $ singleReportPage content
   toHtmlRaw = toHtml
 
 
+-- | (reportType, dateLabel, emailHtml)
 singleReportPage :: (Text, Text, Text) -> Html ()
 singleReportPage (reportType, dateLabel, emailHtml) =
   div_ [class_ "w-full flex flex-col h-full"] do
@@ -363,68 +358,62 @@ singleReportPage (reportType, dateLabel, emailHtml) =
       else iframe_ [term "srcdoc" emailHtml, style_ "width:100%;height:100%;border:none;", term "sandbox" "allow-same-origin"] ""
 
 
-reportsPage :: Projects.ProjectId -> V.Vector Issues.ReportListItem -> Maybe Text -> Bool -> Bool -> Html ()
-reportsPage pid reports nextUrl _daily _weekly =
+-- | HTMX attrs loading @url@ into the report detail pane.
+detailPaneAttrs :: Text -> [Attribute]
+detailPaneAttrs url = [hxGet_ url, hxTarget_ "#detailSidebar", hxSwap_ "innerHTML"]
+
+
+-- | Clickable report card: @borderCls@ distinguishes the live entry from history.
+reportCard_ :: Text -> Text -> Html () -> Html ()
+reportCard_ borderCls url body =
+  div_ [class_ $ "shrink-0 w-64 md:w-full flex flex-col border rounded-lg hover:bg-fillWeaker " <> borderCls]
+    $ a_ (class_ "w-full p-4 flex justify-between hover:bg-fillHover cursor-pointer" : detailPaneAttrs url)
+    $ div_ [class_ "flex flex-col grow gap-4"] body
+
+
+-- | Card header row: a pill, optional trailing badge, and the chevron affordance.
+reportCardHead_ :: Text -> Html () -> Html () -> Html ()
+reportCardHead_ pillCls pill badge = div_ [class_ "flex items-center w-full justify-between gap-2"] do
+  div_ [class_ "flex items-center gap-2"] do
+    div_ [class_ $ pillCls <> " text-xs font-medium px-2.5 py-1 rounded-full"] pill
+    badge
+  faSprite_ "chevron-right" "regular" "w-3 h-3"
+
+
+reportCardTitle_ :: Html () -> Html ()
+reportCardTitle_ title = h4_ [class_ "font-medium text-sm flex items-center gap-2"] do
+  faSprite_ "calendar" "regular" "w-4 h-4"
+  title
+
+
+reportsPage :: Projects.ProjectId -> V.Vector Issues.ReportListItem -> Maybe Text -> Html ()
+reportsPage pid reports nextUrl =
   div_ [class_ "flex flex-col md:flex-row h-full w-full border-t"] do
-    when (V.null reports)
-      $ div_ [class_ "flex h-full w-full justify-center items-center"]
-      $ emptyState_ def{icon = Just "empty"} "No reports generated yet" "Scheduled digests will appear here once your project has activity to summarize."
-    unless (V.null reports) do
-      div_ [class_ "w-full md:w-1/3 md:border-r border-b md:border-b-0 border-strokeWeak p-4 overflow-x-auto md:overflow-y-auto"] do
-        div_ [class_ "mt-4 flex flex-row md:flex-col gap-4 w-full"] do
-          -- "Week to Date" live preview entry
-          div_ [class_ "shrink-0 w-64 md:w-full flex flex-col border border-strokeBrand-weak bg-fillBrand-weak/10 rounded-lg cursor-pointer hover:bg-fillWeaker"] do
-            div_ [class_ "w-full"] do
-              a_
-                [ class_ "w-full p-4 flex justify-between hover:bg-fillHover cursor-pointer"
-                , hxGet_ $ "/p/" <> pid.toText <> "/reports/live"
-                , hxTarget_ "#detailSidebar"
-                , hxSwap_ "innerHTML"
-                ]
-                $ div_ [class_ "flex flex-col grow gap-4"] do
-                  div_ [class_ "flex items-center w-full justify-between gap-2"] do
-                    div_ [class_ "flex items-center gap-2"] do
-                      div_ [class_ "bg-fillBrand-weak text-xs font-medium px-2.5 py-1 rounded-full"] "Weekly report"
-                      span_ [class_ "bg-fillSuccess-strong text-textInverse-strong text-2xs font-bold px-1.5 py-0.5 rounded-full uppercase"] "Live"
-                    faSprite_ "chevron-right" "regular" "w-3 h-3"
-                  h4_ [class_ "font-medium text-sm flex items-center gap-2"] do
-                    faSprite_ "calendar" "regular" "w-4 h-4"
-                    "Week to Date"
-          -- Historical reports
-          reportListItems pid reports nextUrl
-      div_ [class_ "w-full md:w-2/3 overflow-y-auto"] do
-        div_ [class_ "flex h-full", id_ "detailSidebar"] do
-          -- Auto-load the live preview on initial page load
-          a_
-            [ class_ "w-full text-center cursor-pointer"
-            , hxGet_ $ "/p/" <> pid.toText <> "/reports/live"
-            , hxTarget_ "#detailSidebar"
-            , hxSwap_ "innerHTML"
-            , hxTrigger_ "intersect once"
-            ]
-            $ div_ [class_ "w-full p-4 flex justify-between hover:bg-fillHover cursor-pointer"] do
-              loadingIndicatorWith_ LdSM LdDots "text-textWeak"
+    if V.null reports
+      then
+        div_ [class_ "flex h-full w-full justify-center items-center"]
+          $ emptyState_ def{icon = Just "empty"} "No reports generated yet" "Scheduled digests will appear here once your project has activity to summarize."
+      else do
+        div_ [class_ "w-full md:w-1/3 md:border-r border-b md:border-b-0 border-strokeWeak p-4 overflow-x-auto md:overflow-y-auto"]
+          $ div_ [class_ "mt-4 flex flex-row md:flex-col gap-4 w-full"] do
+            reportCard_ "border-strokeBrand-weak bg-fillBrand-weak/10" ("/p/" <> pid.toText <> "/reports/live") do
+              reportCardHead_ "bg-fillBrand-weak" "Weekly report"
+                $ span_ [class_ "bg-fillSuccess-strong text-textInverse-strong text-2xs font-bold px-1.5 py-0.5 rounded-full uppercase"] "Live"
+              reportCardTitle_ "Week to Date"
+            reportListItems pid reports nextUrl
+        div_ [class_ "w-full md:w-2/3 overflow-y-auto"]
+          $ div_ [class_ "flex h-full", id_ "detailSidebar"]
+          $ a_ (class_ "w-full text-center cursor-pointer" : hxTrigger_ "intersect once" : detailPaneAttrs ("/p/" <> pid.toText <> "/reports/live"))
+          $ div_ [class_ "w-full p-4 flex justify-between hover:bg-fillHover cursor-pointer"]
+          $ loadingIndicatorWith_ LdSM LdDots "text-textWeak"
 
 
 reportListItems :: Projects.ProjectId -> V.Vector Issues.ReportListItem -> Maybe Text -> Html ()
 reportListItems pid reports nextUrl =
   div_ [class_ "flex flex-row md:flex-col gap-4 w-full"] do
-    forM_ reports $ \report -> do
-      let isWeeklyData = report.reportType == "weekly"
-      div_ [class_ "shrink-0 w-64 md:w-full flex flex-col border border-strokeWeak rounded-lg cursor-pointer hover:bg-fillWeaker"] do
-        div_ [class_ "w-full"] do
-          a_
-            [ class_ "w-full p-4 flex justify-between hover:bg-fillHover cursor-pointer"
-            , hxGet_ $ "/p/" <> pid.toText <> "/reports/" <> report.id.toText
-            , hxTarget_ "#detailSidebar"
-            , hxSwap_ "innerHTML"
-            ]
-            $ div_ [class_ "flex flex-col grow gap-4"] do
-              div_ [class_ "flex items-center w-full justify-between gap-2"] do
-                div_ [class_ $ (if isWeeklyData then "bg-fillBrand-weak" else "bg-fillWeak") <> " text-xs font-medium px-2.5 py-1 rounded-full capitalize"] $ toHtml report.reportType <> " report"
-                faSprite_ "chevron-right" "regular" "w-3 h-3"
-              h4_ [class_ "font-medium text-sm flex items-center gap-2"] do
-                faSprite_ "calendar" "regular" "w-4 h-4"
-                toHtml $ formatTime defaultTimeLocale "%a, %b %d %Y" (zonedTimeToLocalTime report.createdAt)
+    forM_ reports \report ->
+      reportCard_ "border-strokeWeak" ("/p/" <> pid.toText <> "/reports/" <> report.id.toText) do
+        reportCardHead_ (if report.reportType == "weekly" then "bg-fillBrand-weak capitalize" else "bg-fillWeak capitalize") (toHtml report.reportType <> " report") mempty
+        reportCardTitle_ $ toHtml $ formatTime defaultTimeLocale "%a, %b %d %Y" (zonedTimeToLocalTime report.createdAt)
     whenJust nextUrl \url ->
       a_ [class_ "w-full cursor-pointer block p-1 text-textBrand bg-fillBrand-weak hover:bg-fillBrand-weak text-center mb-4", hxTrigger_ "click", hxSwap_ "outerHTML", hxGet_ url] "LOAD MORE"

--- a/src/Pages/Settings.hs
+++ b/src/Pages/Settings.hs
@@ -62,6 +62,7 @@ import Data.Char (isDigit, isHexDigit)
 import Data.Default
 import Data.Effectful.Hasql qualified as Hasql
 import Data.Effectful.Notify qualified as Notify
+import Data.List (lookup)
 import Data.Text qualified as T
 import Data.Time (Day, UTCTime (..), addDays, addUTCTime, diffUTCTime, getZonedTime)
 import Data.Time.Clock.POSIX (utcTimeToPOSIXSeconds)
@@ -69,7 +70,6 @@ import Data.Time.Format (defaultTimeLocale, formatTime)
 import Data.UUID qualified as UUID
 import Data.UUID.V4 qualified as UUIDV4
 import Data.Vector qualified as V
-import Database.PostgreSQL.Simple (FromRow, ToRow)
 import Deriving.Aeson qualified as DAE
 import Deriving.Aeson.Stock qualified as DAE
 import Effectful.Error.Static (throwError)
@@ -93,7 +93,6 @@ import Models.Projects.ProjectApiKeys qualified as ProjectApiKeys
 import Models.Projects.ProjectMembers (Team (..), getTeamsById, resolveTeamEmails)
 import Models.Projects.ProjectMembers qualified as ProjectMembers
 import Models.Projects.Projects qualified as Projects
-import NeatInterpolation (text)
 import Network.HTTP.Types (urlEncode)
 import Network.Minio qualified as Minio
 import Network.URI (parseURI, uriAuthority, uriRegName, uriScheme)
@@ -182,8 +181,7 @@ awsRegions =
 brings3PostH :: Projects.ProjectId -> Projects.ProjectS3Bucket -> ATAuthCtx (RespHeaders (Html ()))
 brings3PostH pid s3Form = do
   let connectInfo = getMinioConnectInfo s3Form.accessKey s3Form.secretKey s3Form.region s3Form.bucket s3Form.endpointUrl
-  res <- liftIO $ Minio.runMinio connectInfo do
-    Minio.bucketExists s3Form.bucket
+  res <- liftIO $ Minio.runMinio connectInfo $ Minio.bucketExists s3Form.bucket
   case res of
     Left err -> do
       addErrorToast (humanizeMinioErr err) Nothing
@@ -203,8 +201,7 @@ brings3PostH pid s3Form = do
 
 brings3RemoveH :: Projects.ProjectId -> ATAuthCtx (RespHeaders (Html ()))
 brings3RemoveH pid = do
-  (sess, project) <- Projects.sessionAndProject pid
-  appCtx <- ask @AuthContext
+  (sess, _) <- Projects.sessionAndProject pid
   _ <- Projects.updateProjectS3Bucket pid Nothing
   Projects.logAuditS pid Projects.AES3Removed sess Nothing
   addSuccessToast "Removed S3 bucket" Nothing
@@ -257,46 +254,39 @@ data GenerateAPIKeyForm = GenerateAPIKeyForm
 
 apiPostH :: Projects.ProjectId -> GenerateAPIKeyForm -> ATAuthCtx (RespHeaders ApiMut)
 apiPostH pid apiKeyForm = do
-  (sess, project) <- Projects.sessionAndProject pid
+  (sess, _) <- Projects.sessionAndProject pid
   authCtx <- ask @AuthContext
   projectKeyUUID <- liftIO UUIDV4.nextRandom
   let encryptedKeyB64 = ProjectApiKeys.encodeApiKeyB64 authCtx.config.apiKeyEncryptionSecretKey projectKeyUUID
-  pApiKey <- ProjectApiKeys.newProjectApiKeys pid projectKeyUUID (title apiKeyForm) encryptedKeyB64
-  apiKeys <- do
-    ProjectApiKeys.insertProjectApiKey pApiKey
-    V.fromList <$> ProjectApiKeys.projectApiKeysByProjectId pid
+  pApiKey <- ProjectApiKeys.newProjectApiKeys pid projectKeyUUID apiKeyForm.title encryptedKeyB64
+  ProjectApiKeys.insertProjectApiKey pApiKey
+  apiKeys <- V.fromList <$> ProjectApiKeys.projectApiKeysByProjectId pid
   Projects.logAuditS pid Projects.AEApiKeyCreated sess
     $ Just
-    $ AE.object ["key_title" AE..= title apiKeyForm]
+    $ AE.object ["key_title" AE..= apiKeyForm.title]
   addSuccessToast "Created API Key Successfully" Nothing
   addTriggerEvent "closeModal" ""
-  case from apiKeyForm of
-    Just v -> addRespHeaders $ ApiPostCopy (Just (pApiKey, encryptedKeyB64)) True
-    Nothing -> addRespHeaders $ ApiPost pid apiKeys (Just (pApiKey, encryptedKeyB64))
+  let newKey = Just (pApiKey, encryptedKeyB64)
+  addRespHeaders $ maybe (ApiPost pid apiKeys newKey) (const $ ApiPostCopy newKey True) apiKeyForm.from
 
 
 apiDeleteH :: Projects.ProjectId -> ProjectApiKeys.ProjectApiKeyId -> ATAuthCtx (RespHeaders ApiMut)
-apiDeleteH pid keyid = do
-  (sess, project) <- Projects.sessionAndProject pid
-  res <- ProjectApiKeys.revokeApiKey keyid
-  apikeys <- V.fromList <$> ProjectApiKeys.projectApiKeysByProjectId pid
-  if res > 0
-    then do
-      Projects.logAuditS pid Projects.AEApiKeyRevoked sess Nothing
-      addSuccessToast "Revoked API Key Successfully" Nothing
-    else addErrorToast "Something went wrong" Nothing
-  addRespHeaders $ ApiPost pid apikeys Nothing
+apiDeleteH pid keyid = apiKeySetActive pid ProjectApiKeys.revokeApiKey Projects.AEApiKeyRevoked "Revoked" keyid
 
 
 apiActivateH :: Projects.ProjectId -> ProjectApiKeys.ProjectApiKeyId -> ATAuthCtx (RespHeaders ApiMut)
-apiActivateH pid keyid = do
-  (sess, project) <- Projects.sessionAndProject pid
-  res <- ProjectApiKeys.activateApiKey keyid
+apiActivateH pid keyid = apiKeySetActive pid ProjectApiKeys.activateApiKey Projects.AEApiKeyActivated "Activated" keyid
+
+
+apiKeySetActive :: Projects.ProjectId -> (ProjectApiKeys.ProjectApiKeyId -> ATAuthCtx Int64) -> Projects.AuditEvent -> Text -> ProjectApiKeys.ProjectApiKeyId -> ATAuthCtx (RespHeaders ApiMut)
+apiKeySetActive pid act event verb keyid = do
+  (sess, _) <- Projects.sessionAndProject pid
+  res <- act keyid
   apikeys <- V.fromList <$> ProjectApiKeys.projectApiKeysByProjectId pid
   if res > 0
     then do
-      Projects.logAuditS pid Projects.AEApiKeyActivated sess Nothing
-      addSuccessToast "Activated API Key Successfully" Nothing
+      Projects.logAuditS pid event sess Nothing
+      addSuccessToast (verb <> " API Key Successfully") Nothing
     else addErrorToast "Something went wrong" Nothing
   addRespHeaders $ ApiPost pid apikeys Nothing
 
@@ -347,10 +337,7 @@ apiKeysPage pid apiKeys = do
 apiMainContent :: Projects.ProjectId -> V.Vector ProjectApiKeys.ProjectApiKey -> Maybe (ProjectApiKeys.ProjectApiKey, Text) -> Html ()
 apiMainContent pid apiKeys newKeyM = section_ [] do
   copyNewApiKey newKeyM False
-  let activeKeys = V.filter (\x -> x.active) apiKeys
-      revokedKeys = V.filter (\x -> not x.active) apiKeys
-      activeTable = makeApiKeysTable pid activeKeys "active_content"
-      revokedTable = makeApiKeysTable pid revokedKeys "revoked_content"
+  let (activeKeys, revokedKeys) = V.partition (.active) apiKeys
       tabs =
         Table.TabFilter
           { current = "Active keys"
@@ -363,49 +350,37 @@ apiMainContent pid apiKeys newKeyM = section_ [] do
           }
 
   toHtml tabs
-  div_ [class_ "a-tab-content", id_ "active_content"] $ toHtml activeTable
-  div_ [class_ "hidden a-tab-content", id_ "revoked_content"] $ toHtml revokedTable
+  div_ [class_ "a-tab-content", id_ "active_content"] $ toHtml $ makeApiKeysTable pid activeKeys "active_content"
+  div_ [class_ "hidden a-tab-content", id_ "revoked_content"] $ toHtml $ makeApiKeysTable pid revokedKeys "revoked_content"
 
 
-makeApiKeysTable :: Projects.ProjectId -> V.Vector ProjectApiKeys.ProjectApiKey -> Text -> Table.Table (Int, ProjectApiKeys.ProjectApiKey)
+makeApiKeysTable :: Projects.ProjectId -> V.Vector ProjectApiKeys.ProjectApiKey -> Text -> Table.Table ProjectApiKeys.ProjectApiKey
 makeApiKeysTable pid apiKeys elemId =
   Table.Table
     { config = def{Table.elemID = elemId, Table.renderAsTable = True}
     , columns = apiKeyColumns pid
-    , rows = V.indexed apiKeys
+    , rows = apiKeys
     , features = Table.Features{rowLink = Nothing, rowId = Nothing, rowAttrs = Just $ const [class_ "group/row hover:bg-fillWeaker"], selectRow = Nothing, bulkActions = [], search = Nothing, tabs = Nothing, sort = Nothing, sortableColumns = Nothing, tableHeaderActions = Nothing, pagination = Nothing, zeroState = Just Table.ZeroState{icon = "key", title = "No API keys", description = "Create an API key to start integrating with your project.", actionText = "", destination = Right ""}, header = Nothing, treeConfig = Nothing}
     }
 
 
-apiKeyColumns :: Projects.ProjectId -> [Table.Column (Int, ProjectApiKeys.ProjectApiKey)]
+apiKeyColumns :: Projects.ProjectId -> [Table.Column ProjectApiKeys.ProjectApiKey]
 apiKeyColumns pid =
-  [ Table.col "Title" \(_, apiKey) ->
+  [ Table.col "Title" \apiKey ->
       span_ [class_ "text-textStrong font-semibold text-sm truncate min-w-0 block max-w-48"] $ toHtml apiKey.title
-  , Table.col "Key" \(i, apiKey) -> do
-      let idx = "key-" <> show i
-      div_ [class_ "whitespace-nowrap w-full flex items-center gap-2 text-sm text-textWeak"] do
-        span_ [class_ $ "min-w-0 " <> idx] $ toHtml $ T.take 8 apiKey.keyPrefix <> T.replicate 20 "*"
+  , Table.col "Key" \apiKey -> do
+      -- Reveal is pure CSS: the sr-only checkbox flips both spans and both eye labels
+      -- via `group-has-[:checked]` on the row container (no hyperscript, survives morph).
+      -- Keyed by key id, not row index — the active and archived tables both index from 0.
+      let revealId = "reveal-key-" <> apiKey.id.toText
+      div_ [class_ "group whitespace-nowrap w-full flex items-center gap-2 text-sm text-textWeak"] do
+        input_ [type_ "checkbox", id_ revealId, class_ "sr-only"]
+        span_ [class_ "min-w-0 group-has-[:checked]:hidden"] $ toHtml $ T.take 8 apiKey.keyPrefix <> T.replicate 20 "*"
+        span_ [class_ "min-w-0 hidden group-has-[:checked]:inline"] $ toHtml apiKey.keyPrefix
         div_ [class_ "flex items-center gap-1.5 shrink-0 ml-auto"] do
-          button_
-            [ class_ "p-1 rounded hover:bg-fillWeaker cursor-pointer"
-            , term "data-key" apiKey.keyPrefix
-            , term "data-state" "hide"
-            , type_ "button"
-            , term "data-tippy-content" "Show key"
-            , term "data-prefix" (T.take 8 apiKey.keyPrefix <> T.replicate 20 "*")
-            , term
-                "_"
-                [text|on click
-                 if my @data-state is "hide"
-                   put my @data-key into <.$idx/>
-                   put "show" into my @data-state
-                   put "Hide key" into my @data-tippy-content
-                 else
-                   put my @data-prefix into <.$idx/>
-                   put "hide" into my @data-state
-                   put "Show key" into my @data-tippy-content
-                 end |]
-            ]
+          label_ [Lucid.for_ revealId, class_ "p-1 rounded hover:bg-fillWeaker cursor-pointer group-has-[:checked]:hidden", term "data-tippy-content" "Show key"]
+            $ faSprite_ "eye" "regular" "h-3.5 w-3.5 text-iconNeutral"
+          label_ [Lucid.for_ revealId, class_ "p-1 rounded hover:bg-fillWeaker cursor-pointer hidden group-has-[:checked]:block", term "data-tippy-content" "Hide key"]
             $ faSprite_ "eye" "regular" "h-3.5 w-3.5 text-iconNeutral"
           button_
             [ class_ "p-1 rounded hover:bg-fillWeaker cursor-pointer"
@@ -428,7 +403,6 @@ apiKeyColumns pid =
             , hxMethod $ "/p/" <> pid.toText <> "/apis/" <> apiKey.id.toText
             , hxConfirm_ confirmMsg
             , hxTarget_ settingsContentTarget
-            , id_ $ "key" <> show i
             , term "data-tippy-content" tip
             ]
             $ faSprite_ icon "regular"
@@ -438,48 +412,33 @@ apiKeyColumns pid =
 
 
 copyNewApiKey :: Maybe (ProjectApiKeys.ProjectApiKey, Text) -> Bool -> Html ()
-copyNewApiKey newKeyM hasNext =
-  case newKeyM of
-    Nothing -> ""
-    Just (keyObj, newKey) -> do
-      div_ [id_ "apiFeedbackSection", class_ "pb-8"] do
-        div_ [class_ "rounded-md bg-fillSuccess-weak p-4"] do
-          div_ [class_ "flex"] do
-            div_ [class_ "shrink-0"] do
-              faSprite_ "circle-check" "regular" "h-5 w-5 text-iconSuccess"
-            div_ [class_ "ml-3"] do
-              h3_ [class_ " font-medium text-textSuccess"] "API Key was generated successfully"
-              div_ [class_ "mt-2  text-textSuccess py-2"] do
-                strong_ [class_ "block pt-2", id_ "newKey"] $ toHtml newKey
-              div_ [class_ "mt-4"] do
-                div_ [class_ "-mx-2 -my-1.5 flex"] do
-                  button_
-                    [ type_ "button"
-                    , class_ "btn btn-sm btn-success"
-                    , [__|
+copyNewApiKey newKeyM hasNext = whenJust newKeyM \(_, newKey) ->
+  div_ [id_ "apiFeedbackSection", class_ "pb-8"] do
+    div_ [class_ "rounded-md bg-fillSuccess-weak p-4"] do
+      div_ [class_ "flex"] do
+        div_ [class_ "shrink-0"] do
+          faSprite_ "circle-check" "regular" "h-5 w-5 text-iconSuccess"
+        div_ [class_ "ml-3"] do
+          h3_ [class_ " font-medium text-textSuccess"] "API Key was generated successfully"
+          div_ [class_ "mt-2  text-textSuccess py-2"] do
+            strong_ [class_ "block pt-2", id_ "newKey"] $ toHtml newKey
+          div_ [class_ "mt-4"] do
+            div_ [class_ "-mx-2 -my-1.5 flex"] do
+              button_
+                [ type_ "button"
+                , class_ "btn btn-sm btn-success"
+                , [__|
                       on click
                         if 'clipboard' in window.navigator then
                           call navigator.clipboard.writeText(#newKey's innerText)
                           send successToast(value:['API Key has been added to the Clipboard']) to <body/>
                         end
                         |]
-                    ]
-                    "Copy Key"
-                  if not hasNext
-                    then do
-                      button_
-                        [ type_ "button"
-                        , class_ "btn btn-sm btn-ghost text-textSuccess ml-2"
-                        , [__|on click remove #apiFeedbackSection|]
-                        ]
-                        "Dismiss"
-                    else do
-                      button_
-                        [ type_ "button"
-                        , class_ "btn btn-sm btn-ghost text-textBrand ml-4"
-                        , [__|on click call window.location.reload()|]
-                        ]
-                        "Next"
+                ]
+                "Copy Key"
+              if hasNext
+                then button_ [type_ "button", class_ "btn btn-sm btn-ghost text-textBrand ml-4", [__|on click call window.location.reload()|]] "Next"
+                else button_ [type_ "button", class_ "btn btn-sm btn-ghost text-textSuccess ml-2", [__|on click remove #apiFeedbackSection|]] "Dismiss"
 
 
 ----------------------------------------------------------------------
@@ -521,20 +480,31 @@ prometheusGetH pid = do
   addRespHeaders $ PrometheusGet $ PageCtx bw{pageTitle = "Prometheus", isSettingsPage = True} (pid, cfgs)
 
 
+-- | A 'PrometheusForm' that passed validation: trimmed, SSRF-checked, interval floored.
+data ScrapeTarget = ScrapeTarget
+  { name :: Text
+  , url :: Text
+  , interval :: Int
+  , authHeader :: Maybe Text
+  , labels :: AE.Value
+  }
+
+
 -- | Validate + normalise a target form. Name is required because it becomes the
 -- @service.name@ the scraped metrics are grouped under — blank names would silently
 -- collide multiple targets into one series namespace.
-validatePrometheusForm :: PrometheusForm -> Either Text (Text, Text, Int, Maybe Text, AE.Value)
+validatePrometheusForm :: PrometheusForm -> Either Text ScrapeTarget
 validatePrometheusForm form = do
   url <- validateScrapeUrl form.url
   when (T.null name) $ Left "A name is required — it groups the scraped metrics under service.name"
   Right
-    ( name
-    , url
-    , max 60 (fromMaybe 60 form.scrapeInterval) -- floor at the 60s dispatcher cadence
-    , mfilter (not . T.null) (T.strip <$> form.authHeader)
-    , parseLabelsText (fromMaybe "" form.extraLabels)
-    )
+    ScrapeTarget
+      { name
+      , url
+      , interval = max 60 (fromMaybe 60 form.scrapeInterval) -- floor at the 60s dispatcher cadence
+      , authHeader = mfilter (not . T.null) (T.strip <$> form.authHeader)
+      , labels = parseLabelsText (fromMaybe "" form.extraLabels)
+      }
   where
     name = T.strip form.name
 
@@ -605,31 +575,31 @@ safeScrapeUrl u = case parseURI (toString (T.strip u)) of
 
 
 prometheusPostH :: Projects.ProjectId -> PrometheusForm -> ATAuthCtx (RespHeaders PrometheusMut)
-prometheusPostH pid form = promSave pid form "Added" \(name, url, interval, authH, labels) -> PromCfg.insertConfig pid name url interval authH labels
+prometheusPostH pid form = promSave pid form "Added" \t -> PromCfg.insertConfig pid t.name t.url t.interval t.authHeader t.labels
 
 
 prometheusUpdateH :: Projects.ProjectId -> PromCfg.PrometheusScrapeConfigId -> PrometheusForm -> ATAuthCtx (RespHeaders PrometheusMut)
-prometheusUpdateH pid cid form = promSave pid form "Updated" \(name, url, interval, authH, labels) -> do
+prometheusUpdateH pid cid form = promSave pid form "Updated" \t -> do
   -- The edit form never echoes the saved token back into the password field, so a blank
   -- auth field means "keep the existing token" — unless "Clear saved token" was ticked.
-  keptAuth <- case authH of
-    Just t -> pure (Just t)
+  keptAuth <- case t.authHeader of
+    Just a -> pure (Just a)
     Nothing | isJust form.clearAuth -> pure Nothing
     Nothing -> PromCfg.getConfigByProject pid cid <&> (>>= (.authHeader))
-  PromCfg.updateConfig pid cid name url interval keptAuth labels
+  PromCfg.updateConfig pid cid t.name t.url t.interval keptAuth t.labels
 
 
 -- | Shared create/edit flow. The DB UNIQUE(project_id, name) constraint (migration 0103)
 -- is the real guard: catching its violation here — rather than a pre-check scan that two
 -- concurrent saves can both pass before either inserts — closes the race, saves a roundtrip,
 -- and still turns the collision into a friendly message.
-promSave :: Projects.ProjectId -> PrometheusForm -> Text -> ((Text, Text, Int, Maybe Text, AE.Value) -> ATAuthCtx Int64) -> ATAuthCtx (RespHeaders PrometheusMut)
+promSave :: Projects.ProjectId -> PrometheusForm -> Text -> (ScrapeTarget -> ATAuthCtx Int64) -> ATAuthCtx (RespHeaders PrometheusMut)
 promSave pid form verb persist = do
   _ <- Projects.sessionAndProject pid
   case validatePrometheusForm form of
     Left err -> addErrorToast err Nothing
-    Right vals@(name, _, _, _, _) ->
-      try (persist vals) >>= \case
+    Right target ->
+      try (persist target) >>= \case
         -- 0 rows means the edit targeted a row that no longer matches (concurrently deleted,
         -- or a cid that isn't this project's) — don't claim success for a write that did nothing.
         Right 0 -> addErrorToast "That Prometheus target no longer exists" Nothing
@@ -637,7 +607,7 @@ promSave pid form verb persist = do
           addSuccessToast (verb <> " Prometheus target") Nothing
           addTriggerEvent "closeModal" ""
         Left e
-          | Hasql.isUniqueViolation e -> addErrorToast ("A target named “" <> name <> "” already exists") Nothing
+          | Hasql.isUniqueViolation e -> addErrorToast ("A target named “" <> target.name <> "” already exists") Nothing
           | otherwise -> throwIO e
   prometheusMut pid
 
@@ -649,14 +619,14 @@ prometheusTestH :: Projects.ProjectId -> PrometheusForm -> ATAuthCtx (RespHeader
 prometheusTestH pid form = do
   _ <- Projects.sessionAndProject pid
   case validateScrapeUrl form.url of
-    Left err -> addRespHeaders $ prometheusTestResult (Left err)
+    Left err -> addRespHeaders $ prometheusTestResult $ Just $ Left err
     Right url -> do
       let opts = PromCfg.prometheusScrapeOpts (mfilter (not . T.null) (T.strip <$> form.authHeader))
       t0 <- Time.currentTime
       res <- tryAny (W.getWith opts (toString url))
       t1 <- Time.currentTime
       let ms = round (realToFrac (diffUTCTime t1 t0) * 1000 :: Double) :: Int
-      addRespHeaders $ prometheusTestResult $ case res of
+      addRespHeaders $ prometheusTestResult $ Just $ case res of
         Left e -> Left (T.take 300 (show e))
         Right resp ->
           -- Count only the samples ingestScrapedBody would store (shared isFiniteSample).
@@ -788,13 +758,13 @@ prometheusFields_ pid modalId submitLabel mcfg = do
       , class_ "btn btn-ghost gap-1.5"
       , hxPost_ $ "/p/" <> pid.toText <> "/settings/prometheus/test"
       , term "hx-include" "closest form"
-      , term "hx-target" "next .prom-test-result"
+      , hxTarget_ "next .prom-test-result"
       , hxSwap_ "outerHTML"
       ]
       $ do faSprite_ "circle-play" "regular" "w-3.5 h-3.5"; "Test connection"
     label_ [class_ "btn btn-ghost ml-auto", Lucid.for_ modalId] "Cancel"
     button_ [type_ "submit", class_ "btn btn-primary"] (toHtml submitLabel)
-  prometheusTestResult (Left "")
+  prometheusTestResult Nothing
   where
     field_ :: Text -> Text -> Text -> Text -> Bool -> Maybe Text -> Text -> Html ()
     field_ nm lbl ph ty req helpM val = label_ [class_ "flex flex-col gap-1 text-sm"] do
@@ -803,12 +773,12 @@ prometheusFields_ pid modalId submitLabel mcfg = do
       whenJust helpM $ span_ [class_ "text-xs text-textWeak"] . toHtml
 
 
-prometheusTestResult :: Either Text (Int, Int) -> Html ()
+-- | @Nothing@ is the not-yet-tested placeholder the form renders on first paint.
+prometheusTestResult :: Maybe (Either Text (Int, Int)) -> Html ()
 prometheusTestResult res = div_ [class_ "prom-test-result text-sm"] $ case res of
-  Right (n, ms) -> span_ [class_ "cbadge-sm badge-success inline-flex items-center gap-1"] $ faSprite_ "circle-check" "solid" "w-3 h-3" >> toHtml ("Scraped " <> show n <> " samples · " <> show ms <> "ms" :: Text)
-  Left err
-    | T.null err -> mempty
-    | otherwise -> span_ [class_ "cbadge-sm badge-error inline-flex items-center gap-1 max-w-full"] $ faSprite_ "circle-exclamation" "solid" "w-3 h-3 shrink-0" >> span_ [class_ "break-all"] (toHtml err)
+  Nothing -> mempty
+  Just (Right (n, ms)) -> span_ [class_ "cbadge-sm badge-success inline-flex items-center gap-1"] $ faSprite_ "circle-check" "solid" "w-3 h-3" >> toHtml ("Scraped " <> show n <> " samples · " <> show ms <> "ms" :: Text)
+  Just (Left err) -> span_ [class_ "cbadge-sm badge-error inline-flex items-center gap-1 max-w-full"] $ faSprite_ "circle-exclamation" "solid" "w-3 h-3 shrink-0" >> span_ [class_ "break-all"] (toHtml err)
 
 
 prometheusTargetsList :: Projects.ProjectId -> V.Vector PromCfg.PrometheusScrapeConfig -> Html ()
@@ -881,7 +851,7 @@ data TestHistory = TestHistory
   , createdAt :: UTCTime
   }
   deriving stock (Eq, Generic, Show)
-  deriving anyclass (FromRow, HI.DecodeRow, ToRow)
+  deriving anyclass (HI.DecodeRow)
 
 
 newtype NotificationTestHistoryGet = NotificationTestHistoryGet {tests :: [TestHistory]}
@@ -890,7 +860,7 @@ newtype NotificationTestHistoryGet = NotificationTestHistoryGet {tests :: [TestH
 
 instance ToHtml NotificationTestHistoryGet where
   toHtml (NotificationTestHistoryGet tests) = toHtmlRaw $ historyHtml_ tests
-  toHtmlRaw (NotificationTestHistoryGet tests) = toHtmlRaw $ historyHtml_ tests
+  toHtmlRaw = toHtml
 
 
 notificationsTestPostH :: Projects.ProjectId -> TestForm -> ATAuthCtx (RespHeaders (Html ()))
@@ -903,67 +873,52 @@ notificationsTestPostH pid TestForm{..} = do
 
   (_, project) <- Projects.sessionAndProject pid
   let baseAlert = bool (sampleAlertByIssueTypeText issueType project.title) (sampleReport project.title) (issueType == "report")
-      getTeam tid = listToMaybe <$> getTeamsById pid (V.singleton tid)
   -- Build a real signed widget URL so the test exercises the same image path
   -- as production alerts (webhook transport lifts it into attachments.image_url).
   -- The chart may be empty for the sample hash; what matters is that signing,
   -- URL length, and the webhook flatten/lift logic are all on the critical path.
-  appCtxForChart <- ask @AuthContext
-  nowUtc <- Time.currentTime
-  let fromUtc = addUTCTime (-3600) nowUtc
+  appCtx <- ask @AuthContext
   alert <- case baseAlert of
     RuntimeErrorAlert{errorData} -> do
       let errHash = (errorData :: ErrorPatterns.ATError).hash
-      chartUrlM <- errorTrendChartUrl appCtxForChart pid errHash (formatUTC fromUtc) (formatUTC nowUtc)
+      chartUrlM <- errorTrendChartUrl appCtx pid errHash (formatUTC (addUTCTime (-3600) now)) (formatUTC now)
       pure baseAlert{chartUrl = chartUrlM}
     _ -> pure baseAlert
 
   Log.logTrace "Sending test notification" (channel, pid, issueType)
-  appCtx <- ask @AuthContext
 
   let projectUrl = "/p/" <> pid.toText
       fullProjectUrl = appCtx.env.hostUrl <> "p/" <> pid.toText
-      testTemplate = case issueType of
-        "runtime_exception" -> ET.runtimeErrorsEmail project.title (fullProjectUrl <> "/issues/") [] Nothing Nothing Nothing
-        "escalating_errors" -> ET.escalatingErrorsEmail project.title (fullProjectUrl <> "/issues/") [] Nothing Nothing Nothing
-        "regressed_errors" -> ET.regressedErrorsEmail project.title (fullProjectUrl <> "/issues/") [] Nothing Nothing Nothing
-        "error_spike" -> ET.errorSpikesEmail project.title (fullProjectUrl <> "/issues/") [] Nothing Nothing Nothing
-        "report" -> ET.sampleWeeklyReport "" ""
-        _ -> ET.anomalyEndpointEmail "Test User" project.title (fullProjectUrl <> "/issues") [ET.EndpointAlertRow "GET /api/v1/test" (Just "api.example.com") (Just "api-service") (Just "production")]
+      testTemplate
+        | Just mk <- lookup issueType [("runtime_exception", ET.runtimeErrorsEmail), ("escalating_errors", ET.escalatingErrorsEmail), ("regressed_errors", ET.regressedErrorsEmail), ("error_spike", ET.errorSpikesEmail)] =
+            mk project.title (fullProjectUrl <> "/issues/") [] Nothing Nothing Nothing
+        | issueType == "report" = ET.sampleWeeklyReport "" ""
+        | otherwise = ET.anomalyEndpointEmail "Test User" project.title (fullProjectUrl <> "/issues") [ET.EndpointAlertRow "GET /api/v1/test" (Just "api.example.com") (Just "api-service") (Just "production")]
       sendTestEmail email = let (subj, html) = testTemplate; subj' = "[Test] " <> subj in sendRenderedEmail email subj' (ET.renderEmail subj' html)
 
   -- The @everyone team is the single source of truth for project notification settings,
   -- so tests always resolve against a team — the provided one, or @everyone when omitted.
-  let targetTeam = case teamId of
-        Just tid -> getTeam tid
-        Nothing -> ProjectMembers.getEveryoneTeam pid
-      countingSend mChKey (count, reason) run =
+  let targetTeam = maybe (ProjectMembers.getEveryoneTeam pid) (\tid -> listToMaybe <$> getTeamsById pid (V.singleton tid)) teamId
+      countingSend mChKey run =
         targetTeam >>= \case
-          Nothing -> pure (count, Just "no_team")
-          Just t | Just chKey <- mChKey, not (ProjectMembers.isChannelEnabled chKey t) -> pure (count, Just "channel_disabled")
-          Just t -> (,reason) . (+ count) <$> run t
-      sent = pure
-      -- per-channel attempt counts
-      slack t = do forM_ t.slack_channels (sendSlackAlert alert pid project.title . Just); sent (V.length t.slack_channels)
-      discord t = do forM_ t.discord_channels (sendDiscordAlert alert pid project.title . Just); sent (V.length t.discord_channels)
-      whatsapp t = if V.null t.phone_numbers then sent 0 else sent (V.length t.phone_numbers) <* sendWhatsAppAlert alert pid project.title t.phone_numbers
-      pagerduty t = do forM_ t.pagerduty_services \k -> sendPagerdutyAlertToService k alert project.title projectUrl; sent (V.length t.pagerduty_services)
-      email t = let emails = map CI.original (resolveTeamEmails t) in forM_ emails sendTestEmail *> sent (length emails)
+          Nothing -> pure (0 :: Int, Just "no_team")
+          Just t | Just chKey <- mChKey, not (ProjectMembers.isChannelEnabled chKey t) -> pure (0, Just "channel_disabled")
+          Just t -> (,Nothing) <$> run t
+      -- per-channel attempt counts, keyed by the form's `channel` value
+      senders :: [(Text, Maybe ProjectMembers.NotificationChannel, Team -> ATAuthCtx Int)]
+      senders =
+        [ ("email", Nothing, \t -> let emails = map CI.original (resolveTeamEmails t) in forM_ emails sendTestEmail $> length emails)
+        , ("slack", Just ProjectMembers.Slack, \t -> forM_ t.slack_channels (sendSlackAlert alert pid project.title . Just) $> V.length t.slack_channels)
+        , ("discord", Just ProjectMembers.Discord, \t -> forM_ t.discord_channels (sendDiscordAlert alert pid project.title . Just) $> V.length t.discord_channels)
+        , ("whatsapp", Just ProjectMembers.Phone, \t -> if V.null t.phone_numbers then pure 0 else sendWhatsAppAlert alert pid project.title t.phone_numbers $> V.length t.phone_numbers)
+        , ("pagerduty", Just ProjectMembers.Pagerduty, \t -> forM_ t.pagerduty_services (\k -> sendPagerdutyAlertToService k alert project.title projectUrl) $> V.length t.pagerduty_services)
+        ]
 
   (attempts, skipReason) <- case channel of
-    "all" -> countingSend Nothing (0, Nothing) \t -> do
-      e <- email t
-      s <- slack t
-      d <- discord t
-      w <- whatsapp t
-      p <- pagerduty t
-      pure (e + s + d + w + p)
-    "email" -> countingSend Nothing (0, Nothing) email
-    "slack" -> countingSend (Just ProjectMembers.Slack) (0, Nothing) slack
-    "discord" -> countingSend (Just ProjectMembers.Discord) (0, Nothing) discord
-    "whatsapp" -> countingSend (Just ProjectMembers.Phone) (0, Nothing) whatsapp
-    "pagerduty" -> countingSend (Just ProjectMembers.Pagerduty) (0, Nothing) pagerduty
-    _ -> throwError err400{errBody = "Unknown notification channel"}
+    "all" -> countingSend Nothing \t -> sum <$> traverse (\(_, _, run) -> run t) senders
+    c -> case find (\(n, _, _) -> n == c) senders of
+      Just (_, chKey, run) -> countingSend chKey run
+      Nothing -> throwError err400{errBody = "Unknown notification channel"}
 
   let (status, err) = case (attempts, skipReason) of
         (_, Just r) -> ("skipped" :: Text, Just r)
@@ -974,10 +929,10 @@ notificationsTestPostH pid TestForm{..} = do
       [HI.sql|INSERT INTO apis.notification_test_history (project_id, issue_type, channel, target, status, error) VALUES (#{pid}, #{issueType}, #{channel}, #{("" :: Text)}, #{status}, #{err})|]
 
   Log.logTrace "Test notification complete" (channel, pid, status, attempts)
-  let toast = case status of
-        "sent" -> addSuccessToast (if channel == "all" then "Test notification sent to all channels!" else "Test " <> channel <> " notification sent!") Nothing
-        _ -> addErrorToast ("Test skipped: " <> fromMaybe "unknown" err) Nothing
-  toast >> addRespHeaders mempty
+  if status == "sent"
+    then addSuccessToast (if channel == "all" then "Test notification sent to all channels!" else "Test " <> channel <> " notification sent!") Nothing
+    else addErrorToast ("Test skipped: " <> fromMaybe "unknown" err) Nothing
+  addRespHeaders mempty
 
 
 notificationsTestHistoryGetH :: Projects.ProjectId -> ATAuthCtx (RespHeaders NotificationTestHistoryGet)
@@ -987,12 +942,11 @@ notificationsTestHistoryGetH pid = do
 
 
 historyHtml_ :: [TestHistory] -> Html ()
-historyHtml_ tests = if null tests then emptyMsg else renderTable tests
+historyHtml_ [] = div_ [class_ "text-center py-12"] do
+  div_ [class_ "text-textWeak mb-2"] "No test notifications sent yet"
+  p_ [class_ "text-sm text-textWeaker"] "Test your integrations to see results here"
+historyHtml_ tests = div_ [class_ "bg-bgRaised rounded-lg border border-strokeWeak overflow-hidden"] $ table_ [class_ "table table-sm w-full"] (thead_ [class_ "text-xs text-left text-textStrong font-semibold uppercase bg-fillWeaker border-b border-strokeWeak"] (tr_ (th_ [class_ "p-3"] "Status" <> th_ [class_ "p-3"] "Channel" <> th_ [class_ "p-3"] "Alert Type" <> th_ [class_ "p-3 text-right"] "Time")) <> tbody_ [class_ "text-sm divide-y divide-strokeWeak"] (foldMap' renderRow tests))
   where
-    emptyMsg = div_ [class_ "text-center py-12"] do
-      div_ [class_ "text-textWeak mb-2"] "No test notifications sent yet"
-      p_ [class_ "text-sm text-textWeaker"] "Test your integrations to see results here"
-    renderTable ts = div_ [class_ "bg-bgRaised rounded-lg border border-strokeWeak overflow-hidden"] $ table_ [class_ "table table-sm w-full"] (thead_ [class_ "text-xs text-left text-textStrong font-semibold uppercase bg-fillWeaker border-b border-strokeWeak"] (tr_ (th_ [class_ "p-3"] "Status" <> th_ [class_ "p-3"] "Channel" <> th_ [class_ "p-3"] "Alert Type" <> th_ [class_ "p-3 text-right"] "Time")) <> tbody_ [class_ "text-sm divide-y divide-strokeWeak"] (foldMap' renderRow ts))
     renderRow t = tr_ [class_ "hover-only:hover:bg-fillWeaker transition-colors"] (td_ [class_ "p-3"] (if t.status == "sent" then span_ [class_ "badge badge-success badge-sm gap-1"] (faSprite_ "check" "solid" "h-3 w-3" >> "Sent") else span_ [class_ "badge badge-error badge-sm gap-1"] (faSprite_ "xmark" "solid" "h-3 w-3" >> "Failed")) <> td_ [class_ "p-3 capitalize font-medium"] (toHtml $ if t.channel == "all" then "All channels" else t.channel) <> td_ [class_ "p-3 text-textWeak"] (toHtml $ T.replace "_" " " t.issueType) <> td_ [class_ "p-3 text-right tabular-nums text-textWeak"] (localTimeFmt_ "MMM dd, HH:mm" t.createdAt))
 
 
@@ -1080,14 +1034,10 @@ webhookPostH :: Maybe Text -> ByteString -> ATBaseCtx (Html ())
 webhookPostH sigHeaderM rawBody = do
   envConfig <- asks env
   let secret = encodeUtf8 envConfig.lemonSqueezyWebhookSecret
-      sigValid = case sigHeaderM of
-        Just h -> verifyLemonSqueezySignature h rawBody secret
-        Nothing -> False
+      sigValid = maybe False (\h -> verifyLemonSqueezySignature h rawBody secret) sigHeaderM
   unless sigValid $ Log.logAttention "ls_webhook_sig_mismatch" (T.take 8 <$> sigHeaderM, BS.length rawBody)
-  when envConfig.lsWebhookSigEnforce $ case sigHeaderM of
-    Nothing -> throwError err400{errBody = "missing signature"}
-    Just _ | not sigValid -> throwError err400{errBody = "invalid signature"}
-    _ -> pass
+  when (envConfig.lsWebhookSigEnforce && not sigValid)
+    $ throwError err400{errBody = bool "invalid signature" "missing signature" (isNothing sigHeaderM)}
   dat <- case AE.eitherDecodeStrict rawBody :: Either String WebhookData of
     Right d -> pure d
     Left err -> do
@@ -1101,8 +1051,7 @@ webhookPostH sigHeaderM rawBody = do
         users <- Projects.usersByProjectId pid
         forM_ users \u -> sendRenderedEmail (CI.original u.email) subj (ET.renderEmail subj html)
       downgrade reason = do
-        projectM <- Projects.projectByOrderId (show orderId)
-        case projectM of
+        Projects.projectByOrderId (show orderId) >>= \case
           Just project -> do
             rows <- Projects.downgradeToFree orderId subItem.subscriptionId subItem.id
             when (rows == 0) $ Log.logAttention "LS downgrade touched 0 rows" (show orderId :: Text, reason)
@@ -1115,8 +1064,7 @@ webhookPostH sigHeaderM rawBody = do
         rows <- Projects.upgradeToPaid orderId subItem.subscriptionId subItem.id plan
         when (rows == 0) $ Log.logAttention "LS upgrade touched 0 rows" (show orderId :: Text, subItem.subscriptionId, plan)
         when (rows > 1) $ Log.logAttention "LS upgrade touched multiple rows" (show orderId :: Text, rows)
-        projectM <- Projects.projectBySubId (show subItem.subscriptionId)
-        case projectM of
+        Projects.projectBySubId (show subItem.subscriptionId) >>= \case
           Just project -> notifyMembers project.id $ ET.planUpgradedEmail project.title plan (billingUrl project.id)
           Nothing -> Log.logAttention "LS upgrade: no project for sub_id" (show orderId :: Text, subItem.subscriptionId, plan)
         pure "upgraded"
@@ -1124,10 +1072,8 @@ webhookPostH sigHeaderM rawBody = do
     "subscription_created" -> do
       currentTime <- liftIO getZonedTime
       subId <- Projects.LemonSubId <$> liftIO UUIDV4.nextRandom
-      let projectId = case dat.meta.customData of
-            Nothing -> ""
-            Just d -> fromMaybe "" d.projectId
-      let sub =
+      let projectId = fromMaybe "" (dat.meta.customData >>= (.projectId))
+          sub =
             Projects.LemonSub
               { id = subId
               , createdAt = currentTime
@@ -1229,31 +1175,23 @@ manageBillingGetH pid from = do
         ]
   let last_reported = toText (formatTime defaultTimeLocale "%b %-d" project.usageLastReported)
       bwconf = bw{pageTitle = "Billing", isSettingsPage = True}
-  let lemonUrl = envCfg.lemonSqueezyUrl <> "&checkout[custom][project_id]=" <> pid.toText
+      lemonUrl = envCfg.lemonSqueezyUrl <> "&checkout[custom][project_id]=" <> pid.toText
       critical = envCfg.lemonSqueezyCriticalUrl <> "&checkout[custom][project_id]=" <> pid.toText
-  -- Free-tier display shows no provider even for a historically-paid-then-downgraded project
-  -- (which keeps its stored provider so trial-reminder/auto-migration logic still works).
-  let provider = if Projects.isFreeTier project.paymentPlan then Projects.NoBillingProvider else Projects.projectProvider project
+      -- Free-tier display shows no provider even for a historically-paid-then-downgraded project
+      -- (which keeps its stored provider so trial-reminder/auto-migration logic still works).
+      provider = if Projects.isFreeTier project.paymentPlan then Projects.NoBillingProvider else Projects.projectProvider project
   addRespHeaders $ BillingGet $ PageCtx bwconf BillingData{pid, totalReqs = totalRequests, totalBytes, lastReported = last_reported, lemonUrl, critical, paymentPlan = project.paymentPlan, enableFreetier = envCfg.enableFreetier, basicAuthEnabled = envCfg.basicAuthEnabled, provider, dailyUsage, cycleStart = utctDay cycleStart, pastCycles}
 
 
 billingPage :: BillingData -> Html ()
 billingPage d = div_ [] do
-  let pid = d.pid
-      reqs = d.totalReqs
-      last_reported = d.lastReported
-      lemonUrl = d.lemonUrl
-      critical = d.critical
-      paymentPlan = d.paymentPlan
-      enableFreetier = d.enableFreetier
-      basicAuthEnabled = d.basicAuthEnabled
-      provider = d.provider
-      pidTxt = pid.toText
-      isFree = Projects.isFreeTier paymentPlan
+  let reqs = d.totalReqs
+      pidTxt = d.pid.toText
+      isFree = Projects.isFreeTier d.paymentPlan
       basePriceNum =
         if
           | isFree -> 0
-          | paymentPlan == "Bring your own storage" -> 199
+          | d.paymentPlan == "Bring your own storage" -> 199
           | otherwise -> 29 :: Int64
       planPrice = show basePriceNum
       overageNum = max 0 (reqs - 20_000_000)
@@ -1268,7 +1206,7 @@ billingPage d = div_ [] do
     -- Current plan row
     headerRow_ [] do
       div_ [class_ "flex items-center gap-3"] do
-        span_ [class_ "text-sm font-medium text-textStrong"] $ toHtml paymentPlan
+        span_ [class_ "text-sm font-medium text-textStrong"] $ toHtml d.paymentPlan
         span_ [class_ "rounded-md text-textWeak bg-fillWeak border border-strokeWeak py-0.5 px-2 text-xs"] "Active"
       div_ [class_ "flex items-baseline gap-0.5"] do
         span_ [class_ "text-2xl text-textStrong font-bold tabular-nums"] $ toHtml $ "$" <> planPrice
@@ -1287,15 +1225,15 @@ billingPage d = div_ [] do
                 then fmt (commaizeF reqs) <> " requests" <> bytesSuffix
                 else "$" <> planPrice <> " plan + " <> fmtUSD overageCost <> " usage (" <> fmt (commaizeF reqs) <> " requests" <> bytesSuffix <> ")"
         div_ [class_ "text-xs text-textWeak mt-1 tabular-nums"] $ toHtml usageLine
-      unless (T.null last_reported)
+      unless (T.null d.lastReported)
         $ div_ [class_ "text-xs text-textWeak"]
-        $ toHtml ("Last reported " <> last_reported)
+        $ toHtml ("Last reported " <> d.lastReported)
 
     -- Actions (kept above the breakdown so they remain near the headline numbers)
     div_ [class_ "border-t border-strokeWeak pt-6 flex items-center gap-3"] do
       label_ [Lucid.for_ "pricing-modal", class_ "btn btn-sm btn-primary cursor-pointer"] "Change plan"
       unless isFree
-        $ a_ [class_ "btn btn-sm btn-ghost text-textBrand", hxGet_ [text| /p/$pidTxt/manage_subscription |]] "Manage subscription"
+        $ a_ [class_ "btn btn-sm btn-ghost text-textBrand", hxGet_ $ "/p/" <> pidTxt <> "/manage_subscription"] "Manage subscription"
 
     -- Daily breakdown
     dailyUsageBreakdown_ isFree d.cycleStart d.dailyUsage
@@ -1307,7 +1245,7 @@ billingPage d = div_ [] do
     div_ [class_ "text-center text-sm text-textWeak w-full mx-auto max-w-96"] do
       span_ [class_ "text-textStrong text-2xl font-semibold"] "Compare Plans"
       p_ [class_ "mt-2 mb-4"] "Drag the slider to estimate costs at different usage levels."
-    paymentPlanPicker pid lemonUrl critical paymentPlan enableFreetier basicAuthEnabled False provider
+    paymentPlanPicker d.pid d.lemonUrl d.critical d.paymentPlan d.enableFreetier d.basicAuthEnabled False d.provider
 
 
 -- | Format a byte count with the largest unit it fits into. KB-step decimal
@@ -1320,6 +1258,11 @@ humanBytes b
   | otherwise = fmtNum (fromIntegral b / 1_073_741_824 :: Double) <> " GB"
   where
     fmtNum n = toText (printf "%.1f" n :: String)
+
+
+-- | Sticky table header cell: opaque background so scrolled rows can't show through.
+stickyTh_ :: Text -> Html () -> Html ()
+stickyTh_ cls = th_ [class_ ("font-medium px-3 py-2 sticky top-0 z-10 bg-fillWeak border-b border-strokeWeak " <> cls)]
 
 
 -- | Per-day usage table for the last 30 days. Cost shown is the marginal
@@ -1372,17 +1315,15 @@ dailyUsageBreakdown_ isFree cycleStartDay rows = div_ [class_ "border-t border-s
           span_ [] "Only logs and traces have been ingested."
       div_ [class_ "border border-strokeWeak rounded-md overflow-hidden max-h-96 overflow-y-auto"] do
         table_ [class_ "w-full text-sm tabular-nums border-separate border-spacing-0"] do
-          -- Sticky header: each <th> carries its own opaque background so that
-          -- body rows can't show through during scroll. `border-separate` keeps
-          -- the border-bottom rule from being clipped by sticky positioning.
-          let th_h cls = th_ [class_ ("font-medium px-3 py-2 sticky top-0 z-10 bg-fillWeak border-b border-strokeWeak " <> cls)]
+          -- `border-separate` keeps the header's border-bottom from being clipped
+          -- by sticky positioning.
           thead_ [class_ "text-textWeak text-xs uppercase tracking-wide"] do
             tr_ do
-              th_h "text-left" "Date"
-              th_h "text-right" "Events"
-              th_h "text-right" "Metrics"
-              th_h "text-left w-1/4" ""
-              th_h "text-right" "Est. cost"
+              stickyTh_ "text-left" "Date"
+              stickyTh_ "text-right" "Events"
+              stickyTh_ "text-right" "Metrics"
+              stickyTh_ "text-left w-1/4" ""
+              stickyTh_ "text-right" "Est. cost"
           let countCell :: Int64 -> Int64 -> Bool -> Html ()
               countCell bytes n0 strong = td_ [class_ "px-3 py-2 text-right whitespace-nowrap"] do
                 div_ [class_ (if strong then "text-textStrong" else "text-textWeak")]
@@ -1433,13 +1374,12 @@ pastCyclesSection_ isFree basePrice cycles = div_ [class_ "border-t border-strok
     span_ [class_ "text-xs text-textWeak"] $ toHtml @Text (show (length cycles) <> " cycle" <> (if length cycles == 1 then "" else "s"))
   div_ [class_ "border border-strokeWeak rounded-md overflow-hidden"] do
     table_ [class_ "w-full text-sm tabular-nums border-separate border-spacing-0"] do
-      let th_h cls = th_ [class_ ("font-medium px-3 py-2 sticky top-0 z-10 bg-fillWeak border-b border-strokeWeak " <> cls)]
       thead_ [class_ "text-textWeak text-xs uppercase tracking-wide"] do
         tr_ do
-          th_h "text-left" "Cycle"
-          th_h "text-right" "Requests"
-          th_h "text-right" "Volume"
-          th_h "text-right" "Est. cost"
+          stickyTh_ "text-left" "Cycle"
+          stickyTh_ "text-right" "Requests"
+          stickyTh_ "text-right" "Volume"
+          stickyTh_ "text-right" "Est. cost"
       tbody_ do
         forM_ cycles \(cs, ce, reqs, bytes) -> do
           -- ce is exclusive end; subtract 1 day for the human-facing label.
@@ -1583,12 +1523,14 @@ stripeWebhookPostH sigHeaderM rawBody = do
             billingUrl pid = envConfig.hostUrl <> "p/" <> pid.toText <> "/manage_billing"
         case (eventType, sessionObj) of
           (Just "checkout.session.completed", Just obj) -> handleStripeCheckout envConfig obj notifyMembers billingUrl
-          (Just "customer.subscription.deleted", Just obj) -> handleStripeSubDeleted obj notifyMembers billingUrl
+          (Just "customer.subscription.deleted", Just obj) -> handleStripeDowngrade "subscription.deleted" "was cancelled" obj notifyMembers billingUrl
           (Just "customer.subscription.updated", Just obj) -> handleStripeSubUpdated obj
-          (Just "customer.subscription.paused", Just obj) -> handleStripeSubPaused obj notifyMembers billingUrl
+          (Just "customer.subscription.paused", Just obj) -> handleStripeDowngrade "subscription.paused" "was paused" obj notifyMembers billingUrl
           (Just "customer.subscription.resumed", Just obj) -> handleStripeSubResumed envConfig obj notifyMembers billingUrl
           (Just "invoice.payment_failed", Just obj) -> handleStripePaymentFailed obj notifyMembers billingUrl
-          _ -> pure ""
+          _ -> do
+            Log.logInfo "Stripe webhook unhandled event" (eventType, isJust sessionObj)
+            pure ""
 
 
 handleStripeCheckout :: EnvConfig -> AE.Value -> (Projects.ProjectId -> (Text, Html ()) -> ATBaseCtx ()) -> (Projects.ProjectId -> Text) -> ATBaseCtx (Html ())
@@ -1615,7 +1557,7 @@ handleStripeCheckout envConfig obj notifyMembers billingUrl = do
               _ -> pass
           subDetails <- liftIO $ BJ.getStripeSubDetails envConfig.stripeSecretKey subId
           when (isNothing subDetails) $ Log.logAttention "Stripe sub fetch failed after checkout" (pid.toText, subId)
-          let subItemId = maybe "" (\BJ.StripeSubDetails{subItemId = i} -> i) subDetails
+          let subItemId = maybe "" (.subItemId) subDetails
           void $ Projects.updateStripeProjectBilling pid plan subId subItemId customerId
           void $ ProjectMembers.activateAllMembers pid
           case subDetails of
@@ -1630,26 +1572,20 @@ handleStripeCheckout envConfig obj notifyMembers billingUrl = do
       pure "missing fields"
 
 
--- Returns (first subscription item id, first price id) so callers can reverse-map
--- the price id back to our internal plan name.
-getStripeSubItemAndPrice :: Text -> Text -> IO (Maybe (Text, Text))
-getStripeSubItemAndPrice apiKey subId =
-  fmap (\BJ.StripeSubDetails{subItemId = i, priceId = p} -> (i, p)) <$> BJ.getStripeSubDetails apiKey subId
-
-
-handleStripeSubDeleted :: AE.Value -> (Projects.ProjectId -> (Text, Html ()) -> ATBaseCtx ()) -> (Projects.ProjectId -> Text) -> ATBaseCtx (Html ())
-handleStripeSubDeleted obj notifyMembers billingUrl = do
-  let subIdM = jsonField "id" obj :: Maybe Text
-  case subIdM of
+-- | Shared body of subscription.deleted / .paused: downgrade by sub_id, then notify.
+-- @event@ names the Stripe event in logs, @reason@ is the user-facing wording.
+handleStripeDowngrade :: Text -> Text -> AE.Value -> (Projects.ProjectId -> (Text, Html ()) -> ATBaseCtx ()) -> (Projects.ProjectId -> Text) -> ATBaseCtx (Html ())
+handleStripeDowngrade event reason obj notifyMembers billingUrl =
+  case jsonField "id" obj :: Maybe Text of
     Just subId -> do
       rows <- Projects.downgradeToFreeBySubId subId
-      when (rows == 0) $ Log.logAttention "Stripe subscription.deleted: no project for sub_id" subId
-      when (rows > 1) $ Log.logAttention "Stripe subscription.deleted touched multiple rows" (subId, rows)
+      when (rows == 0) $ Log.logAttention ("Stripe " <> event <> ": no project for sub_id") subId
+      when (rows > 1) $ Log.logAttention ("Stripe " <> event <> " touched multiple rows") (subId, rows)
       whenJustM (Projects.projectBySubId subId) \project ->
-        notifyMembers project.id $ ET.planDowngradedEmail project.title "was cancelled" (billingUrl project.id)
-      pure "subscription deleted"
+        notifyMembers project.id $ ET.planDowngradedEmail project.title reason (billingUrl project.id)
+      pure $ toHtml $ T.replace "." " " event
     Nothing -> do
-      Log.logAttention "Stripe subscription.deleted: missing sub id" ()
+      Log.logAttention ("Stripe " <> event <> ": missing sub id") ()
       pure "missing sub id"
 
 
@@ -1668,45 +1604,25 @@ handleStripeSubUpdated obj = do
 -- Downgrade happens via customer.subscription.deleted when Stripe gives up.
 handleStripePaymentFailed :: AE.Value -> (Projects.ProjectId -> (Text, Html ()) -> ATBaseCtx ()) -> (Projects.ProjectId -> Text) -> ATBaseCtx (Html ())
 handleStripePaymentFailed obj notifyMembers billingUrl = do
-  let customerIdM = jsonField "customer" obj :: Maybe Text
-      attemptCount = jsonField "attempt_count" obj :: Maybe Int
+  let attemptCount = jsonField "attempt_count" obj :: Maybe Int
       nextAttempt = jsonField "next_payment_attempt" obj :: Maybe Int
-  case customerIdM of
-    Just customerId -> do
-      whenJustM (Projects.projectByCustomerId customerId) \project -> do
-        Log.logAttention "Stripe invoice.payment_failed" (project.id, attemptCount, nextAttempt)
-        notifyMembers project.id $ ET.planDowngradedEmail project.title "payment failed" (billingUrl project.id)
-    Nothing -> pass
+  whenJust (jsonField "customer" obj :: Maybe Text) \customerId ->
+    whenJustM (Projects.projectByCustomerId customerId) \project -> do
+      Log.logAttention "Stripe invoice.payment_failed" (project.id, attemptCount, nextAttempt)
+      notifyMembers project.id $ ET.planDowngradedEmail project.title "payment failed" (billingUrl project.id)
   pure "payment failed handled"
 
 
--- Preserve IDs on pause so resume can restore plan without re-checkout.
-handleStripeSubPaused :: AE.Value -> (Projects.ProjectId -> (Text, Html ()) -> ATBaseCtx ()) -> (Projects.ProjectId -> Text) -> ATBaseCtx (Html ())
-handleStripeSubPaused obj notifyMembers billingUrl = do
-  let subIdM = jsonField "id" obj :: Maybe Text
-  case subIdM of
-    Just subId -> do
-      rows <- Projects.downgradeToFreeBySubId subId
-      when (rows == 0) $ Log.logAttention "Stripe subscription.paused: no project for sub_id" subId
-      when (rows > 1) $ Log.logAttention "Stripe subscription.paused touched multiple rows" (subId, rows)
-      when (rows > 0)
-        $ whenJustM (Projects.projectBySubId subId) \project ->
-          notifyMembers project.id $ ET.planDowngradedEmail project.title "was paused" (billingUrl project.id)
-      pure "subscription paused"
-    Nothing -> do
-      Log.logAttention "Stripe subscription.paused: missing sub id" ()
-      pure "missing sub id"
-
-
 -- Look up the sub's price via the Stripe API, reverse-map to our plan name, and re-upgrade.
+-- (Pause preserved the IDs, so resume never needs a re-checkout.)
 handleStripeSubResumed :: EnvConfig -> AE.Value -> (Projects.ProjectId -> (Text, Html ()) -> ATBaseCtx ()) -> (Projects.ProjectId -> Text) -> ATBaseCtx (Html ())
-handleStripeSubResumed envConfig obj notifyMembers billingUrl = do
-  let subIdM = jsonField "id" obj :: Maybe Text
-  case subIdM of
+handleStripeSubResumed envConfig obj notifyMembers billingUrl =
+  case jsonField "id" obj :: Maybe Text of
     Just subId -> do
-      itemAndPriceM <- liftIO $ getStripeSubItemAndPrice envConfig.stripeSecretKey subId
-      case itemAndPriceM of
-        Just (itemId, priceId) -> do
+      subDetailsM <- liftIO $ BJ.getStripeSubDetails envConfig.stripeSecretKey subId
+      case subDetailsM of
+        -- the price id reverse-maps to our internal plan name
+        Just BJ.StripeSubDetails{subItemId = itemId, priceId} -> do
           let plan
                 | priceId == envConfig.stripePriceIdByos = "SystemsPricing"
                 | otherwise = "GraduatedPricing"

--- a/src/Pages/Settings.hs
+++ b/src/Pages/Settings.hs
@@ -271,11 +271,11 @@ apiPostH pid apiKeyForm = do
 
 
 apiDeleteH :: Projects.ProjectId -> ProjectApiKeys.ProjectApiKeyId -> ATAuthCtx (RespHeaders ApiMut)
-apiDeleteH pid keyid = apiKeySetActive pid ProjectApiKeys.revokeApiKey Projects.AEApiKeyRevoked "Revoked" keyid
+apiDeleteH pid = apiKeySetActive pid ProjectApiKeys.revokeApiKey Projects.AEApiKeyRevoked "Revoked"
 
 
 apiActivateH :: Projects.ProjectId -> ProjectApiKeys.ProjectApiKeyId -> ATAuthCtx (RespHeaders ApiMut)
-apiActivateH pid keyid = apiKeySetActive pid ProjectApiKeys.activateApiKey Projects.AEApiKeyActivated "Activated" keyid
+apiActivateH pid = apiKeySetActive pid ProjectApiKeys.activateApiKey Projects.AEApiKeyActivated "Activated"
 
 
 apiKeySetActive :: Projects.ProjectId -> (ProjectApiKeys.ProjectApiKeyId -> ATAuthCtx Int64) -> Projects.AuditEvent -> Text -> ProjectApiKeys.ProjectApiKeyId -> ATAuthCtx (RespHeaders ApiMut)

--- a/src/Pages/Share.hs
+++ b/src/Pages/Share.hs
@@ -167,7 +167,7 @@ sharePage v = do
     ShareMissing -> Nothing
   section_ [class_ "share-view max-w-6xl mx-auto w-full px-4 pt-6 flex flex-col gap-6"] $ case v of
     ShareLive{breakdown, detail, replay} -> do
-      whenJust breakdown \bd -> div_ [class_ "border border-strokeWeak rounded-lg bg-bgBase"] bd
+      whenJust breakdown $ div_ [class_ "border border-strokeWeak rounded-lg bg-bgBase"]
       whenJust replay \(shareId, projectId, sessionId) ->
         div_ [class_ "flex flex-col gap-2"] do
           div_ [class_ "flex items-center gap-2 px-1"] do

--- a/src/Pages/Share.hs
+++ b/src/Pages/Share.hs
@@ -1,4 +1,4 @@
-module Pages.Share (ReqForm (..), shareLinkPostH, shareLinkGetH, shareReplaySessionGetH, ShareLinkGet (..), ShareLinkPost (..)) where
+module Pages.Share (shareLinkPostH, shareLinkGetH, shareReplaySessionGetH, ShareLinkGet (..), ShareLinkPost (..)) where
 
 import Data.Default (def)
 import Data.Effectful.Hasql qualified as Hasql
@@ -26,7 +26,6 @@ import Servant (err404)
 import System.Config (AuthContext (..), EnvConfig (..))
 import System.Types (ATAuthCtx, ATBaseCtx, RespHeaders, addRespHeaders)
 import UnliftIO.Exception (throwIO)
-import Web.FormUrlEncoded (FromForm)
 
 
 -- | Result of resolving a share id: missing entirely, expired, or live with hours-remaining + body.
@@ -41,38 +40,19 @@ data ShareView
       }
 
 
-data ReqForm = ReqForm
-  { expiresIn :: Text
-  , reqId :: UUID.UUID
-  , reqCreatedAt :: UTCTime
-  }
-  deriving stock (Generic, Show)
-  deriving anyclass (FromForm)
-
-
 shareLinkPostH :: Projects.ProjectId -> UUID.UUID -> UTCTime -> Maybe Text -> ATAuthCtx (RespHeaders ShareLinkPost)
 shareLinkPostH pid eventId createdAt reqTypeM = do
   _ <- Projects.sessionAndProject pid
   shareId <- liftIO UUIDV4.nextRandom
   ShareEvents.createShareLink shareId pid eventId (fromMaybe "request" reqTypeM) createdAt
-  addRespHeaders $ ShareLinkPost $ show shareId
+  addRespHeaders $ ShareLinkPost $ UUID.toText shareId
 
 
-data ShareLinkPost
-  = ShareLinkPost Text
-  | ShareLinkPostError
+newtype ShareLinkPost = ShareLinkPost Text
 
 
 instance ToHtml ShareLinkPost where
-  toHtml (ShareLinkPost shareId) = toHtml $ copyLink shareId
-  toHtml ShareLinkPostError = toHtml ""
-  toHtmlRaw = toHtml
-
-
-copyLink :: Text -> Html ()
-copyLink rid = do
-  let url = "https://app.monoscope.tech/share/r/" <> rid
-  div_ [id_ "invite-modal-container"] do
+  toHtml (ShareLinkPost rid) = toHtml @(Html ()) $ div_ [id_ "invite-modal-container"] do
     modalWith_ "shareModal" def{autoOpen = True, boxClass = "max-w-md p-6"} Nothing do
       h3_ [class_ "text-textStrong text-lg font-semibold"] "Share link"
       p_ [class_ "text-textWeak text-sm"] "Anyone with this link can view the event. Expires in 48 hours."
@@ -81,9 +61,9 @@ copyLink rid = do
           [ type_ "text"
           , readonly_ "readonly"
           , id_ "shareURL"
-          , value_ url
+          , value_ $ "https://app.monoscope.tech/share/r/" <> rid
           , class_ "flex-1 min-w-0 bg-fillWeaker border border-strokeWeak rounded-md px-3 py-1.5 font-mono text-xs text-textWeak cursor-text transition-colors focus:outline-hidden focus:border-strokeBrand"
-          , [__|on focus call my.select()|]
+          , onfocus_ "this.select()"
           ]
         button_
           [ type_ "button"
@@ -97,6 +77,7 @@ copyLink rid = do
                |]
           ]
           "Copy link"
+  toHtmlRaw = toHtml
 
 
 -- | Resolved share row. Fetched without a SQL time filter so callers can
@@ -111,18 +92,12 @@ data ShareRow = ShareRow
 
 
 resolveShare :: UUID.UUID -> UTCTime -> ATBaseCtx (Maybe ShareRow)
-resolveShare sid now = do
-  rowM <-
-    Hasql.interpOne
-      [HI.sql|SELECT project_id, event_id, event_type, event_created_at, created_at
-              FROM apis.share_events WHERE id=#{sid} LIMIT 1|]
-  pure $ rowM <&> \(pid, eid, ty :: Text, eca, createdAt :: UTCTime) ->
-    ShareRow pid eid ty eca (ceiling (diffUTCTime (addUTCTime (48 * 3600) createdAt) now / 3600))
-
-
--- | 404 helper.
-note404 :: Maybe a -> ATBaseCtx a
-note404 = maybe (throwIO err404) pure
+resolveShare sid now =
+  Hasql.interpOne
+    [HI.sql|SELECT project_id, event_id, event_type, event_created_at, created_at
+            FROM apis.share_events WHERE id=#{sid} LIMIT 1|]
+    <&> fmap \(pid, eid, ty :: Text, eca, createdAt :: UTCTime) ->
+      ShareRow pid eid ty eca (ceiling (diffUTCTime (addUTCTime (48 * 3600) createdAt) now / 3600))
 
 
 shareLinkGetH :: UUID.UUID -> ATBaseCtx ShareLinkGet
@@ -134,41 +109,28 @@ shareLinkGetH sid = do
       Nothing -> pure ShareMissing
       Just row | row.hoursLeft <= 0 -> pure ShareExpired
       Just row -> resolveBody sid now row
-  let bwconf =
-        (def :: BWConfig)
-          { sessM = Nothing
-          , currProject = Nothing
-          , pageTitle = "Shared event"
-          , config = authCtx.config
-          }
-  pure $ ShareLinkGet $ PageCtx bwconf view
+  pure $ ShareLinkGet $ PageCtx (def :: BWConfig){pageTitle = "Shared event", config = authCtx.config} view
 
 
 resolveBody :: UUID.UUID -> UTCTime -> ShareRow -> ATBaseCtx ShareView
-resolveBody _ _ row | row.eventType == "log" = do
-  Telemetry.otelRecordByProjectAndId row.pid row.eventCreatedAt row.eventId <&> \case
-    Just req -> ShareLive row.hoursLeft Nothing (LogItem.expandedItemView row.pid req Nothing Nothing) Nothing
-    Nothing -> ShareMissing
-resolveBody sid now row = do
-  useTf <- (.env.enableTimefusionReads) <$> Effectful.Reader.Static.ask @AuthContext
+resolveBody sid now row =
   Telemetry.otelRecordByProjectAndId row.pid row.eventCreatedAt row.eventId >>= \case
     Nothing -> pure ShareMissing
     Just anchor -> do
-      breakdownM <- runMaybeT do
-        tid <- hoistMaybe $ anchor.context >>= (.trace_id) >>= guarded (not . T.null)
-        (traceItem, spans) <- MaybeT $ Telemetry.getTraceDetails useTf row.pid tid (Just row.eventCreatedAt) now
-        let recs = V.mapMaybe Telemetry.convertOtelLogsAndSpansToSpanRecord (V.fromList spans)
-        pure $ PTelemetry.tracePage row.pid traceItem recs
-      let replayInfo =
-            Telemetry.atMapText "session.id" (unAesonTextMaybe anchor.attributes)
-              >>= UUID.fromText
-              <&> (UUID.toText sid,row.pid.toText,)
-      pure
-        $ ShareLive
-          row.hoursLeft
-          breakdownM
-          (LogItem.expandedItemView row.pid anchor Nothing Nothing)
-          replayInfo
+      let detail = LogItem.expandedItemView row.pid anchor Nothing Nothing
+      if row.eventType == "log"
+        then pure $ ShareLive row.hoursLeft Nothing detail Nothing
+        else do
+          useTf <- (.env.enableTimefusionReads) <$> Effectful.Reader.Static.ask @AuthContext
+          breakdownM <- runMaybeT do
+            tid <- hoistMaybe $ anchor.context >>= (.trace_id) >>= guarded (not . T.null)
+            (traceItem, spans) <- MaybeT $ Telemetry.getTraceDetails useTf row.pid tid (Just row.eventCreatedAt) now
+            pure $ PTelemetry.tracePage row.pid traceItem $ V.mapMaybe Telemetry.convertOtelLogsAndSpansToSpanRecord (V.fromList spans)
+          let replayInfo =
+                Telemetry.atMapText "session.id" (unAesonTextMaybe anchor.attributes)
+                  >>= UUID.fromText
+                  <&> (UUID.toText sid,row.pid.toText,)
+          pure $ ShareLive row.hoursLeft breakdownM detail replayInfo
 
 
 newtype ShareLinkGet = ShareLinkGet (PageCtx ShareView)
@@ -186,12 +148,11 @@ instance ToHtml ShareLinkGet where
 shareReplaySessionGetH :: UUID.UUID -> UUID.UUID -> ATBaseCtx Replay.ReplaySessionResp
 shareReplaySessionGetH sid sessionId = do
   now <- Time.currentTime
-  row <- resolveShare sid now >>= note404
+  row <- resolveShare sid now `whenNothingM` throwIO err404
   when (row.hoursLeft <= 0 || row.eventType == "log") $ throwIO err404
-  anchor <- Telemetry.otelRecordByProjectAndId row.pid row.eventCreatedAt row.eventId >>= note404
-  let attrSessionId = Telemetry.atMapText "session.id" (unAesonTextMaybe anchor.attributes) >>= UUID.fromText
-  when (attrSessionId /= Just sessionId) $ throwIO err404
-  project <- Projects.projectById row.pid >>= note404
+  anchor <- Telemetry.otelRecordByProjectAndId row.pid row.eventCreatedAt row.eventId `whenNothingM` throwIO err404
+  when ((Telemetry.atMapText "session.id" (unAesonTextMaybe anchor.attributes) >>= UUID.fromText) /= Just sessionId) $ throwIO err404
+  project <- Projects.projectById row.pid `whenNothingM` throwIO err404
   Replay.fetchReplaySession project sessionId
 
 
@@ -200,14 +161,14 @@ sharePage v = do
   -- Hide embedded controls that don't apply on a standalone share page
   -- (sidebar close, internal share button marked data-share-hide).
   style_ ".share-view .detail-close-btn,.share-view [data-share-hide]{display:none!important}.share-view .urlPath{user-select:text}"
-  shareTopBar $ case v of
+  shareTopBar case v of
     ShareLive{hoursLeft} -> Just hoursLeft
-    _ -> Nothing
+    ShareExpired -> Nothing
+    ShareMissing -> Nothing
   section_ [class_ "share-view max-w-6xl mx-auto w-full px-4 pt-6 flex flex-col gap-6"] $ case v of
     ShareLive{breakdown, detail, replay} -> do
-      whenJust breakdown $ \bd -> div_ [class_ "border border-strokeWeak rounded-lg bg-bgBase"] bd
-      whenJust replay $ \(shareId, projectId, sessionId) -> do
-        let replayUrl = "/share/r/" <> shareId <> "/replay_session/" <> UUID.toText sessionId
+      whenJust breakdown \bd -> div_ [class_ "border border-strokeWeak rounded-lg bg-bgBase"] bd
+      whenJust replay \(shareId, projectId, sessionId) ->
         div_ [class_ "flex flex-col gap-2"] do
           div_ [class_ "flex items-center gap-2 px-1"] do
             span_ [class_ "text-xs uppercase tracking-wider text-textWeak font-medium"] "Session replay"
@@ -216,19 +177,21 @@ sharePage v = do
             "session-replay"
             [ term "projectId" projectId
             , term "initialSession" (UUID.toText sessionId)
-            , term "sessionUrl" replayUrl
+            , term "sessionUrl" $ "/share/r/" <> shareId <> "/replay_session/" <> UUID.toText sessionId
             , term "hideControls" "1"
             , class_ "block"
             ]
             pass
       div_ [id_ "share-detail-inner", class_ "border border-strokeWeak rounded-lg bg-bgBase overflow-hidden"] detail
-    ShareExpired -> emptyState_ def{icon = Just "clock", action = ESLink "https://monoscope.tech" "Learn about Monoscope"} "Link expired" "This share link was valid for 48 hours and has passed its expiry. Ask the sender for a fresh link."
-    ShareMissing -> emptyState_ def{icon = Just "empty", action = ESLink "https://monoscope.tech" "Learn about Monoscope"} "Event not found" "This share link doesn't exist or the underlying event is no longer available."
+    ShareExpired -> blank "clock" "Link expired" "This share link was valid for 48 hours and has passed its expiry. Ask the sender for a fresh link."
+    ShareMissing -> blank "empty" "Event not found" "This share link doesn't exist or the underlying event is no longer available."
+  where
+    blank i = emptyState_ def{icon = Just i, action = ESLink "https://monoscope.tech" "Learn about Monoscope"}
 
 
 -- | Slim sticky top bar: logo, "Shared event" label, expiry pill, About link.
 shareTopBar :: Maybe Int -> Html ()
-shareTopBar hoursLeftM = do
+shareTopBar hoursLeftM =
   nav_ [class_ "sticky top-0 z-20 h-12 w-full border-b border-strokeWeak bg-bgBase/90 backdrop-blur-sm"] do
     div_ [class_ "max-w-6xl mx-auto h-full px-4 flex items-center justify-between gap-4 flex-nowrap"] do
       div_ [class_ "flex items-center gap-3 min-w-0 flex-nowrap"] do

--- a/src/Pages/Telemetry.hs
+++ b/src/Pages/Telemetry.hs
@@ -685,7 +685,7 @@ metricDimension pid metricName source selected label =
 
 relatedMetrics :: Projects.ProjectId -> Text -> Telemetry.MetricDataPoint -> V.Vector Telemetry.MetricChartListData -> Html ()
 relatedMetrics pid source metric candidates =
-  case take 6 $ map snd $ sortOn (Down . fst) [(score, c) | c <- V.toList candidates, c.metricName /= metric.metricName, let score = relatedMetricScore metric c, score > 0] of
+  case take 6 $ map snd $ sortWith (Down . fst) [(score, c) | c <- V.toList candidates, c.metricName /= metric.metricName, let score = relatedMetricScore metric c, score > 0] of
     [] -> div_ [class_ "px-5 py-8 text-sm text-textWeak"] $ if source == "all" then "No metrics with a similar name or dimensions were found." else "No similar metrics in this source. Try All sources."
     related -> do
       div_ [class_ "px-5 pb-3 pt-5"] do
@@ -764,7 +764,7 @@ metricReferences metricName dashboards monitors = (filter ((> 0) . countWidgetsW
 
 countWidgetsWithMetric :: Text -> Dashboards.DashboardVM -> Int
 countWidgetsWithMetric metricName dashboard =
-  length $ filter (widgetRefsMetric metricName) $ flip foldMap dashboard.schema \schema -> schema.widgets <> foldMap (concatMap (.widgets)) schema.tabs
+  sum $ map (fromEnum . widgetRefsMetric metricName) $ flip foldMap dashboard.schema \schema -> schema.widgets <> foldMap (concatMap (.widgets)) schema.tabs
 
 
 monitorHasMetric :: Text -> Monitors.QueryMonitor -> Bool

--- a/src/Pages/Telemetry.hs
+++ b/src/Pages/Telemetry.hs
@@ -16,7 +16,7 @@ module Pages.Telemetry (
 import Data.Aeson qualified as AE
 import Data.Aeson.Key qualified as AEKey
 import Data.Default
-import Data.HashMap.Internal.Strict qualified as HM
+import Data.HashMap.Strict qualified as HM
 import Data.Map qualified as Map
 import Data.Set qualified as S
 import Data.Text qualified as T
@@ -29,7 +29,6 @@ import Effectful.Reader.Static qualified as Reader
 import Effectful.Time qualified as Time
 import Lucid
 import Lucid.Aria qualified as Aria
-import Lucid.Base (makeAttribute)
 import Lucid.Htmx
 import Lucid.Hyperscript (__)
 import Models.Apis.Monitors qualified as Monitors
@@ -73,9 +72,6 @@ data TraceDetailsGet
   | TraceDetailsNotFound Projects.ProjectId
 
 
-data ServiceData = ServiceData {name :: Text, duration :: Integer}
-
-
 data SpanMin = SpanMin
   { parentSpanId :: Maybe Text
   , spanId :: Text
@@ -89,8 +85,6 @@ data SpanMin = SpanMin
   , timestamp :: UTCTime
   , attributes :: Maybe (Map Text AE.Value)
   }
-  deriving stock (Generic, Show)
-  deriving anyclass (AE.FromJSON, AE.ToJSON)
 
 
 -- | Extract a human-readable label from span attributes (db query, http route, rpc method, messaging).
@@ -139,7 +133,7 @@ resizeDivider_ cssVar minPct maxPct resizeEvt extraCls =
    in div_
         [ class_ $ "absolute top-0 bottom-0 w-2 cursor-col-resize z-20 flex justify-center group " <> extraCls
         , style_ $ "left:calc(var(" <> cssVar <> ") - 4px)"
-        , makeAttribute "_" script
+        , term "_" script
         ]
         $ div_ [class_ "w-px h-full bg-strokeWeak group-hover:bg-fillBrand-strong group-active:bg-fillBrand-strong transition-colors pointer-events-none relative"] do
           div_ [class_ "absolute top-1/2 -translate-y-1/2 -translate-x-[3px] w-2 h-6 flex flex-col justify-center gap-px opacity-0 group-hover:opacity-100 transition-opacity"] do
@@ -150,43 +144,37 @@ data SpanTree = SpanTree
   { spanRecord :: SpanMin
   , children :: [SpanTree]
   }
-  deriving (Generic, Show)
-  deriving anyclass (AE.FromJSON, AE.ToJSON)
 
 
 -- Metric tree types
-data MetricNode = MetricNode {parent :: Text, current :: Text} deriving (Eq, Show)
+data MetricNode = MetricNode {parent :: Maybe Text, current :: Text} deriving stock (Eq)
 
 
 data MetricTree = MetricTree MetricNode [MetricTree]
 
 
+nodePath :: MetricNode -> Text
+nodePath nd = maybe nd.current (<> "." <> nd.current) nd.parent
+
+
 pathToNodes :: Text -> [MetricNode]
 pathToNodes path =
   let segments = T.splitOn "." path
-   in zipWith MetricNode ("___root___" : scanl1 (\acc s -> acc <> "." <> s) segments) segments
+   in zipWith MetricNode (Nothing : map Just (scanl1 (\acc s -> acc <> "." <> s) segments)) segments
 
 
 buildMetricTree :: [Text] -> [MetricTree]
-buildMetricTree metrics =
-  let nodeMap = foldr insertNode Map.empty (concatMap pathToNodes metrics)
-   in buildTree_ nodeMap Nothing
+buildMetricTree metrics = buildTree_ (foldr insertNode Map.empty (concatMap pathToNodes metrics)) Nothing
   where
-    insertNode sp m =
-      let k = if sp.parent == "___root___" then Nothing else Just sp.parent
-       in Map.insertWith (\new old -> if sp `elem` old then old else new ++ old) k [sp] m
-    buildTree_ nodeMap parentId = case Map.lookup parentId nodeMap of
-      Nothing -> []
-      Just nodes ->
-        [ MetricTree mt (buildTree_ nodeMap (if mt.parent == "___root___" then Just mt.current else Just $ mt.parent <> "." <> mt.current))
-        | mt <- nodes
-        ]
+    insertNode sp = Map.insertWith (\new old -> if sp `elem` old then old else new ++ old) sp.parent [sp]
+    buildTree_ nodeMap parentId =
+      [MetricTree mt (buildTree_ nodeMap (Just $ nodePath mt)) | mt <- Map.findWithDefault [] parentId nodeMap]
 
 
 data MetricRow = MetricRow
   { level :: Int
   , segment :: Text
-  , parentPath :: Text
+  , parentPath :: Maybe Text
   , fullPath :: Text
   , isGroup :: Bool
   , childCount :: Int
@@ -196,16 +184,13 @@ data MetricRow = MetricRow
 
 
 flattenMetricTree :: Map Text Telemetry.MetricDataPoint -> [MetricTree] -> Int -> [Bool] -> V.Vector MetricRow
-flattenMetricTree dataMap trees lvl conts = V.concat $ zipWith flatten trees isLastFlags
+flattenMetricTree dataMap trees lvl conts = V.concat $ map flatten trees
   where
-    isLastFlags = replicate (length trees - 1) False ++ [True]
-    flatten (MetricTree nd children) isLast =
-      let fp = if nd.parent == "___root___" then nd.current else nd.parent <> "." <> nd.current
-          hasChildren = not (null children)
-          row = MetricRow{level = lvl, segment = nd.current, parentPath = nd.parent, fullPath = fp, isGroup = hasChildren, childCount = length children, continuations = conts, metric = Map.lookup fp dataMap}
+    flatten (MetricTree nd children) =
+      let fp = nodePath nd
+          row = MetricRow{level = lvl, segment = nd.current, parentPath = nd.parent, fullPath = fp, isGroup = not (null children), childCount = length children, continuations = conts, metric = Map.lookup fp dataMap}
           childIsLast = replicate (length children - 1) False ++ [True]
-          childRows = V.concat $ zipWith (\c cLast -> flattenMetricTree dataMap [c] (lvl + 1) (conts ++ [not cLast])) children childIsLast
-       in V.cons row childRows
+       in V.cons row $ V.concat $ zipWith (\c cLast -> flattenMetricTree dataMap [c] (lvl + 1) (conts ++ [not cLast])) children childIsLast
 
 
 instance ToHtml TraceDetailsGet where
@@ -240,8 +225,8 @@ metricsOverViewGetH pid tabM fromM toM sinceM sourceM prefixM cursorM expandM la
   ctx <- Reader.ask @AuthContext
   (_, _, bw) <- mkPageCtx pid
   now <- Time.currentTime
-  let tab = bool "datapoints" "charts" $ maybe True (== "charts") tabM
-  let (from, to, currentRange) = parseTime fromM toM sinceM now
+  let dataPointsTab = any (/= "charts") tabM
+      (from, to, currentRange) = parseTime fromM toM sinceM now
       bwconf =
         bw
           { prePageTitle = Just "Explorer"
@@ -255,7 +240,7 @@ metricsOverViewGetH pid tabM fromM toM sinceM sourceM prefixM cursorM expandM la
               TimePicker.timepicker_ Nothing currentRange Nothing
               TimePicker.refreshButton_
           }
-  if tab == "datapoints"
+  if dataPointsTab
     then do
       dataPoints <- Telemetry.getDataPointsData ctx.env.enableTimefusionReads pid (from, to)
       dashboards <- Dashboards.selectDashboardsSortedBy pid "updated_at"
@@ -268,17 +253,11 @@ metricsOverViewGetH pid tabM fromM toM sinceM sourceM prefixM cursorM expandM la
       let cutoff = addUTCTime (-(7 * 24 * 3600)) now
           (active, inactive) = V.partition (\m -> m.lastSeen >= cutoff) allMetrics
           pageSize = 20
-          metricList = V.slice (min cursor (V.length active)) (min pageSize (max 0 (V.length active - cursor))) active
-          sourceQ = maybe "" ("&metric_source=" <>) sourceM
-          fromQ = maybe "" ("&from=" <>) fromM
-          toQ = maybe "" ("&to=" <>) toM
-          sinceQ = maybe "" ("&since=" <>) sinceM
-          prfixQ = maybe "" ("&metric_prefix=" <>) prefixM
-          cursorQ = "&cursor=" <> show (cursor + pageSize)
-          nextFetchUrl =
-            if cursor + pageSize >= V.length active
-              then Nothing
-              else Just $ "/p/" <> pid.toText <> "/metrics?tab=charts" <> sourceQ <> fromQ <> toQ <> sinceQ <> prfixQ <> cursorQ
+          metricList = V.take pageSize $ V.drop cursor active
+          params = foldMap (\(k, v) -> foldMap (\x -> "&" <> k <> "=" <> x) v) ([("metric_source", sourceM), ("from", fromM), ("to", toM), ("since", sinceM), ("metric_prefix", prefixM)] :: [(Text, Maybe Text)])
+          nextFetchUrl = do
+            guard $ cursor + pageSize < V.length active
+            pure $ "/p/" <> pid.toText <> "/metrics?tab=charts" <> params <> "&cursor=" <> show (cursor + pageSize)
       let labels = Map.fromList $ (\metric -> (metric.metricName, metric.metricLabels)) <$> V.toList metricList
       if cursor == 0
         then do
@@ -297,7 +276,7 @@ metricsOverViewGetH pid tabM fromM toM sinceM sourceM prefixM cursorM expandM la
 
 metricDetailsGetH :: Projects.ProjectId -> Text -> Maybe Text -> Maybe Text -> Maybe Text -> Maybe Text -> Maybe Text -> ATAuthCtx (RespHeaders (Html ()))
 metricDetailsGetH pid metricName fromM toM sinceM source labelM = do
-  (sess, project) <- Projects.sessionAndProject pid
+  void $ Projects.sessionAndProject pid
   now <- Time.currentTime
   let (_, _, currentRange) = parseTime fromM toM sinceM now
   metricM <- Telemetry.getMetricData pid metricName
@@ -325,16 +304,16 @@ traceH pid trId timestamp spanIdM nav = do
     if isJust nav
       then do
         spanRecords' <- V.fromList <$> Telemetry.getSpanRecordsByTraceId useTf pid trId timestamp now
-        let sid = fromMaybe "" spanIdM
-            matchesSpan x = maybe False (\s -> s.span_id == Just sid) x.context
-            clicked = fromMaybe (V.head spanRecords') (V.find matchesSpan spanRecords')
-            bySpanId i = V.find (\x -> (x.context >>= (.span_id)) == Just i) spanRecords'
-            sdkNear =
-              V.find
-                (\x -> x.name == Just Telemetry.sdkSpanStoredName && x.start_time >= addUTCTime (-1) clicked.start_time && x.start_time <= addUTCTime 1 (LogItem.spanEndOrCap clicked))
-                spanRecords'
-            (targetSpan, atpSpan) = runIdentity $ LogItem.anchorSdkSpan (pure . bySpanId) (pure sdkNear) clicked
-        addRespHeaders $ SpanDetails pid targetSpan atpSpan
+        let bySpanId i = V.find (\x -> (x.context >>= (.span_id)) == Just i) spanRecords'
+        case (spanIdM >>= bySpanId) <|> spanRecords' V.!? 0 of
+          Nothing -> addRespHeaders $ TraceDetailsNotFound pid
+          Just clicked -> do
+            let sdkNear =
+                  V.find
+                    (\x -> x.name == Just Telemetry.sdkSpanStoredName && x.start_time >= addUTCTime (-1) clicked.start_time && x.start_time <= addUTCTime 1 (LogItem.spanEndOrCap clicked))
+                    spanRecords'
+                (targetSpan, atpSpan) = runIdentity $ LogItem.anchorSdkSpan (pure . bySpanId) (pure sdkNear) clicked
+            addRespHeaders $ SpanDetails pid targetSpan atpSpan
       else do
         traceItemM <- Telemetry.getTraceDetails useTf pid trId timestamp now
         addRespHeaders $ maybe (TraceDetailsNotFound pid) (\(traceItem, spans) -> TraceDetails pid traceItem (V.mapMaybe Telemetry.convertOtelLogsAndSpansToSpanRecord (V.fromList spans))) traceItemM
@@ -360,6 +339,19 @@ overViewTabs pid tab =
       viewTab "Table" "datapoints"
 
 
+-- | A "select ... reload with query param" dropdown, shared by the service/metric-group filters.
+filterSelect_ :: Foldable f => Text -> Text -> Text -> Text -> Text -> f Text -> (Text -> Html ()) -> Html ()
+filterSelect_ widthCls param ariaLbl allLabel current opts display =
+  select_
+    [ class_ $ "join-item select select-sm bg-bgBase border border-strokeWeak h-10 " <> widthCls <> " max-md:w-1/2 shadow-none cursor-pointer hover:border-strokeStrong transition-colors focus:outline-hidden focus:ring-2 focus:ring-strokeFocus"
+    , Aria.label_ ariaLbl
+    , onchange_ $ "window.setQueryParamAndReload('" <> param <> "', this.value)"
+    ]
+    do
+      option_ ([selected_ "all" | "all" == current] ++ [value_ "all"]) $ toHtml allLabel
+      forM_ opts $ \o -> option_ ([selected_ o | o == current] ++ [value_ o]) $ display o
+
+
 chartsPage :: Projects.ProjectId -> V.Vector Telemetry.MetricChartListData -> Map Text (V.Vector Text) -> V.Vector Telemetry.MetricChartListData -> V.Vector Text -> Text -> Text -> Int -> Maybe Text -> Html ()
 chartsPage pid metricList labels inactive sources source mFilter activeCount nextUrl = do
   div_ [class_ "flex flex-col gap-4 px-4 overflow-y-scroll", term "preload" "false"]
@@ -371,30 +363,16 @@ chartsPage pid metricList labels inactive sources source mFilter activeCount nex
           let metricNames =
                 ordNub
                   $ ( \x ->
-                        let (n, pr) = if length (T.splitOn "." x.metricName) == 1 then (T.splitOn "_" x.metricName, "_") else (T.splitOn "." x.metricName, ".")
-                         in fromMaybe "" (viaNonEmpty head n) <> pr
+                        let sep = if "." `T.isInfixOf` x.metricName then "." else "_"
+                         in fst (T.breakOn sep x.metricName) <> sep
                     )
                   <$> V.toList metricList
               stripTrailing t = fromMaybe t $ T.stripSuffix "." t <|> T.stripSuffix "_" t
           div_ [class_ "flex items-center gap-2 shrink-0 max-md:w-full max-md:flex-wrap"] do
             span_ [class_ "text-xs font-medium text-textWeak"] "Scope"
             div_ [class_ "join max-md:w-full"] do
-              select_
-                [ class_ "join-item select select-sm bg-bgBase border border-strokeWeak h-10 w-36 max-md:w-1/2 shadow-none cursor-pointer hover:border-strokeStrong transition-colors focus:outline-hidden focus:ring-2 focus:ring-strokeFocus"
-                , Aria.label_ "Filter by service"
-                , onchange_ "(() => {window.setQueryParamAndReload('metric_source', this.value)})()"
-                ]
-                do
-                  option_ ([selected_ "all" | "all" == source] ++ [value_ "all"]) "All Services"
-                  forM_ sources $ \s -> option_ ([selected_ s | s == source] ++ [value_ s]) $ toHtml s
-              select_
-                [ class_ "join-item select select-sm bg-bgBase border border-strokeWeak h-10 w-auto max-md:w-1/2 shadow-none cursor-pointer hover:border-strokeStrong transition-colors focus:outline-hidden focus:ring-2 focus:ring-strokeFocus"
-                , Aria.label_ "Filter by metric group"
-                , onchange_ "(() => {window.setQueryParamAndReload('metric_prefix', this.value)})()"
-                ]
-                do
-                  option_ ([selected_ "all" | "all" == mFilter] ++ [value_ "all"]) "All metric groups"
-                  forM_ metricNames $ \m -> option_ ([selected_ m | m == mFilter] ++ [value_ m]) $ toHtml (stripTrailing m)
+              filterSelect_ "w-36" "metric_source" "Filter by service" "All Services" source sources toHtml
+              filterSelect_ "w-auto" "metric_prefix" "Filter by metric group" "All metric groups" mFilter metricNames (toHtml . stripTrailing)
           div_ [class_ "w-px h-6 bg-strokeWeak max-md:hidden"] pass
           label_ [class_ "input input-sm flex grow min-w-0 max-md:w-full max-md:flex-none h-10 bg-bgBase border border-strokeWeak shadow-none overflow-hidden items-center gap-2 hover:border-strokeStrong transition-colors focus-within:outline-hidden focus-within:ring-2 focus-within:ring-strokeFocus focus-within:border-strokeFocus"] do
             faSprite_ "magnifying-glass" "regular" "w-4 h-4 opacity-50"
@@ -428,22 +406,21 @@ metricExpandUrl :: Projects.ProjectId -> Text -> Text -> Maybe Text -> Text
 metricExpandUrl pid metricName source labelM = "/p/" <> pid.toText <> "/metrics?tab=charts&metric_source=" <> source <> "&expand=" <> metricName <> maybe "" ("&label=" <>) labelM
 
 
--- | Shared WTTimeseriesLine widget for a metric. @mTitle@/@mId@/@mExpandBtn@/@mDescription@
+-- | Shared WTTimeseriesLine widget for a metric. @mTitle@/@mId@/@mExpandBtn@
 -- carry the per-callsite differences between the chart-list card and the details page.
-metricWidget :: Projects.ProjectId -> Text -> Text -> Text -> Maybe Text -> Maybe Text -> Maybe Text -> Maybe Text -> Maybe Text -> Widget.Widget
-metricWidget pid metricName metricType metricUnit mLabel mTitle mId mExpandBtn mDescription =
+metricWidget :: Projects.ProjectId -> Text -> Text -> Text -> Maybe Text -> Maybe Text -> Maybe Text -> Maybe Text -> Widget.Widget
+metricWidget pid metricName metricType metricUnit mLabel mTitle mId mExpandBtn =
   def
     { Widget.wType = Widget.WTTimeseriesLine
     , Widget.title = if isDistributionMetricType metricType then (<> " · mean") <$> mTitle else mTitle
     , Widget.query = Just $ metricQuery metricName metricType mLabel
     , Widget.layout = Just $ Widget.Layout{x = Just 0, y = Just 0, w = Just 2, h = Just 1}
     , Widget.unit = Just metricUnit
-    , Widget.hideLegend = Nothing
     , Widget.eager = Just True
+    , Widget.hideSubtitle = Just True
     , Widget._projectId = Just pid
     , Widget.id = mId
     , Widget.expandBtnFn = mExpandBtn
-    , Widget.description = mDescription
     }
 
 
@@ -485,15 +462,14 @@ metricCardGetH pid metricName labelM = do
 
 metricCard :: Projects.ProjectId -> Text -> Text -> Text -> Text -> V.Vector Text -> Maybe Text -> Html ()
 metricCard pid source metricName metricType metricUnit labels selectedM = do
-  let selected = if selectedM == Just "all" then Nothing else selectedM <|> listToMaybe (V.toList labels)
+  let selected = if selectedM == Just "all" then Nothing else selectedM <|> labels V.!? 0
       cardId = "metric_" <> T.replace "." "_" metricName
       detailUrl = metricDetailUrl pid metricName source selected
   div_ [class_ "w-full flex flex-col gap-2 metric_filterble", id_ cardId]
     $ div_ [class_ "h-56"]
     $ toHtml
-    $ (metricWidget pid metricName metricType metricUnit selected (Just metricName) Nothing (Just detailUrl) Nothing)
-      { Widget.hideSubtitle = Just True
-      , Widget.expandPushUrl = Just $ metricExpandUrl pid metricName source selected
+    $ (metricWidget pid metricName metricType metricUnit selected (Just metricName) Nothing (Just detailUrl))
+      { Widget.expandPushUrl = Just $ metricExpandUrl pid metricName source selected
       , Widget.groupByOptions = V.toList labels <$ guard (not $ V.null labels)
       , Widget.groupBySelected = selectedM <|> selected
       , Widget.groupByUrl = Just $ "/p/" <> pid.toText <> "/metrics/card/" <> metricName
@@ -512,16 +488,14 @@ inactiveMetricsList pid source metrics = do
       <> " (no data in 7 days)"
     div_ [class_ "collapse-content"] do
       div_ [class_ "flex flex-col divide-y divide-strokeWeak"] do
-        forM_ metrics $ \metric -> do
-          let detailUrl = metricDetailUrl pid metric.metricName source Nothing
-          let lastSeenStr = formatTime defaultTimeLocale "%b %d, %Y" metric.lastSeen
+        forM_ metrics $ \metric ->
           div_
-            (class_ "flex items-center justify-between py-2 px-2 cursor-pointer hover:bg-fillWeak rounded" : drawerLoadAttrs_ detailUrl)
+            (class_ "flex items-center justify-between py-2 px-2 cursor-pointer hover:bg-fillWeak rounded" : drawerLoadAttrs_ (metricDetailUrl pid metric.metricName source Nothing))
             do
               div_ [class_ "flex items-center gap-2"] do
                 faSprite_ "chart-line" "regular" "w-3.5 h-3.5 text-textWeak"
                 span_ [class_ "text-sm font-mono"] $ toHtml metric.metricName
-              span_ [class_ "text-xs text-textWeak"] $ toHtml $ "Last seen " <> lastSeenStr
+              span_ [class_ "text-xs text-textWeak"] $ toHtml $ "Last seen " <> formatTime defaultTimeLocale "%b %d, %Y" metric.lastSeen
 
 
 dataPointsPage :: Projects.ProjectId -> V.Vector Telemetry.MetricDataPoint -> Map Text (Int, Int, Int) -> Html ()
@@ -556,7 +530,7 @@ dataPointsPage pid metrics refCounts = do
                       $ div_ [class_ "w-full border border-strokeWeak flex justify-between gap-1 items-center rounded-sm px-1 py-0.5"] do
                         faSprite_ "chevron-right" "regular" "h-3 w-3 shrink-0 text-textStrong tree-chevron rotate-90 transition-transform"
                         span_ [class_ "text-xs"] $ toHtml $ show r.childCount
-                    unless (r.parentPath == "___root___") $ span_ [class_ "text-textDisabled"] $ toHtml $ r.parentPath <> "."
+                    whenJust r.parentPath \p -> span_ [class_ "text-textDisabled"] $ toHtml $ p <> "."
                     case r.metric of
                       Nothing -> span_ [class_ "text-textStrong font-medium"] $ toHtml r.segment
                       Just _ -> do
@@ -635,7 +609,7 @@ metricsDetailsPage pid sources metric candidates (dashboards, monitors) source s
             TimePicker.timepicker_ (Just refreshId) currentRange (Just "metric-details")
             TimePicker.refreshButton_
             label_ [class_ "btn btn-ghost btn-circle btn-sm cursor-pointer tap-target text-iconNeutral hover:text-iconBrand", Aria.label_ "Close metric detail", data_ "tippy-content" "Close metric detail", Lucid.for_ "global-data-drawer"] $ faSprite_ "xmark" "regular" "w-3 h-3"
-        div_ [id_ refreshId, class_ "hidden", term "_" "on submit trigger 'update-query' on window"] ""
+        div_ [id_ refreshId, class_ "hidden", [__|on submit trigger 'update-query' on window|]] ""
       metricDetailChart pid metric source selected chartId
 
       div_ [class_ "flex flex-col gap-2 rounded-2xl border border-strokeWeak", id_ "metric-tabs-container"] $ do
@@ -711,7 +685,7 @@ metricDimension pid metricName source selected label =
 
 relatedMetrics :: Projects.ProjectId -> Text -> Telemetry.MetricDataPoint -> V.Vector Telemetry.MetricChartListData -> Html ()
 relatedMetrics pid source metric candidates =
-  case take 6 $ sortOn (Down . relatedMetricScore metric) $ filter (\c -> c.metricName /= metric.metricName && relatedMetricScore metric c > 0) $ V.toList candidates of
+  case take 6 $ map snd $ sortOn (Down . fst) [(score, c) | c <- V.toList candidates, c.metricName /= metric.metricName, let score = relatedMetricScore metric c, score > 0] of
     [] -> div_ [class_ "px-5 py-8 text-sm text-textWeak"] $ if source == "all" then "No metrics with a similar name or dimensions were found." else "No similar metrics in this source. Try All sources."
     related -> do
       div_ [class_ "px-5 pb-3 pt-5"] do
@@ -739,35 +713,40 @@ relatedMetrics pid source metric candidates =
             faSprite_ "arrow-right" "regular" "w-3 shrink-0 text-iconNeutral transition-transform group-hover:translate-x-0.5"
 
 
+-- | Common leading dot-segments of two metric names, shared by scoring and display.
+sharedNameSegments :: Text -> Text -> [Text]
+sharedNameSegments a b = map fst $ takeWhile (uncurry (==)) $ zip (T.splitOn "." a) (T.splitOn "." b)
+
+
+sharedLabelCount :: Telemetry.MetricDataPoint -> Telemetry.MetricChartListData -> Int
+sharedLabelCount metric candidate = length $ S.intersection (S.fromList $ V.toList metric.metricLabels) (S.fromList $ V.toList candidate.metricLabels)
+
+
 relatedMetricContext :: Telemetry.MetricDataPoint -> Telemetry.MetricChartListData -> Text
 relatedMetricContext metric candidate =
   namespace <> sharedDimensions
   where
-    sharedNamespace = T.intercalate "." $ map fst $ takeWhile (uncurry (==)) $ zip (T.splitOn "." metric.metricName) (T.splitOn "." candidate.metricName)
-    namespace = if T.null sharedNamespace then "Similar dimensions" else "Same " <> sharedNamespace <> " namespace"
-    sharedAttributesCount = length $ S.intersection (S.fromList $ V.toList metric.metricLabels) (S.fromList $ V.toList candidate.metricLabels)
+    shared = sharedNameSegments metric.metricName candidate.metricName
+    namespace = if null shared then "Similar dimensions" else "Same " <> T.intercalate "." shared <> " namespace"
+    sharedAttributesCount = sharedLabelCount metric candidate
     sharedDimensions = if sharedAttributesCount == 0 then "" else " · " <> prettyPrintCount sharedAttributesCount <> " shared dimensions"
 
 
 relatedMetricScore :: Telemetry.MetricDataPoint -> Telemetry.MetricChartListData -> Int
 relatedMetricScore metric candidate =
-  100
-    * length (takeWhile id $ zipWith (==) (T.splitOn "." metric.metricName) (T.splitOn "." candidate.metricName))
-    + length (S.intersection (S.fromList $ V.toList metric.metricLabels) (S.fromList $ V.toList candidate.metricLabels))
+  100 * length (sharedNameSegments metric.metricName candidate.metricName) + sharedLabelCount metric candidate
 
 
 metricDetailChart :: Projects.ProjectId -> Telemetry.MetricDataPoint -> Text -> Maybe Text -> Text -> Html ()
 metricDetailChart pid metric source selected chartId =
-  let containerId = chartId <> "-container"
-   in div_ [class_ "h-72 w-full", id_ containerId]
-        $ toHtml
-        $ (metricWidget pid metric.metricName metric.metricType metric.metricUnit selected Nothing (Just chartId) Nothing Nothing)
-          { Widget.hideSubtitle = Just True
-          , Widget.groupByOptions = V.toList metric.metricLabels <$ guard (not $ V.null metric.metricLabels)
-          , Widget.groupBySelected = selected
-          , Widget.groupByUrl = Just $ metricDetailUrl pid metric.metricName source Nothing
-          , Widget.groupByTarget = Just "#metric-details-content"
-          }
+  div_ [class_ "h-72 w-full", id_ $ chartId <> "-container"]
+    $ toHtml
+    $ (metricWidget pid metric.metricName metric.metricType metric.metricUnit selected Nothing (Just chartId) Nothing)
+      { Widget.groupByOptions = V.toList metric.metricLabels <$ guard (not $ V.null metric.metricLabels)
+      , Widget.groupBySelected = selected
+      , Widget.groupByUrl = Just $ metricDetailUrl pid metric.metricName source Nothing
+      , Widget.groupByTarget = Just "#metric-details-content"
+      }
 
 
 -- Metric reference counting: (dashboardCount, widgetCount, alertCount) per metric
@@ -780,20 +759,12 @@ metricRefCounts dashboards monitors = Map.fromList . map countRefs
 
 
 metricReferences :: Text -> [Dashboards.DashboardVM] -> [Monitors.QueryMonitor] -> ([Dashboards.DashboardVM], [Monitors.QueryMonitor])
-metricReferences metricName dashboards monitors = (filter (dashboardHasMetric metricName) dashboards, filter (monitorHasMetric metricName) monitors)
-
-
-dashboardHasMetric :: Text -> Dashboards.DashboardVM -> Bool
-dashboardHasMetric metricName = (> 0) . countWidgetsWithMetric metricName
+metricReferences metricName dashboards monitors = (filter ((> 0) . countWidgetsWithMetric metricName) dashboards, filter (monitorHasMetric metricName) monitors)
 
 
 countWidgetsWithMetric :: Text -> Dashboards.DashboardVM -> Int
 countWidgetsWithMetric metricName dashboard =
-  length [widget | widget <- dashboardWidgets dashboard, widgetRefsMetric metricName widget]
-
-
-dashboardWidgets :: Dashboards.DashboardVM -> [Widget.Widget]
-dashboardWidgets dashboard = flip foldMap dashboard.schema \schema -> schema.widgets <> foldMap (concatMap (.widgets)) schema.tabs
+  length $ filter (widgetRefsMetric metricName) $ flip foldMap dashboard.schema \schema -> schema.widgets <> foldMap (concatMap (.widgets)) schema.tabs
 
 
 monitorHasMetric :: Text -> Monitors.QueryMonitor -> Bool
@@ -825,8 +796,8 @@ tracePage :: Projects.ProjectId -> Telemetry.Trace -> V.Vector Telemetry.SpanRec
 tracePage pid traceItem rawSpanRecords = do
   -- Collapse once so every tab (waterfall, timeline, services list) hides the SDK row.
   let spanRecords = collapseSdkSpans rawSpanRecords
-      serviceData = V.toList $ getServiceData <$> spanRecords
-      serviceNames = V.fromList $ ordNub $ (.name) <$> serviceData
+      serviceDurations = Map.fromListWith (+) [(getServiceName sp.resource, sp.spanDurationNs) | sp <- V.toList spanRecords]
+      serviceNames = V.fromList $ ordNub $ V.toList $ getServiceName . (.resource) <$> spanRecords
       serviceColors = getServiceColors serviceNames
       rootSpans = buildSpanTree spanRecords
   div_ [class_ "w-full h-full flex overflow-hidden", id_ "trace_span_container"] $ do
@@ -919,10 +890,9 @@ tracePage pid traceItem rawSpanRecords = do
                   span_ [] "Services"
                   span_ [] "Exec Time %"
                 div_ [class_ "w-full overflow-x-hidden text-textWeak text-xs", id_ $ "services-" <> traceItem.traceId] do
-                  let allDur = sum $ (.duration) <$> serviceData
+                  let allDur = sum serviceDurations
                   forM_ serviceNames $ \s -> do
-                    let spans = filter (\x -> x.name == s) serviceData
-                        duration = sum $ (.duration) <$> spans
+                    let duration = Map.findWithDefault 0 s serviceDurations
                         percent = show $ (fromIntegral duration / fromIntegral allDur) * 100
                         color = getServiceColor s serviceColors
                     div_ [class_ "flex items-center justify-between px-2 py-1"] $ do
@@ -952,7 +922,7 @@ tracePage pid traceItem rawSpanRecords = do
                 div_ [class_ "shrink-0 px-2 pb-1 text-textWeak font-medium", style_ "width:var(--wf-left)"] "Service / Span"
                 div_ [class_ "relative grow min-w-0", id_ $ "waterfall-time-container-" <> traceItem.traceId] pass
               div_ [class_ "py-1", id_ $ "waterfall-rows-" <> traceItem.traceId] do
-                waterFallTree pid rootSpans traceItem.traceId serviceColors
+                forM_ rootSpans \c -> buildSpanTree_ pid c 0 serviceColors
 
           div_ [role_ "tabpanel", class_ "a-tab-content pt-2 hidden", id_ "span_list"] do
             div_ [class_ "border border-strokeWeak w-full rounded-2xl min-h-[230px] overflow-x-hidden "] do
@@ -982,28 +952,20 @@ tracePage pid traceItem rawSpanRecords = do
           , "hasErrors" AE..= sp.hasErrors
           , "totalSpans" AE..= (1 :: Int)
           ]
-  let spanJson = decodeUtf8 $ AE.encode $ spanMinToFlame <$> flattenTrees rootSpans
-  let colorsJson = decodeUtf8 $ AE.encode $ AE.object [AEKey.fromText k AE..= v | (k, v) <- HM.toList serviceColors]
-  let trId = traceItem.traceId
+      spanJson = decodeUtf8 $ AE.encode $ spanMinToFlame <$> flattenTrees rootSpans
+      colorsJson = decodeUtf8 $ AE.encode $ AE.object [AEKey.fromText k AE..= v | (k, v) <- HM.toList serviceColors]
+      trId = traceItem.traceId
   script_
     [text|
-      function navigateSpans(spans, direction) {
-         const container = document.querySelector('#currentSpanIndex')
-         const currentSpan = Number(container.dataset.span)
-         if (direction == 'next' && currentSpan >= spans.length) {
-           return
-         }
-         if (direction == 'prev' && currentSpan <= 0) {
-           return
-         }
-         const spandInd = direction == 'next' ? currentSpan + 1 : currentSpan - 1
-         const span = spans[spandInd]
-         container.dataset.span = spandInd
-         htmx.trigger('#trigger-span-' + span, 'click')
-      }
-  |]
-  script_
-    [text|
+    function navigateSpans(spans, direction) {
+      const container = document.querySelector('#currentSpanIndex')
+      const currentSpan = Number(container.dataset.span)
+      if (direction == 'next' && currentSpan >= spans.length) return;
+      if (direction == 'prev' && currentSpan <= 0) return;
+      const spandInd = direction == 'next' ? currentSpan + 1 : currentSpan - 1
+      container.dataset.span = spandInd
+      htmx.trigger('#trigger-span-' + spans[spandInd], 'click')
+    }
     function initTraceCharts() {
       var el = document.getElementById('trace-tabs');
       if (typeof flameGraphChart === 'undefined' || !el || el.dataset.init) return;
@@ -1084,14 +1046,12 @@ tracePage pid traceItem rawSpanRecords = do
 renderSpanRecordRow :: V.Vector Telemetry.SpanRecord -> HashMap Text Text -> Text -> Html ()
 renderSpanRecordRow spanRecords colors service = do
   let totalDuration = sum $ (.spanDurationNs) <$> spanRecords
-  let filterRecords = V.filter (\x -> getServiceName x.resource == service) spanRecords
-  let listLen = V.length filterRecords
-  let duration = sum $ (.spanDurationNs) <$> filterRecords
-  let errCount = V.length $ V.filter spanHasErrors filterRecords
+      filterRecords = V.filter (\x -> getServiceName x.resource == service) spanRecords
+      listLen = V.length filterRecords
+      duration = sum $ (.spanDurationNs) <$> filterRecords
+      errCount = V.length $ V.filter spanHasErrors filterRecords
       hasErr = errCount > 0
-      -- Guard against divide-by-zero: a service group may have 0 records if
-      -- a caller passes a service name that no longer matches any span
-      -- (race, filter), and a trace of all-instant spans has totalDuration=0.
+      -- Zero guards: a service name may match no span, and all-instant traces have totalDuration=0.
       avgDuration = if listLen == 0 then 0 else duration `div` toInteger listLen
       pctOfTotal = if totalDuration == 0 then 0 else duration * 100 `div` totalDuration
   tr_
@@ -1172,10 +1132,6 @@ spanTable records =
                 span_ [class_ "cbadge-sm badge-neutral"] $ toHtml $ getDurationNSMS spanRecord.spanDurationNs
 
 
-getServiceData :: Telemetry.SpanRecord -> ServiceData
-getServiceData sp = ServiceData{name = getServiceName sp.resource, duration = sp.spanDurationNs}
-
-
 stBox :: Text -> Text -> Maybe (Html ()) -> Html ()
 stBox label value iconM =
   div_ [class_ "flex items-center px-2 gap-1.5 border-r last:border-r-0 whitespace-nowrap shrink-0", title_ label] do
@@ -1203,19 +1159,14 @@ collapseSdkSpans spans =
         $ V.filter (\sp -> not (Map.member sp.spanId remap)) spans
 
 
--- | Orphan handling lives in 'buildSpanTree' (synthetic placeholders) — keep
--- this map keyed by literal parent_id so we can detect them.
-buildSpanMap :: V.Vector Telemetry.SpanRecord -> Map.Map (Maybe Text) [Telemetry.SpanRecord]
-buildSpanMap = V.foldr (\sp m -> Map.insertWith (++) sp.parentSpanId [sp] m) Map.empty
-
-
 -- | Build span tree with clock skew adjustment: if a child starts before its
 -- parent, shift it forward to the parent's start time. Orphans cluster under
 -- one synthetic placeholder per missing parent_id, instead of flattening as
 -- sibling roots.
 buildSpanTree :: V.Vector Telemetry.SpanRecord -> [SpanTree]
 buildSpanTree spans =
-  let spanMap = buildSpanMap spans
+  -- Keyed by literal parent_id so missing parents (orphans) stay detectable.
+  let spanMap = V.foldr (\sp m -> Map.insertWith (++) sp.parentSpanId [sp] m) Map.empty spans
       ids :: Set Text
       ids = V.foldr (S.insert . (.spanId)) S.empty spans
       missingParents :: [Text]
@@ -1281,13 +1232,8 @@ spanMinFromRecord sp =
     }
 
 
-waterFallTree :: Projects.ProjectId -> [SpanTree] -> Text -> HashMap Text Text -> Html ()
-waterFallTree pid records trId scols =
-  forM_ records \c -> buildSpanTree_ pid c trId 0 scols
-
-
-buildSpanTree_ :: Projects.ProjectId -> SpanTree -> Text -> Int -> HashMap Text Text -> Html ()
-buildSpanTree_ pid sp trId level scol = do
+buildSpanTree_ :: Projects.ProjectId -> SpanTree -> Int -> HashMap Text Text -> Html ()
+buildSpanTree_ pid sp level scol = do
   let hasChildren = not $ null sp.children
       serviceCol = getServiceColor sp.spanRecord.serviceName scol
       tme = fromString (formatShow iso8601Format sp.spanRecord.timestamp)
@@ -1350,4 +1296,4 @@ buildSpanTree_ pid sp trId level scol = do
     when hasChildren
       $ div_ [class_ "waterfall-children"] do
         forM_ sp.children \c ->
-          buildSpanTree_ pid c trId (level + 1) scol
+          buildSpanTree_ pid c (level + 1) scol

--- a/src/Pkg/AI.hs
+++ b/src/Pkg/AI.hs
@@ -13,7 +13,7 @@ module Pkg.AI (
   -- * Response Parsing
   parseLLMResponse,
   parseAgenticResponse,
-  getNormalTupleReponse,
+  getNormalTupleResponse,
 
   -- * Basic LLM Calls
   callOpenAIAPI,
@@ -123,8 +123,8 @@ callOpenAIAPIEff :: ELLM.LLM :> es => Text -> Text -> Text -> Eff es (Either Tex
 callOpenAIAPIEff = ELLM.callLLM
 
 
-getNormalTupleReponse :: Text -> Either Text (Text, Maybe Text)
-getNormalTupleReponse response =
+getNormalTupleResponse :: Text -> Either Text (Text, Maybe Text)
+getNormalTupleResponse response =
   let lines' = lines $ T.strip response
       queryLine = fromMaybe "" (viaNonEmpty head lines')
       vizTypeM = viaNonEmpty head (drop 1 lines') >>= parseVisualizationType

--- a/src/Pkg/Components/LogQueryBox.hs
+++ b/src/Pkg/Components/LogQueryBox.hs
@@ -1,6 +1,4 @@
-{-# OPTIONS_GHC -Wno-orphans #-}
-
-module Pkg.Components.LogQueryBox (logQueryBox_, visTypes, queryLibrary_, queryEditorInitializationCode, enrichSchemaWithFacets, LogQueryBoxConfig (..), visualizationTabs_) where
+module Pkg.Components.LogQueryBox (logQueryBox_, visTypes, queryLibraryDropdown_, queryEditorInitializationCode, enrichSchemaWithFacets, LogQueryBoxConfig (..), visualizationTabs_) where
 
 import Data.Aeson qualified as AE
 import Data.Default
@@ -23,9 +21,6 @@ import Relude
 import Utils (displayTimestamp, faSprite_, formatUTC, onpointerdown_, popoverPanel_, popoverTrigger_)
 
 
-instance Default (Html ()) where def = mempty
-
-
 sortedSchemaFieldNames :: [Text]
 sortedSchemaFieldNames = sort $ Map.keys Schema.telemetrySchema.fields
 
@@ -41,9 +36,9 @@ data LogQueryBoxConfig = LogQueryBoxConfig
   , queryLibRecent :: V.Vector Projects.QueryLibItem
   , queryLibSaved :: V.Vector Projects.QueryLibItem
   , updateUrl :: Bool
+  -- ^ Whether to update the URL when the query changes
   , alert :: Bool
   , patternSelected :: Maybe Text
-  -- ^ Whether to update the URL when the query changes
   , targetWidgetPreview :: Maybe Text
   -- ^ ID of the widget preview element to update when the query changes
   , mobileExtra :: Maybe (Html ())
@@ -59,7 +54,7 @@ data LogQueryBoxConfig = LogQueryBoxConfig
 -- This component provides a unified interface for querying logs and visualizing data
 logQueryBox_ :: LogQueryBoxConfig -> Html ()
 logQueryBox_ config = do
-  let noActiveQuery = isNothing config.query || config.query == Just ""
+  let noActiveQuery = maybe True T.null config.query
   modal_ "saveQueryMdl" "" $ form_
     [ class_ "flex flex-col p-3 gap-3"
     , id_ "saveQueryForm"
@@ -89,31 +84,17 @@ logQueryBox_ config = do
               , type_ "checkbox"
               , id_ "ai-search-chkbox"
               , [__|on change if me.checked then call #ai-search-input.focus() end
-                  on keydown[key=='Space' and shiftKey] from document set #ai-search-chkbox.checked to true
+                  on keydown[key=='Space' and shiftKey] from document set my.checked to true
+                  on keydown[key=='?' and not ctrlKey and not metaKey and not altKey] from document
+                    if event.target.tagName is not 'INPUT' and event.target.tagName is not 'TEXTAREA' and event.target.contentEditable is not 'true'
+                      set my.checked to true
+                      set #ai-search-input.value to ''
+                      call #ai-search-input.focus()
+                      halt
+                    end
                   |]
               ]
             <> [checked_ | isJust config.targetWidgetPreview || noActiveQuery]
-          script_
-            [text|
-            document.addEventListener('keydown', function(e) {
-              if (e.key === "?" && !e.ctrlKey && !e.metaKey && !e.altKey && (e.target.tagName !== 'INPUT') && (e.target.tagName !== 'TEXTAREA') && (e.target.contentEditable !== 'true')) {
-                e.preventDefault();
-                e.stopPropagation();
-                document.getElementById("ai-search-chkbox").checked = true;
-                document.getElementById("ai-search-input").focus()
-                document.getElementById("ai-search-input").value=""
-              }
-            });
-            window.handleVisualizationUpdate = function(vizType, widgetId) {
-              window.requestAnimationFrame(() => {
-                updateVizTypeInUrl(vizType);
-                document.querySelector(`#visualizationTabs input[value='$${vizType}']`).checked = true;
-                window.widgetJSON.type = vizType;
-                const containerId = widgetId || 'visualization-widget-container';
-                document.getElementById(containerId).dispatchEvent(new Event('update-widget'));
-              });
-            }
-            |]
           div_ [class_ "w-full gap-2 items-center px-2 hidden group-has-[.ai-search:checked]/fltr:flex"] do
             span_ [class_ "text-2xs font-semibold text-textBrand bg-fillBrand-weak px-1.5 py-0.5 rounded shrink-0"] "AI"
             input_
@@ -129,7 +110,7 @@ logQueryBox_ config = do
               , hxVals_ "js:{timezone: Intl.DateTimeFormat().resolvedOptions().timeZone}"
               , term "hx-validate" "false"
               , hxIndicator_ "#ai-search-loader"
-              , term "data-container-id" (fromMaybe "visualization-widget-container" config.targetWidgetPreview)
+              , data_ "container-id" (fromMaybe "visualization-widget-container" config.targetWidgetPreview)
               , [__|on keydown[key=='Escape'] set #ai-search-chkbox.checked to false
                    on keydown[key=='Enter'] 
                      if my.value.trim().length > 0 
@@ -175,7 +156,7 @@ logQueryBox_ config = do
                 )
                 ("" :: Text)
 
-            unless (isJust config.targetWidgetPreview) $ do
+            whenNothing_ config.targetWidgetPreview $ do
               div_ [class_ "gap-[2px] flex items-center max-md:hidden"] do
                 span_ [class_ "text-textWeak"] "in"
                 select_
@@ -185,11 +166,8 @@ logQueryBox_ config = do
                   , Aria.label_ "Target span type"
                   , onchange_ "this.form.dispatchEvent(new Event('submit', {bubbles: true}))"
                   ]
-                  do
-                    let target = fromMaybe "all-spans" config.targetSpan
-                    option_ (value_ "all-spans" : ([selected_ "true" | target == "all-spans"])) "All spans"
-                    option_ (value_ "root-spans" : ([selected_ "true" | target == "root-spans"])) "Trace Root Spans"
-                    option_ (value_ "service-entry-spans" : ([selected_ "true" | target == "service-entry-spans"])) "Service Entry Spans"
+                  $ forM_ ([("all-spans", "All spans"), ("root-spans", "Trace Root Spans"), ("service-entry-spans", "Service Entry Spans")] :: [(Text, Text)]) \(v, label) ->
+                    option_ (value_ v : [selected_ "true" | fromMaybe "all-spans" config.targetSpan == v]) $ toHtml label
 
               div_ [class_ "inline-block max-md:hidden"] do
                 button_ ([type_ "button", class_ "rounded-lg px-3 py-1 text-textStrong inline-flex items-center border border-strokeStrong h-full cursor-pointer", Aria.label_ "Save query"] <> popoverTrigger_ "save-query-pop") $ faSprite_ "floppy-disk" "regular" "h-5 w-5 text-iconNeutral"
@@ -203,25 +181,20 @@ logQueryBox_ config = do
               ]
               do
                 faSprite_ "magnifying-glass" "regular" "h-4 w-4 inline-block"
-      -- Inline parse error display
-      case config.parseError of
-        Just err -> div_ [class_ "text-xs text-textError px-2 py-1 bg-fillError-weak rounded flex items-center gap-1", id_ "query-parse-error"] do
-          faSprite_ "triangle-exclamation" "regular" "h-3 w-3 shrink-0"
-          toHtml err
-        Nothing -> div_ [class_ "hidden text-xs text-textError px-2 py-1 bg-fillError-weak rounded flex items-center gap-1", id_ "query-parse-error"] ""
+      div_ [class_ $ "text-xs text-textError px-2 py-1 bg-fillError-weak rounded flex items-center gap-1" <> bool " hidden" "" (isJust config.parseError), id_ "query-parse-error"]
+        $ whenJust config.parseError \err -> faSprite_ "triangle-exclamation" "regular" "h-3 w-3 shrink-0" >> toHtml err
 
       div_ [class_ "flex items-between justify-between max-md:flex-wrap max-md:gap-0.5"] do
         div_ [class_ "flex items-center gap-2 max-md:gap-1 max-md:w-full"] do
           visualizationTabs_ config.vizType config.updateUrl config.targetWidgetPreview config.alert
           div_ [class_ "hidden group-has-[#viz-sessions:checked]/pg:flex items-center gap-1"] do
-            let sortOptions = [("last_seen", "Last seen"), ("first_seen", "First seen"), ("duration", "Duration"), ("errors", "Errors"), ("events", "Events")] :: [(Text, Text)]
             span_ [class_ "text-textWeak text-xs"] "Sort:"
             select_
               [ class_ "select select-sm max-w-[130px]"
               , id_ "session-sort-select"
               , onchange_ "window.setQueryParamAndReload('sort_by', this.value)"
               ]
-              $ forM_ sortOptions \(v, label) ->
+              $ forM_ ([("last_seen", "Last seen"), ("first_seen", "First seen"), ("duration", "Duration"), ("errors", "Errors"), ("events", "Events")] :: [(Text, Text)]) \(v, label) ->
                 option_ [value_ v] $ toHtml label
             script_ "document.getElementById('session-sort-select').value = new URLSearchParams(window.location.search).get('sort_by') || 'last_seen';"
           div_ [class_ "hidden group-has-[#viz-patterns:checked]/pg:flex items-center gap-1"] do
@@ -241,8 +214,8 @@ logQueryBox_ config = do
               ]
               do
                 forM_ knownPatternFields \(v, label) ->
-                  option_ ([value_ v] <> [selected_ "" | config.patternSelected == Just v || (v == "summary" && isNothing config.patternSelected)]) $ toHtml label
-                option_ ([value_ "__custom__"] <> [selected_ "" | isCustom]) "Other field..."
+                  option_ (value_ v : [selected_ "" | config.patternSelected == Just v || (v == "summary" && isNothing config.patternSelected)]) $ toHtml label
+                option_ (value_ "__custom__" : [selected_ "" | isCustom]) "Other field..."
             input_
               [ class_ $ "input input-sm max-w-[200px]" <> bool " hidden" "" isCustom
               , id_ "pattern-target-input"
@@ -266,51 +239,37 @@ logQueryBox_ config = do
                 option_ [value_ f] ""
           span_ [class_ "text-textDisabled mx-2 text-xs max-md:hidden"] "|"
           termRaw "query-builder" [term "query-editor-selector" "#filterElement"] ("" :: Text)
-          unless (isJust config.targetWidgetPreview)
-            $ popularSearchChips_ config.pid config.queryLibSaved config.queryLibRecent noActiveQuery
+          whenNothing_ config.targetWidgetPreview
+            $ popularSearchChips_ config.queryLibSaved config.queryLibRecent noActiveQuery
           -- Mobile-only hide timeline, inside the viz tabs row so it stays on the same line
           fieldset_ [class_ "fieldset md:hidden ml-auto"] $ label_ [class_ "label space-x-1 group-has-[.default-chart:checked]/pg:block"] do
-            input_ [type_ "checkbox", class_ "checkbox checkbox-xs rounded-sm toggle-chart"] >> span_ [class_ "text-xs"] "Hide timeline"
-            script_ "if(window.innerWidth<768){const c=document.currentScript.parentElement.querySelector('.toggle-chart');if(c)c.checked=true;}"
+            input_ [type_ "checkbox", class_ "checkbox checkbox-xs rounded-sm toggle-chart", [__|init if window.innerWidth < 768 set my.checked to true|]]
+              >> span_ [class_ "text-xs"] "Hide timeline"
 
         whenJust config.mobileExtra
           $ div_ [class_ "md:hidden flex items-center gap-2 text-sm w-full hidden"]
 
-        div_
-          [ class_ "flex justify-end gap-2 max-md:hidden"
-          , [__|init
-            if window.location.hash.includes('create-alert-toggle')
-                set #create-alert-toggle.checked to true
-                set #viz-timeseries.checked to true
-                call updateVizTypeInUrl('timeseries', true)
-                set widgetJSON.type to 'timeseries'
-                send 'update-widget' to #visualization-widget-container
-              end
+        div_ [class_ "flex justify-end gap-2 max-md:hidden"] do
+          fieldset_ [class_ "fieldset"] $ label_ [class_ "label space-x-1 hidden group-has-[.default-chart:checked]/pg:block"] do
+            input_ [type_ "checkbox", class_ "checkbox checkbox-sm rounded-sm toggle-chart"] >> span_ "Hide timeline"
+          fieldset_ [class_ "fieldset"] $ label_ [class_ "label space-x-1 group-has-[#viz-patterns:checked]/pg:hidden group-has-[#viz-sessions:checked]/pg:hidden"] do
+            input_
+              $ [ type_ "checkbox"
+                , id_ "create-alert-toggle"
+                , class_ "checkbox checkbox-sm rounded-sm"
+                , -- The #create-alert-toggle hash deep-link replays this element's own change
+                  -- handler rather than duplicating the force-switch body on an ancestor init.
+                  [__|init if window.location.hash.includes('create-alert-toggle') then set my.checked to true then send change to me end
+                   on change if me.checked
+                     set #viz-timeseries.checked to true
+                     call updateVizTypeInUrl('timeseries', true)
+                     set widgetJSON.type to 'timeseries'
+                     send 'update-widget' to #visualization-widget-container
+                   end|]
+                ]
+              <> [checked_ | config.alert]
+            span_ "Create monitor"
 
-          |]
-          ]
-          do
-            fieldset_ [class_ "fieldset"] $ label_ [class_ "label space-x-1 hidden group-has-[.default-chart:checked]/pg:block"] do
-              input_ [type_ "checkbox", class_ "checkbox checkbox-sm rounded-sm toggle-chart"] >> span_ "Hide timeline"
-            fieldset_ [class_ "fieldset"] $ label_ [class_ "label space-x-1 group-has-[#viz-patterns:checked]/pg:hidden group-has-[#viz-sessions:checked]/pg:hidden"] do
-              input_
-                $ [ type_ "checkbox"
-                  , id_ "create-alert-toggle"
-                  , class_ "checkbox checkbox-sm rounded-sm"
-                  , [__|on change 
-                     if me.checked
-                       -- Force switch to chart visualization when creating alert
-                       set #viz-timeseries.checked to true
-                       call updateVizTypeInUrl('timeseries', true)
-                       set widgetJSON.type to 'timeseries'
-                       send 'update-widget' to #visualization-widget-container
-                     end
-                  |]
-                  ]
-                <> [checked_ | config.alert]
-              span_ "Create monitor"
-
-  -- Include initialization code for the query editor
   queryEditorInitializationCode config.queryLibRecent config.queryLibSaved config.vizType config.pid
 
 
@@ -318,53 +277,43 @@ logQueryBox_ config = do
 visualizationTabs_ :: Maybe Text -> Bool -> Maybe Text -> Bool -> Html ()
 visualizationTabs_ vizTypeM updateUrl widgetContainerId alert =
   div_ [class_ "tabs tabs-box tabs-outline tabs-xs bg-fillWeak p-1 rounded-lg", id_ "visualizationTabs", role_ "radiogroup", Aria.label_ "Visualization type"] do
-    -- Use vizTypeM if provided, otherwise default to timeseries for alerts or logs otherwise
     let defaultVizType = fromMaybe (if alert then "timeseries" else "logs") vizTypeM
         containerSelector = fromMaybe "visualization-widget-container" widgetContainerId
-        showEmojis = isJust widgetContainerId -- Only show emojis in widget mode, not in log explorer
         -- Sessions tab is hidden in alert mode (not a valid alerting surface).
-    let visible = if alert then filter (\(_, _, t, _) -> t /= "sessions") visTypes else visTypes
-    forM_ visible $ \(icon, label, vizType, emoji) -> do
-      label_
-        [ term "data-value" vizType
-        , class_ "tab !shadow-none !border-strokeWeak flex gap-1"
-        ]
-        do
-          input_
-            $ [ type_ "radio"
-              , name_ "visualization"
-              , id_ $ "viz-" <> vizType
-              , class_ $ if vizType == "logs" || vizType == "patterns" || vizType == "sessions" then "default-chart" else "no-chart"
-              , value_ vizType
-              , term "data-update-url" (if updateUrl then "true" else "false")
-              , term "data-container-id" containerSelector
-              , -- swapSessionsRegionIfNeeded (defined in queryEditorInitializationCode) refetches
-                -- #page-summary-region when a viz change crosses the sessions boundary, since
-                -- sessions renders a different server region than other viz types.
-                [__| on change if my.checked
-                            set prevViz to window.currentVisualizationType
-                            call updateVizTypeInUrl(my.value, @data-update-url === 'true')
-                            if window.widgetJSON
-                              set widgetJSON.type to my.value
-                              send 'update-widget' to #{@data-container-id}
-                            end
-                            if #resultTable exists
-                              set #resultTable's mode to my.value
-                              set #resultTable's mode to 'logs' unless my.value is 'patterns' or my.value is 'sessions'
-                              call #resultTable.refetchLogs()
-                            end
-                            if window.swapSessionsRegionIfNeeded then call window.swapSessionsRegionIfNeeded(my.value, prevViz)
+        visible = if alert then filter (\(_, _, t, _) -> t /= "sessions") visTypes else visTypes
+    forM_ visible \(_icon, label, vizType, emoji) ->
+      label_ [data_ "value" vizType, class_ "tab !shadow-none !border-strokeWeak flex gap-1"] do
+        input_
+          $ [ type_ "radio"
+            , name_ "visualization"
+            , id_ $ "viz-" <> vizType
+            , class_ $ bool "no-chart" "default-chart" (vizType `elem` ["logs", "patterns", "sessions"])
+            , value_ vizType
+            , data_ "update-url" (bool "false" "true" updateUrl)
+            , data_ "container-id" containerSelector
+            , -- swapSessionsRegionIfNeeded (defined in queryEditorInitializationCode) refetches
+              -- #page-summary-region when a viz change crosses the sessions boundary, since
+              -- sessions renders a different server region than other viz types.
+              [__| on change if my.checked
+                          set prevViz to window.currentVisualizationType
+                          call updateVizTypeInUrl(my.value, @data-update-url === 'true')
+                          if window.widgetJSON
+                            set widgetJSON.type to my.value
+                            send 'update-widget' to #{@data-container-id}
                           end
-                       |]
-              ]
-            <> [checked_ | vizType == defaultVizType]
-          when showEmojis $ span_ [class_ "text-iconNeutral leading-none"] $ toHtml emoji
-          span_ [] $ toHtml label
-
-
--- | HTMX partial response wrapper — hxSelect extracts #queryLibraryContent from the rendered popover
-queryLibrary_ :: Projects.ProjectId -> V.Vector Projects.QueryLibItem -> V.Vector Projects.QueryLibItem -> Html ()
-queryLibrary_ _pid = queryLibraryDropdown_
+                          if #resultTable exists
+                            set #resultTable's mode to my.value
+                            set #resultTable's mode to 'logs' unless my.value is 'patterns' or my.value is 'sessions'
+                            call #resultTable.refetchLogs()
+                          end
+                          if window.swapSessionsRegionIfNeeded then call window.swapSessionsRegionIfNeeded(my.value, prevViz)
+                        end
+                     |]
+            ]
+          <> [checked_ | vizType == defaultVizType]
+        -- Emojis only in widget mode, not in the log explorer
+        when (isJust widgetContainerId) $ span_ [class_ "text-iconNeutral leading-none"] $ toHtml emoji
+        span_ $ toHtml label
 
 
 -- | Shared dropdown content for the query library (Popular + Saved + Recent tabs)
@@ -414,7 +363,7 @@ queryLibraryDropdown_ queryLibSaved queryLibRecent =
           [ type_ "text"
           , class_ "grow"
           , placeholder_ "Search"
-          , term "data-filterParent" $ "dataLibContent" <> label
+          , data_ "filterParent" $ "dataLibContent" <> label
           , [__|on keyup
                  if the event's key is 'Escape' set my value to '' then trigger keyup
                  else show <.query-item/> in .{@data-filterParent} when its textContent.toLowerCase() contains my value.toLowerCase()|]
@@ -422,8 +371,8 @@ queryLibraryDropdown_ queryLibSaved queryLibRecent =
       when (label == "Saved")
         $ label_ [class_ "tabs tabs-sm tabs-box tabs-outline bg-fillWeak text-textInverse-weak shrink items-center h-8", role_ "tablist"] do
           input_ [class_ "hidden", type_ "checkbox", id_ "queryLibraryGroup"]
-          div_ [role_ "tab", class_ "tab h-full bg-fillWeaker group-has-[#queryLibraryGroup:checked]/pg:bg-transparent px-2", term "data-tippy-content" "My queries"] $ faSprite_ "user" "regular" "w-3 h-3"
-          div_ [role_ "tab", class_ "tab h-full group-has-[#queryLibraryGroup:checked]/pg:bg-fillWeaker px-2", term "data-tippy-content" "All team queries"] $ faSprite_ "users" "regular" "w-3 h-3"
+          div_ [role_ "tab", class_ "tab h-full bg-fillWeaker group-has-[#queryLibraryGroup:checked]/pg:bg-transparent px-2", data_ "tippy-content" "My queries"] $ faSprite_ "user" "regular" "w-3 h-3"
+          div_ [role_ "tab", class_ "tab h-full group-has-[#queryLibraryGroup:checked]/pg:bg-fillWeaker px-2", data_ "tippy-content" "All team queries"] $ faSprite_ "users" "regular" "w-3 h-3"
 
 
 hidePopoverJS :: Text
@@ -472,12 +421,10 @@ queryLibItem_ :: Bool -> Projects.QueryLibItem -> Html ()
 queryLibItem_ isRecent qli =
   div_
     [ class_ $ "query-item px-3 py-2 hover:bg-fillWeak cursor-pointer group relative transition-colors " <> if qli.byMe then "" else "hidden group-has-[#queryLibraryGroup:checked]/pg:block"
-    , term "data-query" qli.queryText
-    , term "data-query-id" qli.id.toText
-    , term "data-pid" qli.projectId.toText
+    , data_ "query" qli.queryText
+    , data_ "query-id" qli.id.toText
     ]
     do
-      -- Main content area
       div_ [class_ "pr-8", onclick_ $ "document.getElementById('filterElement').handleAddQuery(JSON.parse(this.closest('.query-item').dataset.query)); " <> hidePopoverJS] do
         div_ [class_ "flex items-baseline gap-2 mb-1"] do
           whenJust qli.title (\title -> span_ [class_ "font-medium text-sm"] $ toHtml title <> " •")
@@ -486,51 +433,39 @@ queryLibItem_ isRecent qli =
             >> when qli.byMe " • by me"
         code_ [class_ "queryText text-xs block whitespace-pre-wrap break-words opacity-75"] $ toHtml qli.queryText
 
-      -- Actions (simplified, shown on hover)
       div_ [class_ "query-actions absolute top-0 right-3 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 focus-within:opacity-100 flex gap-1"] do
-        button_
-          [ type_ "button"
-          , class_ "p-1 hover:bg-fillWeak rounded cursor-pointer"
-          , term "data-tippy-content" "Run this query"
-          , onclick_ $ "event.preventDefault(); document.getElementById('filterElement').handleAddQuery(this.closest('.query-item').dataset.query, true); " <> hidePopoverJS
-          ]
-          $ faSprite_ "play" "regular" "h-3 w-3"
-        button_
-          [ type_ "button"
-          , class_ "p-1 hover:bg-fillWeak rounded cursor-pointer"
-          , term "data-tippy-content" "Copy query to clipboard"
-          , onclick_ "event.preventDefault(); navigator.clipboard.writeText(this.closest('.query-item').dataset.query).then(() => { document.body.dispatchEvent(new CustomEvent('successToast', {detail: {value: ['Query copied to clipboard']}})); })"
-          ]
-          $ faSprite_ "copy" "regular" "h-3 w-3"
+        actionBtn_ "Run this query" "play" [onclick_ $ "event.preventDefault(); document.getElementById('filterElement').handleAddQuery(this.closest('.query-item').dataset.query, true); " <> hidePopoverJS]
+        actionBtn_ "Copy query to clipboard" "copy" [onclick_ "event.preventDefault(); navigator.clipboard.writeText(this.closest('.query-item').dataset.query).then(() => { document.body.dispatchEvent(new CustomEvent('successToast', {detail: {value: ['Query copied to clipboard']}})); })"]
         when qli.byMe do
-          button_
-            [ type_ "button"
-            , class_ "p-1 hover:bg-fillWeak rounded cursor-pointer"
-            , term "data-tippy-content" $ if isRecent then "Save as named query" else "Edit query title"
-            , onclick_
+          actionBtn_
+            (if isRecent then "Save as named query" else "Edit query title")
+            (if isRecent then "floppy-disk" else "pen-to-square")
+            [ onclick_
                 $ if isRecent
                   then "event.preventDefault(); document.getElementById('saveQueryMdl').dataset.pendingQuery = this.closest('.query-item').dataset.query; document.getElementById('queryLibId').value = ''; document.getElementById('saveQueryMdl').checked = true;"
                   else "event.preventDefault(); document.getElementById('queryLibId').value = '" <> qli.id.toText <> "'; document.getElementById('saveQueryMdl').checked = true;"
             ]
-            $ faSprite_ (if isRecent then "floppy-disk" else "pen-to-square") "regular" "h-3 w-3"
           unless isRecent
-            $ button_
-              [ type_ "button"
-              , class_ "p-1 hover:bg-fillWeak rounded cursor-pointer"
-              , term "data-tippy-content" "Delete query"
-              , hxDelete_ $ "/p/" <> qli.projectId.toText <> "/log_explorer/queries/" <> qli.id.toText
+            $ actionBtn_
+              "Delete query"
+              "trash"
+              [ hxDelete_ $ "/p/" <> qli.projectId.toText <> "/log_explorer/queries/" <> qli.id.toText
               , hxTarget_ "#queryLibraryContent"
               , hxSwap_ "outerHTML"
               , hxSelect_ "#queryLibraryContent"
               , hxPushUrl_ "false"
               ]
-            $ faSprite_ "trash" "regular" "h-3 w-3"
+  where
+    actionBtn_ :: Text -> Text -> [Attribute] -> Html ()
+    actionBtn_ tip icon attrs =
+      button_ ([type_ "button", class_ "p-1 hover:bg-fillWeak rounded cursor-pointer", data_ "tippy-content" tip] <> attrs)
+        $ faSprite_ icon "regular" "h-3 w-3"
 
 
 -- | Popular search chips + query library dropdown, unified as one component.
 -- When no query is active, shows "Try:" chips inline. "more" opens the full library dropdown.
-popularSearchChips_ :: Projects.ProjectId -> V.Vector Projects.QueryLibItem -> V.Vector Projects.QueryLibItem -> Bool -> Html ()
-popularSearchChips_ _pid queryLibSaved queryLibRecent showChips =
+popularSearchChips_ :: V.Vector Projects.QueryLibItem -> V.Vector Projects.QueryLibItem -> Bool -> Html ()
+popularSearchChips_ queryLibSaved queryLibRecent showChips =
   div_ [class_ "max-md:hidden group-has-[.ai-search:checked]/fltr:hidden inline-flex gap-1.5 text-xs items-center", id_ "queryLibraryParentEl"] do
     when showChips
       $ span_
@@ -540,7 +475,7 @@ popularSearchChips_ _pid queryLibSaved queryLibRecent showChips =
         ]
         do
           span_ [class_ "text-textDisabled"] "Try:"
-          forM_ defaultChips \(q, l) ->
+          forM_ (take 3 popularQueries) \(q, l, _) ->
             button_
               [ type_ "button"
               , class_ "px-2 py-0.5 rounded-md bg-fillWeaker border border-strokeWeak hover:border-strokeBrand-weak hover:bg-fillBrand-weak text-textWeak hover:text-textBrand cursor-pointer transition-colors"
@@ -557,8 +492,6 @@ popularSearchChips_ _pid queryLibSaved queryLibRecent showChips =
         "Library"
         faSprite_ "chevron-down" "regular" "w-2.5 h-2.5"
     queryLibraryDropdown_ queryLibSaved queryLibRecent
-  where
-    defaultChips = [(q, l) | (q, l, _) <- take 3 popularQueries]
 
 
 -- | Merge pre-computed facet values into the schema so the query editor shows real autocomplete values
@@ -611,7 +544,17 @@ queryEditorInitializationCode queryLibRecent queryLibSaved vizTypeM pid = do
         }
       });
     };
-    
+
+    // Called by the AI-search response handler and query-builder.ts to switch viz type.
+    window.handleVisualizationUpdate = function(vizType, widgetId) {
+      window.requestAnimationFrame(() => {
+        updateVizTypeInUrl(vizType);
+        document.querySelector(`#visualizationTabs input[value='$${vizType}']`).checked = true;
+        window.widgetJSON.type = vizType;
+        document.getElementById(widgetId || 'visualization-widget-container').dispatchEvent(new Event('update-widget'));
+      });
+    };
+
     // Immediate init instead of DOMContentLoaded (which never re-fires on HTMX morph).
     var _initRetries = 0;
     (function initEditor() {

--- a/src/Pkg/Components/LogQueryBox.hs
+++ b/src/Pkg/Components/LogQueryBox.hs
@@ -425,7 +425,7 @@ queryLibItem_ isRecent qli =
     , data_ "query-id" qli.id.toText
     ]
     do
-      div_ [class_ "pr-8", onclick_ $ "document.getElementById('filterElement').handleAddQuery(JSON.parse(this.closest('.query-item').dataset.query)); " <> hidePopoverJS] do
+      div_ [class_ "pr-8", onclick_ $ "document.getElementById('filterElement').handleAddQuery(this.closest('.query-item').dataset.query); " <> hidePopoverJS] do
         div_ [class_ "flex items-baseline gap-2 mb-1"] do
           whenJust qli.title (\title -> span_ [class_ "font-medium text-sm"] $ toHtml title <> " •")
           small_ [class_ "text-textWeak text-xs whitespace-nowrap"]

--- a/src/Pkg/Components/Table.hs
+++ b/src/Pkg/Components/Table.hs
@@ -353,6 +353,15 @@ instance ToHtml TabFilter where
 -- Shared bits
 
 -- | Append a query fragment to a url, picking @?@ or @&@.
+--
+-- The separator must be computed on the url as passed — single-select filters
+-- delete the target param first, so a page whose only param was the filter
+-- gets @?@ back, not a malformed @&@ (regression: /x&filter=bar):
+--
+-- >>> withQuery (deleteParam "filter" "/x?filter=old") "filter=bar"
+-- "/x?filter=bar"
+-- >>> withQuery "/x?a=1" "filter=bar"
+-- "/x?a=1&filter=bar"
 withQuery :: Text -> Text -> Text
 withQuery url q = url <> bool "?" "&" ("?" `T.isInfixOf` url) <> q
 

--- a/src/Pkg/Components/Table.hs
+++ b/src/Pkg/Components/Table.hs
@@ -293,30 +293,28 @@ instance Default Config where
 
 instance ToHtml (Table a) where
   {-# INLINE toHtml #-}
-  toHtml tbl = toHtmlRaw $ renderTable tbl
+  toHtml = toHtmlRaw . renderTable
   {-# INLINE toHtmlRaw #-}
-  toHtmlRaw tbl = toHtmlRaw $ renderTable tbl
+  toHtmlRaw = toHtmlRaw . renderTable
 
 
 -- TableRows ToHtml - only renders rows + pagination link for load more
 
 instance ToHtml (TableRows a) where
-  toHtml tr = toHtmlRaw $ renderTableRows tr
-  toHtmlRaw tr = toHtmlRaw $ renderTableRows tr
+  toHtml = toHtmlRaw . renderTableRows
+  toHtmlRaw = toHtmlRaw . renderTableRows
 
 
 {-# INLINE renderTableRows #-}
 renderTableRows :: TableRows a -> Html ()
 renderTableRows tr
   | V.null tr.rows = whenJust tr.emptyState renderSimpleZeroState
-  | tr.renderAsTable = do
-      let getRowAttrs row = maybe [] ($ row) tr.rowAttrs
-      tbody_ [class_ "stagger-fade"] $ V.forM_ tr.rows \row -> tr_ (getRowAttrs row) do
-        whenJust tr.rowId \getId -> td_ [class_ "w-8 align-top pt-4"] $ input_ [term "aria-label" "Select Item", class_ "bulkactionItemCheckbox checkbox checkbox-md checked:checkbox-primary", type_ "checkbox", name_ "itemId", value_ $ getId row]
-        forM_ tr.columns \c -> td_ c.attrs $ c.render row
-      whenJust tr.pagination renderPaginationFooter
   | otherwise = do
-      div_ [class_ "stagger-fade"] $ V.forM_ tr.rows \row -> div_ [class_ "flex gap-8 items-start itemsListItem"] $ forM_ tr.columns \c -> div_ c.attrs $ c.render row
+      if tr.renderAsTable
+        then tbody_ [class_ "stagger-fade"] $ V.forM_ tr.rows \row -> tr_ (maybe [] ($ row) tr.rowAttrs) do
+          whenJust tr.rowId \getId -> td_ [class_ "w-8 align-top pt-4"] $ selectRowCheckbox_ False (getId row)
+          forM_ tr.columns \c -> td_ c.attrs $ c.render row
+        else div_ [class_ "stagger-fade"] $ V.forM_ tr.rows \row -> div_ [class_ "flex gap-8 items-start itemsListItem"] $ forM_ tr.columns \c -> div_ c.attrs $ c.render row
       whenJust tr.pagination renderPaginationFooter
 
 
@@ -350,6 +348,61 @@ instance ToHtml TabFilter where
             do
               span_ $ toHtml opt.name
               whenJust opt.count \c -> when (c > 0) $ span_ [class_ "absolute top-[1px] -right-[5px] text-textInverse-strong text-xs font-medium rounded-full px-1 bg-fillError-strong"] $ show c
+
+
+-- Shared bits
+
+-- | Append a query fragment to a url, picking @?@ or @&@.
+withQuery :: Text -> Text -> Text
+withQuery url q = url <> bool "?" "&" ("?" `T.isInfixOf` url) <> q
+
+
+-- | htmx attrs that fetch @url@ and swap the target container with the same container from the response.
+swapTarget_ :: Text -> Text -> [Attribute]
+swapTarget_ tid url = [hxGet_ url, hxTarget_ $ "#" <> tid, hxSelect_ $ "#" <> tid, hxPushUrl_ "true", hxSwap_ "outerHTML"]
+
+
+selectAllCheckbox_ :: Html ()
+selectAllCheckbox_ = input_ [term "aria-label" "Select All", type_ "checkbox", class_ "checkbox h-6 w-6 checked:checkbox-primary", [__| on click set .bulkactionItemCheckbox.checked to my.checked |]]
+
+
+selectRowCheckbox_ :: Bool -> Text -> Html ()
+selectRowCheckbox_ selected rid =
+  input_
+    $ [term "aria-label" "Select Item", class_ "bulkactionItemCheckbox checkbox checkbox-md checked:checkbox-primary", type_ "checkbox", name_ "itemId", value_ rid]
+    <> [checked_ | selected]
+
+
+-- | One row of a sort dropdown; @linkAttrs@ carries either an href or the htmx swap attrs.
+sortOption_ :: Bool -> [Attribute] -> Text -> Text -> Html ()
+sortOption_ isActive linkAttrs title desc =
+  a_ ([class_ $ "block flex flex-row px-3 py-2 hover:bg-fillBrand-weak rounded-md cursor-pointer " <> bool "" " text-textBrand " isActive] <> linkAttrs) do
+    div_ [class_ "flex flex-col items-center justify-center px-1"] $ if isActive then faSprite_ "icon-checkmark4" "solid" "w-4 h-4" else div_ [class_ "w-4 h-4"] ""
+    div_ [class_ "grow"] do
+      span_ [class_ "block text-sm font-medium"] $ toHtml title
+      span_ [class_ "block text-xs text-textWeak"] $ toHtml desc
+
+
+sortLoader_ :: Html ()
+sortLoader_ = div_ [class_ "p-12 fixed rounded-lg shadow-sm bg-bgOverlay top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 htmx-indicator loading loading-dots loading-md", id_ "sortLoader"] ""
+
+
+-- | Icon + label button that opens the popover @popId@ (sort/filter dropdown triggers).
+dropdownTriggerBtn_ :: Text -> Text -> Text -> Html ()
+dropdownTriggerBtn_ icon label popId =
+  button_ ([class_ "btn btn-xs shadow-none text-xs font-normal border border-strokeWeak text-textWeak bg-transparent", type_ "button"] <> popoverTrigger_ popId) do
+    faSprite_ icon "regular" "h-3 w-3"
+    span_ $ toHtml label
+
+
+-- | Sort dropdown: trigger + popover of options. @optAttrs@ turns a sort key into its link/htmx attrs;
+-- the first option is the implicit default when @current@ is empty.
+sortDropdown_ :: Text -> [Attribute] -> [(Text, Text, Text)] -> Text -> Text -> (Text -> [Attribute]) -> Html ()
+sortDropdown_ popId panelAttrs opts current fallbackLabel optAttrs = do
+  let defaultKey = maybe "" (\(_, _, k) -> k) (listToMaybe opts)
+  dropdownTriggerBtn_ "sort" (maybe fallbackLabel (\(t, _, _) -> t) $ find (\(_, _, k) -> k == current) opts) popId
+  div_ (panelAttrs <> popoverPanel_ popId) $ forM_ opts \(title, desc, k) ->
+    sortOption_ (current == k || (current == "" && k == defaultKey)) (optAttrs k <> [hxIndicator_ "#sortLoader"]) title desc
 
 
 -- Core Rendering Functions
@@ -395,41 +448,20 @@ renderRows tbl =
         $ thead_ do
           tr_ do
             when (isJust tbl.features.rowId)
-              $ th_ [class_ $ tbl.config.thClasses <> " w-8 max-md:hidden"]
-              $ input_
-                [ term "aria-label" "Select All"
-                , type_ "checkbox"
-                , class_ "checkbox h-6 w-6 checked:checkbox-primary"
-                , [__| on click set .bulkactionItemCheckbox.checked to my.checked |]
-                ]
+              $ th_ [class_ $ tbl.config.thClasses <> " w-8 max-md:hidden"] selectAllCheckbox_
             forM_ (zip [0 ..] tbl.columns) \(idx, c) -> do
-              let baseAttrs = [class_ $ tbl.config.thClasses <> " " <> fromMaybe "" c.align]
-                  sortAttrs = case (c.sortField, tbl.features.sortableColumns) of
-                    (Just field, Just cfg) ->
-                      [ hxGet_ $ toggleSortUrl cfg field
-                      , hxTarget_ $ "#" <> cfg.targetId
-                      , hxSelect_ $ "#" <> cfg.targetId
-                      , hxPushUrl_ "true"
-                      , hxSwap_ "outerHTML"
-                      , class_ "cursor-pointer hover:bg-fillWeak"
-                      ]
-                    _ -> []
-                  isSorted = case (c.sortField, tbl.features.sortableColumns) of
-                    (Just field, Just cfg) -> ("+" <> field == cfg.currentSort) || ("-" <> field == cfg.currentSort)
-                    _ -> False
-                  sortOrder = case (c.sortField, tbl.features.sortableColumns) of
-                    (Just field, Just cfg) | "-" <> field == cfg.currentSort -> Just Desc
-                    (Just field, Just cfg) | "+" <> field == cfg.currentSort -> Just Asc
-                    _ -> Nothing
+              let sortable = (,) <$> c.sortField <*> tbl.features.sortableColumns
+                  baseAttrs = [class_ $ tbl.config.thClasses <> " " <> fromMaybe "" c.align]
+                  sortAttrs = foldMap (\(field, cfg) -> swapTarget_ cfg.targetId (toggleSortUrl cfg field) <> [class_ "cursor-pointer hover:bg-fillWeak"]) sortable
+                  sortOrder = sortable >>= \(field, cfg) -> lookup cfg.currentSort [("-" <> field, Desc), ("+" <> field, Asc)]
               th_ (c.attrs <> baseAttrs <> sortAttrs) do
                 span_ [class_ "flex items-center gap-2 min-w-0"] do
                   span_ [class_ $ bool "max-md:hidden" "" (idx > 0)] $ toHtml c.name
                   whenJust c.headerExtra id
-                  when isSorted $ case sortOrder of
-                    Just Asc -> faSprite_ "arrow-up" "regular" "w-3 h-3"
-                    Just Desc -> faSprite_ "arrow-down" "regular" "w-3 h-3"
-                    Nothing -> pass
-                  when (isJust c.sortField && isJust tbl.features.sortableColumns && not isSorted) $ faSprite_ "arrows-up-down" "regular" "w-3 h-3 opacity-30"
+                  whenJust sortOrder \case
+                    Asc -> faSprite_ "arrow-up" "regular" "w-3 h-3"
+                    Desc -> faSprite_ "arrow-down" "regular" "w-3 h-3"
+                  when (isJust sortable && isNothing sortOrder) $ faSprite_ "arrows-up-down" "regular" "w-3 h-3 opacity-30"
                   when (tbl.config.bulkActionsInHeader == Just idx) do
                     renderHeaderBulkActions tbl.features.bulkActions
                     whenJust tbl.features.tableHeaderActions \ha -> do
@@ -473,41 +505,32 @@ renderListRow tbl row = div_ (treeAttrs <> rowAttrs <> [class_ "flex gap-4 md:ga
 renderTableRow :: Table a -> a -> Html ()
 renderTableRow tbl row =
   tr_ ([class_ rowClass] <> treeAttrs <> rowAttrs <> linkHandler) do
-    when (isJust tbl.features.rowId)
-      $ td_ [class_ "w-8 align-top pt-4 max-md:hidden"] do
-        whenJust tbl.features.rowId \getId ->
-          input_
-            $ [ term "aria-label" "Select Item"
-              , class_ "bulkactionItemCheckbox checkbox checkbox-md checked:checkbox-primary"
-              , type_ "checkbox"
-              , name_ "itemId"
-              , value_ $ getId row
-              ]
-            <> [checked_ | isSelected]
-
-    forM_ tbl.columns \c -> td_ (c.attrs <> colAttrs c) $ c.render row
+    whenJust tbl.features.rowId \getId ->
+      td_ [class_ "w-8 align-top pt-4 max-md:hidden"] $ selectRowCheckbox_ (maybe False ($ row) tbl.features.selectRow) (getId row)
+    forM_ tbl.columns \c -> td_ (c.attrs <> (class_ <$> maybeToList c.align)) $ c.render row
   where
     rowAttrs = maybe [] ($ row) tbl.features.rowAttrs
     treeAttrs = maybe [] (treeRowAttrs row) tbl.features.treeConfig
     isTreeGroup = maybe False (\tc -> tc.isGroupRow row) tbl.features.treeConfig
     rowClass = "hover:bg-fillWeak transition-colors duration-75 itemsListItem" <> if isTreeGroup then " cursor-pointer" else ""
     linkHandler = maybe [] (\getLink -> [class_ "cursor-pointer", hxGet_ (getLink row), hxPushUrl_ "true"] <> navTabAttrs) tbl.features.rowLink
-    isSelected = maybe False (\f -> f row) tbl.features.selectRow
-    colAttrs c = foldMap (\a -> [class_ a]) c.align
+
+
+-- | Bulk action button: enabled (via CSS) only while some row checkbox is checked.
+bulkActionBtn_ :: Text -> Text -> BulkAction -> Html ()
+bulkActionBtn_ btnSize iconSize blkA =
+  button_
+    [ class_ $ "btn " <> btnSize <> " btn-disabled group-has-[.bulkactionItemCheckbox:checked]/grid:text-white group-has-[.bulkactionItemCheckbox:checked]/grid:bg-fillBrand-strong group-has-[.bulkactionItemCheckbox:checked]/grid:pointer-events-auto!"
+    , hxPost_ blkA.uri
+    , hxSwap_ "none"
+    ]
+    do
+      whenJust blkA.icon \icon -> faSprite_ icon "regular" $ iconSize <> " inline-block"
+      span_ [class_ "ml-1"] $ toHtml blkA.title
 
 
 renderHeaderBulkActions :: [BulkAction] -> Html ()
-renderHeaderBulkActions bulkActions =
-  span_ [class_ "inline-flex gap-2 ml-2 max-md:hidden"] do
-    forM_ bulkActions \blkA ->
-      button_
-        [ class_ "btn btn-xs btn-disabled group-has-[.bulkactionItemCheckbox:checked]/grid:text-white group-has-[.bulkactionItemCheckbox:checked]/grid:bg-fillBrand-strong group-has-[.bulkactionItemCheckbox:checked]/grid:pointer-events-auto!"
-        , hxPost_ blkA.uri
-        , hxSwap_ "none"
-        ]
-        do
-          whenJust blkA.icon \icon -> faSprite_ icon "regular" "h-3 w-3 inline-block"
-          span_ [class_ "ml-1"] $ toHtml blkA.title
+renderHeaderBulkActions bulkActions = span_ [class_ "inline-flex gap-2 ml-2 max-md:hidden"] $ forM_ bulkActions $ bulkActionBtn_ "btn-xs" "h-3 w-3"
 
 
 renderHeaderTableActions :: TableHeaderActions -> Html ()
@@ -519,81 +542,24 @@ renderHeaderTableActions actions = span_ [class_ "inline-flex gap-2 ml-2"] do
 
 renderSortDropdown :: TableHeaderActions -> Html ()
 renderSortDropdown actions = do
-  let defaultSort = maybe "" (\(_, _, k) -> k) (listToMaybe actions.sortOptions)
-      currentLabel = maybe "Sort" (\(t, _, _) -> t) $ find (\(_, _, k) -> k == actions.currentSort) actions.sortOptions
-      baseUrl' = deleteParam "sort" actions.baseUrl
-      urlPrefix = baseUrl' <> (if T.isInfixOf "?" baseUrl' then "&" else "?") <> "sort="
-      mkSortUrl sortKey = urlPrefix <> toUriStr sortKey
-      popId = "sortDropdown"
-
-  div_ [class_ "inline-block", data_ "tippy-content" "Sort by"] do
-    button_
-      [ class_ "btn btn-xs shadow-none text-xs font-normal border border-strokeWeak text-textWeak bg-transparent"
-      , type_ "button"
-      , term "popovertarget" popId
-      , style_ $ "anchor-name: --anchor-" <> popId
-      ]
-      do
-        faSprite_ "sort" "regular" "h-3 w-3"
-        span_ $ toHtml currentLabel
-    div_
-      [ id_ popId
-      , term "popover" "auto"
-      , class_ "dropdown dropdown-start bg-bgRaised p-1 text-sm normal-case border border-strokeWeak z-50 w-72 rounded-md shadow-lg mt-1"
-      , style_ $ "position-try: flip-block; position-anchor: --anchor-" <> popId
-      ]
-      do
-        forM_ actions.sortOptions \(title, desc, sortKey) -> do
-          let isActive = actions.currentSort == sortKey || (actions.currentSort == "" && sortKey == defaultSort)
-          a_
-            [ class_ $ "block flex flex-row px-3 py-2 hover:bg-fillBrand-weak rounded-md cursor-pointer " <> if isActive then " text-textBrand " else ""
-            , hxGet_ $ mkSortUrl sortKey
-            , hxTarget_ $ "#" <> actions.targetId
-            , hxSelect_ $ "#" <> actions.targetId
-            , hxPushUrl_ "true"
-            , hxSwap_ "outerHTML"
-            , hxIndicator_ "#sortLoader"
-            ]
-            do
-              div_ [class_ "flex flex-col items-center justify-center px-1"] $ if isActive then faSprite_ "icon-checkmark4" "solid" "w-4 h-4" else div_ [class_ "w-4 h-4"] ""
-              div_ [class_ "grow"] do
-                span_ [class_ "block text-sm font-medium"] $ toHtml title
-                span_ [class_ "block text-xs text-textWeak"] $ toHtml desc
-  div_ [class_ "p-12 fixed rounded-lg shadow-sm bg-bgOverlay top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 htmx-indicator loading loading-dots loading-md", id_ "sortLoader"] ""
+  div_ [class_ "inline-block", data_ "tippy-content" "Sort by"]
+    $ sortDropdown_ "sortDropdown" [class_ "dropdown dropdown-start bg-bgRaised p-1 text-sm normal-case border border-strokeWeak z-50 w-72 rounded-md shadow-lg mt-1"] actions.sortOptions actions.currentSort "Sort"
+    $ \k -> swapTarget_ actions.targetId (withQuery (deleteParam "sort" actions.baseUrl) $ "sort=" <> toUriStr k)
+  sortLoader_
 
 
 renderFilterDropdown :: TableHeaderActions -> Html ()
 renderFilterDropdown actions = do
-  let hasActiveFilters = not $ null actions.activeFilters
-      activeCount = sum $ map (length . snd) actions.activeFilters
-      popId = "filterDropdown"
+  let popId = "filterDropdown"
   div_ [class_ "inline-block", data_ "tippy-content" "Filter by"] do
-    button_
-      [ class_ "btn btn-xs shadow-none text-xs font-normal border border-strokeWeak text-textWeak bg-transparent"
-      , type_ "button"
-      , term "popovertarget" popId
-      , style_ $ "anchor-name: --anchor-" <> popId
-      ]
-      do
-        faSprite_ "filter" "regular" "h-3 w-3"
-        span_ $ toHtml $ "Filter" <> if hasActiveFilters then " (" <> show activeCount <> ")" else ""
+    dropdownTriggerBtn_ "filter" ("Filter" <> if null actions.activeFilters then "" else " (" <> show (sum $ map (length . snd) actions.activeFilters) <> ")") popId
     div_
-      [ id_ popId
-      , term "popover" "auto"
-      , class_ "dropdown dropdown-start bg-bgRaised p-1 text-sm normal-case border border-strokeWeak z-50 w-60 rounded-md shadow-lg mt-1"
-      , style_ $ "position-try: flip-block; position-anchor: --anchor-" <> popId
-      ]
+      ([class_ "dropdown dropdown-start bg-bgRaised p-1 text-sm normal-case border border-strokeWeak z-50 w-60 rounded-md shadow-lg mt-1"] <> popoverPanel_ popId)
       do
         div_ [class_ "flex items-center justify-between px-3 py-2 text-sm font-semibold text-textStrong border-b border-strokeWeak"] do
           span_ "Select Filter"
           a_
-            [ class_ "text-xs text-textBrand cursor-pointer flex items-center gap-1"
-            , hxGet_ actions.baseUrl
-            , hxTarget_ $ "#" <> actions.targetId
-            , hxSelect_ $ "#" <> actions.targetId
-            , hxPushUrl_ "true"
-            , hxSwap_ "outerHTML"
-            ]
+            ([class_ "text-xs text-textBrand cursor-pointer flex items-center gap-1"] <> swapTarget_ actions.targetId actions.baseUrl)
             ("Clear all" >> faSprite_ "xmark" "regular" "w-3 h-3")
         div_ [class_ "p-1"] $ forM_ actions.filterMenus (renderFilterMenuItem actions)
 
@@ -602,11 +568,7 @@ renderFilterMenuItem :: TableHeaderActions -> FilterMenu -> Html ()
 renderFilterMenuItem actions menu = div_ [class_ "relative"] do
   let subPopId = "filterSub_" <> menu.paramName
   button_
-    [ class_ "flex items-center justify-between w-full px-3 py-2 text-sm rounded hover:bg-fillWeak cursor-pointer"
-    , type_ "button"
-    , term "popovertarget" subPopId
-    , style_ $ "anchor-name: --anchor-" <> subPopId
-    ]
+    ([class_ "flex items-center justify-between w-full px-3 py-2 text-sm rounded hover:bg-fillWeak cursor-pointer", type_ "button"] <> popoverTrigger_ subPopId)
     do
       span_ $ toHtml $ "By " <> menu.label
       faSprite_ "chevron-right" "regular" "w-3 h-3"
@@ -623,26 +585,20 @@ renderFilterMenuItem actions menu = div_ [class_ "relative"] do
 
 renderFilterOption :: TableHeaderActions -> FilterMenu -> FilterOption -> Html ()
 renderFilterOption actions menu opt = label_ [class_ "flex items-center gap-3 px-3 py-2 rounded cursor-pointer hover:bg-fillWeak"] do
-  let separator = if T.isInfixOf "?" actions.baseUrl then "&" else "?"
-      paramVal = menu.paramName <> "=" <> toUriStr opt.value
+  let paramVal = menu.paramName <> "=" <> toUriStr opt.value
       -- For multi-select: toggle this value; for single-select: replace all with this value
       url
         | menu.multiSelect && opt.isActive = deleteParamValue menu.paramName opt.value actions.baseUrl
-        | menu.multiSelect = actions.baseUrl <> separator <> paramVal
-        | otherwise = deleteParam menu.paramName actions.baseUrl <> separator <> paramVal
-      inputType = if menu.multiSelect then "checkbox" else "radio"
+        | menu.multiSelect = withQuery actions.baseUrl paramVal
+        | otherwise = withQuery (deleteParam menu.paramName actions.baseUrl) paramVal
   input_
-    $ [ type_ inputType
-      , class_ $ if menu.multiSelect then "checkbox checkbox-xs" else "radio radio-xs"
+    $ [ type_ $ bool "radio" "checkbox" menu.multiSelect
+      , class_ $ bool "radio radio-xs" "checkbox checkbox-xs" menu.multiSelect
       , value_ opt.value
       , name_ $ "filter_" <> menu.paramName -- group radios by param name
-      , hxGet_ url
-      , hxTarget_ $ "#" <> actions.targetId
-      , hxSelect_ $ "#" <> actions.targetId
-      , hxPushUrl_ "true"
-      , hxSwap_ "outerHTML"
       , hxTrigger_ "change"
       ]
+    <> swapTarget_ actions.targetId url
     <> [checked_ | opt.isActive]
   span_ [class_ "text-sm"] $ toHtml opt.label
 
@@ -663,24 +619,10 @@ renderToolbar tbl =
     when (isJust tbl.features.rowId && not tbl.config.renderAsTable)
       $ div_ [class_ "h-4 flex space-x-3 w-8 items-center"] do
         span_ [class_ "w-2 h-full"] ""
-        input_
-          [ term "aria-label" "Select All"
-          , type_ "checkbox"
-          , class_ "checkbox h-6 w-6 checked:checkbox-primary"
-          , [__| on click set .bulkactionItemCheckbox.checked to my.checked |]
-          ]
+        selectAllCheckbox_
 
     div_ [class_ "grow flex flex-row gap-2"] do
-      forM_ tbl.features.bulkActions \blkA ->
-        button_
-          [ class_ "btn btn-sm btn-disabled group-has-[.bulkactionItemCheckbox:checked]/grid:text-white group-has-[.bulkactionItemCheckbox:checked]/grid:bg-fillBrand-strong group-has-[.bulkactionItemCheckbox:checked]/grid:pointer-events-auto!"
-          , hxPost_ blkA.uri
-          , hxSwap_ "none"
-          ]
-          do
-            whenJust blkA.icon \icon -> faSprite_ icon "regular" "h-4 w-4 inline-block"
-            span_ (toHtml blkA.title)
-
+      forM_ tbl.features.bulkActions $ bulkActionBtn_ "btn-sm" "h-4 w-4"
       whenJust tbl.features.sort renderSortMenu
 
 
@@ -688,63 +630,19 @@ renderSearch :: Text -> SearchMode -> Html ()
 renderSearch elemID searchMode =
   label_ [class_ "input input-sm max-md:hidden flex w-full h-9 bg-transparent border border-strokeWeak shadow-none overflow-hidden items-center gap-2"] do
     faSprite_ "magnifying-glass" "regular" "w-4 h-4 opacity-70"
-    case searchMode of
-      ServerSide url ->
-        input_
-          [ type_ "text"
-          , class_ "grow"
-          , name_ "search"
-          , id_ "search_box"
-          , placeholder_ "Search"
-          , hxTrigger_ "keyup changed delay:500ms"
-          , hxGet_ url
-          , hxTarget_ "#rowsContainer"
-          , hxSwap_ "innerHTML"
-          , hxIndicator_ "#searchIndicator"
-          ]
-      ClientSide ->
-        input_
-          [ type_ "text"
-          , class_ "grow"
-          , placeholder_ "Search"
-          , term "_" $ "on input show .itemsListItem in #" <> elemID <> "_page when its textContent.toLowerCase() contains my value.toLowerCase()"
-          ]
+    input_
+      $ [type_ "text", class_ "grow", placeholder_ "Search"]
+      <> case searchMode of
+        ServerSide url -> [name_ "search", id_ "search_box", hxTrigger_ "keyup changed delay:500ms", hxGet_ url, hxTarget_ "#rowsContainer", hxSwap_ "innerHTML", hxIndicator_ "#searchIndicator"]
+        ClientSide -> [term "_" $ "on input show .itemsListItem in #" <> elemID <> "_page when its textContent.toLowerCase() contains my value.toLowerCase()"]
 
 
 renderSortMenu :: SortConfig -> Html ()
 renderSortMenu sortCfg = do
-  let currentURL' = deleteParam "sort" sortCfg.currentURL
-  let defaultSort = maybe "" (\(_, _, i) -> i) (listToMaybe sortCfg.options)
-  let currentSortTitle = maybe sortCfg.current (\(t, _, _) -> t) $ find (\(_, _, identifier) -> identifier == sortCfg.current) sortCfg.options
-
-  div_ [class_ "inline-block"] do
-    button_ ([type_ "button", class_ "btn btn-xs shadow-none text-xs font-normal border border-strokeWeak text-textWeak bg-transparent"] <> popoverTrigger_ "sortMenuDiv") do
-      faSprite_ "sort" "regular" "h-3 w-3"
-      span_ $ toHtml currentSortTitle
-
-    div_
-      ( [hxBoost_ "true", class_ "dropdown dropdown-end bg-bgRaised p-1 text-sm border border-strokeWeak mt-2 w-72 origin-top-right rounded-md shadow-lg"]
-          <> popoverPanel_ "sortMenuDiv"
-      )
-      do
-        sortCfg.options & mapM_ \(title, desc, identifier) -> do
-          let isActive = sortCfg.current == identifier || (sortCfg.current == "" && identifier == defaultSort)
-          a_
-            [ class_ $ "block flex flex-row px-3 py-2 hover:bg-fillBrand-weak rounded-md cursor-pointer " <> (if isActive then " text-textBrand " else "")
-            , href_ $ currentURL' <> "&sort=" <> toUriStr identifier
-            , hxIndicator_ "#sortLoader"
-            ]
-            do
-              div_ [class_ "flex flex-col items-center justify-center px-1"]
-                $ if isActive then faSprite_ "icon-checkmark4" "solid" "w-4 h-4" else div_ [class_ "w-4 h-4"] ""
-              div_ [class_ "grow"] do
-                span_ [class_ "block text-sm font-medium"] $ toHtml title
-                span_ [class_ "block text-xs text-textWeak"] $ toHtml desc
-  div_
-    [ class_ "p-12 fixed rounded-lg shadow-sm bg-bgOverlay top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 htmx-indicator loading loading-dots loading-md"
-    , id_ "sortLoader"
-    ]
-    ""
+  div_ [class_ "inline-block"]
+    $ sortDropdown_ "sortMenuDiv" [hxBoost_ "true", class_ "dropdown dropdown-end bg-bgRaised p-1 text-sm border border-strokeWeak mt-2 w-72 origin-top-right rounded-md shadow-lg"] sortCfg.options sortCfg.current sortCfg.current
+    $ \k -> [href_ $ deleteParam "sort" sortCfg.currentURL <> "&sort=" <> toUriStr k]
+  sortLoader_
 
 
 -- Pagination footer with per-page selector and navigation
@@ -762,17 +660,13 @@ renderPaginationFooter pg = div_ [class_ "flex items-center justify-between max-
   where
     startItem = pg.currentPage * pg.perPage + 1
     endItem = min ((pg.currentPage + 1) * pg.perPage) pg.totalCount
-    mkUrl page perPage = pg.baseUrl <> (if T.isInfixOf "?" pg.baseUrl then "&" else "?") <> "page=" <> show page <> "&per_page=" <> show perPage
-    pgAttrs url = [hxGet_ url, hxTarget_ $ "#" <> pg.targetId, hxSelect_ $ "#" <> pg.targetId, hxSwap_ "outerHTML", hxPushUrl_ "true"]
+    mkUrl page perPage = withQuery pg.baseUrl $ "page=" <> show page <> "&per_page=" <> show perPage
+    pgAttrs = swapTarget_ pg.targetId
     navBtn icon enabled url = button_ ([class_ $ "cursor-pointer p-1.5 rounded border border-strokeWeak " <> if enabled then "hover:bg-fillWeak cursor-pointer" else "opacity-40 cursor-not-allowed", type_ "button"] <> if enabled then pgAttrs url else []) $ faSprite_ icon "regular" "w-4 h-4"
 
 
 renderZeroState :: ZeroState -> Html ()
-renderZeroState zs = do
-  let url = case zs.destination of
-        Left labelId -> labelId
-        Right destination -> destination
-  emptyState_ def{icon = Just zs.icon, action = ESLink url zs.actionText} zs.title zs.description
+renderZeroState zs = emptyState_ def{icon = Just zs.icon, action = ESLink (either id id zs.destination) zs.actionText} zs.title zs.description
 
 
 renderSimpleZeroState :: SimpleZeroState -> Html ()
@@ -847,33 +741,19 @@ withColHeaderExtra h column = column{headerExtra = Just h}
 parseSortParam :: Text -> Maybe [(Text, [Text])] -> [SortField]
 parseSortParam sortP overridesM = concatMap parseField (T.splitOn "," sortP)
   where
-    overrideLookup = fromMaybe [] overridesM
-    parseField txt
-      | Just sortField <- T.stripPrefix "+" txt = createSortFields sortField Asc
-      | Just sortField <- T.stripPrefix "-" txt = createSortFields sortField Desc
-      | otherwise = []
-    createSortFields sortField order =
-      let matchingFields = fromMaybe [sortField] (lookup (T.toLower sortField) overrideLookup)
-       in map (`SortField` order) matchingFields
+    parseField txt = case T.uncons txt of
+      Just ('+', f) -> fields f Asc
+      Just ('-', f) -> fields f Desc
+      _ -> []
+    fields f order = map (`SortField` order) $ fromMaybe [f] (lookup (T.toLower f) =<< overridesM)
 
 
 -- Generate ORDER BY clause from sort fields
 sortFieldsToSQL :: [SortField] -> Text
-sortFieldsToSQL sortFields
-  | null sortFields = ""
-  | otherwise = "ORDER BY " <> T.intercalate ", " (map (.toSql) sortFields)
+sortFieldsToSQL [] = ""
+sortFieldsToSQL sortFields = "ORDER BY " <> T.intercalate ", " (map (.toSql) sortFields)
 
 
--- Toggle sort direction for a column, returning the new sort param
-toggleSortParam :: Text -> Text -> Text
-toggleSortParam currentSort field
-  | currentSort == "+" <> field = "-" <> field
-  | otherwise = "+" <> field
-
-
--- Generate URL with new sort param
+-- Generate URL toggling the sort direction of a column
 toggleSortUrl :: SortableConfig -> Text -> Text
-toggleSortUrl cfg field =
-  let urlWithoutSort = deleteParam "sort" cfg.baseUrl
-      separator = if T.isInfixOf "?" urlWithoutSort then "&" else "?"
-   in urlWithoutSort <> separator <> "sort=" <> toUriStr (toggleSortParam cfg.currentSort field)
+toggleSortUrl cfg field = withQuery (deleteParam "sort" cfg.baseUrl) $ "sort=" <> toUriStr (bool "+" "-" (cfg.currentSort == "+" <> field) <> field)

--- a/src/Pkg/Components/Table.hs
+++ b/src/Pkg/Components/Table.hs
@@ -339,7 +339,7 @@ instance ToHtml TabFilter where
         let uri = deleteParam "filter" tf.currentURL
         forM_ tf.options \opt ->
           a_
-            ( [ href_ $ uri <> "&filter=" <> toUriStr opt.name
+            ( [ href_ $ withQuery uri ("filter=" <> toUriStr opt.name)
               , role_ "tab"
               , class_ $ "tab h-auto! " <> if opt.name == tf.current then "tab-active text-textStrong" else ""
               ]
@@ -650,7 +650,7 @@ renderSortMenu :: SortConfig -> Html ()
 renderSortMenu sortCfg = do
   div_ [class_ "inline-block"]
     $ sortDropdown_ "sortMenuDiv" [hxBoost_ "true", class_ "dropdown dropdown-end bg-bgRaised p-1 text-sm border border-strokeWeak mt-2 w-72 origin-top-right rounded-md shadow-lg"] sortCfg.options sortCfg.current sortCfg.current
-    $ \k -> [href_ $ deleteParam "sort" sortCfg.currentURL <> "&sort=" <> toUriStr k]
+    $ \k -> [href_ $ withQuery (deleteParam "sort" sortCfg.currentURL) ("sort=" <> toUriStr k)]
   sortLoader_
 
 

--- a/src/Pkg/Components/TimePicker.hs
+++ b/src/Pkg/Components/TimePicker.hs
@@ -6,8 +6,7 @@ module Pkg.Components.TimePicker (
 ) where
 
 import Data.Aeson qualified as AE
-import Data.Char qualified as Char
-import Data.List qualified as L
+import Data.List (lookup)
 import Data.Text qualified as T
 import Data.Time (UTCTime, addUTCTime, defaultTimeLocale, formatTime, secondsToNominalDiffTime)
 import Data.Time.Format.ISO8601 (iso8601ParseM)
@@ -18,12 +17,11 @@ import Lucid.Aria qualified as Aria
 import Lucid.Base (termRaw)
 import Lucid.Hyperscript (__)
 import NeatInterpolation (text)
-import PyF (fmt)
 import Relude hiding (some)
 import Text.Megaparsec (Parsec, parse, some)
 import Text.Megaparsec.Char (letterChar, space)
 import Text.Megaparsec.Char.Lexer (decimal)
-import Utils (faSprite_, popoverPanel_, popoverTrigger_)
+import Utils (faSprite_, nonEmptyT, popoverPanel_, popoverTrigger_)
 
 
 -- $setup
@@ -43,19 +41,7 @@ data TimePicker = TimePicker
   deriving (AE.FromJSON, AE.ToJSON) via DAE.Snake TimePicker
 
 
--- Mapping of time units to seconds
-unitToSeconds :: String -> Maybe (Int, Text)
-unitToSeconds unit =
-  L.lookup
-    (map Char.toUpper unit)
-    [ ("S", (1, "Seconds"))
-    , ("M", (60, "Minutes"))
-    , ("H", (3600, "Hours"))
-    , ("D", (86400, "Days"))
-    ]
-
-
--- Test parseSince with different time units
+-- | Test parseSince with different time units
 -- >>> parseSince (Unsafe.read "2024-10-31 12:00:00 UTC") "2H"
 -- (Just 2024-10-31 10:00:00 UTC,Just 2024-10-31 12:00:00 UTC,Just ("2H",""))
 --
@@ -67,18 +53,20 @@ unitToSeconds unit =
 --
 -- >>> parseSince (Unsafe.read "2024-10-31 12:00:00 UTC") "1h"
 -- (Just 2024-10-31 11:00:00 UTC,Just 2024-10-31 12:00:00 UTC,Just ("1H",""))
---
 parseSince :: UTCTime -> Text -> (Maybe UTCTime, Maybe UTCTime, Maybe (Text, Text))
 parseSince now since =
   either (const (Nothing, Nothing, Nothing)) buildResult (parse timeParser "" since)
   where
-    buildResult (num, unit) = (Just start, Just now, Just (T.toUpper since, ""))
-      where
-        (secs, _) = fromMaybe (0, "") (unitToSeconds unit)
-        start = addUTCTime (negate . secondsToNominalDiffTime . fromIntegral $ num * secs) now
+    buildResult (num, secs) =
+      ( Just $ addUTCTime (negate . secondsToNominalDiffTime $ fromIntegral (num * secs)) now
+      , Just now
+      , Just (T.toUpper since, "")
+      )
 
-    timeParser :: Parser (Int, String)
-    timeParser = (,) <$> decimal <*> (space *> some letterChar)
+    -- unknown units resolve to 0 seconds, i.e. a zero-width range rather than an unbounded one
+    timeParser :: Parser (Int, Int)
+    timeParser = (,) <$> decimal <*> (space *> (unitSecs . toText <$> some letterChar))
+    unitSecs u = fromMaybe 0 $ lookup (T.toUpper u) [("S", 1), ("M", 60), ("H", 3600), ("D", 86400)]
 
 
 -- | The one place the default time range is decided. Every layer (server SQL,
@@ -106,25 +94,16 @@ defaultSince = "1H"
 -- >>> parseTimeRange (Unsafe.read "2024-10-31 12:00:00 UTC") (TimePicker (Just "") (Just "") (Just ""))
 -- (Just 2024-10-31 11:00:00 UTC,Just 2024-10-31 12:00:00 UTC,Just ("1H",""))
 parseTimeRange :: UTCTime -> TimePicker -> (Maybe UTCTime, Maybe UTCTime, Maybe (Text, Text))
-parseTimeRange now tp = case (nonEmpty' tp.since, nonEmpty' tp.from, nonEmpty' tp.to) of
+parseTimeRange now tp = case (nonEmptyT tp.since, nonEmptyT tp.from, nonEmptyT tp.to) of
   (Just s, _, _) -> parseSince now s
   (_, Nothing, Nothing) -> parseSince now defaultSince
-  (_, fromM, toM) -> case parseFromAndTo now fromM toM of
-    (Nothing, Nothing, _) -> parseSince now defaultSince
-    resolved -> resolved
+  (_, fromM, toM) -> case (parseUTCTime fromM, parseUTCTime toM) of
+    (Nothing, Nothing) -> parseSince now defaultSince
+    (f, t) -> (f, t, liftA2 (,) (fmtTime f) (fmtTime t))
   where
-    nonEmpty' = mfilter (not . T.null)
-
-
-parseFromAndTo :: UTCTime -> Maybe Text -> Maybe Text -> (Maybe UTCTime, Maybe UTCTime, Maybe (Text, Text))
-parseFromAndTo now fromM toM =
-  (parseUTCTime fromM, parseUTCTime toM, formatRange fromM toM)
-  where
+    parseUTCTime :: Maybe Text -> Maybe UTCTime
     parseUTCTime = iso8601ParseM . toString . fromMaybe ""
-    formatRange f t = liftA2 (,) (formatTime' f) (formatTime' t)
-
-    formatTime' :: Maybe Text -> Maybe Text
-    formatTime' = fmap (toText . formatTime defaultTimeLocale "%F %T") . parseUTCTime
+    fmtTime = fmap (toText . formatTime defaultTimeLocale "%F %T")
 
 
 -----------------------------------------------------------------------------------------------------
@@ -149,54 +128,47 @@ timePickerItems =
 timepicker_ :: Maybe Text -> Maybe (Text, Text) -> Maybe Text -> Html ()
 timepicker_ submitForm currentRange targetIdM = do
   let targetPr = fromMaybe "n" targetIdM
-  input_ [type_ "hidden", id_ $ targetPr <> "-since_input"]
+      -- with a form we submit it; without one the caller-supplied fallback reloads/updates params
+      submitVia noForm = maybe noForm (\fm -> [text|htmx.trigger("#${fm}", "submit")|]) submitForm
+  -- read/written by window.updateTimePicker + window.getTimeRange (main.ts)
   input_ [type_ "hidden", id_ $ targetPr <> "-custom_range_input"]
-  -- Trigger button using DaisyUI popover approach
   button_
     [ term "popovertarget" (targetPr <> "-timepicker-popover")
-    , term "style" $ "anchor-name:--" <> targetPr <> "-timepicker-anchor"
+    , style_ $ "anchor-name:--" <> targetPr <> "-timepicker-anchor"
     , term "popovertargetaction" "toggle"
-    , term "onclick" "event.stopPropagation()"
+    , onclick_ "event.stopPropagation()"
     , class_ "flex items-center gap-2 max-md:gap-1.5 py-2 max-md:py-1.5 px-3 max-md:px-2 border border-strokeWeak rounded-lg shadow-xs text-sm text-textWeak cursor-pointer"
     ]
     do
       faSprite_ "calendar" "regular" "h-4 w-4 text-iconNeutral"
-      let attrs = maybe [] (\(s, e) -> [term "data-start" s, term "data-end" e]) currentRange
+      let attrs = maybe [] (\(s, e) -> [data_ "start" s, data_ "end" e]) currentRange
       span_ (attrs ++ [class_ "inline-block leading-none", id_ $ targetPr <> "-currentRange"]) $ toHtml (maybe defaultSince (\(s, e) -> s <> if T.null e then "" else " - " <> e) currentRange)
-      span_ [id_ "offsetIndicator", class_ "text-2xs text-textWeak max-md:hidden"] "UTC+00"
+      span_ [id_ $ targetPr <> "-offsetIndicator", class_ "text-2xs text-textWeak max-md:hidden"] "UTC+00"
       faSprite_ "chevron-down" "regular" "h-3 w-3"
 
-  -- DaisyUI popover content
   div_ [class_ "relative w-max"] do
     div_
       [ class_ "border dropdown dropdown-end menu w-96 max-md:w-[calc(100vw-1rem)] rounded-box bg-bgRaised shadow-lg"
       , term "popover" "manual"
       , id_ $ targetPr <> "-timepicker-popover"
-      , term "style" $ "position-anchor:--" <> targetPr <> "-timepicker-anchor"
+      , style_ $ "position-anchor:--" <> targetPr <> "-timepicker-anchor"
       ]
       do
         div_ [class_ "absolute top-0 left-0 z-50 hidden", id_ $ targetPr <> "-timepickerSidebar", [__| on click halt|]] $ div_ [id_ $ targetPr <> "-startTime", class_ "hidden"] ""
         ul_ [] do
           li_ [class_ "menu-title"] "Select Time Range"
-          let action =
-                maybe
-                  "window.setQueryParamAndReload('since', my @data-value)"
-                  (\fm -> [fmt|htmx.trigger("#{fm}", "submit")|])
-                  submitForm
-              popoverId = "#" <> targetPr <> "-timepicker-popover"
+          let action = submitVia "window.setQueryParamAndReload('since', my @data-value)"
               onClickHandler =
-                [text|on click call window.updateTimePicker({since: @data-value}, {targetPr: '${targetPr}', label: @data-title}) then $action then call $popoverId.hidePopover()|]
-              timePickerLink val title =
-                li_ $ button_
-                  [ class_ "flex items-center justify-between hover:bg-fillWeak rounded-lg px-3 py-2 w-full text-left"
-                  , term "data-value" val
-                  , term "data-title" val
-                  , termRaw "_" onClickHandler
-                  ]
-                  do
-                    span_ [class_ "text-sm"] $ toHtml title
-                    span_ [class_ "text-xs text-textWeak"] $ toHtml val
-          mapM_ (uncurry timePickerLink) timePickerItems
+                [text|on click call window.updateTimePicker({since: @data-value}, {targetPr: '${targetPr}', label: @data-value}) then $action then call #${targetPr}-timepicker-popover.hidePopover()|]
+          forM_ timePickerItems \(val, title) ->
+            li_ $ button_
+              [ class_ "flex items-center justify-between hover:bg-fillWeak rounded-lg px-3 py-2 w-full text-left"
+              , data_ "value" val
+              , termRaw "_" onClickHandler
+              ]
+              do
+                span_ [class_ "text-sm"] $ toHtml title
+                span_ [class_ "text-xs text-textWeak"] $ toHtml val
           li_ $ button_
             [ class_ "w-full text-left"
             , term "_" [text| on click toggle .hidden on #$targetPr-timepickerSidebar |]
@@ -205,66 +177,55 @@ timepicker_ submitForm currentRange targetIdM = do
               faSprite_ "calendar" "regular" "h-4 w-4 mr-2 text-iconNeutral"
               span_ "Custom date range"
 
-        -- Custom date range picker (hidden by default)
-        let submitAction =
-              maybe
-                -- updateTimePicker already set params; reload page for non-form case
-                "window.setParams({}, true); document.getElementById(`$targetPr-timepicker-popover`).hidePopover();"
-                (\fm -> [text|htmx.trigger("#${fm}", "submit"); document.getElementById(`$targetPr-timepicker-popover`).hidePopover();|])
-                submitForm
+        -- updateTimePicker already set the params; the formless case just reloads
+        let submitAction = submitVia "window.setParams({}, true)"
         script_
           [text|
       (function() {
-        var formatDateLocal = (date) => new Date(date).toLocaleString();
-        // Initialize display once main.js (deferred) has loaded getUTCOffset
+        const fmt = (d) => new Date(d).toLocaleString();
+        const el = (suffix) => document.getElementById("$targetPr-" + suffix);
+        const hideSidebar = () => el('timepickerSidebar').classList.add('hidden');
+        // main.js and easepick are deferred, so poll until they land
         function initTimeDisplay() {
           if (typeof getUTCOffset === 'undefined') { setTimeout(initTimeDisplay, 50); return; }
-          const offsetEl = document.getElementById('offsetIndicator');
+          const offsetEl = el('offsetIndicator');
           if (offsetEl) offsetEl.innerText = getUTCOffset();
-          const range = document.getElementById("$targetPr-currentRange");
+          const range = el('currentRange');
           if (!range) return;
-          const start = range.dataset.start;
-          const end = range.dataset.end;
-          if(start && end) {
-              range.innerText = `$${formatDateLocal(start)} - $${formatDateLocal(end)}`
-            }
+          const { start, end } = range.dataset;
+          if (start && end) range.innerText = `$${fmt(start)} - $${fmt(end)}`;
         }
-        initTimeDisplay();
         function initEasepick() {
           if (typeof easepick === 'undefined') { setTimeout(initEasepick, 100); return; }
           if (window["$targetPr-picker"]) return;
           window["$targetPr-picker"] = new easepick.create({
-          element: '#$targetPr-startTime',
-          css: ['https://cdn.jsdelivr.net/npm/@easepick/bundle@1.2.0/dist/index.css'],
-          inline: true,
-          plugins: ['RangePlugin', 'TimePlugin'],
-          autoApply: false,
-          documentClick: (e) => {
-            if(e.target.classList.contains('easepick-wrapper')) {
-              return;
-            }
-            document.querySelector('#$targetPr-timepickerSidebar').classList.add('hidden');
-            return true;
-          },
-          setup(picker) {
-            picker.on("clear", () => {
-              document.querySelector('#$targetPr-timepickerSidebar').classList.add('hidden');
-            });
-            
-            picker.on('select', ({ detail: { start, end } }) => {
-              if (start.getTime() >= end.getTime()) end = new Date();
-              window.updateTimePicker({from: start.toISOString(), to: end.toISOString()}, {targetPr: "$targetPr"});
-              ${submitAction}
-            });
-          },
-        });
+            element: '#$targetPr-startTime',
+            css: ['https://cdn.jsdelivr.net/npm/@easepick/bundle@1.2.0/dist/index.css'],
+            inline: true,
+            plugins: ['RangePlugin', 'TimePlugin'],
+            autoApply: false,
+            documentClick: (e) => {
+              if (e.target.classList.contains('easepick-wrapper')) return;
+              hideSidebar();
+              return true;
+            },
+            setup(picker) {
+              picker.on("clear", hideSidebar);
+              picker.on('select', ({ detail: { start, end } }) => {
+                if (start.getTime() >= end.getTime()) end = new Date();
+                window.updateTimePicker({from: start.toISOString(), to: end.toISOString()}, {targetPr: "$targetPr"});
+                ${submitAction};
+                el('timepicker-popover').hidePopover();
+              });
+            },
+          });
         }
+        initTimeDisplay();
         initEasepick();
       })()
     |]
 
 
--- | Common refresh options used throughout the application
 refreshOptions :: [(Text, Text, Text)]
 refreshOptions =
   [ ("paused", "Paused", "0")
@@ -280,8 +241,8 @@ refreshOptions =
   ]
 
 
--- | Refresh button with auto-refresh dropdown
--- No parameters needed as it's now fully standardized to work with the global event system
+-- | Refresh button with auto-refresh dropdown. Driven entirely by the global
+-- @setRefreshInterval@ / @update-query@ event system, so it takes no arguments.
 refreshButton_ :: Html ()
 refreshButton_ = do
   div_ [class_ "join"] do

--- a/src/Pkg/Components/Widget.hs
+++ b/src/Pkg/Components/Widget.hs
@@ -305,45 +305,36 @@ signWidgetUrl secret pid widgetJson =
 
 -- use either index or the xxhash as id
 widget_ :: Widget -> Html ()
-widget_ = widgetHelper_
-
-
-widgetHelper_ :: Widget -> Html ()
-widgetHelper_ w' = case w.wType of
+widget_ w' = case w.wType of
   WTAnomalies -> gridItem_ $ div_ [class_ "h-full group/wgt "] $ div_ [class_ "gap-0.5 flex flex-col h-full"] do
     unless (w.naked == Just True) $ renderWidgetHeader w (maybeToMonoid w.id) w.title Nothing Nothing Nothing (Just ("View all", "/p/" <> maybeToMonoid (w._projectId <&> (.toText)) <> "/issues")) (w.hideSubtitle == Just True)
     div_ [class_ "flex-1 flex min-h-0"] $ div_ [class_ $ "h-full w-full " <> if w.naked == Just True then "" else "surface-raised rounded-2xl", id_ $ maybeToMonoid w.id <> "_bordered"] $ div_ [class_ "h-full overflow-auto p-3"] $ whenJust w.html toHtmlRaw
   WTGroup -> gridItem_ $ div_ [class_ "h-full flex flex-col border border-strokeWeak rounded-lg surface-raised overflow-hidden group/wgt"] do
     -- Header: auto height (no flex), group-header class for CSS targeting when collapsed
-    div_ [class_ $ "group-header py-2 px-4 flex items-center justify-between " <> gridStackHandleClass] do
+    div_ [class_ $ "group-header py-2 px-4 flex items-center justify-between " <> gridStackHandleClassFor w] do
       div_ [class_ "inline-flex gap-2 items-center group/h"] do
         span_ [class_ "hidden group-hover/h:inline-flex cursor-move"] $ Utils.faSprite_ "grip-dots-vertical" "regular" "w-4 h-4"
         whenJust w.icon \icon -> span_ [] $ Utils.faSprite_ icon "regular" "w-5 h-5"
-        span_ ([class_ "text-lg font-medium"] <> foldMap (\t -> [data_ "var-template" t | "{{var-" `T.isInfixOf` t]) w.title) $ toHtml $ maybeToMonoid w.title
-        whenJust w.description \desc -> span_ [class_ "hidden group-hover/wgt:inline-flex items-center", data_ "tippy-content" desc] $ Utils.faSprite_ "circle-info" "regular" "w-4 h-4"
+        span_ ([class_ "text-lg font-medium"] <> varTemplateAttr w.title) $ toHtml $ maybeToMonoid w.title
+        descIcon_ w.description ""
       -- Collapse chevron: only for full-width groups
       when isFullWidth $ button_ [class_ "collapse-toggle p-2 rounded hover:bg-fillWeak transition-colors cursor-pointer tap-target", Aria.label_ "Toggle group", [__|on click toggle .hidden on .nested-grid in closest .grid-stack-item then toggle .collapsed on closest .grid-stack-item|]] $ Utils.faSprite_ "chevron-up" "regular" "w-5 h-5 transition-transform"
     -- Nested grid: flex-1 fills remaining space
-    div_ [class_ "grid-stack nested-grid flex-1"] $ forM_ (fromMaybe [] w.children) (\wChild -> widgetHelper_ (wChild{_isNested = Just True}))
+    div_ [class_ "grid-stack nested-grid flex-1"] $ forM_ (fromMaybe [] w.children) (\wChild -> widget_ (wChild{_isNested = Just True}))
   WTTable -> gridItem_ $ div_ [class_ "h-full group/wgt "] $ renderTable w
   WTLogs -> gridItem_ $ div_ [class_ "h-full group/wgt "] $ renderLogsWidget w
   WTTraces -> gridItem_ $ div_ [class_ "h-full group/wgt "] $ renderTraceTable w
   WTFlamegraph -> gridItem_ $ div_ [class_ "h-full "] $ div_ [class_ "p-3"] "Flamegraph widget coming soon"
   _ -> gridItem_ $ div_ [class_ " w-full h-full group/wgt "] $ renderChart w
   where
-    w = w' & #id %~ maybe (slugify <$> w'.title) Just
-    gridStackHandleClass = if w._isNested == Just True then "nested-grid-stack-handle" else "grid-stack-handle"
+    w = w' & #id %~ (<|> (slugify <$> w'.title))
     isFullWidth = (== Just 12) $ w.layout >>= (.w)
-    groupRequiredHeight = case w.wType of
+    -- For groups: full-width uses the height the children require, partial-width uses max(yamlH, requiredHeight)
+    effectiveHeight = case w.wType of
       WTGroup ->
-        let childWidgets = fromMaybe [] w.children
-            maxRow = foldl' (\acc c -> max acc $ fromMaybe 0 (c.layout >>= (.y)) + fromMaybe 1 (c.layout >>= (.h))) 1 childWidgets
-         in Just (1 + maxRow)
-      _ -> Nothing
-    -- For groups: full-width uses requiredHeight, partial-width uses max(yamlH, requiredHeight)
-    effectiveHeight = case groupRequiredHeight of
-      Just reqH -> Just $ if isFullWidth then reqH else maybe reqH (max reqH) (w.layout >>= (.h))
-      Nothing -> w.layout >>= (.h)
+        let reqH = 1 + foldl' (\acc c -> max acc $ fromMaybe 0 (c.layout >>= (.y)) + fromMaybe 1 (c.layout >>= (.h))) 1 (fromMaybe [] w.children)
+         in Just $ if isFullWidth then reqH else maybe reqH (max reqH) (w.layout >>= (.h))
+      _ -> w.layout >>= (.h)
     layoutFields = [("x", (.x)), ("y", (.y)), ("w", (.w))] :: [(Text, Layout -> Maybe Int)]
     attrs =
       foldMap (\(name, field) -> foldMap (\v -> [term ("gs-" <> name) (show v)]) (w.layout >>= field)) layoutFields
@@ -354,6 +345,22 @@ widgetHelper_ w' = case w.wType of
       if w.naked == Just True
         then Relude.id
         else div_ ([class_ "grid-stack-item h-full flex-1 !overflow-visible has-[details[open]]:z-50 [.nested-grid_&]:overflow-hidden ", id_ $ maybeToMonoid w.id <> "_widgetEl", data_ "widget" widgetJson] <> attrs <> autoFitAttr) . div_ [class_ "grid-stack-item-content h-full !overflow-visible [.grid-stack_&]:h-auto"]
+
+
+gridStackHandleClassFor :: Widget -> Text
+gridStackHandleClassFor w = bool "grid-stack-handle" "nested-grid-stack-handle" (w._isNested == Just True)
+
+
+-- | Marks text that still contains @{{var-…}}@ placeholders so the client can
+-- re-render it when dashboard variables change.
+varTemplateAttr :: Maybe Text -> [Attribute]
+varTemplateAttr = foldMap \t -> [data_ "var-template" t | "{{var-" `T.isInfixOf` t]
+
+
+-- | Hover-revealed info icon carrying the widget description tooltip.
+descIcon_ :: Maybe Text -> Text -> Html ()
+descIcon_ descM extraCls = whenJust descM \desc ->
+  span_ [class_ "hidden group-hover/wgt:inline-flex items-center", data_ "tippy-content" desc] $ Utils.faSprite_ "circle-info" "regular" ("w-4 h-4" <> extraCls)
 
 
 renderDottedTitle :: Text -> Html ()
@@ -384,30 +391,26 @@ renderWidgetHeader widget wId title valueM subValueM expandBtnFn ctaM hideSub = 
     span_ [class_ "text-sm text-textStrong font-semibold flex items-center gap-1 min-w-0"] do
       unless (widget.standalone == Just True) $ span_ [class_ "hidden group-hover/h:inline-flex"] $ Utils.faSprite_ "grip-dots-vertical" "regular" "w-4 h-4"
       whenJust widget.icon \icon -> span_ [] $ Utils.faSprite_ icon "regular" "w-4 h-4"
-      span_ ([class_ "flex min-w-0 overflow-hidden", title_ $ maybeToMonoid title] <> foldMap (\t -> [data_ "var-template" t | "{{var-" `T.isInfixOf` t]) title) $ renderDottedTitle $ maybeToMonoid title
-      whenJust widget.description \desc -> span_ [class_ "hidden group-hover/wgt:inline-flex items-center", data_ "tippy-content" desc] $ Utils.faSprite_ "circle-info" "regular" "w-4 h-4"
+      span_ ([class_ "flex min-w-0 overflow-hidden", title_ $ maybeToMonoid title] <> varTemplateAttr title) $ renderDottedTitle $ maybeToMonoid title
+      descIcon_ widget.description ""
     span_ [class_ $ "bg-fillWeak border border-strokeWeak text-sm font-semibold px-2 py-1 rounded-3xl leading-none text-textWeak max-md:hidden whitespace-nowrap " <> if isJust valueM then "" else "hidden", id_ $ wId <> "Value"]
       $ whenJust valueM toHtml
-    span_ ([class_ $ "text-textDisabled widget-subtitle text-sm max-md:hidden " <> bool "" "hidden" hideSub, id_ $ wId <> "Subtitle"] <> foldMap (\t -> [data_ "var-template" t | "{{var-" `T.isInfixOf` t]) subValueM) $ toHtml $ maybeToMonoid subValueM
+    span_ ([class_ $ "text-textDisabled widget-subtitle text-sm max-md:hidden " <> bool "" "hidden" hideSub, id_ $ wId <> "Subtitle"] <> varTemplateAttr subValueM) $ toHtml $ maybeToMonoid subValueM
     -- Add hidden loader with specific ID that can be toggled from JS
     span_ [class_ "hidden", id_ $ wId <> "_loader"] $ Utils.faSprite_ "spinner" "regular" "w-4 h-4 animate-spin"
   div_ [class_ "text-iconNeutral flex items-center gap-0.5"] do
     -- Alert status indicator (visible on hover, always visible when alerting/warning)
-    whenJust widget.alertId \_ -> do
-      let (iconColor, iconType, tooltip) = case widget.alertStatus of
-            Just "alerting" -> ("text-fillError-strong", "bell-exclamation", "Monitor triggered")
-            Just "warning" -> ("text-fillWarning-strong", "bell", "Warning threshold exceeded")
-            _ -> ("text-iconNeutral", "bell", "Monitor configured")
-          visibilityClass = case widget.alertStatus of
-            Just "alerting" -> ""
-            Just "warning" -> ""
-            _ -> "opacity-0 group-hover/wgt:opacity-100 touch:opacity-50"
-      span_
-        [ class_ $ "p-1 transition-opacity " <> visibilityClass
-        , data_ "tippy-content" tooltip
-        , id_ $ wId <> "_alert_indicator"
-        ]
-        $ Utils.faSprite_ iconType "regular" ("w-3.5 h-3.5 " <> iconColor)
+    when (isJust widget.alertId)
+      $ let (iconColor, iconType, tooltip, visibilityClass) = case widget.alertStatus of
+              Just "alerting" -> ("text-fillError-strong", "bell-exclamation", "Monitor triggered", "")
+              Just "warning" -> ("text-fillWarning-strong", "bell", "Warning threshold exceeded", "")
+              _ -> ("text-iconNeutral", "bell", "Monitor configured", "opacity-0 group-hover/wgt:opacity-100 touch:opacity-50")
+         in span_
+              [ class_ $ "p-1 transition-opacity " <> visibilityClass
+              , data_ "tippy-content" tooltip
+              , id_ $ wId <> "_alert_indicator"
+              ]
+              $ Utils.faSprite_ iconType "regular" ("w-3.5 h-3.5 " <> iconColor)
 
     whenJust ctaM \(ctaTitle, uri) -> a_ [class_ "underline underline-offset-2 text-textBrand", href_ uri] $ toHtml ctaTitle
     whenJust expandBtnFn \url ->
@@ -623,8 +626,6 @@ renderTraceTable widget = do
   script_ [type_ "text/javascript"] """htmx.process(".widget-target")"""
 
 
--- Table widget rendering
--- class_ "progress-brand "
 renderTable :: Widget -> Html ()
 renderTable widget = renderTableShell widget [(col.title, col.align) | col <- fromMaybe [] widget.columns] (rowClickTableAttrs widget)
 
@@ -647,18 +648,14 @@ renderTableShell widget headerCols tableAttrs = do
       , hxSwap_ "outerHTML"
       , hxExt_ "forward-page-params"
       ]
-      do
-        case widget.html of
-          Just html -> toHtmlRaw html
-          Nothing ->
-            table_
-              ([class_ "table table-zebra table-sm w-full relative", id_ tableId] <> tableAttrs)
-              do
-                sortableTableHead_ tableId True headerCols
-                tbody_ []
-                  $ tr_ []
-                  $ td_ [colspan_ "100", class_ "text-center py-8"]
-                  $ loadingIndicator_ LdSM LdSpinner
+    $ case widget.html of
+      Just html -> toHtmlRaw html
+      Nothing -> table_ ([class_ "table table-zebra table-sm w-full relative", id_ tableId] <> tableAttrs) do
+        sortableTableHead_ tableId True headerCols
+        tbody_ []
+          $ tr_ []
+          $ td_ [colspan_ "100", class_ "text-center py-8"]
+          $ loadingIndicator_ LdSM LdSpinner
 
 
 -- | Render stat widget content with HTMX lazy loading support
@@ -668,9 +665,7 @@ renderStatContent widget chartId valueM = do
   let statContentId = chartId <> "_stat"
       hasData = widget.eager == Just True || isJust (widget.dataset >>= (.value))
       paddingClass = "px-3 flex flex-col " <> bool "py-3 " "py-2 " (widget._isNested == Just True)
-      -- Always use eager widget JSON for HTMX requests
       eagerWidget = widget & #eager ?~ True
-  -- Always include HTMX attributes for refresh capability
   div_
     [ id_ statContentId
     , class_ paddingClass
@@ -681,45 +676,30 @@ renderStatContent widget chartId valueM = do
     , hxSwap_ "outerHTML"
     , hxExt_ "forward-page-params"
     ]
-    $ if hasData
-      then renderStatValue widget chartId valueM
-      else renderStatPlaceholder widget chartId
+    $ renderStatBody widget chartId (if hasData then whenJust valueM toHtml else loadingIndicator_ LdSM LdSpinner)
 
 
--- | Render placeholder with loading spinner for lazy-loaded stats
-renderStatPlaceholder :: Widget -> Text -> Html ()
-renderStatPlaceholder widget chartId = div_ [class_ "flex flex-col gap-1"] do
-  strong_ [class_ "text-textStrong text-4xl font-bold tabular-nums", id_ $ chartId <> "Value"]
-    $ loadingIndicator_ LdSM LdSpinner
+-- | Stat body: the big number (a spinner while lazy-loading) plus icon/title/description.
+renderStatBody :: Widget -> Text -> Html () -> Html ()
+renderStatBody widget chartId value = div_ [class_ "flex flex-col gap-1"] do
+  strong_ [class_ "text-textStrong text-4xl font-bold tabular-nums", id_ $ chartId <> "Value"] value
   div_ [class_ "inline-flex gap-1 items-center text-sm"] do
     whenJust widget.icon \icon -> Utils.faSprite_ icon "regular" "w-4 h-4 text-iconBrand"
     toHtml $ maybeToMonoid widget.title
-    whenJust widget.description \desc -> span_ [class_ "hidden group-hover/wgt:inline-flex items-center", data_ "tippy-content" desc] $ Utils.faSprite_ "circle-info" "regular" "w-4 h-4 text-iconNeutral"
-
-
--- | Render actual stat value content
-renderStatValue :: Widget -> Text -> Maybe Text -> Html ()
-renderStatValue widget chartId valueM = div_ [class_ "flex flex-col gap-1"] do
-  strong_ [class_ "text-textStrong text-4xl font-bold tabular-nums", id_ $ chartId <> "Value"]
-    $ whenJust valueM toHtml
-  div_ [class_ "inline-flex gap-1 items-center text-sm"] do
-    whenJust widget.icon \icon -> Utils.faSprite_ icon "regular" "w-4 h-4 text-iconBrand"
-    toHtml $ maybeToMonoid widget.title
-    whenJust widget.description \desc -> span_ [class_ "hidden group-hover/wgt:inline-flex items-center", data_ "tippy-content" desc] $ Utils.faSprite_ "circle-info" "regular" "w-4 h-4 text-iconNeutral"
+    descIcon_ widget.description " text-iconNeutral"
 
 
 renderChart :: Widget -> Html ()
 renderChart widget = do
-  let rateM = widget.dataset >>= (.rowsPerMin) >>= \r -> Just $ Utils.prettyPrintCount (round r) <> "/min"
+  let rateM = widget.dataset >>= (.rowsPerMin) <&> \r -> Utils.prettyPrintCount (round r) <> "/min"
   let chartId = maybeToMonoid widget.id
   let unitSuffix = maybe "" displayUnit widget.unit
-  let valueM = widget.dataset >>= (.value) >>= \x -> Just $ Utils.prettyPrintCount (round x) <> unitSuffix
+  let valueM = widget.dataset >>= (.value) <&> \x -> Utils.prettyPrintCount (round x) <> unitSuffix
   let isStat = widget.wType `elem` [WTTimeseriesStat, WTStat]
-  let gridStackHandleClass = if widget._isNested == Just True then "nested-grid-stack-handle" else "grid-stack-handle"
   div_ [class_ "gap-0.5 flex flex-col h-full justify-end "] do
-    unless (widget.naked == Just True || widget.wType `elem` [WTTimeseriesStat, WTStat])
+    unless (widget.naked == Just True || isStat)
       $ renderWidgetHeader widget chartId widget.title valueM rateM widget.expandBtnFn Nothing (widget.hideSubtitle == Just True)
-    div_ [class_ $ "flex-1 flex min-h-0 " <> bool "" gridStackHandleClass isStat] do
+    div_ [class_ $ "flex-1 flex min-h-0 " <> bool "" (gridStackHandleClassFor widget) isStat] do
       div_
         [ class_
             $ "h-full w-full flex flex-col justify-end "
@@ -730,9 +710,8 @@ renderChart widget = do
         do
           whenJust ((,) <$> widget.groupByOptions <*> widget.groupByUrl) \(options, url) ->
             let selectedLabel = case widget.groupBySelected of
-                  Just "all" -> "All values"
-                  Just label -> label
-                  Nothing -> "All values"
+                  Just l | l /= "all" -> l
+                  _ -> "All values"
              in div_ [class_ "flex shrink-0 justify-end px-2 pt-2"]
                   $ details_ [class_ "dropdown dropdown-end relative max-w-[calc(100%-1rem)]"] do
                     summary_ [class_ "btn btn-xs min-w-0 cursor-pointer justify-between gap-1 border-strokeWeak bg-bgRaised px-2 text-left text-textWeak opacity-100 hover:bg-fillWeak", data_ "tippy-content" "Group by"] do
@@ -840,21 +819,13 @@ renderChart widget = do
 -- Echarts Logic
 -----------------------------------------------------------------------------
 
--- -- -- Helper: Select tooltip formatter
--- -- selectFormatter :: WidgetType -> Text
--- -- selectFormatter WTTimeseries = "{a} <br/>{b}: {c}ms"
--- -- selectFormatter _ = "{a} <br/>{b}: {c}"
-
 -- Helper: Extract series names from dataset source (headers[1:])
 extractSeriesNamesFromDataset :: Maybe WidgetDataset -> [Text]
-extractSeriesNamesFromDataset (Just wd) = case wd.source of
-  AE.Array arr | not (V.null arr) -> case V.head arr of
-    AE.Array headers | V.length headers > 1 -> mapMaybe getText $ V.toList $ V.tail headers
-    _ -> []
+extractSeriesNamesFromDataset ds = case ds <&> (.source) of
+  Just (AE.Array arr) | Just (AE.Array headers) <- arr V.!? 0 -> mapMaybe getText $ drop 1 $ V.toList headers
   _ -> []
   where
-    getText (AE.String t) = Just t; getText _ = Nothing
-extractSeriesNamesFromDataset Nothing = []
+    getText = \case AE.String t -> Just t; _ -> Nothing
 
 
 -- | JS expression formatting a numeric @value@ for a widget's unit: duration
@@ -873,7 +844,6 @@ widgetToECharts :: Widget -> AE.Value
 widgetToECharts widget =
   let isStat = widget.wType == WTTimeseriesStat
       axisVisibility = not isStat
-      gridLinesVisibility = not isStat
       legendVisibility = not isStat && widget.hideLegend /= Just True
       seriesNames = extractSeriesNamesFromDataset widget.dataset
       -- Detect categorical widget types (no time axis)
@@ -950,7 +920,7 @@ widgetToECharts widget =
               , "max" AE..= maybe AE.Null (AE.Number . fromFloatDigits) (widget ^? #dataset . _Just . #stats . _Just . #maxGroupSum)
               , "splitLine"
                   AE..= AE.object
-                    [ "show" AE..= gridLinesVisibility
+                    [ "show" AE..= axisVisibility
                     , "lineStyle" AE..= AE.object ["type" AE..= "dotted", "color" AE..= "#0011661A"]
                     , "interval"
                         AE..= if fromMaybe False $ widget ^? #yAxis . _Just . #showOnlyMaxLabel . _Just
@@ -992,10 +962,7 @@ widgetToECharts widget =
 -- Helper: Add markLines to first series for alert thresholds
 addMarkLinesToFirstSeries :: Widget -> [AE.Value] -> [AE.Value]
 addMarkLinesToFirstSeries widget series
-  | shouldShowLines
-  , not (null markLineData) = case series of
-      [] -> series
-      (s : rest) -> addMarkLine s : rest
+  | shouldShowLines, not (null markLineData) = series & _head %~ addMarkLine
   | otherwise = series
   where
     shouldShowLines = case widget.showThresholdLines of
@@ -1103,21 +1070,15 @@ renderTableWithDataAndParams widget dataRows params = do
       tableId = maybeToMonoid widget.id
       currentVar = widget.onRowClick >>= (.setVariable) >>= \var -> find ((== "var-" <> var) . fst) params >>= snd
 
-  -- Render complete table with data
   table_
     ( [class_ "table table-zebra table-sm w-full relative", id_ tableId]
         <> rowClickTableAttrs widget
     )
     do
-      -- Table header
       sortableTableHead_ tableId True [(col.title, col.align) | col <- columns]
-
-      -- Table body with data
       tbody_ [] do
-        -- Calculate max values for column percentages
         let maxValues = calculateMaxValues columns dataRows
-
-        -- Calculate max formatted width for each progress column
+        -- max formatted width per progress column, so bars line up
         let valueWidths =
               M.fromList
                 [ (col.field, V.foldl' (\acc row -> max acc (T.length $ formatColumnValue col (fromMaybe "" $ row V.!? idx))) 5 dataRows)
@@ -1125,34 +1086,26 @@ renderTableWithDataAndParams widget dataRows params = do
                 , isJust col.progress
                 ]
 
-        -- Render table rows
         V.forM_ dataRows \row -> do
           let rowData = AE.object [(K.fromText col.field, AE.String $ getRowValue idx row) | (col, idx) <- zip columns [0 ..]]
-          let firstColValue = maybe "" (const $ getRowValue 0 row) (listToMaybe columns)
-          let rowValue = case widget.onRowClick >>= (.value) of
-                Just tmpl -> T.replace "{{row.resource_name}}" firstColValue tmpl
-                Nothing -> firstColValue
-          let isSelected = Just rowValue == currentVar
-
+          let firstColValue = memptyIfFalse (not $ null columns) (getRowValue 0 row)
+          let rowValue = maybe firstColValue (T.replace "{{row.resource_name}}" firstColValue) (widget.onRowClick >>= (.value))
           tr_
-            [ class_ $ "hover cursor-pointer" <> if isSelected then " bg-fillBrand/20 border-l-4 border-borderBrand" else ""
+            [ class_ $ "hover cursor-pointer" <> memptyIfFalse (Just rowValue == currentVar) " bg-fillBrand/20 border-l-4 border-borderBrand"
             , data_ "row" (encodeText rowData)
             ]
-            do
-              ifor_ columns \idx col -> do
-                let value = getRowValue idx row
-                td_ [class_ $ fromMaybe "" col.align <> if col.columnType `elem` [Just ("number" :: Text), Just ("duration" :: Text)] then " monospace" else ""] do
-                  if isJust col.progress
-                    then renderProgressCell col value maxValues valueWidths
-                    else renderLongTextOr col value
+            $ ifor_ columns \idx col -> do
+              let value = getRowValue idx row
+              td_ [class_ $ cellClass col]
+                $ if isJust col.progress
+                  then renderProgressCell col value maxValues valueWidths
+                  else renderLongTextOr col value
 
 
 renderTraceDataTable :: Widget -> V.Vector (V.Vector Text) -> HashMap Text [(Text, Int, Int)] -> HashMap Text [Telemetry.SpanRecord] -> Text -> Html ()
 renderTraceDataTable widget dataRows spGroup spansGrouped colorsJson = do
   let columns = fromMaybe [] widget.columns
   let tableId = maybeToMonoid widget.id
-
-  -- Render complete table with data
   table_ [class_ "table table-sm w-full relative", id_ tableId] do
     sortableTableHead_ tableId False [(col.title, col.align) | col <- columns]
     tbody_ [] do
@@ -1167,22 +1120,19 @@ renderTraceDataTable widget dataRows spGroup spansGrouped colorsJson = do
                 <$> fromMaybe [] (HM.lookup val spansGrouped)
         let spjson = encodeText spansJson
         let clcFun = [text|on click toggle .hidden on the next <tr/> then call flameGraphChart($spjson, "$val", $colorsJson)|]
-        tr_ [term "_" clcFun, class_ "cursor-pointer"] do
-          ifor_ columns \idx col -> do
-            let value = getRowValue idx row
+        tr_ [term "_" clcFun, class_ "cursor-pointer"]
+          $ ifor_ columns \idx col ->
             if col.field == "latency_breakdown"
-              then td_ [class_ "py-2"] do
-                renderLatencyBreakdown cdrn
-              else td_ [class_ $ fromMaybe "" col.align <> if col.columnType `elem` [Just ("number" :: Text), Just ("duration" :: Text)] then " monospace" else ""] do
-                toHtml $ formatColumnValue col value
+              then td_ [class_ "py-2"] $ renderLatencyBreakdown cdrn
+              else td_ [class_ $ cellClass col] $ toHtml $ formatColumnValue col (getRowValue idx row)
         tr_ [class_ "hidden"] do
           td_ [colspan_ "100%"] do
-            whenJust widget._projectId \p ->
-              div_
+            when (isJust widget._projectId)
+              $ div_
                 [ class_ "w-full group px-2 pt-4 border relative flex flex-col rounded-lg overflow-hidden"
                 , id_ $ "flame-graph-container-" <> val
                 ]
-                $ renderFlameGraph val
+              $ renderFlameGraph val
 
 
 getSpanJson :: Maybe (Int, Int) -> Telemetry.SpanRecord -> AE.Value
@@ -1191,14 +1141,12 @@ getSpanJson tgtM sp =
     [ "spanId" AE..= sp.spanId
     , "name" AE..= sp.spanName
     , "value" AE..= maybe sp.spanDurationNs (\(d, _) -> fromIntegral d) tgtM
-    , "start" AE..= start
+    , "start" AE..= utcTimeToNanoseconds sp.startTime
     , "parentId" AE..= sp.parentSpanId
     , "serviceName" AE..= getServiceName sp.resource
     , "hasErrors" AE..= spanHasErrors sp
     , "totalSpans" AE..= maybe 1 snd tgtM
     ]
-  where
-    start = utcTimeToNanoseconds sp.startTime
 
 
 renderFlameGraph :: Text -> Html ()
@@ -1216,10 +1164,10 @@ renderLatencyBreakdown groups = do
   div_ [class_ "flex h-5 overflow-hidden relative bg-fillWeak rounded", style_ "width:150px"] $ do
     let totalDur = sum (map (\(_, d, _) -> fromIntegral d) groups) :: Double
     let colors = getServiceColors $ V.fromList (fmap (\(n, _, _) -> n) groups)
-    mapM_ (renderGroup totalDur colors) (zip [0 ..] groups)
+    ifor_ groups (renderGroup totalDur colors)
   where
-    renderGroup :: Double -> HM.HashMap Text Text -> (Int, (Text, Int, Int)) -> Html ()
-    renderGroup totalDur colors (i, (name, dur, _)) = do
+    renderGroup :: Double -> HM.HashMap Text Text -> Int -> (Text, Int, Int) -> Html ()
+    renderGroup totalDur colors i (name, dur, _) = do
       let barWidth = 150.0
           width = (fromIntegral dur / totalDur) * barWidth
           left =
@@ -1250,56 +1198,44 @@ calculateMaxValues columns dataRows =
 
 -- Render a progress bar cell
 renderProgressCell :: TableColumn -> Text -> M.Map Text Double -> M.Map Text Int -> Html ()
-renderProgressCell col value maxValues valueWidths = do
-  div_ [class_ "flex items-center gap-2"] do
-    -- Format and display the value using the same logic as formatColumnValue
-    let formattedValue = formatColumnValue col value
-    -- Use calculated max width for this column
-    let width = M.findWithDefault 8 col.field valueWidths
-
-    span_ [class_ "inline-block text-left monospace", style_ $ "width: " <> show width <> "ch"] do
-      toHtml formattedValue
-
-    -- Calculate progress percentage
-    let numValue = fromMaybe 0 $ readMaybe (toString value) :: Double
-    let percentage = case col.progress of
-          Just "value_percent" -> min 100 (max 0 numValue)
-          Just "column_percent" -> case M.lookup col.field maxValues of
-            Just maxVal | maxVal > 0 -> (numValue / maxVal) * 100
-            _ -> 0
-          _ -> 0
-
-    -- Render progress bar
-    let progressClass = "progress w-12 ml-2 " <> getProgressVariantClass col.progressVariant
-    progress_ [class_ progressClass, value_ (show percentage), max_ "100"] ""
+renderProgressCell col value maxValues valueWidths = div_ [class_ "flex items-center gap-2"] do
+  let numValue = fromMaybe 0 (readMaybe $ toString value) :: Double
+      percentage = case col.progress of
+        Just "value_percent" -> min 100 (max 0 numValue)
+        Just "column_percent" | Just maxVal <- M.lookup col.field maxValues, maxVal > 0 -> (numValue / maxVal) * 100
+        _ -> 0
+      variantClass = case col.progressVariant of
+        Just "error" -> "progress-error"
+        Just "warning" -> "progress-warning"
+        Just "success" -> "progress-success"
+        _ -> "progress-brand"
+  span_ [class_ "inline-block text-left monospace", style_ $ "width: " <> show (M.findWithDefault 8 col.field valueWidths) <> "ch"]
+    $ toHtml
+    $ formatColumnValue col value
+  progress_ [class_ $ "progress w-12 ml-2 " <> variantClass, value_ (show percentage), max_ "100"] ""
 
 
--- Get progress bar variant class
-getProgressVariantClass :: Maybe Text -> Text
-getProgressVariantClass variant = case variant of
-  Just "error" -> "progress-error"
-  Just "warning" -> "progress-warning"
-  Just "success" -> "progress-success"
-  _ -> "progress-brand"
+isNumericCol :: TableColumn -> Bool
+isNumericCol col = col.columnType `elem` [Just ("number" :: Text), Just "duration"]
+
+
+-- | @td@ classes: column alignment plus monospace for numeric/duration columns.
+cellClass :: TableColumn -> Text
+cellClass col = fromMaybe "" col.align <> memptyIfFalse (isNumericCol col) " monospace"
 
 
 -- Format column value based on column type
 formatColumnValue :: TableColumn -> Text -> Text
 formatColumnValue col value = case col.columnType of
-  Just "number" ->
-    case readMaybe (toString value) :: Maybe Double of
-      Just n ->
-        let formatted =
-              if n < 100 && n /= fromIntegral (round n :: Int)
-                then toText (printf "%.2g" n :: String) -- Keep significant digits for small numbers
-                else prettyPrintCount (round n) -- Use pretty print for larger numbers
-         in formatted <> foldMap (" " <>) col.unit
-      Nothing -> value <> foldMap (" " <>) col.unit
-  Just "duration" ->
-    case readMaybe (toString value) :: Maybe Double of
-      Just v -> toText $ getDurationNSMS (fromIntegral (round v :: Int))
-      Nothing -> value <> foldMap (" " <>) col.unit
-  _ -> fromMaybe value (formatTimestampValue value) <> foldMap (" " <>) col.unit
+  Just "number" -> maybe value fmtNumber (readMaybe (toString value) :: Maybe Double) <> unitSuffix
+  Just "duration" -> maybe (value <> unitSuffix) (\v -> toText $ getDurationNSMS (fromIntegral (round v :: Int))) (readMaybe (toString value) :: Maybe Double)
+  _ -> fromMaybe value (formatTimestampValue value) <> unitSuffix
+  where
+    unitSuffix = foldMap (" " <>) col.unit
+    -- keep significant digits for small non-integral numbers, pretty-print the rest
+    fmtNumber n
+      | n < 100, n /= fromIntegral (round n :: Int) = toText (printf "%.2g" n :: String)
+      | otherwise = prettyPrintCount (round n)
 
 
 -- | Try to parse a PostgreSQL timestamp and format as "Mar 19, 09:05"
@@ -1315,25 +1251,14 @@ formatTimestampValue (T.strip -> val)
     fmt = toText . formatTime defaultTimeLocale "%b %d, %H:%M"
 
 
--- | Render cell value, parsing summary tags (field;style⇒value) into badges
-renderCellValue :: TableColumn -> Text -> Html ()
-renderCellValue col value
-  | T.isInfixOf "⇒" formatted = renderSummaryTags formatted
-  | otherwise = toHtml formatted
-  where
-    formatted = formatColumnValue col value
-
-
--- | Render a text cell. Long values get a truncated single-line view with a
--- tippy tooltip (delegated body-wide in BodyWrapper) showing the full text on
--- hover. Number/duration columns skip the wrapper since they're always short.
+-- | Render a text cell, parsing summary tags (field;style⇒value) into badges.
+-- Long values get a truncated single-line view with a tippy tooltip (delegated
+-- body-wide in BodyWrapper) showing the full text on hover. Number/duration
+-- columns skip the wrapper since they're always short.
 renderLongTextOr :: TableColumn -> Text -> Html ()
 renderLongTextOr col value
-  | col.columnType `elem` [Just ("number" :: Text), Just "duration"] = renderCellValue col value
-  | T.length value > 60 =
-      div_
-        [ class_ "truncate max-w-2xl"
-        , term "data-tippy-content" value
-        ]
-        $ renderCellValue col value
-  | otherwise = renderCellValue col value
+  | not (isNumericCol col), T.length value > 60 = div_ [class_ "truncate max-w-2xl", term "data-tippy-content" value] cell
+  | otherwise = cell
+  where
+    formatted = formatColumnValue col value
+    cell = if T.isInfixOf "⇒" formatted then renderSummaryTags formatted else toHtml formatted

--- a/src/Pkg/QueryCache.hs
+++ b/src/Pkg/QueryCache.hs
@@ -15,6 +15,7 @@ module Pkg.QueryCache (
 ) where
 
 import Data.Char (isDigit)
+import Data.Default (def)
 import Data.Effectful.Hasql qualified as Hasql
 import Data.Map.Strict qualified as M
 import Data.Text qualified as T
@@ -243,7 +244,7 @@ recalculateStats rows =
     rowSums = V.map (sum . V.mapMaybe id . V.drop 1) rows
    in
     if V.null allValues
-      then MetricsStats 0 0 0 0 0 0 0
+      then def
       else
         let h = V.head allValues
             maxFreqEntries = 1000 -- cap frequency map to prevent memory issues with high-cardinality data

--- a/src/Pkg/TestUtils.hs
+++ b/src/Pkg/TestUtils.hs
@@ -711,7 +711,7 @@ requireMinio tr pending action
 sharedTestLogger :: Log.Logger
 -- tolerantLogger (the production wrapper) swallows write-after-shutdown / flush-thread
 -- crashes so a logger hiccup can't take down a parallel worker.
-sharedTestLogger = unsafePerformIO $ Logging.tolerantLogger <$> mkBulkLogger "test-stdout-bulk" (mapM_ (putTextLn . showLogMessage Nothing)) (pure ())
+sharedTestLogger = unsafePerformIO $ Logging.tolerantLogger <$> mkBulkLogger "test-stdout-bulk" (mapM_ (putTextLn . showLogMessage Nothing)) pass
 
 
 withSharedLogger :: (Log.Logger -> m a) -> m a

--- a/src/Pkg/TestUtils.hs
+++ b/src/Pkg/TestUtils.hs
@@ -24,6 +24,7 @@ module Pkg.TestUtils (
   setBjRunAtInThePast,
   toServantResponse,
   toBaseServantResponse,
+  runAsBaseRecordingHTTP,
   runAsBase,
   atAuthToBase,
   effToServantHandlerTest,
@@ -94,7 +95,7 @@ import Data.Effectful.Hasql (Hasql, runHasqlPool)
 import Data.Effectful.LLM qualified as ELLM
 import Data.Effectful.Notify qualified
 import Data.Effectful.UUID (UUIDEff, runStaticUUID, runUUID)
-import Data.Effectful.Wreq (HTTP (..), runHTTPGolden, runHTTPWreq)
+import Data.Effectful.Wreq (HTTP (..), runHTTPGolden, runHTTPRecord, runHTTPWreq)
 import Data.Either.Extra
 import Data.HashMap.Strict qualified as HM
 import Data.Pool (Pool, defaultPoolConfig, destroyAllResources, newPool, withResource)
@@ -189,7 +190,7 @@ import System.Logging qualified as Logging
 import System.Server qualified as Server
 import System.Tracing (Tracing)
 import System.Tracing qualified as Tracing
-import System.Types (ATAuthCtx, ATBackgroundCtx, ATBaseCtx, RespHeaders, atAuthToBase, atAuthToBaseTest, effToServantHandlerTest)
+import System.Types (ATAuthCtx, ATBackgroundCtx, ATBaseCtx, RespHeaders, atAuthToBase, atAuthToBaseTest, effToServantHandlerTest, effToServantHandlerTestHTTP)
 import Unsafe.Coerce (unsafeCoerce)
 import Web.ApiHandlers qualified as ApiH
 import Web.Auth qualified as Auth
@@ -884,6 +885,24 @@ toBaseServantResponse TestResources{..} k = do
       & ServantS.runHandler
     )
     <&> fromRightShow
+
+
+-- | Like 'toBaseServantResponse' but records outgoing HTTP requests instead of
+-- golden-replaying them, returning them as (url, rendered body) alongside the
+-- result — the seam for asserting what a handler actually sent.
+runAsBaseRecordingHTTP :: TestResources -> ATBaseCtx a -> IO ([(Text, LByteString)], a)
+runAsBaseRecordingHTTP TestResources{..} k = do
+  tp <- getGlobalTracerProvider
+  uuidRef <- freshUUIDRef
+  reqsRef <- newIORef []
+  r <-
+    ( k
+        & effToServantHandlerTestHTTP (runHTTPRecord reqsRef) trTestClock uuidRef trATCtx trLogger tp
+        & ServantS.runHandler
+      )
+      <&> fromRightShow
+  reqs <- reverse <$> readIORef reqsRef
+  pure (reqs, r)
 
 
 -- | Like `toBaseServantResponse` but draws UUIDs from the TestResources-scoped

--- a/src/Pkg/TestUtils.hs
+++ b/src/Pkg/TestUtils.hs
@@ -899,7 +899,7 @@ runAsBaseRecordingHTTP TestResources{..} k = do
     ( k
         & effToServantHandlerTestHTTP (runHTTPRecord reqsRef) trTestClock uuidRef trATCtx trLogger tp
         & ServantS.runHandler
-      )
+    )
       <&> fromRightShow
   reqs <- reverse <$> readIORef reqsRef
   pure (reqs, r)

--- a/src/System/Types.hs
+++ b/src/System/Types.hs
@@ -160,7 +160,7 @@ effToServantHandlerTest = effToServantHandlerTestHTTP (runHTTPGolden "./tests/go
 
 -- | 'effToServantHandlerTest' with a caller-chosen HTTP interpreter, e.g.
 -- 'Data.Effectful.Wreq.runHTTPRecord' to assert on outgoing request payloads.
-effToServantHandlerTestHTTP :: (forall x hes. IOE :> hes => Eff (HTTP : hes) x -> Eff hes x) -> TestClock -> IORef [UUID.UUID] -> AuthContext -> Log.Logger -> TracerProvider -> ATBaseCtx a -> Servant.Handler a
+effToServantHandlerTestHTTP :: (forall x hes. IOE :> hes => Eff (HTTP ': hes) x -> Eff hes x) -> TestClock -> IORef [UUID.UUID] -> AuthContext -> Log.Logger -> TracerProvider -> ATBaseCtx a -> Servant.Handler a
 effToServantHandlerTestHTTP http clock uuidRef env logger tp app =
   app
     & ELLM.runLLMGolden "./tests/golden/"

--- a/src/System/Types.hs
+++ b/src/System/Types.hs
@@ -20,6 +20,7 @@ module System.Types (
   redirectCS,
   effToServantHandler,
   effToServantHandlerTest,
+  effToServantHandlerTestHTTP,
   effToHandler,
   atAuthToBase,
   atAuthToBaseTest,
@@ -154,12 +155,18 @@ effToServantHandler env logger tp app =
 -- The 'TestClock' drives the 'Time' effect and is shared across handler
 -- invocations so tests can advance time between calls.
 effToServantHandlerTest :: TestClock -> IORef [UUID.UUID] -> AuthContext -> Log.Logger -> TracerProvider -> ATBaseCtx a -> Servant.Handler a
-effToServantHandlerTest clock uuidRef env logger tp app =
+effToServantHandlerTest = effToServantHandlerTestHTTP (runHTTPGolden "./tests/golden/")
+
+
+-- | 'effToServantHandlerTest' with a caller-chosen HTTP interpreter, e.g.
+-- 'Data.Effectful.Wreq.runHTTPRecord' to assert on outgoing request payloads.
+effToServantHandlerTestHTTP :: (forall x hes. IOE :> hes => Eff (HTTP : hes) x -> Eff hes x) -> TestClock -> IORef [UUID.UUID] -> AuthContext -> Log.Logger -> TracerProvider -> ATBaseCtx a -> Servant.Handler a
+effToServantHandlerTestHTTP http clock uuidRef env logger tp app =
   app
     & ELLM.runLLMGolden "./tests/golden/"
     & Effectful.Reader.Static.runReader env
     & runStaticUUIDRef uuidRef
-    & runHTTPGolden "./tests/golden/"
+    & http
     & runHasqlPool env.hasqlPool
     & runLabeled @"timefusion" (runHasqlPool env.hasqlTimefusionPool)
     & runMutableTime clock

--- a/src/Utils.hs
+++ b/src/Utils.hs
@@ -46,6 +46,7 @@ module Utils (
   formatWithCommas,
   sanitizeBackendError,
   extractMessageFromLog,
+  nonEmptyT,
   -- Fill color helpers
   statusFillColorText,
   methodFillColor,
@@ -134,6 +135,11 @@ instance Eq ZonedTime where
 
 escapedQueryPartial :: Text -> Text
 escapedQueryPartial x = toText $ escapeURIString isUnescapedInURI $ toString x
+
+
+-- | Drop empty text so \"\" and Nothing collapse to one absent case.
+nonEmptyT :: Maybe Text -> Maybe Text
+nonEmptyT = mfilter (not . T.null)
 
 
 data DBField = forall a. (Show a, ToField a) => MkDBField a

--- a/test/integration/Pages/AnomaliesSpec.hs
+++ b/test/integration/Pages/AnomaliesSpec.hs
@@ -19,6 +19,7 @@ import Data.Pool (withResource)
 import Database.PostgreSQL.Simple (Only (..))
 import Database.PostgreSQL.Simple qualified as PGS
 import Database.PostgreSQL.Simple.SqlQQ (sql)
+import Models.Apis.Anomalies qualified as Anomalies
 import Models.Apis.Issues qualified as Issues
 import Models.Projects.Projects (Session (..))
 import Models.Projects.Projects qualified as Projects
@@ -300,6 +301,49 @@ spec = sequential $ aroundAll withTestResources do
           (issueId, testPid) :: IO [Only Int]
         pure n
       pendingCascade `shouldBe` 0
+
+    -- Regression: the issues UPDATE in acknowlegeCascade used target_hash=ANY() with
+    -- %-suffixed prefixes, so the legacy-hash sweep never matched any issue row.
+    it "acknowlegeCascade prefix-sweeps issues as well as anomalies" \tr -> do
+      runTestBg frozenTime tr pass
+      let sess = Servant.getResponse tr.trSessAndHeader
+          prefix = "casc-legacy-001" :: Text
+      iid <- (UUIDId :: DataUUID.UUID -> Issues.IssueId) <$> UUID.nextRandom
+      withResource tr.trPool \conn -> do
+        void $ PGS.execute conn
+          [sql| INSERT INTO apis.issues
+                  (id, project_id, issue_type, target_hash, endpoint_hash, title,
+                   severity, critical, affected_requests, affected_clients,
+                   issue_data, created_at, updated_at)
+                VALUES (?, ?, 'runtime_exception', ?, ?, 't', 'warning',
+                        false, 1, 1, '{}'::jsonb, ?, ?) |]
+          (iid, testPid, prefix <> ":child", prefix <> ":child", frozenTime, frozenTime)
+        void $ PGS.execute conn
+          [sql| INSERT INTO apis.anomalies (project_id, target_hash)
+                VALUES (?, ?) ON CONFLICT DO NOTHING |]
+          (testPid, prefix <> ":anom")
+
+      void $ runTestBg frozenTime tr $ Anomalies.acknowlegeCascade sess.user.id (V.singleton prefix)
+
+      ackedIssue <- withResource tr.trPool \conn -> PGS.query conn
+        [sql| SELECT id FROM apis.issues WHERE id=? AND acknowledged_at IS NOT NULL |] (Only iid) :: IO [Only Issues.IssueId]
+      length ackedIssue `shouldBe` 1
+      ackedAnoms <- withResource tr.trPool \conn -> do
+        [Only n] <- PGS.query conn
+          [sql| SELECT COUNT(*)::INT FROM apis.anomalies
+                WHERE project_id=? AND target_hash=? AND acknowledged_at IS NOT NULL |]
+          (testPid, prefix <> ":anom") :: IO [Only Int]
+        pure n
+      ackedAnoms `shouldBe` 1
+
+    -- Regression: createAPIChangeIssue hard-coded a string that differed from
+    -- defaultRecommendedAction, so the detail page's "not yet LLM-enhanced" check
+    -- never matched api_change issues and always rendered the boilerplate.
+    it "api_change issues carry defaultRecommendedAction" \tr -> do
+      ras <- withResource tr.trPool \conn -> PGS.query conn
+        [sql| SELECT DISTINCT recommended_action FROM apis.issues WHERE project_id=? AND issue_type='api_change' |]
+        (Only testPid) :: IO [Only Text]
+      map (\(Only t) -> t) ras `shouldBe` [Issues.defaultRecommendedAction]
 
     -- Regression: the ApiChange detail page used to render an empty Investigation
     -- panel because hashPrefix returned Nothing for ApiChange and there was no

--- a/test/integration/Pages/AnomaliesSpec.hs
+++ b/test/integration/Pages/AnomaliesSpec.hs
@@ -388,20 +388,20 @@ spec = sequential $ aroundAll withTestResources do
       -- 23h in: still within the 24h window
       advanceHours tr 23
       (within, _) <- runHasqlEffect tr
-        $ Issues.selectIssues testPid Nothing Nothing Nothing 100 0 Nothing Nothing "24h" [] []
+        $ Issues.selectIssues testPid Nothing Nothing 100 0 Nothing Nothing "24h" [] []
       map (.base.id) within `shouldSatisfy` elem iid
 
       -- 25h in: outside window — query still returns row, but activityBuckets all zero
       advanceHours tr 2
       (after, _) <- runHasqlEffect tr
-        $ Issues.selectIssues testPid Nothing Nothing Nothing 100 0 Nothing Nothing "24h" [] []
+        $ Issues.selectIssues testPid Nothing Nothing 100 0 Nothing Nothing "24h" [] []
       case find (\r -> r.base.id == iid) after of
         Just row -> V.sum row.activityBuckets `shouldBe` 0
         Nothing -> pure () -- also acceptable: filtered out entirely
 
 
 isApiChangeSingleRow :: Issues.IssueType -> AnomalyList.IssueVM -> Bool
-isApiChangeSingleRow ty (AnomalyList.IssueVM _ _ _ _ c) = c.base.issueType == ty
+isApiChangeSingleRow ty (AnomalyList.IssueVM _ _ _ c) = c.base.issueType == ty
 
 
 -- | Pull the first ApiChange issue id created by earlier tests. Fails the test

--- a/test/integration/Pages/Bots/WhatsappSpec.hs
+++ b/test/integration/Pages/Bots/WhatsappSpec.hs
@@ -2,8 +2,12 @@ module Pages.Bots.WhatsappSpec (spec) where
 
 import Data.Aeson qualified as AE
 import Data.Aeson.KeyMap qualified as KEM
+import Data.ByteString.Lazy qualified as LBS
+import Data.Pool (withResource)
 import Data.Text qualified as T
 import Data.Vector qualified as V
+import Database.PostgreSQL.Simple qualified as PGS
+import Database.PostgreSQL.Simple.SqlQQ (sql)
 import Pages.Bots.BotFixtures
 import Pages.Bots.BotTestHelpers
 import Pages.Bots.Whatsapp (BodyType (..), TwilioWhatsAppMessage (..), getWhatsappList, parseWhatsappBody, whatsappIncomingPostH)
@@ -74,6 +78,23 @@ spec = around withTestResources do
         KEM.lookup "7" (varsAt 0) `shouldBe` Just (AE.String "dashboard___2")
         -- Page 1 (skip=2): window actually advances to "c".
         KEM.lookup "2" (varsAt 2) `shouldBe` Just (AE.String "c")
+
+      -- Same regression, end-to-end: the handler (not just the parser/list
+      -- helpers) must thread the parsed skip into the Twilio template vars.
+      it "handler threads Load-More skip into the Twilio contentVariables" \tr -> do
+        let testPhone = getTestPhoneNumber tr
+        setupWhatsappNumber tr testPid testPhone
+        -- 6 dashboards: the skip=2 window still overflows, so the next Load-More
+        -- token must be dashboard___4; the hardcoded-0 bug would emit dashboard___2.
+        void $ withResource tr.trPool \conn ->
+          PGS.execute
+            conn
+            [sql|INSERT INTO projects.dashboards (project_id, created_by, title)
+                 SELECT ?, (SELECT id FROM users.users LIMIT 1), 'wa-dash-' || i FROM generate_series(1, 6) i|]
+            (PGS.Only testPid)
+        (reqs, _) <- runAsBaseRecordingHTTP tr $ whatsappIncomingPostH (twilioWhatsAppPrompt tr testPhone "dashboard___2")
+        let twilioBodies = [b | (u, b) <- reqs, "twilio" `T.isInfixOf` u]
+        twilioBodies `shouldSatisfy` any ("dashboard___4" `LBS.isInfixOf`)
 
     describe "Response format" do
       it "uses template-based responses" \_ -> do

--- a/test/integration/Pages/Bots/WhatsappSpec.hs
+++ b/test/integration/Pages/Bots/WhatsappSpec.hs
@@ -1,13 +1,15 @@
 module Pages.Bots.WhatsappSpec (spec) where
 
 import Data.Aeson qualified as AE
+import Data.Aeson.KeyMap qualified as KEM
 import Data.Text qualified as T
+import Data.Vector qualified as V
 import Pages.Bots.BotFixtures
 import Pages.Bots.BotTestHelpers
-import Pages.Bots.Whatsapp (TwilioWhatsAppMessage (..), whatsappIncomingPostH)
+import Pages.Bots.Whatsapp (BodyType (..), TwilioWhatsAppMessage (..), getWhatsappList, parseWhatsappBody, whatsappIncomingPostH)
 import Pkg.TestUtils
 import Relude
-import Test.Hspec (Spec, around, describe, it, shouldBe, shouldSatisfy)
+import Test.Hspec (Spec, around, describe, expectationFailure, it, shouldBe, shouldSatisfy)
 
 
 spec :: Spec
@@ -56,6 +58,22 @@ spec = around withTestResources do
 
       it "detects dashboard pagination" \_ -> do
         isDashboardPagination "dashboard___2" `shouldBe` True
+
+      -- Regression: the handler used to discard the parsed skip and always send
+      -- page 0, so the dashboard list's "Load More" button never advanced.
+      it "Load More advances the dashboard list window" \_ -> do
+        case parseWhatsappBody "dashboard___2" of
+          DashboardLoad n -> n `shouldBe` 2
+          _ -> expectationFailure "expected DashboardLoad"
+        let dashes = V.fromList [(l, "dash___" <> l) | l <- ["a", "b", "c", "d", "e"]]
+            varsAt skip = case getWhatsappList "dashboard" "pick" dashes skip of
+              AE.Object o -> o
+              _ -> mempty
+        -- Page 0: first item is "a", Load More points at skip=2.
+        KEM.lookup "2" (varsAt 0) `shouldBe` Just (AE.String "a")
+        KEM.lookup "7" (varsAt 0) `shouldBe` Just (AE.String "dashboard___2")
+        -- Page 1 (skip=2): window actually advances to "c".
+        KEM.lookup "2" (varsAt 2) `shouldBe` Just (AE.String "c")
 
     describe "Response format" do
       it "uses template-based responses" \_ -> do

--- a/test/integration/Pages/Bots/WhatsappSpec.hs
+++ b/test/integration/Pages/Bots/WhatsappSpec.hs
@@ -2,7 +2,7 @@ module Pages.Bots.WhatsappSpec (spec) where
 
 import Data.Aeson qualified as AE
 import Data.Aeson.KeyMap qualified as KEM
-import Data.ByteString.Lazy qualified as LBS
+import Data.ByteString qualified as BS
 import Data.Pool (withResource)
 import Data.Text qualified as T
 import Data.Vector qualified as V
@@ -94,7 +94,7 @@ spec = around withTestResources do
             (PGS.Only testPid)
         (reqs, _) <- runAsBaseRecordingHTTP tr $ whatsappIncomingPostH (twilioWhatsAppPrompt tr testPhone "dashboard___2")
         let twilioBodies = [b | (u, b) <- reqs, "twilio" `T.isInfixOf` u]
-        twilioBodies `shouldSatisfy` any ("dashboard___4" `LBS.isInfixOf`)
+        twilioBodies `shouldSatisfy` any (("dashboard___4" `BS.isInfixOf`) . toStrict)
 
     describe "Response format" do
       it "uses template-based responses" \_ -> do

--- a/test/integration/Pages/DashboardsSpec.hs
+++ b/test/integration/Pages/DashboardsSpec.hs
@@ -1,14 +1,21 @@
 module Pages.DashboardsSpec (spec) where
 
+import Data.Default (def)
+import Data.Text qualified as T
+import Data.Text.Lazy qualified as TL
+import Data.UUID qualified as UUID
 import Data.Vector qualified as V
+import Lucid (renderText, toHtml)
 import Models.Projects.Dashboards (DashboardVM (..))
 import Models.Projects.Dashboards qualified as DashboardModel
 import Models.Projects.ProjectMembers (TeamVM (..))
+import Models.Projects.Projects qualified as Projects
 import Pages.BodyWrapper (PageCtx (..))
 import Pages.Dashboards (DashboardFilters (..))
 import Pages.Dashboards qualified as Dashboards
 import Pages.Projects (TeamForm (..))
 import Pages.Projects qualified as ManageMembers
+import Pkg.DeriveUtils (UUIDId (..))
 import Pkg.TestUtils
 import Relude
 import Relude.Unsafe qualified as Unsafe
@@ -31,6 +38,49 @@ spec = sequential $ aroundAll withTestResources do
   describe "Dashboards Tests" do
     let mkDashboard t = Dashboards.DashboardForm{Dashboards.title = t, Dashboards.file = "overview.yaml", Dashboards.teams = [], Dashboards.fileDir = Nothing}
         dashboard = mkDashboard "Test Dashboard"
+
+    -- Regression: the variable input emitted data-tagify-mode twice for multi
+    -- variables; Lucid merges duplicate attrs with (<>), so multi-select vars
+    -- silently rendered as single-select ("" <> "select"). Multi vars must carry
+    -- NO tagify-mode attr (main.ts only sets options.mode when it is present).
+    it "renders data-tagify-mode=select only for single-select variables" \_ -> do
+      let mkVar k m =
+            DashboardModel.Variable
+              { key = k
+              , title = Nothing
+              , multi = m
+              , required = Nothing
+              , reloadOnChange = Nothing
+              , helpText = Nothing
+              , _vType = DashboardModel.VTValues
+              , sql = Nothing
+              , facetField = Nothing
+              , query = Nothing
+              , options = Nothing
+              , value = Nothing
+              , dependsOn = Nothing
+              }
+          dash = (def :: DashboardModel.Dashboard){DashboardModel.variables = Just [mkVar "single" Nothing, mkVar "multi" (Just True)]}
+          vm =
+            DashboardVM
+              { id = UUIDId UUID.nil
+              , projectId = testPid
+              , createdAt = frozenTime
+              , updatedAt = frozenTime
+              , createdBy = Projects.UserId UUID.nil
+              , baseTemplate = Nothing
+              , schema = Just dash
+              , starredSince = Nothing
+              , homepageSince = Nothing
+              , tags = V.empty
+              , title = "t"
+              , teams = V.empty
+              , filePath = Nothing
+              , fileSha = Nothing
+              }
+          html = TL.toStrict $ renderText $ toHtml $ Dashboards.DashboardGet testPid (UUIDId UUID.nil) dash vm []
+      T.count "data-tagify-mode" html `shouldBe` 1
+      html `shouldSatisfy` T.isInfixOf "data-tagify-mode=\"select\""
 
     it "overview template uses the native metric store" \_ -> do
       overview <- DashboardModel.readDashboardFile "static/public/dashboards" "_overview.yaml"

--- a/test/integration/Pages/Endpoints/ApiCatalogSpec.hs
+++ b/test/integration/Pages/Endpoints/ApiCatalogSpec.hs
@@ -430,3 +430,36 @@ spec = sequential $ aroundAll withTestResources do
           all3 = hashes page0Rows <> hashes page1Rows <> hashes page2Rows
       length all3 `shouldBe` 12
       length (ordNub all3) `shouldBe` 12 -- pages are disjoint
+
+    -- Regression: the "last_seen" sort ordered by endpoint created_at (like
+    -- first_seen, just reversed) instead of the row's actual lastSeen traffic time.
+    it "last_seen sort orders by span recency, not endpoint created_at" \tr -> do
+      let hostName = "lastseen.example"
+          mkEp path =
+            (def :: Endpoints.Endpoint)
+              { Endpoints.projectId = testPid
+              , Endpoints.urlPath = path
+              , Endpoints.urlParams = AE.object []
+              , Endpoints.method = "GET"
+              , Endpoints.host = hostName
+              , Endpoints.hash = toXXHash (testPid.toText <> hostName <> "GET" <> path)
+              , Endpoints.outgoing = False
+              }
+      runQueryEffect tr $ Endpoints.bulkInsertEndpoints $ V.fromList [mkEp "/old", mkEp "/new"]
+      withPool tr.trPool $ do
+        -- "/old" was created first but has the most recent traffic.
+        void $ DBT.execute [sql| UPDATE apis.endpoints SET created_at = ?::timestamptz - interval '2 days' WHERE project_id = ? AND host = ? AND url_path = '/old' |] (frozenTime, testPid, hostName)
+        void $ DBT.execute [sql| UPDATE apis.endpoints SET created_at = ?::timestamptz - interval '1 hour' WHERE project_id = ? AND host = ? AND url_path = '/new' |] (frozenTime, testPid, hostName)
+        let insertSpan (path :: Text) (offsetMins :: Int) =
+              void $ DBT.execute
+                [sql| INSERT INTO otel_logs_and_spans
+                        (id, project_id, timestamp, start_time,
+                         attributes___http___request___method, attributes___url___path,
+                         hashes, context, kind, status_code, summary)
+                      VALUES (gen_random_uuid(), ?, ?::timestamptz - make_interval(mins => ?), ?::timestamptz - make_interval(mins => ?),
+                              'GET', ?, ARRAY[?], '{}'::jsonb, 'SERVER', '200', '{}') |]
+                (testPid, frozenTime, offsetMins, frozenTime, offsetMins, path, (mkEp path).hash)
+        insertSpan "/old" 5
+        insertSpan "/new" 120
+      stats <- runTestBg frozenTime tr $ Endpoints.endpointRequestStatsByProject False testPid False (Just hostName) (Just "last_seen") Nothing 0 10 "Incoming" "7d"
+      map (.urlPath) (V.toList stats) `shouldBe` ["/old", "/new"]

--- a/test/integration/Pages/Endpoints/ApiCatalogSpec.hs
+++ b/test/integration/Pages/Endpoints/ApiCatalogSpec.hs
@@ -247,10 +247,10 @@ spec = sequential $ aroundAll withTestResources do
       V.length activeEndpoints `shouldBe` 2
       
       -- Verify endpoint details
-      let enp1 = (\(ApiCatalog.EnpReqStatsVM _ _ _ c) -> c) <$>
-            Unsafe.fromJust $ find (\(ApiCatalog.EnpReqStatsVM _ _ _ c) -> c.urlPath == "/") activeEndpoints
-      let enp2 = (\(ApiCatalog.EnpReqStatsVM _ _ _ c) -> c) <$>
-            Unsafe.fromJust $ find (\(ApiCatalog.EnpReqStatsVM _ _ _ c) -> c.urlPath == "/api/v1/user/login") activeEndpoints
+      let enp1 = (\(ApiCatalog.EnpReqStatsVM _ _ c) -> c) <$>
+            Unsafe.fromJust $ find (\(ApiCatalog.EnpReqStatsVM _ _ c) -> c.urlPath == "/") activeEndpoints
+      let enp2 = (\(ApiCatalog.EnpReqStatsVM _ _ c) -> c) <$>
+            Unsafe.fromJust $ find (\(ApiCatalog.EnpReqStatsVM _ _ c) -> c.urlPath == "/api/v1/user/login") activeEndpoints
 
       enp1.endpointHash `shouldBe` toXXHash (testPid.toText <> "172.31.29.11" <> "GET" <> "/")
       enp2.endpointHash `shouldBe` toXXHash (testPid.toText <> "api.test.com" <> "POST" <> "/api/v1/user/login")
@@ -426,7 +426,7 @@ spec = sequential $ aroundAll withTestResources do
       V.length page0Rows `shouldBe` 5
       V.length page1Rows `shouldBe` 5
       V.length page2Rows `shouldBe` 2 -- 12 mod 5
-      let hashes vm = [enp.endpointHash | ApiCatalog.EnpReqStatsVM _ _ _ enp <- V.toList vm]
+      let hashes vm = [enp.endpointHash | ApiCatalog.EnpReqStatsVM _ _ enp <- V.toList vm]
           all3 = hashes page0Rows <> hashes page1Rows <> hashes page2Rows
       length all3 `shouldBe` 12
       length (ordNub all3) `shouldBe` 12 -- pages are disjoint

--- a/test/integration/Pages/ErrorPatternsSpec.hs
+++ b/test/integration/Pages/ErrorPatternsSpec.hs
@@ -274,7 +274,7 @@ spec = sequential $ aroundAll withTestResources do
           void $ runTestBg frozenTime tr $ ErrorPatterns.updateErrorPatternState r.errorId ESOngoing frozenTime
 
       -- Acknowledge existing issues so ON CONFLICT doesn't deduplicate the new spike issue
-      (issues, _) <- runTestBg frozenTime tr $ Issues.selectIssues pid Nothing (Just False) Nothing 100 0 Nothing Nothing "24h" [] []
+      (issues, _) <- runTestBg frozenTime tr $ Issues.selectIssues pid (Just False) Nothing 100 0 Nothing Nothing "24h" [] []
       forM_ issues \issue -> runTestBg frozenTime tr $ Issues.acknowledgeIssue issue.base.id sess.user.id
 
       -- Find an established pattern with stddev > 0
@@ -339,7 +339,7 @@ spec = sequential $ aroundAll withTestResources do
               (PGS.Only errRate.errorId)
           -- Acknowledge existing RuntimeException issues to avoid ON CONFLICT dedup
           let sess = Servant.getResponse tr.trSessAndHeader
-          (issues, _) <- runTestBg frozenTime tr $ Issues.selectIssues pid Nothing (Just False) Nothing 100 0 Nothing Nothing "24h" [] []
+          (issues, _) <- runTestBg frozenTime tr $ Issues.selectIssues pid (Just False) Nothing 100 0 Nothing Nothing "24h" [] []
           forM_ issues \issue -> runTestBg frozenTime tr $ Issues.acknowledgeIssue issue.base.id sess.user.id
 
           -- Insert a massive spike (200, well above mean=100 + minAbsoluteDelta=50)
@@ -380,7 +380,7 @@ spec = sequential $ aroundAll withTestResources do
 
           -- Acknowledge existing issues to avoid ON CONFLICT dedup
           let sess = Servant.getResponse tr.trSessAndHeader
-          (issues, _) <- runTestBg frozenTime tr $ Issues.selectIssues pid Nothing (Just False) Nothing 100 0 Nothing Nothing "24h" [] []
+          (issues, _) <- runTestBg frozenTime tr $ Issues.selectIssues pid (Just False) Nothing 100 0 Nothing Nothing "24h" [] []
           forM_ issues \issue -> runTestBg frozenTime tr $ Issues.acknowledgeIssue issue.base.id sess.user.id
 
           issuesBefore <- countIssues tr Issues.RuntimeException
@@ -411,7 +411,7 @@ spec = sequential $ aroundAll withTestResources do
           forM_ [r1, r2] \r -> void $ runTestBg frozenTime tr $ ErrorPatterns.updateErrorPatternState r.errorId ESOngoing frozenTime
           -- Acknowledge existing issues to avoid ON CONFLICT dedup
           let sess = Servant.getResponse tr.trSessAndHeader
-          (issues, _) <- runTestBg frozenTime tr $ Issues.selectIssues pid Nothing (Just False) Nothing 100 0 Nothing Nothing "24h" [] []
+          (issues, _) <- runTestBg frozenTime tr $ Issues.selectIssues pid (Just False) Nothing 100 0 Nothing Nothing "24h" [] []
           forM_ issues \issue -> runTestBg frozenTime tr $ Issues.acknowledgeIssue issue.base.id sess.user.id
           -- Spike both patterns in the same hour bucket
           let concurrentTime = addUTCTime 14400 frozenTime

--- a/test/integration/Pages/LogExplorer/LogSpec.hs
+++ b/test/integration/Pages/LogExplorer/LogSpec.hs
@@ -6,7 +6,7 @@ import Data.HashMap.Strict qualified as HashMap
 import Data.Map.Strict qualified as Map
 import Data.Text qualified as T
 import Data.Text.Lazy qualified as LT
-import Data.Time (UTCTime, defaultTimeLocale, formatTime)
+import Data.Time (UTCTime, defaultTimeLocale, formatTime, getCurrentTime)
 import Data.Time.Clock (addUTCTime)
 import Data.Time.Format.ISO8601 (iso8601ParseM, iso8601Show)
 import Data.UUID qualified as UUID
@@ -26,6 +26,8 @@ import Opentelemetry.OtlpServer qualified as OtlpServer
 import Pages.LogExplorer.Log qualified as Log
 import Pages.LogExplorer.LogItem qualified as LogItem
 import Pages.Telemetry qualified as TelemetryPage
+import Pkg.Components.LogQueryBox qualified as LogQueryBox
+import Pkg.DeriveUtils (UUIDId (..))
 import Pkg.Parser.Stats (Sources (..))
 import Pkg.TestUtils
 import ProcessMessage (processMessages)
@@ -360,6 +362,18 @@ spec = around withTestResources do
       r.cols `shouldBe` ["id", "timestamp", "service", "summary", "latency_breakdown"]
 
   describe "Trace Tree" do
+    -- Regression: startNs was folded with a 0 seed, so every synthetic orphan
+    -- header started at 0 and its duration spanned from the epoch to the last span.
+    it "synthesizeOrphanHeaders anchors start_time_ns at the earliest child span" \_ -> do
+      let colIdxMap = HashMap.fromList $ zip ["trace_id", "parent_id", "latency_breakdown", "start_time_ns", "duration"] [0 ..]
+          row sid start dur = V.fromList [AE.String "t1", AE.String "missing-parent", AE.String sid, AE.Number start, AE.Number dur]
+          synth = Log.synthesizeOrphanHeaders colIdxMap $ V.fromList [row "s1" 1000 10, row "s2" 2000 20]
+          cell k r = HashMap.lookup k colIdxMap >>= (r V.!?)
+      V.length synth `shouldBe` 1
+      let hdr = Unsafe.fromJust $ synth V.!? 0
+      cell "start_time_ns" hdr `shouldBe` Just (AE.Number 1000)
+      cell "duration" hdr `shouldBe` Just (AE.Number 1020)
+
     it "should include traces field with tree structure" \tr -> do
       let nowTxt = toText $ formatTime defaultTimeLocale "%FT%T%QZ" frozenTime
           reqMsg = Unsafe.fromJust $ convert $ testRequestMsgs.reqMsg1 nowTxt
@@ -409,6 +423,30 @@ spec = around withTestResources do
         _ -> pass
 
   describe "Query library endpoints (saveQueryH/deleteQueryH)" do
+    -- Regression: the item-body onclick wrapped dataset.query in JSON.parse, but
+    -- data-query holds raw KQL — clicking any saved query threw a SyntaxError
+    -- while the sibling "Run this query" button passed it raw.
+    it "query library items pass dataset.query to handleAddQuery unparsed" \_ -> do
+      now' <- getCurrentTime
+      qid <- nextRandom
+      let qli =
+            Projects.QueryLibItem
+              { id = UUIDId qid
+              , projectId = testPid
+              , createdAt = now'
+              , updatedAt = now'
+              , userId = Projects.UserId UUID.nil
+              , queryType = Projects.QLTSaved
+              , queryText = "status_code == \"500\""
+              , queryAst = AE.Null
+              , title = Just "errors"
+              , byMe = True
+              }
+          html = LT.toStrict $ Lucid.renderText $ LogQueryBox.queryLibraryDropdown_ (V.singleton qli) V.empty
+      -- Lucid escapes quotes in attributes, so match quote-free fragments:
+      -- "dataset.query)" is the raw pass-through; the Run button renders "dataset.query, true".
+      html `shouldSatisfy` T.isInfixOf "dataset.query)"
+      html `shouldNotSatisfy` T.isInfixOf "JSON.parse"
     -- Mutations used to be smuggled through the log-fetch GET via ?layout=.
     -- They are now their own POST/DELETE endpoints; this exercises the full
     -- create → rename → delete round-trip through the DB.

--- a/test/integration/Pages/LogPatternsSpec.hs
+++ b/test/integration/Pages/LogPatternsSpec.hs
@@ -2,6 +2,7 @@ module Pages.LogPatternsSpec (spec) where
 
 import BackgroundJobs qualified
 import Data.Pool (withResource)
+import Data.Text qualified as T
 import Data.Time (UTCTime, addUTCTime, zonedTimeToUTC)
 import Effectful.Time qualified as Time
 import Data.UUID qualified as UUID
@@ -756,3 +757,28 @@ spec = sequential $ aroundAll withTestResources do
       Just p2 <- runHasqlEffect tr $ LogPatterns.getLogPatternByHash pid srcField h
       p2.state `shouldBe` LPSAcknowledged
       fmap zonedTimeToUTC p2.acknowledgedAt `shouldBe` Just (addUTCTime (8 * 86400) frozenTime)
+
+    -- Regression: showRate already appends "/hr"; the title must not append a second one ("5/hr/hr").
+    it "16. rateChangeIssueTitle_singleHrSuffix" \tr -> do
+      let lp =
+            LogPatterns.LogPatternWithRate
+              { patternId = LogPatterns.LogPatternId 0
+              , projectId = pid
+              , logPattern = "timeout calling <SVC>"
+              , patternHash = "hr-suffix-title-001"
+              , sourceField = "body"
+              , serviceName = Just "checkout"
+              , logLevel = Just "error"
+              , sampleMessage = Nothing
+              , baselineState = BSEstablished
+              , baselineMean = Just 2
+              , baselineMad = Just 1
+              , currentHourCount = 5
+              , pendingAnomalyDirection = Nothing
+              , pendingAnomalyDetectedAt = Nothing
+              , isError = True
+              }
+          sr = Issues.SpikeResult{currentRate = 5, mean = 2, mad = 1, zScore = 9, direction = LogPatterns.Spike}
+      issue <- runTestBg frozenTime tr $ Issues.createLogPatternRateChangeIssue pid lp sr
+      issue.title `shouldSatisfy` T.isInfixOf "(5/hr vs 2/hr)"
+      issue.title `shouldSatisfy` (not . T.isInfixOf "/hr/hr")

--- a/test/integration/Pages/ReportsSpec.hs
+++ b/test/integration/Pages/ReportsSpec.hs
@@ -17,11 +17,11 @@ spec = around withTestResources do
       -- Get initial state
       (_, res1) <- testServant tr $ PageReports.reportsGetH testPid Nothing Nothing Nothing
       case res1 of
-        PageReports.ReportsGetMain (PageCtx _ (_, _, _, daily1, weekly1)) -> do
-          -- Initial state should be daily=True, weekly=True from testSessionHeader
-          daily1 `shouldBe` False
-          weekly1 `shouldBe` True
+        PageReports.ReportsGetMain (PageCtx _ (pid1, _, _)) -> pid1 `shouldBe` testPid
         _ -> error "Unexpected response"
+      initial <- runTestBg frozenTime tr $ Projects.projectById testPid
+      fmap (.dailyNotif) initial `shouldBe` Just False
+      fmap (.weeklyNotif) initial `shouldBe` Just True
 
       -- Toggle daily
       _ <-
@@ -41,7 +41,7 @@ spec = around withTestResources do
       -- Also check via the reports page
       (_, res) <- testServant tr $ PageReports.reportsGetH testPid Nothing Nothing Nothing
       case res of
-        PageReports.ReportsGetMain (PageCtx _ (pid, reports, _, _, _)) -> do
+        PageReports.ReportsGetMain (PageCtx _ (pid, reports, _)) -> do
           pid `shouldBe` testPid
           length reports `shouldBe` 0
         _ -> error "Unexpected response"

--- a/test/integration/SchemaLearningSpec.hs
+++ b/test/integration/SchemaLearningSpec.hs
@@ -155,6 +155,23 @@ spec = sequential $ aroundAll withTestResources $
       -- One NewAnomaly job per (project, anomaly_type) — 4 jobs total.
       countAnomalyJobs tr `shouldReturn` 4
 
+    -- Regression: upsertTemplates wrote @fields@ without scrubNulValue, so one NUL
+    -- byte in a field path 22P05-poisoned the whole template batch (cf. upsertSummary).
+    it "flush survives NUL bytes in field paths" $ \tr -> do
+      clearAll tr
+      ref <- newIORef Hot.emptySchemaShardState
+      let obs = mkObs frozenTime "api.example.com" "GET" "/nul"
+            [("request.body.bad\NULkey", AE.String "v\NULv", Catalog.FCRequestBody)]
+      r <- observeAndFlush tr ref [obs]
+      r.catalogRowsWritten `shouldBe` 1
+      trows :: V.Vector (Only Int) <-
+        withPool tr.trPool $ DBT.query
+          [sql| SELECT COUNT(*)::int FROM apis.schema_template t
+                JOIN apis.schema_catalog c ON c.template_hash = t.template_hash
+                WHERE c.project_id = ? |]
+          (Only pid)
+      (maybe 0 (\(Only n) -> n) (trows V.!? 0) :: Int) `shouldBe` 1
+
     it "second flush of identical observations dedupes — no new anomalies, no extra jobs" $ \tr -> do
       clearAll tr
       ref <- newIORef Hot.emptySchemaShardState

--- a/web-components/test/log-list-harness.ts
+++ b/web-components/test/log-list-harness.ts
@@ -113,6 +113,11 @@ export const deferredTransport = () => {
 
 export const ids = (el: LogList) => (el as any).spanListTree.map((r: any) => r.id);
 
+// updateTimePicker is installed by main.ts in the real app; expandTimeRangeUrl
+// calls it to sync the picker label. Default no-op stub — tests that assert on
+// it (log-list-chart-anchor) install their own vi.fn over this.
+(window as any).updateTimePicker ??= () => '';
+
 // Mount with the mount-time auto-fetch disabled so tests drive fetchData explicitly.
 export const mountList = async (props: Partial<LogList> = {}) => {
   const el = new LogList();


### PR DESCRIPTION
## Summary
Multi-round quality pass (distill / locality-of-behavior / evasion review) over ~50 modules. Net **−2,265 lines** with no intended behavior change:

- Remove dead code, unused imports, and orphaned helpers
- Consolidate near-duplicate functions instead of keeping parallel variants
- Inline single-use bindings and `where`-clause extractions back to their use sites (locality of behavior)
- Simplify rendering paths in Pages/ (Bots, LogExplorer, Dashboards, Onboarding, BodyWrapper, …)
- Tighten Models/ query helpers (Anomalies, Issues, Telemetry, LogQueries, GitSync, …)
- Adjust integration specs to match consolidated APIs (AnomaliesSpec, ApiCatalogSpec, ErrorPatternsSpec, ReportsSpec)

Follow-up commits resolve 10 bug leads the sweep deferred (each with a failing-first regression test) and act on review feedback.

## Behavior changes (accidental fixes bundled into the cleanup)
Called out for reviewers/QA — each is an improvement, but not a pure no-op:

- **WhatsApp `/dashboard` list**: `skip` is now actually threaded into `getWhatsappList` — "load more" pagination previously never advanced (was hardcoded to 0). Regression test added.
- **Table filter URLs**: the `?`/`&` separator is computed after the target param is deleted, fixing malformed `/x&filter=bar` URLs on single-param pages. Pinned by doctest on `withQuery`.
- **TimePicker**: offset-indicator DOM id is now per-instance (`$targetPr-offsetIndicator`) instead of page-global, fixing pages with multiple pickers; JS updated to match.
- **Endpoints `pickZoned`**: tie-break on exact-UTC-instant ties flipped earliest→latest wins (`maximumBy` vs the old manual fold). Cosmetic impact on firstSeen/lastSeen display only.
- **`getTeamsByHandles`**: now shares `teamsVMQuery`'s `ORDER BY is_everyone DESC, created_at ASC` (previously unordered; only caller does `listToMaybe` on a single handle).
- **Crash→fallback hardening**: three partial functions replaced with safe fallbacks (Anomalies `Unsafe.read`→`readMaybe`, Onboarding `Unsafe.!!`→`foldMap`, Telemetry `V.head`→`<|>` + explicit not-found).
- **Pricing slider script** (Components): now correctly gated behind `unless basicAuthEnabled`; previously it referenced a DOM element that only exists outside basic-auth mode and threw.
- **`DataType` OpenAPI schema** (Charts/Types): consolidating hand-rolled Swagger instances into `WrappedEnumSC` changes the emitted spec from a named `#/components/schemas/DataType` ref to an inline schema. JSON encode/decode unchanged.
- **GitSync / Dashboards**: exact text of a few log/error messages changed (Dashboards YAML errors now tagged `read error:` / `YAML error:` to keep the phases distinguishable).
- **GitSync redirects**: JS `window.location.href` redirects replaced with `<meta http-equiv="refresh">` + fallback link (also fixes unescaped URL interpolation into a raw `<script>`).
- From the deferred-bug-leads commit (e762d87f3), each with a regression test: **Endpoints** "last_seen" sort now keys on `.lastSeen` (was `.createdAt`); **Anomalies** `acknowlegeCascade` issues UPDATE fixed from `= ANY` to `LIKE ANY` (previously never matched); **SchemaCatalog** `upsertTemplates` scrubs NUL bytes before insert (avoids PG 22P05); **Dashboards** multi-select variables no longer get a conflicting `tagify-mode="select"`; **LogExplorer** orphan-header rows get a real `start_time_ns` instead of epoch-0; **Slack** view_submission chart URL read via fixed `metaField 3` instead of last-split-element (3-part metadata now yields `""` instead of a wrong URL); **Issues** rate-change titles no longer render `"/hr/hr"`; **WhatsApp** Load-More skip threading (also covered end-to-end via the new HTTP-recording test seam).

## Test plan
- ghcid: all modules load clean, zero warnings
- 10 deferred bug leads fixed failing-test-first (see e762d87f3)
- Local integration suite green modulo known env-dependent baselines (TF down, GitSync live API); CI runs the full suite on this PR
- Manual smoke test suggested: facet search filter (LogExplorer hyperscript consolidation) — logically equivalent but hyperscript isn't type-checked
