### PR TITLE
review: restore sparkline peak fallback, make api_change test self-seeding

### DIFF
--- a/src/Pages/Components.hs
+++ b/src/Pages/Components.hs
@@ -837,7 +837,9 @@ sparkline_ buckets
           barW = max 2 (120 `div` n - gap)
           barsEnd = n * (barW + gap)
           topPad = h - barZone
-          peakIdx = length $ takeWhile (/= peakVal) buckets
+          -- fall back to 0 when nothing matches peakVal (all-negative buckets,
+          -- where the seed 1 wins) so the marker stays on-chart
+          peakIdx = maybe 0 fst $ find ((== peakVal) . snd) $ zip [0 ..] buckets
           lineX1 = peakIdx * (barW + gap) + barW
           lineX2 = barsEnd + 2
           w = lineX2 + labelW

--- a/test/integration/Pages/AnomaliesSpec.hs
+++ b/test/integration/Pages/AnomaliesSpec.hs
@@ -340,6 +340,19 @@ spec = sequential $ aroundAll withTestResources do
     -- defaultRecommendedAction, so the detail page's "not yet LLM-enhanced" check
     -- never matched api_change issues and always rendered the boilerplate.
     it "api_change issues carry defaultRecommendedAction" \tr -> do
+      -- Seed through the real pipeline when running in isolation; the file's
+      -- earlier tests normally created the api_change issue already.
+      existing <- withResource tr.trPool \conn -> PGS.query conn
+        [sql| SELECT id FROM apis.issues WHERE project_id=? AND issue_type='api_change' |]
+        (Only testPid) :: IO [Only Issues.IssueId]
+      when (null existing) do
+        currentTime <- getCurrentTime
+        let nowTxt = toText $ formatTime defaultTimeLocale "%FT%T%QZ" currentTime
+            reqMsg1 = Unsafe.fromJust $ convert $ testRequestMsgs.reqMsg1 nowTxt
+        processMessagesAndBackgroundJobs tr [("m1", toStrict $ AE.encode reqMsg1)]
+        void $ runBackgroundJobsWhere frozenTime tr.trATCtx \case
+          BackgroundJobs.NewAnomaly{} -> True
+          _ -> False
       ras <- withResource tr.trPool \conn -> PGS.query conn
         [sql| SELECT DISTINCT recommended_action FROM apis.issues WHERE project_id=? AND issue_type='api_change' |]
         (Only testPid) :: IO [Only Text]


### PR DESCRIPTION
Post-merge follow-up to #472, addressing the final review round:

- **Components**: `sparkline_` peak index falls back to 0 when no bucket matches `peakVal` (all-negative series, where the `foldr max 1` seed wins) instead of `length buckets`, which pushed the marker off-chart.
- **AnomaliesSpec**: the `defaultRecommendedAction` regression test now seeds an api_change issue through the real pipeline when run in isolation, instead of depending on earlier tests in the file.

The other two findings from that round were analyzed and answered on #472: the dropped Stripe `rows > 0` guard is provably equivalent to the `whenJustM projectBySubId` it merged into (the UPDATE has no plan predicate), and the `defaultRecommendedAction` wording change is intentional now that the string is shared across issue types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ExECCj9BwAnXC7GkVSKtwx