### PR TITLE
fix(htmx4): migrate event names and drop removed detail fields

### DIFF
--- a/src/Pages/Anomalies.hs
+++ b/src/Pages/Anomalies.hs
@@ -771,7 +771,7 @@ anomalyDetailPage pid issue tr spanRecs errM now isFirst tp sampleOverride = do
                 add .opacity-0 .pointer-events-none to #resizer-details_width-wrapper
                 call updateUrlState('details_width', '', 'delete')
               end
-              on htmx:afterSwap if event.target is me
+              on htmx:after:swap if event.target is me
                 set my *width to ''
                 remove .opacity-0 .pointer-events-none from #resizer-details_width-wrapper
                 if window.innerWidth < 1024 call me.scrollIntoView({behavior:'smooth', block:'start'}) end
@@ -1591,7 +1591,7 @@ highlightJsHead_ = do
     }
     function highlightSnippets(root) { root.querySelectorAll('code:not(.hljs)').forEach(el => hljs.highlightElement(el)); }
     document.addEventListener('DOMContentLoaded', () => { setHljsTheme(); highlightSnippets(document); });
-    document.addEventListener('htmx:afterSettle', e => highlightSnippets(e.detail.elt));
+    document.addEventListener('htmx:after:swap', e => highlightSnippets(e.detail.elt));
     """
 
 

--- a/src/Pages/BodyWrapper.hs
+++ b/src/Pages/BodyWrapper.hs
@@ -177,7 +177,6 @@ bodyWrapper bcfg child = do
       -- stops table containers leaking their own hx-get/hx-trigger onto ~80 descendants.
       -- NB `useExplicitInheritace` is spelled that way in the compat extension.
       meta_ [name_ "htmx-config", content_ "{\"compat\":{\"useExplicitInheritace\":true}}"]
-      meta_ [name_ "htmx-config", content_ [text|{"selfRequestsOnly":false}|]]
       -- favicon items
       link_ [rel_ "apple-touch-icon", sizes_ "180x180", href_ "/public/apple-touch-icon.png"]
       link_ [rel_ "icon", type_ "image/png", sizes_ "32x32", href_ "/public/favicon-32x32.png"]
@@ -226,15 +225,16 @@ bodyWrapper bcfg child = do
         deferScript
         [ $(hashAssetFile "/public/assets/deps/htmx/htmx-4.0.0-beta6.min.js")
         , -- Must load immediately after htmx: restores implicit attribute inheritance
-          -- (v4 requires `:inherited` otherwise), 4xx/5xx no-swap, and the htmx 2 event
-          -- names (htmx:afterSwap, htmx:configRequest, ...) this app is written against.
+          -- (v4 requires `:inherited` otherwise) and 4xx/5xx no-swap. The app's own
+          -- listeners use v4 event names directly, so the shim's legacy-name replay is
+          -- only load-bearing for third-party code (hyperscript binds the legacy load event).
           $(hashAssetFile "/public/assets/deps/htmx/htmx-2-compat.js")
         , $(hashAssetFile "/public/assets/deps/htmx/hx-preload-4.js")
         , $(hashAssetFile "/public/assets/js/main.js")
         , -- Dropped with the htmx 4 upgrade: multi-swap and response-targets had no
           -- users (no `multi:` swaps, no hx-target-4xx/5xx) and no v4 port; idiomorph
           -- is superseded by built-in outerMorph; preload.js and json-enc-2.js call the
-          -- removed htmx.defineExtension (v4 preload ships above; json-enc and
+          -- removed defineExtension API (v4 preload ships above; json-enc and
           -- forward-page-params are re-registered in main.ts via registerExtension).
           $(hashAssetFile "/public/assets/js/thirdparty/_hyperscript_web0_9_93.min.js")
         , $(hashAssetFile "/public/assets/deps/tagify/tagify.min.js")
@@ -547,7 +547,7 @@ sideNav sess project pageTitle menuItem = aside_ [class_ "relative bg-fillWeaker
       -- Collapsed: search icon
       button_ ([class_ "group-has-[#sidenav-toggle:checked]/pg:hidden flex items-center justify-center p-2 rounded-lg border border-strokeWeak hover:border-strokeStrong hover:bg-fillWeak text-textWeak cursor-pointer transition-colors", searchScript, Aria.label_ "Search"] <> tippyRight_ "Search (\x2318K)") do
         faSprite_ "magnifying-glass" "regular" "w-4 h-4"
-    nav_ [id_ "main-sidenav", class_ "mt-2 flex flex-col gap-1 text-textWeak [&_.main-nav-link.active]:bg-fillBrand-weak [&_.main-nav-link.active]:text-textStrong [&_.main-nav-link.active]:font-medium [&_.main-nav-link.active]:border-l-strokeBrand-strong [&_.main-nav-link.active]:border-y-transparent [&_.main-nav-link.active]:border-r-transparent [&_.main-nav-link.active_.nav-icon]:text-textBrand", [__|on click set #mobile-nav-toggle.checked to false end on htmx:pushedIntoHistory from window or popstate from window settle then set p to window.location.pathname then for link in .main-nav-link set h to link.getAttribute('href') set extra to (link.getAttribute('data-match') or '') set matched to (p is h or p.startsWith(h + '/')) if not matched and extra is not '' for m in extra.split(' ') if m is not '' and (p is m or p.startsWith(m + '/')) set matched to true end end end if matched add .active to link else remove .active from link end end|]] do
+    nav_ [id_ "main-sidenav", class_ "mt-2 flex flex-col gap-1 text-textWeak [&_.main-nav-link.active]:bg-fillBrand-weak [&_.main-nav-link.active]:text-textStrong [&_.main-nav-link.active]:font-medium [&_.main-nav-link.active]:border-l-strokeBrand-strong [&_.main-nav-link.active]:border-y-transparent [&_.main-nav-link.active]:border-r-transparent [&_.main-nav-link.active_.nav-icon]:text-textBrand", [__|on click set #mobile-nav-toggle.checked to false end on htmx:after:history:push from window or popstate from window settle then set p to window.location.pathname then for link in .main-nav-link set h to link.getAttribute('href') set extra to (link.getAttribute('data-match') or '') set matched to (p is h or p.startsWith(h + '/')) if not matched and extra is not '' for m in extra.split(' ') if m is not '' and (p is m or p.startsWith(m + '/')) set matched to true end end end if matched add .active to link else remove .active from link end end|]] do
       let pidTxt = project.id.toText
           flyoutLink (linkText, link) =
             a_ ([href_ link, class_ "flex gap-2.5 items-center px-3 py-2 text-sm text-textWeak hover:bg-fillWeak hover:text-textStrong whitespace-nowrap"] <> navTabAttrs)

--- a/src/Pages/CommandPalette.hs
+++ b/src/Pages/CommandPalette.hs
@@ -102,7 +102,7 @@ paletteShell_ pid = do
     , class_ "cmd-palette-backdrop hidden fixed inset-0 flex flex-col items-center pt-[15vh] bg-black/40"
     , style_ "z-index:99999"
     , [__|on click if event.target is me add .hidden to me end
-          on htmx:beforeRequest from <body/> add .hidden to me end|]
+          on htmx:before:request from <body/> add .hidden to me end|]
     ]
     do
       -- Header

--- a/src/Pages/Dashboards.hs
+++ b/src/Pages/Dashboards.hs
@@ -484,7 +484,7 @@ dashboardPage_ pid dashId dash dashVM allParams = do
         waitForGridStack();
 
         // Re-initialize grids after htmx settles new tab content
-        document.body.addEventListener('htmx:afterSettle', function(e) {
+        document.body.addEventListener('htmx:after:swap', function(e) {
           if (e.detail.target && e.detail.target.id === 'dashboard-tabs-content') {
             initializeGrids();
             window.interpolateVarTemplates();
@@ -1205,18 +1205,18 @@ widgetViewerEditor_ pid paymentPlan dashboardIdM tabSlugM currentRange existingW
     , hxTrigger_ "submit"
     , term
         "_"
-        [text| on htmx:beforeRequest 
+        [text| on htmx:before:request 
             set widgetJSON.title to #{'${widgetTitleInputId}'}.value then 
             if not widgetJSON.id
               gridStackInstance.removeWidget('#add_a_widget_label', true, false)
             end
-           on htmx:beforeSwap 
-            set event.detail.shouldSwap to false then
+           on htmx:before:swap 
+            call event.preventDefault() then
             set #${drawerStateCheckbox}.checked to false then
             if @data-formMode == "edit"
-              call gridStackInstance.update(#{'${sourceWid}_widgetEl'}, {content: event.detail.serverResponse})
+              call gridStackInstance.update(#{'${sourceWid}_widgetEl'}, {content: event.detail.ctx.text})
             else
-              call gridStackInstance.addWidget({w: 3, h: 3, content: event.detail.serverResponse})
+              call gridStackInstance.addWidget({w: 3, h: 3, content: event.detail.ctx.text})
             end
         |]
     ]
@@ -1358,7 +1358,7 @@ widgetAlertConfig_ _pid paymentPlan alertFormId alertEndpoint chartTargetId widg
     , hxTrigger_ "submit"
     , hxVals_ "js:{teams: window.getTagValues('#teamHandlesInput')}"
     , class_ "flex flex-col gap-3 hidden group-has-[.alert-enable:checked]/walert:flex"
-    , [__|on htmx:afterRequest if event.detail.successful set my value to '' then call me.reset() end|]
+    , [__|on htmx:after:request if event.detail.ctx.response.status < 400 set my value to '' then call me.reset() end|]
     ]
     do
       input_ [type_ "hidden", name_ "widgetId", value_ widgetId]
@@ -1662,7 +1662,7 @@ dashboardsGet_ dg = do
                         [ class_ "cursor-pointer hover:bg-fillWeak tap-target"
                         , hxPost_ $ "/p/" <> dg.projectId.toText <> "/dashboards/" <> dash.id.toText <> "/widgets/" <> widgetId <> "/duplicate?source_dashboard_id=" <> sourceDashId.toText
                         , hxSwap_ "none"
-                        , [__| on htmx:afterRequest set #dashboards-modal.checked to false |]
+                        , [__| on htmx:after:request set #dashboards-modal.checked to false |]
                         ]
                       Nothing -> [class_ "group/row"]
                   , Table.bulkActions =

--- a/src/Pages/LogExplorer/Log.hs
+++ b/src/Pages/LogExplorer/Log.hs
@@ -466,7 +466,7 @@ renderFacets :: FacetSummary -> Html ()
 renderFacets facetSummary = do
   let (FacetData facetMap) = facetSummary.facetJson
   -- Checkbox↔query sync lives in web-components/src/main.ts (syncFacetCheckboxes),
-  -- wired to `update-query` + `htmx:afterSettle` so swapped-in facets re-sync.
+  -- wired to `update-query` + `htmx:after:swap` so swapped-in facets re-sync.
   forM_ (universe :: [FacetGroup]) \g ->
     renderFacetSection (facetGroupLabel g) (Map.findWithDefault [] g facetsByGroup) facetMap (g /= FGCommon)
   where
@@ -1434,7 +1434,7 @@ virtualTable pid initialFetchUrl modeM = do
 -- morph optimises 4% of the interaction — and idiomorph mutates nodes in place, so
 -- hyperscript never processes `install FieldMenuDelegate` on morphed-in content and the
 -- field context menu silently stops opening. Revisit only with an explicit
--- `_hyperscript.processNode` on htmx:afterSwap (see the LogItemMenuable behavior, which
+-- `_hyperscript.processNode` on htmx:after:swap (see the LogItemMenuable behavior, which
 -- already has to do this by hand).
 lazyLoad_ :: Text -> Text -> Text -> [Attribute] -> Html ()
 lazyLoad_ target url trigger extra =
@@ -1722,10 +1722,10 @@ apiLogsPage page = do
                     add .hidden to me then send toggleFullscreen(mode: 'trace', active: false) to #apiLogsPage
                     call updateUrlState('showTrace', '', 'delete')
                   end
-                  on htmx:afterSwap[#apiLogsPage's @data-fullscreen is 'details'] from me
+                  on htmx:after:swap[#apiLogsPage's @data-fullscreen is 'details'] from me
                     send toggleFullscreen(mode: 'trace', active: true) to #apiLogsPage
                   end
-                  on htmx:responseError from me
+                  on htmx:response:error from me
                     remove .hidden from #trace-load-error
                   end
                   on loadTrace(url)
@@ -1777,7 +1777,7 @@ apiLogsPage page = do
             end
           end
         end
-        on htmx:afterSwap send checkMobileOpen to me end
+        on htmx:after:swap send checkMobileOpen to me end
         on keydown[key=='Escape' and not (the event's target matches <input, textarea, select, [contenteditable]/>) and no <[popover]:popover-open/> and no <dialog[open]/>] from window
           -- `the first <…/> exists`, not a bare `<…/>`: a query literal is a lazy query object
           -- that stays truthy at zero matches, so a bare `if <sel/>` never falls through.
@@ -1945,7 +1945,7 @@ alertConfigurationForm_ project alertM teams = do
         , hxVals_ "js:{query:getQueryFromEditor(), since: getTimeRange().since, from: getTimeRange().from, to:getTimeRange().to, source: params().source || 'spans', vizType: getVizType(), teams: window.getTagValues('#alert-form-teams')}"
         , hxSwap_ "none"
         , class_ "flex flex-col gap-3"
-        , [__|on htmx:afterRequest[detail.successful] set my value to '' then call me.reset()|]
+        , [__|on htmx:after:request[detail.ctx.response.status < 400] set my value to '' then call me.reset()|]
         ]
         do
           input_ [type_ "hidden", name_ "alertId", value_ $ maybe "" ((.id.toText)) alertM]

--- a/src/Pages/Onboarding.hs
+++ b/src/Pages/Onboarding.hs
@@ -677,7 +677,7 @@ integrationsPage pid apikey =
         }
 
         // Re-highlight after HTMX swaps content
-        document.body.addEventListener('htmx:afterSwap', function(event) {
+        document.body.addEventListener('htmx:after:swap', function(event) {
           // Only highlight content in the integration documentation area
           const target = event.detail.target;
           if (target && (target.id.startsWith('fw-content-') || target.classList.contains('lang-guide'))) {

--- a/src/Pages/Projects.hs
+++ b/src/Pages/Projects.hs
@@ -502,7 +502,7 @@ integrationsBody IntegrationsConfig{..} = do
 
 -- | Fired after a "send test alert" form submits, so any `testSent from:body`-listening panel refreshes.
 testSentAttr_ :: Attribute
-testSentAttr_ = [__| on htmx:afterRequest from closest <form/> trigger testSent on body |]
+testSentAttr_ = [__| on htmx:after:request from closest <form/> trigger testSent on body |]
 
 
 -- | Shared htmx target/select/swap for actions that re-render the integrations panel.

--- a/src/Pages/Telemetry.hs
+++ b/src/Pages/Telemetry.hs
@@ -681,7 +681,7 @@ metricsDetailsPage pid sources metric candidates (dashboards, monitors) source s
       , hxGet_ $ metricDetailUrl pid metric.metricName source selected
       , hxTrigger_ "update-query from:window"
       , term "hx-ext" "forward-page-params"
-      , [__|on htmx:afterSwap if event.target is me call window.evalScriptsFromContent(me) end end|]
+      , [__|on htmx:after:swap if event.target is me call window.evalScriptsFromContent(me) end end|]
       ]
         <> metricDetailSwap_
     )

--- a/src/Pkg/Components/LogQueryBox.hs
+++ b/src/Pkg/Components/LogQueryBox.hs
@@ -60,7 +60,7 @@ logQueryBox_ config = do
     , hxSwap_ "outerHTML"
     , hxSelect_ "#queryLibraryContent"
     , hxPushUrl_ "false"
-    , [__|on htmx:afterRequest set #saveQueryMdl.dataset.pendingQuery to null|]
+    , [__|on htmx:after:request set #saveQueryMdl.dataset.pendingQuery to null|]
     ]
     do
       strong_ "Name your query"
@@ -116,8 +116,8 @@ logQueryBox_ config = do
                      if my.value.trim().length > 0 
                        then halt then trigger htmx:trigger 
                      end
-                   on htmx:afterRequest
-                     if event.detail.successful
+                   on htmx:after:request
+                     if event.detail.ctx.response.status < 400
                        then
                          call JSON.parse(event.detail.ctx.text) set :result to it
                          if :result.time_range then call window.updateTimePicker(:result.time_range) end

--- a/src/Pkg/Components/Widget.hs
+++ b/src/Pkg/Components/Widget.hs
@@ -547,13 +547,13 @@ renderWidgetHeader widget valueM subValueM expandBtnFn ctaM = div_ [class_ $ "le
               , hxTrigger_ "click"
               , hxSwap_ "none"
               , [__| on click call (the closest <[popover]/>).hidePopover()
-                     on htmx:beforeSwap
-                        set event.detail.shouldSwap to false then
+                     on htmx:before:swap
+                        call event.preventDefault() then
                         set widgetData to JSON.parse(event.detail.ctx.response.headers.get('X-Widget-JSON')) then
                         set gridEl to me.closest('.grid-stack') then
                         set layout to widgetData.layout or {w: 3, h: 3} then
                         make a <template/> called tpl then
-                        set tpl.innerHTML to event.detail.serverResponse then
+                        set tpl.innerHTML to event.detail.ctx.text then
                         set widgetEl to tpl.content.firstElementChild then
                         set newId to widgetEl.id then
                         call gridEl.gridstack.addWidget(widgetEl, {w: layout.w, h: layout.h}) then

--- a/web-components/src/index.ts
+++ b/web-components/src/index.ts
@@ -36,4 +36,4 @@ const loadComponents = () => components.forEach(([selector, load]) => {
 });
 
 loadComponents();
-document.addEventListener('htmx:afterSettle', loadComponents);
+document.addEventListener('htmx:after:swap', loadComponents);

--- a/web-components/src/main.ts
+++ b/web-components/src/main.ts
@@ -453,4 +453,4 @@ initAllTagifyInputs();
 if (document.readyState === 'loading') {
   document.addEventListener('DOMContentLoaded', () => { initAllTagifyInputs(); (window as any).interpolateVarTemplates(); });
 }
-document.addEventListener('htmx:afterSettle', (e: any) => { initAllTagifyInputs(e.detail?.elt || document); (window as any).interpolateVarTemplates(); syncFacetCheckboxes(e.detail?.elt || document); });
+document.addEventListener('htmx:after:swap', (e: any) => { initAllTagifyInputs(e.detail?.elt || document); (window as any).interpolateVarTemplates(); syncFacetCheckboxes(e.detail?.elt || document); });

--- a/web-components/src/page-chrome.ts
+++ b/web-components/src/page-chrome.ts
@@ -37,7 +37,6 @@
   : fn();
 
 onReady(function(){
-          // htmx.config.useTemplateFragments = true
           // Tooltip warmth tracking - skip delay when moving between tooltips
           let tooltipWarmTimeout: ReturnType<typeof setTimeout>;
           let isTooltipWarm = false;
@@ -119,10 +118,10 @@ onReady(function(){
           window.addEventListener('beforeunload', () => { clearTimeout(tooltipWarmTimeout); destroyTip(); });
           // A swap can remove the tooltip's reference element; drop the instance with it
           // so the detached node and its popper aren't retained until the next hover.
-          document.body.addEventListener('htmx:beforeSwap', () => { clearTimeout(tooltipWarmTimeout); destroyTip(); });
+          document.body.addEventListener('htmx:before:swap', () => { clearTimeout(tooltipWarmTimeout); destroyTip(); });
 
           // Animate stat values on HTMX content swap for delightful updates
-          document.body.addEventListener('htmx:afterSwap', (e: any) => {
+          document.body.addEventListener('htmx:after:swap', (e: any) => {
             e.target.querySelectorAll('.stat-value[data-value]').forEach((el: HTMLElement) => {
               const newVal = parseFloat(el.dataset.value!);
               if (!isNaN(newVal) && typeof (window as any).animateStatValue === 'function') {
@@ -132,21 +131,21 @@ onReady(function(){
           });
 
           // Add aria-busy during HTMX requests for screen reader feedback
-          document.body.addEventListener('htmx:beforeRequest', (e: any) => {
+          document.body.addEventListener('htmx:before:request', (e: any) => {
             e.target.setAttribute('aria-busy', 'true');
           });
-          document.body.addEventListener('htmx:afterRequest', (e: any) => {
+          document.body.addEventListener('htmx:after:request', (e: any) => {
             e.target.removeAttribute('aria-busy');
           });
 
           // Progress bar for HTMX requests
           const progressBar = document.getElementById('htmx-progress');
           if (progressBar) {
-            document.body.addEventListener('htmx:beforeRequest', () => {
+            document.body.addEventListener('htmx:before:request', () => {
               progressBar.classList.remove('htmx-settling');
               progressBar.classList.add('htmx-request');
             });
-            document.body.addEventListener('htmx:afterRequest', () => {
+            document.body.addEventListener('htmx:after:request', () => {
               progressBar.classList.remove('htmx-request');
               progressBar.classList.add('htmx-settling');
             });

--- a/web-components/src/widgets.ts
+++ b/web-components/src/widgets.ts
@@ -503,7 +503,7 @@ const disposeChartsIn = (root: Element) => {
 // htmx 4's beforeSwap detail has no `target` (htmx 2 did), and the compat shim re-fires
 // the old event name with the new payload — so read the swap target defensively and fall
 // back to the element the event was dispatched on.
-document.addEventListener('htmx:beforeSwap', (event) => {
+document.addEventListener('htmx:before:swap', (event) => {
   const e = event as CustomEvent<any>;
   const target = e.detail?.target ?? e.detail?.ctx?.target ?? (e.target instanceof Element ? e.target : null);
   if (target instanceof Element) disposeChartsIn(target);


### PR DESCRIPTION
The htmx 4 upgrade left every listener bound to htmx 2 names. The compat extension replays the camelCase aliases, so most kept working, but the `hx-on::` attributes did not: an attribute maps `::x` to `htmx:x` verbatim, and `htmx:before-request` is dispatched by neither htmx 4 nor the shim. All 8 were inert, which is why the trace details panel stopped opening. Rename every event to its v4 name so nothing depends on the shim's replay.

`hx-on::after:settle` on #trace_details_content rather than after:swap: htmx fires swap events on the requesting element and they bubble, and that panel is a sibling subtree of the waterfall rows, so after:swap never reached it. Only the settle pair is dispatched on the swap target.

htmx:afterSettle maps to after:swap, not after:settle: the shim raised afterSettle from its swap hook, and native after:settle carries {newContent, settleTasks, task} with no `elt`, which these handlers read. after:swap preserves both the timing and the detail shape.

Also replace the detail fields v4 removed, which the upgrade checker does not flag and which were failing silently:

  detail.shouldSwap = false -> event.preventDefault()
  detail.serverResponse     -> detail.ctx.text
  detail.successful         -> detail.ctx.response.status < 400

preventDefault is the only one of these that works; the migration guide's suggested ctx.target = null does not cancel a swap in 4.0.0-beta6, nor do detail.cancelled or ctx.swap. Consequences of the dead fields: the AI search branch in LogQueryBox never ran, two form resets never fired, and the dashboard widget save both swapped and hand-inserted into gridstack.

Drop the selfRequestsOnly config meta, removed in v4.

upgrade-check.py now reports 0 issues across 153 files (was 34).

<!-- Thank you for contributing to Monscope! -->

<!-- Briefly describe what your PR does here as much as you can. -->

Closes #

<!-- If your PR is related to an issue, provide the number(s) above (after the #); if it resolves multiple issues, be sure to add a comma (e.g. "closes #1000, #1001"). -->

## How to test

<!-- Please include the steps to test your changes here. -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure you have described your changes and added all relevant screenshots or data.
- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes (or request one from the team).
- [ ] You are **NOT** deprecating/removing a feature.
