### PR TITLE
Fan the service-map rollup out over projects that actually send spans

### DIFF
--- a/src/BackgroundJobs.hs
+++ b/src/BackgroundJobs.hs
@@ -3592,17 +3592,23 @@ prometheusScrapeBatchLimit :: Int
 prometheusScrapeBatchLimit = 1000
 
 
--- | Dispatcher (ServiceMapRollupTick). Fans out one rollup per active project for the
--- bucket that closed 5 minutes ago — the lag absorbs normal SDK export and ingest delay,
--- since the caller's client span and the callee's server span come from different
--- processes and can land seconds apart.
+-- | Dispatcher (ServiceMapRollupTick). Fans out one rollup per /project that sent a span
+-- this slice/ for the bucket that closed 5 minutes ago — the lag absorbs normal SDK export
+-- and ingest delay, since the caller's client span and the callee's server span come from
+-- different processes and can land seconds apart.
+--
+-- The fan-out is driven by 'projectsWithSpansInRange', not by every active project. Both
+-- lists produce the same rollup rows — a project with no spans has no edges — but the
+-- blind version pays a full self-join per project to discover that, and the great majority
+-- of projects are idle at any given tick. One discovery scan replaces that entirely.
 dispatchServiceMapRollups :: Config.AuthContext -> UTCTime -> ATBackgroundCtx ()
 dispatchServiceMapRollups authCtx scheduledTime = when authCtx.config.enableServiceMapRollup do
-  projects <- Projects.activeProjects
   let bucket = floorTo300 (addUTCTime (-600) scheduledTime)
+  projects <- ServiceGraph.projectsWithSpansInRange authCtx.env.enableTimefusionReads bucket (addUTCTime 300 bucket)
+  Log.logInfo "Service-map rollup fan-out" $ AE.object ["bucket" AE..= bucket, "projects" AE..= length projects]
   failures <- liftIO $ withResource authCtx.jobsPool \conn ->
-    lefts <$> forM projects \p ->
-      first (p.id.toText,) <$> tryAny (void $ createJob conn "background_jobs" (ServiceMapRollup p.id bucket))
+    lefts <$> forM projects \pid ->
+      first (pid.toText,) <$> tryAny (void $ createJob conn "background_jobs" (ServiceMapRollup pid bucket))
   forM_ failures \(pid, err) ->
     Log.logAttention "Service-map rollup enqueue failed — this project's map will have a gap for this bucket" (pid, displayException err)
 

--- a/src/Models/Telemetry/ServiceGraph.hs
+++ b/src/Models/Telemetry/ServiceGraph.hs
@@ -23,6 +23,7 @@ module Models.Telemetry.ServiceGraph (
   emptyServiceGraph,
   serviceMapNodeCap,
   RollupEdge (..),
+  projectsWithSpansInRange,
   rollupServiceEdges,
   upsertServiceDependencyEdges,
   serviceGraphForRange,
@@ -45,7 +46,7 @@ import Effectful.Labeled (Labeled)
 import Hasql.Interpolate qualified as HI
 import Models.Projects.Projects qualified as Projects
 import Models.Telemetry.Telemetry (SpanKind (..), SpanRecord (..), SpanStatus (..), atMapText)
-import Pkg.DeriveUtils (AesonText (..), DB, UUIDId (..), WrappedEnumSC (..))
+import Pkg.DeriveUtils (AesonText (..), DB, UUIDId (..), WrappedEnumSC (..), idFromText)
 import Relude
 
 
@@ -373,6 +374,32 @@ sliceRowsToEdges rows =
         [ ((r.src, r.srcKind, r.tgt, r.tgtKind), HopAgg r.n r.errs (LatencyHist $ one (fromIntegral r.latBucket, r.n)) r.durNs)
         | r <- rows
         ]
+
+
+-- | Which projects sent a span this slice that could form an edge. The dispatcher fans the
+-- rollup out over this rather than over every active project: the self-join costs the same
+-- scan whether or not the project has traffic, and the overwhelming majority of projects
+-- have none, so fanning out blindly spends ~all of the budget proving there is nothing to
+-- do. One scan answers for every project at once.
+--
+-- Deliberately the same store, window and @kind@ filter as 'rollupServiceEdges' — this is
+-- that query's @FROM@ clause with the per-project predicate lifted out, so a project is on
+-- this list exactly when the rollup would have found rows for it. A project that drops off
+-- mid-window still gets its bucket; one that has never sent a span never gets a job.
+--
+-- Rows with an unparseable @project_id@ are dropped rather than failing the tick: the span
+-- store's column is text, and one malformed value must not cost every other project its
+-- bucket.
+projectsWithSpansInRange :: (DB es, Labeled "timefusion" Hasql :> es) => Bool -> UTCTime -> UTCTime -> Eff es [Projects.ProjectId]
+projectsWithSpansInRange useTf lo hi =
+  fmap (mapMaybe (idFromText @"project"))
+    $ Hasql.withHasqlTimefusion useTf
+    $ Hasql.interp
+      [HI.sql|
+      SELECT DISTINCT project_id
+      FROM otel_logs_and_spans
+      WHERE timestamp >= #{lo} AND timestamp < #{hi}
+        AND kind IN ('server','client','producer','consumer')|]
 
 
 -- | Derive one closed time slice's edges straight from the span table. This is the only

--- a/src/Pages/Anomalies.hs
+++ b/src/Pages/Anomalies.hs
@@ -793,12 +793,14 @@ anomalyDetailPage pid issue tr spanRecs errM now isFirst tp sampleOverride = do
       [ type_ "checkbox"
       , id_ "ai-panel-toggle"
       , class_ "hidden"
-      , [__|init set my.checked to (localStorage.getItem('ai-panel-open') == 'true')
-              if my.checked trigger load-chat on #ai-response-container end
+      , -- The event name must be quoted: hyperscript tokenizes the `-` in a bare
+        -- `load-chat` as minus, which failed to parse and left the panel never loading.
+        [__|init set my.checked to (localStorage.getItem('ai-panel-open') == 'true')
+              if my.checked trigger 'load-chat' on #ai-response-container end
             end
             on change
               call localStorage.setItem('ai-panel-open', my.checked)
-              if my.checked trigger load-chat on #ai-response-container end
+              if my.checked trigger 'load-chat' on #ai-response-container end
             end|]
       ]
     label_ [Lucid.for_ "ai-panel-toggle", class_ "absolute right-0 top-3 z-10 flex items-center gap-1.5 bg-fillBrand-strong text-white px-2 py-2.5 rounded-l-lg cursor-pointer shadow-md hover:opacity-90 transition-opacity group-has-[#ai-panel-toggle:checked]/ai:hidden", Aria.label_ "Open AI Assistant"] do

--- a/src/Pages/Components.hs
+++ b/src/Pages/Components.hs
@@ -112,10 +112,11 @@ drawer_ drawerId startOpen urlM content trigger = div_ [class_ "drawer drawer-en
       div_
         [ id_ $ drawerId <> "-content"
         , class_ "pb-4 px-8 h-full flex flex-col gap-8"
-        , hxSwap_ "innerHTML"
         , term "hx-on::after:swap" "window.evalScriptsFromContent(this)"
         ]
-        $ div_ (maybe [] (\url -> [hxGet_ url, hxTrigger_ "intersect once"]) urlM)
+        -- hx-swap sits on the requester rather than being inherited from the wrapper:
+        -- htmx 4 resolves inheritance explicitly, so a parent's value no longer reaches here.
+        $ div_ (maybe [] (\url -> [hxGet_ url, hxTrigger_ "intersect once", hxSwap_ "innerHTML"]) urlM)
         $ fromMaybe (loadingIndicator_ LdMD LdDots) content
       div_ [id_ $ drawerId <> "-indicator", class_ "htmx-indicator absolute inset-0 z-10 w-full box-border bg-bgRaised px-8"] drawerLoadingSkeleton_
 

--- a/test/integration/Pages/ServiceMapSpec.hs
+++ b/test/integration/Pages/ServiceMapSpec.hs
@@ -8,7 +8,7 @@ import Data.UUID qualified as UUID
 import Data.UUID.V4 (nextRandom)
 import Data.Vector qualified as V
 import Lucid qualified
-import Models.Telemetry.ServiceGraph (MapStats (..), NodeKind (..), ServiceEdge (..), ServiceGraph (..), ServiceNode (..), rollupServiceEdges, serviceGraphForRange, upsertServiceDependencyEdges)
+import Models.Telemetry.ServiceGraph (MapStats (..), NodeKind (..), ServiceEdge (..), ServiceGraph (..), ServiceNode (..), projectsWithSpansInRange, rollupServiceEdges, serviceGraphForRange, upsertServiceDependencyEdges)
 import Pages.BodyWrapper (BWConfig (..), PageCtx (..))
 import Pages.ServiceMap qualified as ServiceMap
 import Pages.Telemetry qualified as Trace
@@ -110,6 +110,20 @@ spec = around withTestResources do
       second' <- rollAndRead tr frozenTime
       [e.stats.requests | e <- V.toList second'.edges] `shouldBe` [e.stats.requests | e <- V.toList first'.edges]
       V.length second'.edges `shouldBe` V.length first'.edges
+
+    -- The dispatcher fans out over this list, so anything it over-reports is a self-join
+    -- run against a project with nothing to join. An active project that sent no span this
+    -- bucket must not appear — that is the whole point of discovering rather than fanning
+    -- out over projects.activeProjects, which returned all 1726 of them in production.
+    it "projectDiscovery_listsOnlyProjectsThatSentSpansInTheBucket" \tr -> do
+      apiKey <- createTestAPIKey tr testPid "service-map-discovery-key"
+      ingestFixture tr apiKey frozenTime
+      (inBucket, idleBucket) <- runTestBg frozenTime tr do
+        (,)
+          <$> projectsWithSpansInRange False (addUTCTime (-300) frozenTime) (addUTCTime 300 frozenTime)
+          <*> projectsWithSpansInRange False (addUTCTime (-86400) frozenTime) (addUTCTime (-86100) frozenTime)
+      inBucket `shouldBe` [testPid]
+      idleBucket `shouldBe` [] -- testPid is active, but silent in this window
 
     it "rollup_excludesSpansOutsideTheRange" \tr -> do
       apiKey <- createTestAPIKey tr testPid "service-map-range-key"


### PR DESCRIPTION
## What

Two commits:

- **`fix(ai panel)`** — quote the `load-chat` event so the chat actually loads (htmx 4 follow-up).
- **Service-map rollup fan-out** — the dispatcher enqueued one rollup per *active* project (1,726 in production) every 5 minutes. The rollup's span self-join costs the same scan whether or not the project has traffic, and almost none do at a given tick, so nearly all of that budget went to proving there was nothing to do: ~497k odd-jobs/day and ~5.8 TimeFusion self-joins/second, of the query shape that has OOM-killed TF before.

`projectsWithSpansInRange` answers for every project in one scan. It is deliberately `rollupServiceEdges`' own `FROM` clause with the per-project predicate lifted out — same store, window and `kind` filter — so a project is on the list exactly when the rollup would have found rows for it.

## Notes

- `project_id` is read as text and parsed rather than cast with `::uuid` (DataFusion has no uuid type); an unparseable value is dropped rather than costing every other project its bucket.
- Follows `runHourlyJob`, which already derives its project list from the span table with no `projects.active` intersection.
- No behaviour change today: `ENABLE_SERVICE_MAP_ROLLUP` is still off, so `apis.service_dependency_edges` stays empty and every service map still renders "No service activity". This is prep for turning that flag on.

## Testing

`projectDiscovery_listsOnlyProjectsThatSentSpansInTheBucket` pins both directions — the fixture's bucket returns `[testPid]`, and a window where that same still-active project sent nothing returns `[]`. All 8 ServiceMap specs pass.

**Unverified:** the discovery query is exercised against Postgres in tests (`useTf = False`). Its behaviour on TimeFusion — where it will actually run — has not been measured. It is a much gentler shape than the self-join (single column, no join, one 5-minute window, low-cardinality DISTINCT), but it should be timed against real TF before `ENABLE_SERVICE_MAP_ROLLUP` is flipped on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014AteFpMusSMajKqCe2kPJa