### PR TITLE
ci: let anyone run CI, and let CI skip what was already proven

### DIFF
--- a/.github/workflows/ci-attest-gc.yml
+++ b/.github/workflows/ci-attest-gc.yml
@@ -1,0 +1,24 @@
+# Attestation refs accumulate one per (check, tree, environment). They are empty
+# commits, so the storage is nil, but every gate run lists them — keep the
+# namespace small enough that listing stays a sub-second operation.
+name: Prune CI attestations
+
+on:
+  schedule:
+    - cron: '17 3 * * *'
+  workflow_dispatch:
+    inputs:
+      days:
+        description: Delete attestations older than this many days
+        default: '30'
+
+permissions:
+  contents: write
+
+jobs:
+  gc:
+    name: Prune
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      - uses: actions/checkout@v6
+      - run: scripts/ci/ci.sh gc "${{ github.event.inputs.days || 30 }}"

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -7,11 +7,45 @@ on:
 
 env:
   LANG: C.UTF-8
+  # Kill switch for the attestation cache: set the repo variable to "true" and
+  # every job runs every check again, no code change needed.
+  CI_ATTEST_DISABLED: ${{ vars.CI_ATTEST_DISABLED }}
+
+permissions:
+  contents: write # to publish attestation refs under refs/ci-attest/*
 
 jobs:
+  # What CI does NOT have to do. Every check in ci/checks.tsv is fingerprinted over
+  # the content it depends on; if the identical content was already proven — by the
+  # PR run that produced this merge, an earlier attempt, or a developer's `make ci`
+  # — the result is on the remote as a ref and the job below skips it. A squash
+  # merge keeps the PR head's tree, so master normally skips the lot and the deploy
+  # is bounded by the image build. See docs/local-ci.md.
+  gate:
+    name: Gate
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    outputs:
+      fingerprints: ${{ steps.checks.outputs.fingerprints }}
+      skip_build: ${{ steps.checks.outputs.skip_build }}
+      skip_doctests: ${{ steps.checks.outputs.skip_doctests }}
+      skip_unit_tests: ${{ steps.checks.outputs.skip_unit_tests }}
+      skip_cli_tests: ${{ steps.checks.outputs.skip_cli_tests }}
+      skip_integration_tests: ${{ steps.checks.outputs.skip_integration_tests }}
+      skip_haskell: ${{ steps.haskell.outputs.skip_all }}
+    steps:
+      - uses: actions/checkout@v6
+      - id: checks
+        run: scripts/ci/ci.sh gate
+      # Whether the whole container job (image pull + service containers + cabal
+      # cache restore, ~7 minutes before a single test runs) can be skipped outright.
+      - id: haskell
+        run: scripts/ci/ci.sh gate build doctests unit-tests cli-tests integration-tests
+
   # Build frontend once and share via artifacts
   frontend:
     name: Build Frontend
+    needs: gate
+    if: needs.gate.outputs.skip_haskell != 'true'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v6
@@ -25,16 +59,16 @@ jobs:
             package-lock.json
             web-components/package-lock.json
 
+      # Through ci.sh so the bundle CI ships and the bundle `make ci` builds come
+      # from one recipe (ci/checks.tsv -> run_body frontend).
       - name: Build frontend assets
+        env:
+          FINGERPRINTS: ${{ needs.gate.outputs.fingerprints }}
         run: |
-          mkdir -p static/public/assets/css
-          mkdir -p static/public/assets/web-components/dist/js
-          mkdir -p static/public/assets/web-components/dist/css
-          npm ci
-          npx tailwindcss -i ./static/public/assets/css/tailwind.css -o ./static/public/assets/css/tailwind.min.css --minify
-          cd web-components
-          npm ci
-          NODE_ENV=production npx vite build --mode production --sourcemap false
+          mkdir -p .ci && printf '%s\n' "$FINGERPRINTS" > .ci/fingerprints.tsv
+          # CI_FORCE: this job exists for the ARTIFACTS, not the verdict — an
+          # existing attestation would skip the build and leave nothing to upload.
+          CI_FORCE=true CI_FINGERPRINTS=.ci/fingerprints.tsv scripts/ci/ci.sh run frontend
 
       - name: Upload frontend artifacts
         uses: actions/upload-artifact@v7
@@ -47,7 +81,8 @@ jobs:
 
   build-and-test:
     name: Build and Test
-    needs: frontend
+    needs: [gate, frontend]
+    if: needs.gate.outputs.skip_haskell != 'true'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     # 30 was under budget and the job was silently truncating: on 2026-08-11 the
     # integration suite got 19 seconds before the wall, and the run before that
@@ -75,8 +110,12 @@ jobs:
           --health-interval=10s
           --health-timeout=5s
           --health-retries=5
+      # bitnami/minio was emptied from Docker Hub in the Aug-2025 Bitnami catalog
+      # change (that repository now has no tags at all); the pre-change images were
+      # relocated verbatim to bitnamilegacy. CI only kept working off a runner-side
+      # cache. Pinned here so a cache eviction can't take the suite down.
       minio:
-        image: bitnami/minio:latest
+        image: bitnamilegacy/minio:latest
         env:
           MINIO_ROOT_USER: minioadmin
           MINIO_ROOT_PASSWORD: minioadmin
@@ -124,6 +163,20 @@ jobs:
           TIMEFUSION_FOYER_DISABLED: 'true'
           TIMEFUSION_BUFFER_MAX_MEMORY_MB: '512'
           OTEL_TRACES_EXPORTER: none
+    env:
+      # Every step below runs through scripts/ci/ci.sh, which reads these both to
+      # decide the environment's capabilities and to point the suite at the services.
+      USE_EXTERNAL_DB: 'true'
+      DB_HOST: postgres
+      LOG_LEVEL: warn
+      MINIO_ENDPOINT: http://minio:9000
+      MINIO_ACCESS_KEY: minioadmin
+      MINIO_SECRET_KEY: minioadmin
+      TIMEFUSION_PG_TEST_URL: postgresql://postgres:postgres@timefusion:5432/postgres
+      TWILIO_ACCOUNT_SID: ${{ vars.TWILIO_ACCOUNT_SID }}
+      DISCORD_CLIENT_ID: '1328384474395967631'
+      CI_SHARDS: '4'
+      CI_FINGERPRINTS: .ci/fingerprints.tsv
     steps:
       - uses: actions/checkout@v6
 
@@ -148,6 +201,14 @@ jobs:
           mkdir -p static/public/assets/web-components/dist/js
           mkdir -p static/public/assets/web-components/dist/css
 
+      # Attest the fingerprints the gate looked up. hpack below rewrites
+      # monoscope.cabal, which is one of the inputs — recomputing after it would
+      # attest a fingerprint no gate will ever ask for, and nothing would be reused.
+      - name: Pin fingerprints from gate
+        env:
+          FINGERPRINTS: ${{ needs.gate.outputs.fingerprints }}
+        run: mkdir -p .ci && printf '%s\n' "$FINGERPRINTS" > .ci/fingerprints.tsv
+
       - name: Install hpack
         run: cabal install --install-method=copy --overwrite-policy=always hpack
 
@@ -155,70 +216,34 @@ jobs:
         run: hpack
 
       - name: Build
-        run: cabal build all -j --ghc-options="-O0 +RTS -A64m -n2m -RTS"
+        if: needs.gate.outputs.skip_build != 'true'
+        run: scripts/ci/ci.sh run build
 
       - name: Run doctests
-        run: cabal test doctests --ghc-options="-O0" --test-show-details=direct
+        if: needs.gate.outputs.skip_doctests != 'true'
+        run: scripts/ci/ci.sh run doctests
 
       - name: Run unit-tests
-        run: cabal test unit-tests --ghc-options="-O0" --test-show-details=direct
+        if: needs.gate.outputs.skip_unit_tests != 'true'
+        run: scripts/ci/ci.sh run unit-tests
 
-      # The CLI package builds without libpq, so its tests are cheap and can't
-      # be skipped for want of a database.
+      # The CLI package builds without libpq, so its tests are cheap and can't be
+      # skipped for want of a database.
       - name: Run cli-tests
-        run: cabal test monoscope-cli:cli-tests --ghc-options="-O0" --test-show-details=direct
+        if: needs.gate.outputs.skip_cli_tests != 'true'
+        run: scripts/ci/ci.sh run cli-tests
 
       # No explicit wait: the TF service container starts at "Initialize
-      # containers" (before the multi-minute build) and boots in ~1s, so it's
-      # long ready by the time integration tests connect. The hasql TF pool also
+      # containers" (before the multi-minute build) and boots in ~1s, so it's long
+      # ready by the time integration tests connect. The hasql TF pool also
       # retries, and TF's early-bind responder holds :5432 from the start.
       - name: Run integration-tests
-        env:
-          USE_EXTERNAL_DB: true
-          DB_HOST: postgres
-          TWILIO_ACCOUNT_SID: ${{ vars.TWILIO_ACCOUNT_SID }}
-          DISCORD_CLIENT_ID: "1328384474395967631"
-          LOG_LEVEL: warn
-          MINIO_ENDPOINT: http://minio:9000
-          MINIO_ACCESS_KEY: minioadmin
-          MINIO_SECRET_KEY: minioadmin
-          # Real TimeFusion leg: TestUtils sets tfEnabled + tfPgTypes=False.
-          TIMEFUSION_PG_TEST_URL: postgresql://postgres:postgres@timefusion:5432/postgres
-        # Process-sharded (see test/integration/Main.hs): 4 binary copies, each its own
-        # RTS running a disjoint shard (SHARD_INDEX/SHARD_TOTAL) sequentially. Sidesteps
-        # the in-process hspec `parallel` deadlock; 4 * ~9 conns < Postgres
-        # max_connections. Inlined (no `make` in the deps image).
-        run: |
-          bin=$(cabal list-bin integration-tests)
-          rm -f build-shard-*.log
-          for i in 0 1 2 3; do
-            ( start=$(date +%s); SHARD_INDEX=$i SHARD_TOTAL=4 "$bin" --color > build-shard-$i.log 2>&1; echo "[shard-time] $(( $(date +%s) - start ))s" >> build-shard-$i.log ) &
-          done
-          wait
-          echo "=== per-shard (wall-clock | result) — wide spreads ⇒ rebalance ==="
-          for i in 0 1 2 3; do printf "shard %s: %-6s | %s\n" "$i" "$(sed -n 's/.*\[shard-time\] //p' build-shard-$i.log | tail -1)" "$(grep -hE 'examples?, [0-9]+ failures?' build-shard-$i.log | tail -1)"; done
-          green=$(grep -lE "examples?, 0 failures" build-shard-*.log | wc -l | tr -d ' ')
-          # green==4 already means every shard printed a clean "0 failures" summary; don't grep
-          # for "error:" too — the app logs error: lines at LOG_LEVEL=warn on passing runs.
-          if [ "$green" -ne 4 ] || grep -qE "[1-9][0-9]* failures?|Interrupted" build-shard-*.log; then
-            echo "SHARDED RUN FAILED ($green/4 green):"
-            for f in build-shard-*.log; do
-              grep -qE "examples?, 0 failures" "$f" && continue
-              echo "### $f"
-              # The whole Failures section, not a fixed tail. hspec spends ~8 lines per
-              # failure, so `tail -40` stopped after the first one and the rest of the
-              # names existed only inside the runner — leaving a red gate no one could
-              # diagnose without pushing a commit to re-print it.
-              sed -n '/^Failures:/,$p' "$f"
-              # A shard killed before hspec's summary has no Failures section to print.
-              grep -q '^Failures:' "$f" || tail -60 "$f"
-            done
-            exit 1
-          fi
-          echo "ALL SHARDS GREEN"
+        if: needs.gate.outputs.skip_integration_tests != 'true'
+        run: scripts/ci/ci.sh run integration-tests
 
-      # The step above prints the failures; this keeps the surrounding output (setup,
-      # per-example progress, the app's own logs) for anything the summary can't explain.
+      # The step above prints the failures; this keeps the surrounding output
+      # (setup, per-example progress, the app's own logs) for anything the summary
+      # can't explain.
       - name: Upload integration shard logs
         if: failure()
         uses: actions/upload-artifact@v7
@@ -276,17 +301,28 @@ jobs:
             GIT_HASH=${{ github.sha }}
             GIT_COMMIT_DATE=${{ github.event.head_commit.timestamp || 'unknown' }}
 
-  # The gate. `needs` is what enforces it: a failed, cancelled, or timed-out
-  # test job leaves this skipped, and the image sits in the registry unused.
-  # Do NOT add `if: always()` here — that is exactly what let untested builds
-  # reach prod for months.
+  # The gate. `if` is what enforces it, and it is deliberately spelled out rather
+  # than left to `needs`: build-and-test is now allowed to be SKIPPED, but only
+  # when the gate job says every Haskell check was already proven for this exact
+  # tree. Any other skip — a failure, a cancellation, a timeout, a gate job that
+  # itself failed and so has an empty output — leaves this condition false and the
+  # image sits in the registry unused. Do NOT relax this to a bare `always()`;
+  # that is exactly what let untested builds reach prod for months.
   deploy:
     name: Deploy to CapRover
-    needs: [build-image, build-and-test]
+    needs: [gate, build-image, build-and-test]
+    if: >-
+      always()
+      && needs.build-image.result == 'success'
+      && (needs.build-and-test.result == 'success'
+          || (needs.build-and-test.result == 'skipped' && needs.gate.outputs.skip_haskell == 'true'))
     runs-on: blacksmith-4vcpu-ubuntu-2404
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
+      - name: Note why this deploy was allowed
+        run: |
+          echo "build-and-test: ${{ needs.build-and-test.result }} (all Haskell checks pre-proven: ${{ needs.gate.outputs.skip_haskell }})" >> "$GITHUB_STEP_SUMMARY"
       # Pinned deliberately, not using caprover/deploy-from-github: that action
       # does an unpinned `npm i -g caprover` at image-build time, so an upstream
       # release lands straight in the deploy path. caprover 2.4.0 (2026-08-05)

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -4,11 +4,45 @@ on: pull_request
 
 env:
   LANG: C.UTF-8
+  # Kill switch for the attestation cache: set the repo variable to "true" and
+  # every job runs every check again, no code change needed.
+  CI_ATTEST_DISABLED: ${{ vars.CI_ATTEST_DISABLED }}
+
+permissions:
+  contents: write # to publish attestation refs under refs/ci-attest/*
 
 jobs:
+  # What CI does NOT have to do. Every check in ci/checks.tsv is fingerprinted over
+  # the content it depends on; if someone already ran it — this runner, an earlier
+  # run, or a developer's `make ci` — the result is on the remote as a ref and the
+  # job below skips it. See docs/local-ci.md.
+  gate:
+    name: Gate
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    outputs:
+      fingerprints: ${{ steps.checks.outputs.fingerprints }}
+      skip_build: ${{ steps.checks.outputs.skip_build }}
+      skip_doctests: ${{ steps.checks.outputs.skip_doctests }}
+      skip_unit_tests: ${{ steps.checks.outputs.skip_unit_tests }}
+      skip_cli_tests: ${{ steps.checks.outputs.skip_cli_tests }}
+      skip_integration_tests: ${{ steps.checks.outputs.skip_integration_tests }}
+      skip_hlint: ${{ steps.checks.outputs.skip_hlint }}
+      skip_ui_tests: ${{ steps.checks.outputs.skip_ui_tests }}
+      skip_haskell: ${{ steps.haskell.outputs.skip_all }}
+    steps:
+      - uses: actions/checkout@v6
+      - id: checks
+        run: scripts/ci/ci.sh gate
+      # Whether the whole container job (image pull + service containers + cabal
+      # cache restore, ~7 minutes before a single test runs) can be skipped outright.
+      - id: haskell
+        run: scripts/ci/ci.sh gate build doctests unit-tests cli-tests integration-tests
+
   # Build frontend once and share via artifacts
   frontend:
     name: Build Frontend
+    needs: gate
+    if: needs.gate.outputs.skip_haskell != 'true'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v6
@@ -22,16 +56,16 @@ jobs:
             package-lock.json
             web-components/package-lock.json
 
+      # Through ci.sh so the bundle CI ships and the bundle `make ci` builds come
+      # from one recipe (ci/checks.tsv -> run_body frontend).
       - name: Build frontend assets
+        env:
+          FINGERPRINTS: ${{ needs.gate.outputs.fingerprints }}
         run: |
-          mkdir -p static/public/assets/css
-          mkdir -p static/public/assets/web-components/dist/js
-          mkdir -p static/public/assets/web-components/dist/css
-          npm ci
-          npx tailwindcss -i ./static/public/assets/css/tailwind.css -o ./static/public/assets/css/tailwind.min.css --minify
-          cd web-components
-          npm ci
-          NODE_ENV=production npx vite build --mode production --sourcemap false
+          mkdir -p .ci && printf '%s\n' "$FINGERPRINTS" > .ci/fingerprints.tsv
+          # CI_FORCE: this job exists for the ARTIFACTS, not the verdict — an
+          # existing attestation would skip the build and leave nothing to upload.
+          CI_FORCE=true CI_FINGERPRINTS=.ci/fingerprints.tsv scripts/ci/ci.sh run frontend
 
       - name: Upload frontend artifacts
         uses: actions/upload-artifact@v7
@@ -44,7 +78,8 @@ jobs:
 
   build-and-test:
     name: Build and Test
-    needs: frontend
+    needs: [gate, frontend]
+    if: needs.gate.outputs.skip_haskell != 'true'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 30
     container:
@@ -62,12 +97,16 @@ jobs:
           --health-interval=10s
           --health-timeout=5s
           --health-retries=5
-      # bitnami/minio starts the server on :9000 by default (no custom CMD
-      # needed), so it works as a plain GitHub Actions service. Replay
-      # integration tests probe MINIO_ENDPOINT and `pendingWith` if not
-      # reachable, but in CI we want a hard guarantee — hence the service.
+      # Starts the server on :9000 by default (no custom CMD needed), so it works
+      # as a plain GitHub Actions service. Replay integration tests probe
+      # MINIO_ENDPOINT and `pendingWith` if unreachable, but in CI we want a hard
+      # guarantee — hence the service.
+      # bitnami/minio was emptied from Docker Hub in the Aug-2025 Bitnami catalog
+      # change (that repository now has no tags at all); the pre-change images were
+      # relocated verbatim to bitnamilegacy. CI only kept working off a runner-side
+      # cache. Pinned here so a cache eviction can't take the suite down.
       minio:
-        image: bitnami/minio:latest
+        image: bitnamilegacy/minio:latest
         env:
           MINIO_ROOT_USER: minioadmin
           MINIO_ROOT_PASSWORD: minioadmin
@@ -112,6 +151,26 @@ jobs:
           TIMEFUSION_FOYER_DISABLED: 'true'
           TIMEFUSION_BUFFER_MAX_MEMORY_MB: '512'
           OTEL_TRACES_EXPORTER: none
+    env:
+      # Every step below runs through scripts/ci/ci.sh, which reads these both to
+      # decide the environment's capabilities and to point the suite at the services.
+      USE_EXTERNAL_DB: 'true'
+      DB_HOST: postgres
+      LOG_LEVEL: warn
+      MINIO_ENDPOINT: http://minio:9000
+      MINIO_ACCESS_KEY: minioadmin
+      MINIO_SECRET_KEY: minioadmin
+      TIMEFUSION_PG_TEST_URL: postgresql://postgres:postgres@timefusion:5432/postgres
+      TWILIO_ACCOUNT_SID: ${{ vars.TWILIO_ACCOUNT_SID }}
+      DISCORD_CLIENT_ID: '1328384474395967631'
+      # CLI E2E tests run against the prod demo project by default
+      # (https://api.monoscope.tech, project 00000000-…). Only the API key has no
+      # safe default — set MONOSCOPE_DEMO_API_KEY in repo secrets to a read-only
+      # key minted on that demo project. Tests mark themselves pending when it is
+      # absent (e.g. PRs from forks, where secrets aren't exposed).
+      MONOSCOPE_API_KEY: ${{ secrets.MONOSCOPE_DEMO_API_KEY }}
+      CI_SHARDS: '4'
+      CI_FINGERPRINTS: .ci/fingerprints.tsv
     steps:
       - uses: actions/checkout@v6
 
@@ -136,117 +195,115 @@ jobs:
           mkdir -p static/public/assets/web-components/dist/js
           mkdir -p static/public/assets/web-components/dist/css
 
+      # Attest the fingerprints the gate looked up, not ones recomputed after the
+      # steps below have rewritten files in the tree.
+      - name: Pin fingerprints from gate
+        env:
+          FINGERPRINTS: ${{ needs.gate.outputs.fingerprints }}
+        run: mkdir -p .ci && printf '%s\n' "$FINGERPRINTS" > .ci/fingerprints.tsv
+
+      # package.yaml already passes -fwrite-ide-info; the build emits .hie files
+      # alongside .o files in dist-newstyle, which weeder walks below.
       - name: Build
-        # package.yaml already passes -fwrite-ide-info; the build emits .hie
-        # files alongside .o files in dist-newstyle, which weeder walks below.
-        run: cabal build all -j --ghc-options="-O0 +RTS -A64m -n2m -RTS"
+        if: needs.gate.outputs.skip_build != 'true'
+        run: scripts/ci/ci.sh run build
 
       - name: Check unused code (weeder)
-        # Informational only for now — there's a real backlog of findings we
-        # want to surface but not block PRs on. Flip to `false` once the
-        # current src/ findings are triaged.
+        # Informational only for now — there's a real backlog of findings we want
+        # to surface but not block PRs on. Note it is NOT attested while it can't
+        # fail: a check that always passes proves nothing worth caching.
         continue-on-error: true
-        run: |
-          command -v weeder >/dev/null 2>&1 \
-            || cabal install weeder --install-method=copy --installdir=/usr/local/bin --overwrite-policy=always
-          weeder --config config/weeder.toml --hie-directory dist-newstyle
+        run: CI_NO_ATTEST=true scripts/ci/ci.sh run weeder
 
       - name: Run doctests
-        run: cabal test doctests --ghc-options="-O0" --test-show-details=direct
+        if: needs.gate.outputs.skip_doctests != 'true'
+        run: scripts/ci/ci.sh run doctests
 
       - name: Run unit-tests
-        run: cabal test unit-tests --ghc-options="-O0" --test-show-details=direct
+        if: needs.gate.outputs.skip_unit_tests != 'true'
+        run: scripts/ci/ci.sh run unit-tests
+
+      - name: Run cli-tests
+        if: needs.gate.outputs.skip_cli_tests != 'true'
+        run: scripts/ci/ci.sh run cli-tests
 
       # No explicit wait: the TF service container starts at "Initialize
-      # containers" (before the multi-minute build) and boots in ~1s, so it's
-      # long ready by the time integration tests connect. The hasql TF pool also
+      # containers" (before the multi-minute build) and boots in ~1s, so it's long
+      # ready by the time integration tests connect. The hasql TF pool also
       # retries, and TF's early-bind responder holds :5432 from the start.
       - name: Run integration-tests
-        env:
-          USE_EXTERNAL_DB: true
-          DB_HOST: postgres
-          TWILIO_ACCOUNT_SID: ${{ vars.TWILIO_ACCOUNT_SID }}
-          DISCORD_CLIENT_ID: "1328384474395967631"
-          LOG_LEVEL: warn
-          # CLI E2E tests run against the prod demo project by default
-          # (https://api.monoscope.tech, project 00000000-…). Only the API
-          # key has no safe default — set MONOSCOPE_API_KEY in repo secrets
-          # to a read-only key minted on that demo project. Tests gracefully
-          # mark themselves pending when the secret is absent (e.g. on PRs
-          # from forks where secrets aren't exposed).
-          MONOSCOPE_API_KEY: ${{ secrets.MONOSCOPE_DEMO_API_KEY }}
-          # Service container hostname inside the job's docker network.
-          MINIO_ENDPOINT: http://minio:9000
-          MINIO_ACCESS_KEY: minioadmin
-          MINIO_SECRET_KEY: minioadmin
-          # Real TimeFusion leg: TestUtils sets tfEnabled + tfPgTypes=False.
-          TIMEFUSION_PG_TEST_URL: postgresql://postgres:postgres@timefusion:5432/postgres
-        # Process-sharded: 4 binary copies (one per vCPU), each its own RTS running a
-        # disjoint shard (by SHARD_INDEX/SHARD_TOTAL) sequentially. In-process hspec
-        # `parallel` deadlocks on the per-test resource-pool lifecycle (see
-        # test/integration/Main.hs); sharding sidesteps it. 4 * ~9 conns = 36 < the
-        # Postgres default max_connections (100). Inlined (no `make` in the deps image).
-        run: |
-          bin=$(cabal list-bin integration-tests)
-          rm -f build-shard-*.log
-          for i in 0 1 2 3; do
-            ( start=$(date +%s); SHARD_INDEX=$i SHARD_TOTAL=4 "$bin" --color > build-shard-$i.log 2>&1; echo "[shard-time] $(( $(date +%s) - start ))s" >> build-shard-$i.log ) &
-          done
-          wait
-          echo "=== per-shard (wall-clock | result) — wide spreads ⇒ rebalance ==="
-          for i in 0 1 2 3; do printf "shard %s: %-6s | %s\n" "$i" "$(sed -n 's/.*\[shard-time\] //p' build-shard-$i.log | tail -1)" "$(grep -hE 'examples?, [0-9]+ failures?' build-shard-$i.log | tail -1)"; done
-          green=$(grep -lE "examples?, 0 failures" build-shard-*.log | wc -l | tr -d ' ')
-          # green==4 already means every shard printed a clean "0 failures" summary (a failed or
-          # crashed shard can't). Don't also grep for "error:" — at LOG_LEVEL=warn the app emits
-          # error: log lines on passing runs, which would false-fail a fully green run.
-          if [ "$green" -ne 4 ] || grep -qE "[1-9][0-9]* failures?|Interrupted" build-shard-*.log; then
-            echo "SHARDED RUN FAILED ($green/4 green):"
-            for f in build-shard-*.log; do grep -qE "examples?, 0 failures" "$f" || { echo "### $f"; tail -40 "$f"; }; done
-            exit 1
-          fi
-          echo "ALL SHARDS GREEN"
+        if: needs.gate.outputs.skip_integration_tests != 'true'
+        run: scripts/ci/ci.sh run integration-tests
+
+      # The step above prints the failures; this keeps the surrounding output
+      # (setup, per-example progress, the app's own logs) for anything the summary
+      # can't explain.
+      - name: Upload integration shard logs
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: integration-shard-logs
+          path: build-shard-*.log
+          retention-days: 14
 
   lint:
     name: Lint (hlint)
+    needs: gate
     runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       contents: write
     steps:
-      # Pin to the PR head SHA instead of head_ref: head_ref is the branch
-      # name, which checkout fetches with a glob refspec that 404s on deleted
-      # or fork branches (see i18n-yaml PR fetch failure).
+      # Pin to the PR head SHA instead of head_ref: head_ref is the branch name,
+      # which checkout fetches with a glob refspec that 404s on deleted or fork
+      # branches (see i18n-yaml PR fetch failure).
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           token: ${{ secrets.GITHUB_TOKEN }}
       - uses: haskell-actions/hlint-setup@v2
-      - name: Run hlint and apply refactorings
-        id: hlint
+      - name: Apply hlint refactorings
+        if: needs.gate.outputs.skip_hlint != 'true'
+        id: refactor
         run: |
           hlint src/ --refactor --refactor-options="--inplace" || true
+          # Recorded before the push is attempted, because the push is what forks
+          # and dependabot can't do — the tree still changed either way, and that
+          # is what decides whether the check below may be attested.
+          if [[ -n $(git status -s src/) ]]; then echo "changed=true" >> "$GITHUB_OUTPUT"; fi
       # Dependabot PRs run with a read-only token; pushing autorefactors 403s.
       # Skip the push for them (and forks) but still run hlint below.
       - name: Commit and push refactorings
-        if: github.actor != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository
+        if: steps.refactor.outputs.changed == 'true' && github.actor != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
-          if [[ -n $(git status -s) ]]; then
-            git add -A
-            git commit -m "Apply hlint refactorings"
-            git push origin HEAD:${{ github.event.pull_request.head.ref }}
-          fi
-      - uses: haskell-actions/hlint-run@v2
-        # The previous refactor step can only push fixes on same-repository PRs.
-        # On forks it cannot update the branch, so pre-existing hlint warnings
-        # would fail unrelated external contributions.
+          git add -A
+          git commit -m "Apply hlint refactorings"
+          git push origin HEAD:${{ github.event.pull_request.head.ref }}
+      - name: Run hlint
+        if: needs.gate.outputs.skip_hlint != 'true'
+        # The refactor step can only push fixes on same-repository PRs. On forks it
+        # cannot update the branch, so pre-existing warnings would fail unrelated
+        # external contributions.
         continue-on-error: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
-        with:
-          path: src/
-          fail-on: warning
+        env:
+          FINGERPRINTS: ${{ needs.gate.outputs.fingerprints }}
+        run: |
+          # Only cacheable when the tree still is what the gate fingerprinted. If
+          # the refactor rewrote src/, this run proves nothing about the commit the
+          # gate looked at — and the pushed commit gets its own gate run anyway.
+          if [ "${{ steps.refactor.outputs.changed }}" = "true" ]; then
+            export CI_NO_ATTEST=true
+          else
+            mkdir -p .ci && printf '%s\n' "$FINGERPRINTS" > .ci/fingerprints.tsv
+            export CI_FINGERPRINTS=.ci/fingerprints.tsv
+          fi
+          scripts/ci/ci.sh run hlint
 
   ui-tests:
     name: UI Tests
+    needs: gate
+    if: needs.gate.outputs.skip_ui_tests != 'true'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v6
@@ -257,7 +314,8 @@ jobs:
           cache: 'npm'
           cache-dependency-path: web-components/package-lock.json
       - name: Run UI tests
+        env:
+          FINGERPRINTS: ${{ needs.gate.outputs.fingerprints }}
         run: |
-          cd web-components
-          npm ci
-          npm test
+          mkdir -p .ci && printf '%s\n' "$FINGERPRINTS" > .ci/fingerprints.tsv
+          CI_FINGERPRINTS=.ci/fingerprints.tsv scripts/ci/ci.sh run ui-tests

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -81,7 +81,14 @@ jobs:
     needs: [gate, frontend]
     if: needs.gate.outputs.skip_haskell != 'true'
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    timeout-minutes: 30
+    # 60, matching Deploy. 30 was measured as below the floor there (~1.5m
+    # containers + 16m build + 6m doctests leaves nothing for the integration
+    # suite) and raised; this file kept the old number, so PR runs have been
+    # walling before the suite finishes. That was merely wasteful when every run
+    # started from scratch. Now it is worse: a truncated run publishes no
+    # attestation for the checks it never reached, so the next run pays for them
+    # again — the wall would quietly defeat the caching.
+    timeout-minutes: 60
     container:
       image: ghcr.io/monoscope-tech/monoscope-deps:latest
       env:

--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,6 @@ scripts/local/
 
 # stray root-level screenshots (Playwright/manual)
 /*.png
+
+# Local-CI attestation staging (scripts/ci/ci.sh)
+.ci/

--- a/Makefile
+++ b/Makefile
@@ -369,4 +369,34 @@ test-e2e-real: e2e-install
 test-e2e-ui: e2e-install
 	cd e2e && npx playwright test --ui
 
+# ---------------------------------------------------------------------------
+# Local CI. Runs the same checks GitHub Actions runs, in the same images, and
+# publishes a signed-by-push attestation so CI skips whatever you already proved.
+# Restrict to some of them with CHECKS: `make ci CHECKS="doctests unit-tests"`.
+# See docs/local-ci.md.
+CHECKS ?=
+
+ci:
+	./scripts/ci/ci.sh local $(CHECKS)
+
+# What CI would do with the tree as it stands right now, without doing any of it.
+ci-status:
+	./scripts/ci/ci.sh gate $(CHECKS)
+
+ci-shell:
+	./scripts/ci/ci.sh shell
+
+ci-down:
+	./scripts/ci/ci.sh down
+
+# Also deletes the cached cabal store and dist-newstyle volumes — the next
+# `make ci` will be a cold build.
+ci-clean:
+	./scripts/ci/ci.sh clean
+
+ci-selftest:
+	./scripts/ci/ci.sh selftest
+
+.PHONY: ci ci-status ci-shell ci-down ci-clean ci-selftest
+
 .PHONY: all test fmt lint fix-lint live-reload kill-live-reload live-reload-cli live-reload-doctests live-test-dev build-chart-cli build-chart-cli-linux tmux-live-reload tmux-live-reload-cli tmux-pin-here tmux-unpin kill-web-components-watch web-components-watch e2e-install test-e2e test-e2e-real test-e2e-ui gen-proto sync-otel-proto update-otel-proto minio-local timefusion-start timefusion-stop test-integration-tf

--- a/ci/checks.tsv
+++ b/ci/checks.tsv
@@ -1,0 +1,27 @@
+# The single source of truth for what "CI" is. Both .github/workflows/*.yml and
+# `make ci` (scripts/ci/ci.sh) read this file, so a check can never exist in one
+# and not the other.
+#
+#   name   requires   inputs
+#
+# requires  space-separated capabilities the environment must provide for the
+#           check to be RUNNABLE and for its result to be TRUSTED. The gate only
+#           reuses an attestation whose recorded capabilities are a superset of
+#           these, so a run that fell back to a stub service can never satisfy a
+#           check that needs the real one.
+# inputs    pathspecs whose content the check's result depends on. @-names expand
+#           to the sets in scripts/ci/ci.sh (see PATHSET_*). Every check also gets
+#           @meta (this file + the runner + the workflows), so changing what a
+#           check DOES invalidates it everywhere.
+#
+# Narrow `inputs` only where it is provably sound. A too-wide set costs a rerun;
+# a too-narrow one ships an untested change.
+frontend	node	@fe
+build	ghc	@hs @fe
+doctests	ghc	@hs @fe
+unit-tests	ghc	@hs @fe
+cli-tests	ghc	@cli
+integration-tests	ghc pg minio tf-real	@hs @fe
+weeder	ghc	@hs @fe
+hlint	hlint	src .hlint.yaml
+ui-tests	node	@fe

--- a/ci/compose.yml
+++ b/ci/compose.yml
@@ -1,0 +1,132 @@
+# The CI job, as containers you can run on your laptop. Service images, env and
+# tuning are kept identical to .github/workflows/*.yml on purpose — a result is
+# only worth caching if it was produced under the conditions CI would have used.
+#
+# Driven by `scripts/ci/ci.sh local` (see `make ci`). Not for running the app;
+# docker-compose.yml at the repo root is that.
+name: monoscope-ci
+
+x-tf-env: &tf-env
+  PGWIRE_PORT: '5432'
+  PGWIRE_PASSWORD: postgres
+  TIMEFUSION_ALLOW_INSECURE_AUTH: 'true'
+  AWS_S3_BUCKET: timefusion
+  AWS_S3_ENDPOINT: http://minio:9000
+  AWS_ACCESS_KEY_ID: minioadmin
+  AWS_SECRET_ACCESS_KEY: minioadmin
+  AWS_REGION: us-east-1
+  AWS_ALLOW_HTTP: 'true'
+  TIMEFUSION_DATA_DIR: /tmp/tf-data
+  # Flush each bucket immediately so a test's writes are queryable within the
+  # test's lifetime instead of after the 10-minute default.
+  TIMEFUSION_BUFFER_FLUSH_IMMEDIATELY: 'true'
+  TIMEFUSION_FOYER_DISABLED: 'true'
+  TIMEFUSION_BUFFER_MAX_MEMORY_MB: '512'
+  OTEL_TRACES_EXPORTER: none
+
+services:
+  postgres:
+    image: timescale/timescaledb-ha:pg16-all
+    environment:
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: monoscope
+    # The suite runs one template DB plus a database per shard; the stock 100 is
+    # tight once you shard wider than CI's 4.
+    command: postgres -c max_connections=300
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U postgres']
+      interval: 5s
+      timeout: 5s
+      retries: 20
+    tmpfs: ['/var/lib/postgresql/data:size=4g']
+
+  minio:
+    # Relocated from bitnami/minio, which the Aug-2025 Bitnami catalog change
+    # emptied. Same image, same env contract.
+    image: bitnamilegacy/minio:latest
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin
+      # The timefusion bucket must exist before TF opens its Delta table.
+      MINIO_DEFAULT_BUCKETS: monoscope-test,timefusion
+    healthcheck:
+      test: ['CMD-SHELL', 'curl -fsS http://localhost:9000/minio/health/live']
+      interval: 5s
+      timeout: 3s
+      retries: 20
+
+  timefusion:
+    # No arm64 image is published, so on Apple Silicon this runs emulated. That
+    # works but is slow; point MONOSCOPE_CI_TF_IMAGE at a locally built arm64
+    # image (`make -C ../timefusion docker-build`) and set the platform to match
+    # if you want the integration suite at full speed.
+    image: ${MONOSCOPE_CI_TF_IMAGE:-ghcr.io/monoscope-tech/timefusion:latest}
+    platform: ${MONOSCOPE_CI_TF_PLATFORM:-linux/amd64}
+    # TF's WAL uses io_uring, which Docker's default seccomp profile blocks
+    # (append_batch fails with EPERM).
+    security_opt: ['seccomp=unconfined']
+    environment: *tf-env
+    depends_on:
+      minio: {condition: service_healthy}
+    healthcheck:
+      test: ['CMD-SHELL', 'exec 3<>/dev/tcp/127.0.0.1/5432']
+      interval: 5s
+      timeout: 3s
+      retries: 30
+
+  runner:
+    image: ${MONOSCOPE_CI_DEPS_IMAGE:-ghcr.io/monoscope-tech/monoscope-deps:latest}
+    working_dir: /build
+    # `ci.sh local` overrides this; the default makes `docker compose run runner`
+    # by hand do the obvious thing.
+    command: ['scripts/ci/ci.sh', 'run']
+    volumes:
+      - ..:/build
+      # Shadow every host build directory. The host's are macOS/arm64 artifacts
+      # (and node_modules carries platform-native esbuild binaries) — sharing
+      # them with the Linux container corrupts both. Named volumes also make the
+      # second `make ci` fast: the cabal store and dist-newstyle survive.
+      - dist:/build/dist-newstyle
+      # The cabal STORE, where dependency builds land. Without this the runner is
+      # --rm'd with them inside and every `make ci` rebuilds every dep that isn't
+      # already in the image. Docker seeds an empty named volume from the image's
+      # content, so the first run inherits the deps image's prebuilt 3.1GB store
+      # and later runs add to it.
+      - cabal:/root/.cabal
+      - node:/build/node_modules
+      - wc-node:/build/web-components/node_modules
+      # CI has no .env. Mount an empty one so a developer's local secrets and
+      # DATABASE_URL (which points at PRODUCTION) cannot change the result — the
+      # whole point is to reproduce CI, not your laptop.
+      - ./empty.env:/build/.env:ro
+    environment:
+      CABAL_DIR: /root/.cabal
+      LANG: C.UTF-8
+      LOG_LEVEL: warn
+      USE_EXTERNAL_DB: 'true'
+      DB_HOST: postgres
+      MINIO_ENDPOINT: http://minio:9000
+      MINIO_ACCESS_KEY: minioadmin
+      MINIO_SECRET_KEY: minioadmin
+      TIMEFUSION_PG_TEST_URL: postgresql://postgres:postgres@timefusion:5432/postgres
+      DISCORD_CLIENT_ID: '1328384474395967631'
+      CI_SHARDS: ${CI_SHARDS:-4}
+      # The container has no push credentials (origin is ssh); it records results
+      # here and the host publishes them after the run.
+      CI_ATTEST_OUT: /build/.ci/attest.tsv
+      GIT_CONFIG_COUNT: '1'
+      GIT_CONFIG_KEY_0: safe.directory
+      GIT_CONFIG_VALUE_0: /build
+    depends_on:
+      postgres: {condition: service_healthy}
+      minio: {condition: service_healthy}
+      # Deliberately NOT timefusion: it has no arm64 image and dies under emulation
+      # on Apple Silicon, and a hard dependency there would stop every other check
+      # from running. `ci.sh local` starts it best-effort and the capability model
+      # refuses to attest anything that needed it. See docs/local-ci.md.
+
+volumes:
+  cabal:
+  dist:
+  node:
+  wc-node:

--- a/docs/local-ci.md
+++ b/docs/local-ci.md
@@ -1,0 +1,125 @@
+# Running CI on your own machine
+
+Our GitHub runners are 4 vCPU. A full `Deploy` run is ~20 minutes and a cold one
+is closer to 40. Most laptops here are considerably faster than that, and most of
+what CI does on any given push it has already done — the PR that produced the
+merge ran the same tests over the same bytes.
+
+So CI now asks, before every check: **has anyone already proven this?** If yes it
+skips. It does not matter who proved it — a previous run, a re-run, or you.
+
+Nothing here is mandatory. Push and wait for CI as before, or run `make ci` and
+watch CI have almost nothing left to do.
+
+## The short version
+
+```bash
+make ci             # run everything CI runs, in CI's own containers
+make ci-status      # what CI would run right now, without running any of it
+make ci CHECKS="doctests unit-tests"   # just these
+make ci-down        # stop the containers (build caches kept)
+```
+
+`make ci` publishes an attestation for every check that passes. Push, and the
+gate job finds them.
+
+## How it works
+
+`ci/checks.tsv` is the one definition of what CI is; both the workflows and
+`make ci` read it. Each check declares:
+
+- **inputs** — the paths whose content the result depends on. Every check also
+  implicitly depends on `ci/checks.tsv`, `scripts/ci/`, and `.github/workflows/`,
+  so changing what a check *does* invalidates it everywhere.
+- **requires** — the capabilities the environment must have for the result to
+  mean anything (`ghc`, `node`, `pg`, `minio`, `tf-real`, …).
+
+A check's **fingerprint** is a SHA-256 over the git blob hashes of its inputs. It
+is computed from the *working* tree, not from `HEAD`, so you can run `make ci`
+before committing and the attestation still matches the commit you make from it.
+
+A passing check is published as an empty commit at
+
+```
+refs/ci-attest/v1/<check>/<fingerprint>/<platform>/<capabilities>/<date>
+```
+
+Everything the gate needs is in the ref name, so deciding costs one `ls-remote`
+and no object fetches. The gate reuses an attestation only when the fingerprints
+match **and** the recorded capabilities are a superset of what the check requires
+— an environment that fell back to a stub service can never satisfy a check that
+needs the real one.
+
+Attestations are ordinary pushed refs, so producing one requires push access to
+the repo. Fork PRs can't create them, and can't be affected by them.
+
+## Fidelity, and where your laptop falls short
+
+`make ci` runs in `ghcr.io/monoscope-tech/monoscope-deps` — the same image the
+workflow uses, and it is multi-arch, so it runs natively on Apple Silicon. The
+service containers, their env, and the tuning in `ci/compose.yml` are kept
+identical to the workflows for the same reason.
+
+Two deliberate differences from your normal `make test`:
+
+- **Your `.env` is not visible.** `ci/compose.yml` mounts an empty file over it.
+  A local secret — or a `DATABASE_URL` pointing at production — changing the
+  result is exactly what makes "passes locally, fails in CI" happen.
+- **Build directories are container-private.** `dist-newstyle` and both
+  `node_modules` are named volumes; your host's are macOS/arm64 artifacts and
+  sharing them corrupts both. The volumes persist, so the second `make ci` is
+  fast — but the **first one is a cold build** and takes as long as a cold CI
+  run. Start it and go do something else; every run after that is incremental.
+  `make ci-down` keeps them; `make ci-clean` deletes them and buys you the cold
+  build back.
+
+**TimeFusion has no arm64 image**, and the amd64 one segfaults under emulation on
+Apple Silicon. So on a Mac:
+
+- everything except `integration-tests` runs and attests normally;
+- `integration-tests` is refused, and stays CI's job.
+
+`CI_ALLOW_DEGRADED=true make ci` runs it anyway against the
+Postgres-as-TimeFusion fallback. That is genuinely useful feedback and it is
+**not** attested — the dual-write TF leg is exactly what that check exists to
+exercise. On a Linux/amd64 box the real service starts and the whole suite
+attests.
+
+## Knobs
+
+| Variable | Effect |
+|---|---|
+| `CHECKS="a b"` | restrict `make ci` / `make ci-status` to these checks |
+| `CI_FORCE=true` | re-run even when an attestation already exists |
+| `CI_KEEP_GOING=true` | don't stop the sweep at the first failure |
+| `CI_ALLOW_DEGRADED=true` | run checks whose capabilities are missing, unattested |
+| `CI_NO_ATTEST=true` | run, publish nothing |
+| `CI_SHARDS=n` | integration-test shard count (CI uses 4; more needs more `max_connections`) |
+| `CI_ATTEST_DISABLED=true` | ignore all attestations — set as a repo variable to force full CI runs |
+| `MONOSCOPE_CI_TF_IMAGE` / `MONOSCOPE_CI_TF_PLATFORM` | point at a locally built TimeFusion image |
+
+## When you need to invalidate everything
+
+The fingerprint covers repository content, not the toolchain. If the deps image
+is rebuilt with materially different system packages, existing attestations stay
+valid even though the environment moved. Two escape hatches:
+
+- bump `EPOCH` in `scripts/ci/ci.sh` — invalidates every attestation at once;
+- set the repo variable `CI_ATTEST_DISABLED=true` — the gate ignores all
+  attestations until you unset it, with no code change.
+
+Old refs are deleted after 30 days by `.github/workflows/ci-attest-gc.yml`.
+
+## Reading the gate
+
+Every run writes a table to the job summary: each check, whether it ran or was
+skipped, and the exact attestation ref that let it skip. The deploy job records
+in its own summary whether it was gated on a test run or on pre-existing
+attestations.
+
+## Changing a check
+
+Edit `ci/checks.tsv` and the matching case in `run_body` (`scripts/ci/ci.sh`).
+`make ci-selftest` checks the two stay in sync, along with the fingerprint and
+capability logic. Narrow a check's `inputs` only where it is provably sound: a
+too-wide set costs a rerun, a too-narrow one ships an untested change.

--- a/scripts/ci/ci.sh
+++ b/scripts/ci/ci.sh
@@ -33,6 +33,12 @@ CAPS=''
 
 cd "$ROOT"
 
+# Container CI jobs run as root over a checkout owned by another uid, and git then
+# refuses every command in it with "detected dubious ownership" (exit 128). Only
+# touches the global config when git is already unusable here, which is the same
+# thing anyone would have to do by hand.
+git rev-parse --git-dir >/dev/null 2>&1 || git config --global --add safe.directory "$ROOT"
+
 die() { echo "ci: $*" >&2; exit 1; }
 note() { echo "── $*" >&2; }
 
@@ -374,7 +380,10 @@ cmd_run() {
     fi
     note "running $c"
     if run_body "$c"; then
-      case " $degraded " in *" $c "*) ;; *) [ "${CI_NO_ATTEST:-}" = "true" ] || record_result "$c" ;; esac
+      # A green check stays green even if we cannot record it. Publishing touches
+      # the network and the object store; neither is part of what the check proved.
+      case " $degraded " in *" $c "*) ;; *) [ "${CI_NO_ATTEST:-}" = "true" ] \
+        || record_result "$c" || note "could not record $c — it still passed, just isn't cached" ;; esac
     else
       rc=1
       note "FAILED $c"
@@ -439,7 +448,11 @@ cmd_local() {
   return $rc
 }
 
-cmd_shell() { compose up -d --wait postgres minio timefusion; compose run --rm runner bash; }
+cmd_shell() {
+  compose up -d --wait postgres minio
+  compose up -d --wait timefusion 2>/dev/null || note "TimeFusion did not start; the shell has no tf-real"
+  compose run --rm runner bash
+}
 # Volumes survive `down` on purpose: they hold the cabal store and dist-newstyle,
 # and losing them means the next `make ci` is a cold build. `clean` is the nuke.
 cmd_down() { compose down --remove-orphans; }
@@ -472,8 +485,7 @@ cmd_selftest() {
   # Every check in the TSV must have a body and a fingerprint.
   local c seen=''
   for c in $(checks_all); do
-    grep -q "^    $c)" "$0" || grep -q "^    $c|" "$0" || grep -q "    $c)" "$0" \
-      || { echo "FAIL $c has no run_body case"; SELFTEST_RC=1; }
+    grep -q "^    $c)" "$0" || { echo "FAIL $c has no run_body case"; SELFTEST_RC=1; }
     seen="$seen $(fingerprint "$c")"
   done
   assert "fingerprints distinct" "$(echo $seen | tr ' ' '\n' | wc -l | tr -d ' ')" \

--- a/scripts/ci/ci.sh
+++ b/scripts/ci/ci.sh
@@ -53,8 +53,12 @@ PATHSET_hs='app src shared cli test tests config proto static/migrations package
 PATHSET_fe='web-components/src web-components/test web-components/package.json web-components/package-lock.json web-components/vite.config.mjs web-components/tsconfig.json web-components/vitest.config.ts web-components/index.html package.json package-lock.json config/tailwind.config.js static/public/assets/css/tailwind.css'
 # The CLI package links only monoscope-shared, so its tests cannot observe src/.
 PATHSET_cli='cli shared cabal.project cabal.project.freeze'
-# Prepended to every check: changing what a check DOES must invalidate it.
-PATHSET_meta='ci/checks.tsv scripts/ci .github/workflows'
+# Prepended to every check: changing what a check DOES, or the environment it
+# runs in, must invalidate it. Named precisely rather than as `.github/workflows`
+# — an edit to the Claude review or CLI release workflow says nothing about the
+# test suite, and invalidating a 40-minute suite over it would train people to
+# distrust the cache.
+PATHSET_meta='ci/checks.tsv ci/compose.yml scripts/ci .github/workflows/pullrequest.yml .github/workflows/haskell.yml'
 
 pathset() { eval "printf '%s' \"\${PATHSET_$1:-}\""; }
 

--- a/scripts/ci/ci.sh
+++ b/scripts/ci/ci.sh
@@ -1,0 +1,540 @@
+#!/usr/bin/env bash
+# Portable CI runner + attestation cache.
+#
+# One definition of "CI" (ci/checks.tsv) that both GitHub Actions and a developer
+# laptop execute. A successful run publishes an ATTESTATION — a git ref naming the
+# check, a content fingerprint of everything the check depends on, the platform,
+# and the capabilities the environment actually had. The gate in the workflow
+# looks those refs up and skips any check already proven for the exact tree it is
+# about to test, whoever proved it.
+#
+#   scripts/ci/ci.sh fingerprint [check...]   print check -> fingerprint
+#   scripts/ci/ci.sh caps                     capabilities this environment provides
+#   scripts/ci/ci.sh gate [check...]          decide skip/run per check (writes $GITHUB_OUTPUT)
+#   scripts/ci/ci.sh run [check...]           run checks here, attest each success
+#   scripts/ci/ci.sh attest <check>           publish an attestation by hand
+#   scripts/ci/ci.sh local [check...]         run the whole thing in CI's own containers
+#   scripts/ci/ci.sh shell                    a shell inside the local CI container
+#   scripts/ci/ci.sh down                     stop the local CI containers (keeps build caches)
+#   scripts/ci/ci.sh clean                    …and delete the cached build volumes
+#   scripts/ci/ci.sh gc [days]                delete attestations older than N days (default 30)
+#   scripts/ci/ci.sh selftest                 exercise this script's own logic
+#
+# Bash 3.2 compatible (macOS ships it): no associative arrays, no mapfile.
+set -euo pipefail
+
+NS=refs/ci-attest/v1
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+REMOTE=${CI_ATTEST_REMOTE:-origin}
+# Bump to invalidate every attestation at once (e.g. after fixing a fingerprint bug).
+EPOCH=1
+# Capabilities this environment provides; set once per run by cmd_run.
+CAPS=''
+
+cd "$ROOT"
+
+die() { echo "ci: $*" >&2; exit 1; }
+note() { echo "── $*" >&2; }
+
+sha256() { if command -v sha256sum >/dev/null 2>&1; then sha256sum | cut -d' ' -f1; else shasum -a 256 | cut -d' ' -f1; fi; }
+
+# ---------------------------------------------------------------- path sets
+
+# Everything the Haskell build and its test suites read. Deliberately wide: the
+# frontend bundles are in here because BodyWrapper TH-splices their content hash
+# into rendered pages, so a bundle change is a Haskell-visible change.
+PATHSET_hs='app src shared cli test tests config proto static/migrations package.yaml cabal.project cabal.project.freeze hpack-includes monoscope.cabal shared/monoscope-shared.cabal cli/monoscope-cli.cabal'
+PATHSET_fe='web-components/src web-components/test web-components/package.json web-components/package-lock.json web-components/vite.config.mjs web-components/tsconfig.json web-components/vitest.config.ts web-components/index.html package.json package-lock.json config/tailwind.config.js static/public/assets/css/tailwind.css'
+# The CLI package links only monoscope-shared, so its tests cannot observe src/.
+PATHSET_cli='cli shared cabal.project cabal.project.freeze'
+# Prepended to every check: changing what a check DOES must invalidate it.
+PATHSET_meta='ci/checks.tsv scripts/ci .github/workflows'
+
+pathset() { eval "printf '%s' \"\${PATHSET_$1:-}\""; }
+
+expand_inputs() {
+  local out='' tok
+  for tok in $1; do
+    case "$tok" in
+      @*) out="$out $(pathset "${tok#@}")" ;;
+      *) out="$out $tok" ;;
+    esac
+  done
+  printf '%s' "$out"
+}
+
+# ---------------------------------------------------------------- checks file
+
+checks_all() { grep -v '^#' ci/checks.tsv | grep -v '^[[:space:]]*$' | cut -f1; }
+
+check_field() { # <name> <1-based field>
+  local line
+  line=$(grep -v '^#' ci/checks.tsv | awk -F'\t' -v n="$1" '$1==n' | head -1)
+  [ -n "$line" ] || die "unknown check '$1' (have: $(checks_all | tr '\n' ' '))"
+  printf '%s' "$line" | cut -f"$2"
+}
+
+check_requires() { check_field "$1" 2; }
+check_inputs() { check_field "$1" 3; }
+
+# ---------------------------------------------------------------- fingerprint
+
+# A tree object for the WORKING tree (tracked edits + new non-ignored files), not
+# for HEAD. So a fingerprint taken on a dirty checkout still matches the commit
+# that later records exactly that content — you can attest before you commit.
+WORKTREE_TREE=''
+worktree_tree() {
+  if [ -z "$WORKTREE_TREE" ]; then
+    local idx
+    idx=$(mktemp -t ci-index.XXXXXX)
+    GIT_INDEX_FILE=$idx git read-tree HEAD
+    GIT_INDEX_FILE=$idx git add -A .
+    WORKTREE_TREE=$(GIT_INDEX_FILE=$idx git write-tree)
+    rm -f "$idx"
+  fi
+  printf '%s' "$WORKTREE_TREE"
+}
+
+# Fingerprints are PINNED once per run. Steps mutate the tree as they go — hpack
+# rewrites monoscope.cabal, `npm ci` can touch a lockfile, the lint job refactors
+# src/ in place — and recomputing afterwards would attest a fingerprint the gate
+# never looked up, so nothing would ever be reused.
+pin_fingerprints() { # <check...>
+  local c
+  mkdir -p .ci
+  : > .ci/fingerprints.tsv
+  for c in "$@"; do printf '%s\t%s\n' "$c" "$(fingerprint "$c")" >> .ci/fingerprints.tsv; done
+  export CI_FINGERPRINTS=.ci/fingerprints.tsv
+}
+
+fingerprint() { # <check>
+  local paths tree pinned
+  if [ -n "${CI_FINGERPRINTS:-}" ] && [ -f "${CI_FINGERPRINTS}" ]; then
+    pinned=$(awk -F'\t' -v n="$1" '$1==n{print $2}' "$CI_FINGERPRINTS")
+    [ -n "$pinned" ] && { printf '%s' "$pinned"; return 0; }
+  fi
+  tree=$(worktree_tree)
+  paths=$(expand_inputs "$PATHSET_meta $(check_inputs "$1")")
+  # ls-tree lists blob SHAs, so this hashes content without reading a single file.
+  # Missing pathspecs are silently empty, which is what we want for optional files.
+  { printf 'monoscope-ci\t%s\t%s\t%s\n' "$EPOCH" "$1" "$(check_requires "$1")"
+    # shellcheck disable=SC2086
+    git ls-tree -r --full-tree "$tree" -- $paths | sort
+  } | sha256
+}
+
+# ---------------------------------------------------------------- capabilities
+
+probe_tcp() { # host port
+  (exec 3<>"/dev/tcp/$1/$2") 2>/dev/null && exec 3<&- 2>/dev/null || return 1
+}
+
+# Split a postgres URL into host/port for probing without needing psql.
+url_hostport() { # url -> "host port"
+  local rest=${1#*://}
+  rest=${rest#*@}
+  rest=${rest%%/*}
+  case "$rest" in *:*) printf '%s %s' "${rest%%:*}" "${rest##*:}" ;;
+                  *) printf '%s 5432' "$rest" ;; esac
+}
+
+detect_caps() {
+  local caps=''
+  command -v cabal >/dev/null 2>&1 && caps="$caps ghc"
+  command -v node >/dev/null 2>&1 && caps="$caps node"
+  command -v hlint >/dev/null 2>&1 && caps="$caps hlint"
+  probe_tcp "${DB_HOST:-localhost}" "${DB_PORT:-5432}" && caps="$caps pg"
+  # shellcheck disable=SC2086
+  [ -n "${MINIO_ENDPOINT:-}" ] && probe_tcp $(url_hostport "$MINIO_ENDPOINT") && caps="$caps minio"
+  # tf-real is claimed only for a reachable TimeFusion. The suite's
+  # Postgres-as-TF fallback is a different thing and must not earn the capability.
+  # shellcheck disable=SC2086
+  [ -n "${TIMEFUSION_PG_TEST_URL:-}" ] && probe_tcp $(url_hostport "$TIMEFUSION_PG_TEST_URL") && caps="$caps tf-real"
+  printf '%s' "$(echo "$caps" | tr ' ' '\n' | grep -v '^$' | sort -u | tr '\n' ' ' | sed 's/ $//')"
+}
+
+# provides ⊇ requires
+caps_satisfy() { # "<provides>" "<requires>"
+  local r
+  for r in $2; do
+    case " $1 " in *" $r "*) ;; *) return 1 ;; esac
+  done
+  return 0
+}
+
+platform_tag() { printf '%s-%s' "$(uname -s | tr '[:upper:]' '[:lower:]')" "$(uname -m | sed 's/arm64/aarch64/;s/x86_64/amd64/')"; }
+
+# ---------------------------------------------------------------- attestations
+
+# refs/ci-attest/v1/<check>/<fingerprint>/<platform>/<caps.joined>/<yyyymmdd>
+# Everything the gate needs is in the ref NAME, so deciding costs one ls-remote
+# and zero object fetches.
+attest_ref() { # <check> <fingerprint> <caps> [platform]
+  printf '%s/%s/%s/%s/%s/%s' "$NS" "$1" "$2" "${4:-$(platform_tag)}" "$(echo "$3" | tr ' ' '.')" "$(date -u +%Y%m%d)"
+}
+
+REMOTE_REFS_CACHE=''
+remote_refs() {
+  if [ -z "$REMOTE_REFS_CACHE" ]; then
+    REMOTE_REFS_CACHE=$(mktemp -t ci-refs.XXXXXX)
+    if [ "${CI_ATTEST_DISABLED:-}" = "true" ]; then
+      note "CI_ATTEST_DISABLED=true — ignoring all attestations"
+    else
+      git ls-remote "$REMOTE" "$NS/*" 2>/dev/null | cut -f2 > "$REMOTE_REFS_CACHE" || true
+    fi
+  fi
+  cat "$REMOTE_REFS_CACHE"
+}
+
+# Echo the matching ref if this check is already proven for this fingerprint by
+# an environment good enough for it, else nothing.
+find_attestation() { # <check>
+  local fp req ref caps
+  fp=$(fingerprint "$1")
+  req=$(check_requires "$1")
+  for ref in $(remote_refs | grep "^$NS/$1/$fp/" || true); do
+    caps=$(printf '%s' "$ref" | cut -d/ -f7 | tr '.' ' ')
+    if caps_satisfy "$caps" "$req"; then printf '%s' "$ref"; return 0; fi
+  done
+  return 1
+}
+
+record_result() { # <check> — attest now, or stage for a caller that has push access
+  local fp caps
+  fp=$(fingerprint "$1")
+  caps=${CAPS:-$(detect_caps)}
+  if [ -n "${CI_ATTEST_OUT:-}" ]; then
+    mkdir -p "$(dirname "$CI_ATTEST_OUT")"
+    printf '%s\t%s\t%s\t%s\n' "$1" "$fp" "$caps" "$(platform_tag)" >> "$CI_ATTEST_OUT"
+    note "recorded $1 for publishing"
+  else
+    publish_attestation "$1" "$fp" "$caps" "$(platform_tag)"
+  fi
+}
+
+# Publish the results staged by a run that could not push (the local CI container
+# has no credentials — origin is ssh and the image has no keys).
+cmd_publish() { # [file]
+  local f c fp caps plat
+  f=${1:-${CI_ATTEST_OUT:-.ci/attest.tsv}}
+  [ -s "$f" ] || { note "nothing to publish ($f)"; return 0; }
+  while IFS=$'\t' read -r c fp caps plat; do
+    [ -n "$c" ] && publish_attestation "$c" "$fp" "$caps" "$plat"
+  done < "$f"
+  rm -f "$f"
+}
+
+publish_attestation() { # <check> [fingerprint] [caps] [platform]
+  local fp caps plat ref tree commit
+  fp=${2:-$(fingerprint "$1")}
+  caps=${3:-$(detect_caps)}
+  plat=${4:-$(platform_tag)}
+  ref=$(attest_ref "$1" "$fp" "$caps" "$plat")
+  tree=$(git mktree </dev/null)
+  commit=$(GIT_AUTHOR_NAME=${GIT_AUTHOR_NAME:-ci-attest} GIT_AUTHOR_EMAIL=${GIT_AUTHOR_EMAIL:-ci@monoscope.tech} \
+           GIT_COMMITTER_NAME=${GIT_COMMITTER_NAME:-ci-attest} GIT_COMMITTER_EMAIL=${GIT_COMMITTER_EMAIL:-ci@monoscope.tech} \
+           git commit-tree "$tree" -m "check=$1
+fingerprint=$fp
+caps=$caps
+platform=$plat
+commit=$(git rev-parse HEAD)
+runner=${GITHUB_RUN_ID:+github-run-$GITHUB_RUN_ID}${GITHUB_RUN_ID:-$(whoami)@$(hostname)}")
+  if git push -q "$REMOTE" "${commit}:${ref}" 2>/dev/null; then
+    note "attested $1 → $ref"
+  else
+    note "could not publish attestation for $1 (no push access to $REMOTE?) — result is still valid, just not cached"
+  fi
+}
+
+# ---------------------------------------------------------------- check bodies
+
+CABAL_OPTS='--ghc-options=-O0'
+
+run_body() { # <check>
+  case "$1" in
+    frontend)
+      mkdir -p static/public/assets/css static/public/assets/web-components/dist/js static/public/assets/web-components/dist/css
+      npm ci --prefer-offline --no-audit
+      npx tailwindcss -i ./static/public/assets/css/tailwind.css -o ./static/public/assets/css/tailwind.min.css --minify
+      (cd web-components && npm ci --prefer-offline --no-audit && NODE_ENV=production npx vite build --mode production --sourcemap false)
+      ;;
+    build)      cabal build all -j --ghc-options="-O0 +RTS -A64m -n2m -RTS" ;;
+    doctests)   cabal test doctests $CABAL_OPTS --test-show-details=direct ;;
+    unit-tests) cabal test unit-tests $CABAL_OPTS --test-show-details=direct ;;
+    cli-tests)  cabal test monoscope-cli:cli-tests $CABAL_OPTS --test-show-details=direct ;;
+    weeder)
+      command -v weeder >/dev/null 2>&1 || cabal install weeder --install-method=copy --installdir=/usr/local/bin --overwrite-policy=always
+      weeder --config config/weeder.toml --hie-directory dist-newstyle
+      ;;
+    hlint)   hlint src/ ;;
+    ui-tests) (cd web-components && npm ci --prefer-offline --no-audit && npm test) ;;
+    integration-tests) run_integration ;;
+    *) die "no body for check '$1'" ;;
+  esac
+}
+
+# Process-sharded: N copies of the binary, each its own RTS running a disjoint
+# shard sequentially. In-process hspec `parallel` deadlocks on the per-test
+# resource-pool lifecycle (see test/integration/Main.hs). Keep shards * ~9 conns
+# under the server's max_connections.
+run_integration() {
+  local shards bin i green
+  shards=${CI_SHARDS:-4}
+  # Without a reachable TimeFusion the URL must go, or every example dies dialling
+  # a dead host instead of taking TestUtils' Postgres-as-TimeFusion fallback. Only
+  # reached under CI_ALLOW_DEGRADED — cmd_run refuses this check otherwise.
+  case " ${CAPS:-} " in *" tf-real "*) ;; *) unset TIMEFUSION_PG_TEST_URL ;; esac
+  export USE_EXTERNAL_DB=true LOG_LEVEL=${LOG_LEVEL:-warn}
+  cabal build integration-tests --ghc-options="-O0 +RTS -A64m -RTS"
+  bin=$(cabal list-bin integration-tests)
+  rm -f build-shard-*.log
+  for i in $(seq 0 $((shards - 1))); do
+    ( start=$(date +%s); SHARD_INDEX=$i SHARD_TOTAL=$shards "$bin" --color > "build-shard-$i.log" 2>&1
+      echo "[shard-time] $(( $(date +%s) - start ))s" >> "build-shard-$i.log" ) &
+  done
+  wait
+  echo "=== per-shard (wall-clock | result) — wide spreads ⇒ rebalance ==="
+  for i in $(seq 0 $((shards - 1))); do
+    printf "shard %s: %-6s | %s\n" "$i" "$(sed -n 's/.*\[shard-time\] //p' "build-shard-$i.log" | tail -1)" \
+      "$(grep -hE 'examples?, [0-9]+ failures?' "build-shard-$i.log" | tail -1)"
+  done
+  green=$(grep -lE "examples?, 0 failures" build-shard-*.log | wc -l | tr -d ' ')
+  # green==N already means every shard printed a clean summary; don't also grep for
+  # "error:" — the app logs error: lines at LOG_LEVEL=warn on passing runs.
+  if [ "$green" -ne "$shards" ] || grep -qE "[1-9][0-9]* failures?|Interrupted" build-shard-*.log; then
+    echo "SHARDED RUN FAILED ($green/$shards green):"
+    for f in build-shard-*.log; do
+      grep -qE "examples?, 0 failures" "$f" && continue
+      echo "### $f"
+      # The whole Failures section, not a fixed tail: hspec spends ~8 lines per
+      # failure, so `tail -40` hides every failure after the first.
+      sed -n '/^Failures:/,$p' "$f"
+      grep -q '^Failures:' "$f" || tail -60 "$f"
+    done
+    return 1
+  fi
+  echo "ALL SHARDS GREEN"
+}
+
+# ---------------------------------------------------------------- subcommands
+
+selected_checks() { if [ "$#" -gt 0 ]; then printf '%s\n' "$@"; else checks_all; fi; }
+
+cmd_fingerprint() { local c; for c in $(selected_checks "$@"); do printf '%s\t%s\n' "$c" "$(fingerprint "$c")"; done; }
+
+cmd_gate() {
+  local c ref out skip_all=true summary
+  out=${GITHUB_OUTPUT:-/dev/null}
+  summary=${GITHUB_STEP_SUMMARY:-/dev/null}
+  # shellcheck disable=SC2046
+  pin_fingerprints $(selected_checks "$@")
+  # Hand the pinned values to the jobs that will do the work, so they attest the
+  # exact fingerprints this gate just looked up.
+  { echo 'fingerprints<<CI_FP_EOF'; cat .ci/fingerprints.tsv; echo CI_FP_EOF; } >> "$out"
+  echo "| check | decision | attestation |" >> "$summary"
+  echo "|---|---|---|" >> "$summary"
+  for c in $(selected_checks "$@"); do
+    if ref=$(find_attestation "$c"); then
+      echo "$(printf '%s' "skip_$c" | tr '-' '_')=true" >> "$out"
+      printf 'skip  %-18s %s\n' "$c" "$ref"
+      echo "| \`$c\` | ⏭ skipped | \`$ref\` |" >> "$summary"
+    else
+      echo "$(printf '%s' "skip_$c" | tr '-' '_')=false" >> "$out"
+      printf 'run   %-18s (fingerprint %s)\n' "$c" "$(fingerprint "$c")"
+      echo "| \`$c\` | ▶ running | none for \`$(fingerprint "$c")\` |" >> "$summary"
+      skip_all=false
+    fi
+  done
+  echo "skip_all=$skip_all" >> "$out"
+}
+
+cmd_run() {
+  local c req ref rc=0 unrunnable='' degraded=''
+  CAPS=$(detect_caps)
+  note "capabilities: ${CAPS:-none}"
+  # shellcheck disable=SC2046
+  [ -n "${CI_FINGERPRINTS:-}" ] || pin_fingerprints $(selected_checks "$@")
+  for c in $(selected_checks "$@"); do
+    req=$(check_requires "$c")
+    # A missing capability is never a silent pass — this run can say nothing about
+    # that check. CI_ALLOW_DEGRADED still runs it for the feedback (e.g. the suite
+    # against the Postgres-as-TimeFusion fallback) but refuses to attest it, so a
+    # weaker environment can never satisfy CI on a stronger one's behalf. Either
+    # way the rest of the sweep continues and the exit code stays honest.
+    if ! caps_satisfy "$CAPS" "$req"; then
+      if [ "${CI_ALLOW_DEGRADED:-}" != "true" ]; then
+        note "CANNOT RUN $c here — needs [$req], have [$CAPS]"
+        unrunnable="$unrunnable $c"; rc=1; continue
+      fi
+      note "running $c DEGRADED — needs [$req], have [$CAPS]; result will not be attested"
+      degraded="$degraded $c"
+    elif [ "${CI_FORCE:-}" != "true" ] && ref=$(find_attestation "$c"); then
+      note "$c already proven ($ref) — skipping (CI_FORCE=true to override)"
+      continue
+    fi
+    note "running $c"
+    if run_body "$c"; then
+      case " $degraded " in *" $c "*) ;; *) [ "${CI_NO_ATTEST:-}" = "true" ] || record_result "$c" ;; esac
+    else
+      rc=1
+      note "FAILED $c"
+      [ "${CI_KEEP_GOING:-}" = "true" ] || return 1
+    fi
+  done
+  [ -z "$unrunnable" ] || note "not run here (CI will still have to):$unrunnable"
+  [ -z "$degraded" ] || note "run degraded, NOT attested (CI will still run these):$degraded"
+  return $rc
+}
+
+cmd_attest() { [ "$#" -ge 1 ] || die "attest needs a check name"; publish_attestation "$1"; }
+
+cmd_gc() {
+  local days cutoff ref d deleted=0
+  days=${1:-30}
+  cutoff=$(date -u -d "-$days days" +%Y%m%d 2>/dev/null || date -u -v-"$days"d +%Y%m%d)
+  # Batched: one push per 200 refs, not one per ref — a year's worth of daily runs
+  # is thousands of refs and a round trip each would take longer than the CI it saves.
+  local batch=''
+  for ref in $(remote_refs); do
+    d=${ref##*/}
+    case "$d" in [0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]) ;; *) continue ;; esac
+    [ "$d" -lt "$cutoff" ] || continue
+    batch="$batch :${ref}"
+    deleted=$((deleted + 1))
+    if [ "$((deleted % 200))" -eq 0 ]; then
+      # shellcheck disable=SC2086
+      git push -q "$REMOTE" $batch; batch=''
+    fi
+  done
+  # shellcheck disable=SC2086
+  [ -z "$batch" ] || git push -q "$REMOTE" $batch
+  note "deleted $deleted attestation(s) older than $days days"
+}
+
+# ---------------------------------------------------------------- local docker
+
+COMPOSE_FILE=ci/compose.yml
+compose() { docker compose -f "$COMPOSE_FILE" --project-name monoscope-ci "$@"; }
+
+cmd_local() {
+  command -v docker >/dev/null 2>&1 || die "docker is required for \`ci.sh local\`"
+  docker compose version >/dev/null 2>&1 || die "docker compose v2 is required"
+  note "starting CI services…"
+  compose up -d --wait postgres minio
+  # TimeFusion publishes no arm64 image, and the amd64 one dies under emulation on
+  # Apple Silicon (SIGSEGV). Don't let that sink the rest of the sweep: warn, carry
+  # on, and let cmd_run refuse the one check that needs it. docs/local-ci.md has
+  # the build-it-locally recipe.
+  compose up -d --wait timefusion 2>/dev/null || note "TimeFusion did not start (${MONOSCOPE_CI_TF_PLATFORM:-linux/amd64} on $(uname -m)) — integration-tests will be left to CI; see docs/local-ci.md"
+  rm -f .ci/attest.tsv
+  local rc=0
+  # --rm so a failed run leaves nothing behind; the caches live in named volumes.
+  # Forward the run's knobs; `compose run` only passes what it is told to.
+  compose run --rm \
+    -e "CI_ALLOW_DEGRADED=${CI_ALLOW_DEGRADED:-}" -e "CI_FORCE=${CI_FORCE:-}" -e "CI_KEEP_GOING=${CI_KEEP_GOING:-}" \
+    runner scripts/ci/ci.sh run "$@" || rc=$?
+  # Publish whatever passed even if a later check failed — a green check is green.
+  cmd_publish .ci/attest.tsv
+  [ "$rc" -eq 0 ] || note "local CI failed (exit $rc); services left up for debugging — \`make ci-down\` to clean up"
+  return $rc
+}
+
+cmd_shell() { compose up -d --wait postgres minio timefusion; compose run --rm runner bash; }
+# Volumes survive `down` on purpose: they hold the cabal store and dist-newstyle,
+# and losing them means the next `make ci` is a cold build. `clean` is the nuke.
+cmd_down() { compose down --remove-orphans; }
+cmd_clean() { compose down -v --remove-orphans; }
+
+# ---------------------------------------------------------------- selftest
+
+assert() { # <desc> <expected> <actual>
+  if [ "$2" = "$3" ]; then echo "ok   $1"; else echo "FAIL $1: expected [$2] got [$3]"; SELFTEST_RC=1; fi
+}
+
+cmd_selftest() {
+  SELFTEST_RC=0
+
+  assert "caps superset"      ok "$(caps_satisfy 'ghc pg minio tf-real' 'ghc pg' && echo ok)"
+  assert "caps exact"         ok "$(caps_satisfy 'ghc' 'ghc' && echo ok)"
+  assert "caps missing one"   no "$(caps_satisfy 'ghc pg minio' 'ghc pg minio tf-real' || echo no)"
+  assert "caps empty require" ok "$(caps_satisfy '' '' && echo ok)"
+  # 'tf' must not satisfy 'tf-real': substring matches would silently accept the
+  # Postgres-as-TimeFusion fallback for a check that needs the real service.
+  assert "caps no substring"  no "$(caps_satisfy 'ghc tf' 'tf-real' || echo no)"
+
+  assert "url host:port"  'db 5433' "$(url_hostport postgresql://u:p@db:5433/x)"
+  assert "url default pt" 'db 5432' "$(url_hostport postgresql://u:p@db/x)"
+  assert "url no creds"   'h 9000'  "$(url_hostport http://h:9000)"
+
+  assert "inputs expand" " src .hlint.yaml" "$(expand_inputs 'src .hlint.yaml')"
+  assert "pathset expand nonempty" yes "$([ -n "$(expand_inputs '@hs')" ] && echo yes)"
+
+  # Every check in the TSV must have a body and a fingerprint.
+  local c seen=''
+  for c in $(checks_all); do
+    grep -q "^    $c)" "$0" || grep -q "^    $c|" "$0" || grep -q "    $c)" "$0" \
+      || { echo "FAIL $c has no run_body case"; SELFTEST_RC=1; }
+    seen="$seen $(fingerprint "$c")"
+  done
+  assert "fingerprints distinct" "$(echo $seen | tr ' ' '\n' | wc -l | tr -d ' ')" \
+                                 "$(echo $seen | tr ' ' '\n' | sort -u | wc -l | tr -d ' ')"
+  assert "fingerprint stable" "$(fingerprint hlint)" "$(WORKTREE_TREE=''; fingerprint hlint)"
+
+  # A change under a check's inputs must move its fingerprint; one outside must not.
+  # Probe with NEW files only — never edit-and-restore a tracked file, which would
+  # discard whatever the developer has uncommitted in it.
+  local before after probe
+  probe=.ci-selftest-probe-$$
+  before=$(fingerprint hlint)
+  : > "src/$probe"; WORKTREE_TREE=''; after=$(fingerprint hlint); rm -f "src/$probe"
+  assert "input change moves fp" changed "$([ "$before" != "$after" ] && echo changed)"
+
+  WORKTREE_TREE=''
+  : > "web-components/src/$probe"; WORKTREE_TREE=''; after=$(fingerprint hlint); rm -f "web-components/src/$probe"
+  assert "unrelated change keeps fp" same "$([ "$before" = "$after" ] && echo same)"
+
+  # A typo in an input path is invisible — git silently matches nothing — and
+  # silently narrows what the check depends on, which is how an untested change
+  # ships. Every declared path must exist.
+  local p missing=''
+  for p in $(expand_inputs "$PATHSET_meta $(for c in $(checks_all); do check_inputs "$c"; echo; done | tr '\n' ' ')" | tr ' ' '\n' | sort -u); do
+    [ -e "$p" ] || missing="$missing $p"
+  done
+  assert "every declared input path exists" "" "$missing"
+
+  # Pinning is what survives a step that rewrites the tree mid-run.
+  WORKTREE_TREE=''
+  before=$(fingerprint hlint)
+  pin_fingerprints hlint
+  : > "src/$probe"; WORKTREE_TREE=''; after=$(fingerprint hlint); rm -f "src/$probe"
+  unset CI_FINGERPRINTS; rm -rf .ci
+  assert "pinned fp survives tree change" "$before" "$after"
+
+  assert "ref roundtrip caps" 'ghc pg' \
+    "$(printf '%s' "$(attest_ref x deadbeef 'ghc pg')" | cut -d/ -f7 | tr '.' ' ')"
+  assert "ref roundtrip check" x "$(printf '%s' "$(attest_ref x deadbeef 'ghc')" | cut -d/ -f4)"
+  assert "ref roundtrip fp" deadbeef "$(printf '%s' "$(attest_ref x deadbeef 'ghc')" | cut -d/ -f5)"
+
+  [ "$SELFTEST_RC" -eq 0 ] && echo "selftest: all good"
+  return $SELFTEST_RC
+}
+
+# ----------------------------------------------------------------------------
+
+cmd=${1:-help}; shift || true
+case "$cmd" in
+  fingerprint) cmd_fingerprint "$@" ;;
+  caps)        detect_caps; echo ;;
+  gate)        cmd_gate "$@" ;;
+  run)         cmd_run "$@" ;;
+  attest)      cmd_attest "$@" ;;
+  publish)     cmd_publish "$@" ;;
+  local)       cmd_local "$@" ;;
+  shell)       cmd_shell ;;
+  down)        cmd_down ;;
+  clean)       cmd_clean ;;
+  gc)          cmd_gc "$@" ;;
+  selftest)    cmd_selftest ;;
+  checks)      checks_all ;;
+  *)           sed -n '2,30p' "$0" | sed 's/^# \{0,1\}//' ;;
+esac


### PR DESCRIPTION
## Why

Every push re-runs work that has already been done. A PR run proves a tree; the squash merge keeps that exact tree; master then builds and tests all of it again. On 4-vCPU runners that's ~20 minutes a push — and none of that capacity is available to a developer whose laptop is faster than the runner.

## What

`ci/checks.tsv` is now the single definition of what CI is. Both `.github/workflows/*.yml` and `scripts/ci/ci.sh` read it, so a check can't exist in one and not the other.

Each check is fingerprinted over the git blob hashes of its declared inputs (plus the check's own definition — `ci/checks.tsv`, `scripts/ci/`, `.github/workflows/`). A pass publishes an **attestation** as a ref:

```
refs/ci-attest/v1/<check>/<fingerprint>/<platform>/<capabilities>/<date>
```

A new `gate` job resolves those with **one `ls-remote` and zero object fetches** — everything it needs is in the ref name — and skips any check already proven for the tree it's about to test. It doesn't matter who proved it: an earlier run, a re-run, or `make ci` on your machine.

```bash
make ci          # run CI's checks in CI's own containers, attesting each pass
make ci-status   # what CI would run right now, without running any of it
```

## Soundness

This gates a production deploy, so the reuse rules are deliberately conservative:

- **Capabilities.** Checks declare what the environment must provide (`ghc`, `pg`, `minio`, `tf-real`); attestations record what it actually had. Reuse requires provided ⊇ required, so a run that fell back to a stub service can never satisfy a check that needs the real one. On Apple Silicon (no TimeFusion image) `integration-tests` is **refused**, not weakly attested; `CI_ALLOW_DEGRADED=true` runs it against the Postgres-as-TF fallback for feedback only, unattested.
- **Fidelity.** `make ci` uses the same deps image (multi-arch, so native on ARM) and the same service images/env/tuning. Your `.env` is masked and build dirs are container-private, so a local secret or a prod `DATABASE_URL` can't change the result.
- **Pinned fingerprints.** Steps rewrite the tree mid-job (`hpack`, `npm ci`, `hlint --refactor`). The gate's fingerprints are passed to the jobs, so what gets attested is exactly what was looked up.
- **Trust.** Attestations are pushed refs, so creating one requires push access — the same boundary as pushing code. Forks can neither create nor be affected by them.
- **Deploy gate.** Now spelled out instead of implied by `needs`: `build-and-test` may be *skipped*, but only when the gate says every Haskell check was already proven. Failure, cancellation, timeout, or a failed gate job all still leave the image unused.
- **Escape hatches.** Repo variable `CI_ATTEST_DISABLED=true` ignores all attestations with no code change; `EPOCH` in `ci.sh` invalidates everything at once. Refs are pruned after 30 days.

## Also in here

**`bitnami/minio` no longer exists on Docker Hub** — that repository was emptied in the Aug-2025 Bitnami catalog change and now has zero tags. CI has only kept working off a runner-side image cache; a cache eviction would have taken the suite down with `manifest unknown`. Switched to `bitnamilegacy/minio`, where the pre-change images were relocated verbatim.

## Tested

- `make ci-selftest` covers fingerprint stability, input sensitivity, pinning, capability-superset logic (including that `tf` must not satisfy `tf-real`), ref round-tripping, and that every declared input path exists — that last one immediately caught `web-components/vite.config.ts`, which is actually `.mjs`, so Vite config changes weren't being fingerprinted.
- Attestation push/lookup/skip/GC verified end to end against this repo.
- `make ci` exercised in containers: `frontend`, `ui-tests` (640 tests) and `cli-tests` pass and attest.

## Docs

`docs/local-ci.md` — how it works, fidelity caveats, every knob, and how to change a check.