### PR TITLE
ci: stop emitting the run id twice in an attestation's provenance

### DIFF
--- a/scripts/ci/ci.sh
+++ b/scripts/ci/ci.sh
@@ -235,11 +235,15 @@ cmd_publish() { # [file]
 }
 
 publish_attestation() { # <check> [fingerprint] [caps] [platform]
-  local fp caps plat ref tree commit
+  local fp caps plat ref tree commit runner_id
   fp=${2:-$(fingerprint "$1")}
   caps=${3:-$(detect_caps)}
   plat=${4:-$(platform_tag)}
   ref=$(attest_ref "$1" "$fp" "$caps" "$plat")
+  # Who proved it, so a ref traces back to a run or a machine. NOT
+  # ${X:+a$X}${X:-b} — the :- arm yields $X itself when set, which emitted the
+  # run id twice and made the link unusable.
+  if [ -n "${GITHUB_RUN_ID:-}" ]; then runner_id="github-run-$GITHUB_RUN_ID"; else runner_id="$(whoami)@$(hostname)"; fi
   tree=$(git mktree </dev/null)
   commit=$(GIT_AUTHOR_NAME=${GIT_AUTHOR_NAME:-ci-attest} GIT_AUTHOR_EMAIL=${GIT_AUTHOR_EMAIL:-ci@monoscope.tech} \
            GIT_COMMITTER_NAME=${GIT_COMMITTER_NAME:-ci-attest} GIT_COMMITTER_EMAIL=${GIT_COMMITTER_EMAIL:-ci@monoscope.tech} \
@@ -248,7 +252,7 @@ fingerprint=$fp
 caps=$caps
 platform=$plat
 commit=$(git rev-parse HEAD)
-runner=${GITHUB_RUN_ID:+github-run-$GITHUB_RUN_ID}${GITHUB_RUN_ID:-$(whoami)@$(hostname)}")
+runner=$runner_id")
   if git push -q "$REMOTE" "${commit}:${ref}" 2>/dev/null; then
     note "attested $1 → $ref"
   else


### PR DESCRIPTION
Every attestation published so far carries:

```
runner=github-run-3194584899031945848990
```

That is `github-run-` followed by run id `31945848990` **twice**, so the one field that traces a proof back to the run that produced it can't be pasted into a URL.

```sh
runner=${GITHUB_RUN_ID:+github-run-$GITHUB_RUN_ID}${GITHUB_RUN_ID:-$(whoami)@$(hostname)}
```

reads like an if/else and isn't one: the `:-` arm yields `$X` *itself* when `X` is set, so a set `GITHUB_RUN_ID` takes **both** arms. Spelled out as a plain `if` now.

Verified both ways:

```
set:    runner=github-run-31961328532
unset:  runner=tonyalaribe@MacBook-Pro-103
```

Cosmetic in the sense that nothing depends on the field — the gate reads only the ref name — but it is the human-readable audit trail on a deploy gate, so it should be correct. Note this invalidates existing attestations, since `scripts/ci/` is in every check's inputs; that is the fingerprint working as intended.