### PR TITLE
ci: reuse an already-built image, and document running CI locally

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -359,7 +359,10 @@ jobs:
         run: |
           {
             echo "build-and-test: ${{ needs.build-and-test.result }} (all Haskell checks pre-proven: ${{ needs.gate.outputs.skip_haskell }})"
-            scripts/ci/ci.sh image-who "${{ github.sha }}"
+            # Never fatal: this is a note about the deploy, not a condition of it.
+            # A provenance lookup that cannot reach the remote must not be the
+            # reason a green, gated build fails to reach production.
+            scripts/ci/ci.sh image-who "${{ github.sha }}" || echo "built by: (could not read provenance)"
           } >> "$GITHUB_STEP_SUMMARY"
       # Pinned deliberately, not using caprover/deploy-from-github: that action
       # does an unpinned `npm i -g caprover` at image-build time, so an upstream

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -276,7 +276,37 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GH_TOKEN }}
 
+      # The registry is the cache and the commit SHA is the fingerprint: an image
+      # tagged with this SHA is by construction the image for this commit, so
+      # rebuilding it produces the same thing at a cost of ~4 minutes. Turns a
+      # re-run, a workflow_dispatch of an existing commit, or a revert to an
+      # already-built SHA into a ~30-second deploy. It does nothing for a genuinely
+      # new commit, which is the common case — this is for the repeat ones.
+      #
+      # It also lets a developer pre-build and push the image themselves (see
+      # `make deploy-image`); the deploy job records who built it either way.
+      - name: Is this commit's image already in the registry?
+        id: probe
+        run: |
+          img=ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}
+          if docker manifest inspect "$img:${{ github.sha }}" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "Image for \`${{ github.sha }}\` already in the registry — skipping the build." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Skipping the build must not leave :latest pointing at an older commit —
+      # docker-compose.yml (self-hosters) pulls :latest. Re-point it at the image
+      # we just decided to reuse; this copies a manifest, it does not rebuild.
+      - name: Point :latest at the existing image
+        if: steps.probe.outputs.exists == 'true'
+        run: |
+          img=ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}
+          docker buildx imagetools create -t "$img:latest" "$img:${{ github.sha }}"
+
       - name: Build and push Docker Image
+        if: steps.probe.outputs.exists != 'true'
         uses: useblacksmith/build-push-action@v2
         with:
           context: .
@@ -320,9 +350,17 @@ jobs:
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
-      - name: Note why this deploy was allowed
+      - uses: actions/checkout@v6
+
+      # An image cannot be re-derived from source to check it (a Haskell build is
+      # not bit-reproducible), so the only way "what is running in prod, and who
+      # built it" stays answerable is to say so here, every time.
+      - name: Note why this deploy was allowed, and who built the image
         run: |
-          echo "build-and-test: ${{ needs.build-and-test.result }} (all Haskell checks pre-proven: ${{ needs.gate.outputs.skip_haskell }})" >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo "build-and-test: ${{ needs.build-and-test.result }} (all Haskell checks pre-proven: ${{ needs.gate.outputs.skip_haskell }})"
+            scripts/ci/ci.sh image-who "${{ github.sha }}"
+          } >> "$GITHUB_STEP_SUMMARY"
       # Pinned deliberately, not using caprover/deploy-from-github: that action
       # does an unpinned `npm i -g caprover` at image-build time, so an upstream
       # release lands straight in the deploy path. caprover 2.4.0 (2026-08-05)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,6 +119,49 @@ cabal test unit-tests --test-options='--match="/pattern/"'
 make live-test-reload-unit
 ```
 
+## Running CI Locally
+
+Our GitHub runners are small. Your laptop probably isn't. `make ci` runs **the
+same checks CI runs, in the same container images**, so you can find a failure in
+minutes instead of waiting on a queue:
+
+```bash
+make ci                                # everything CI runs
+make ci CHECKS="doctests unit-tests"   # just these
+make ci-status                         # what CI would run right now, without running it
+make ci-down                           # stop the containers (build caches kept)
+```
+
+`ci/checks.tsv` is the single definition of what CI is — the GitHub workflows and
+`make ci` both read it, so the two can't drift apart.
+
+### CI skips what you already proved
+
+Each check is fingerprinted over the content it depends on. When one passes,
+the result is published as a git ref, and CI's gate skips any check already
+proven for the exact tree it's about to test. Run `make ci` before you push and
+CI has little or nothing left to do.
+
+Two things worth knowing:
+
+- **The first run is a cold build** and takes as long as a cold CI run. Every run
+  after that is incremental — the caches live in Docker volumes that survive
+  `make ci-down`. Start it and go do something else.
+- **Publishing a result requires push access**, so if you're contributing from a
+  fork, `make ci` still gives you fast local feedback but CI will re-run the
+  checks itself. That's deliberate: an attestation is only as trustworthy as the
+  ability to push code in the first place.
+
+Reuse is conservative by design. Each check declares the capabilities it needs
+(`ghc`, `pg`, `minio`, `tf-real`) and each result records what the environment
+actually had, so a run that fell back to a stub service can never stand in for
+one that needs the real thing. On Apple Silicon, where TimeFusion has no image,
+`integration-tests` is refused rather than weakly cached — run it with
+`CI_ALLOW_DEGRADED=true` for feedback and CI will still verify it properly.
+
+Full reference, including every knob and how to add or change a check:
+[docs/local-ci.md](docs/local-ci.md).
+
 ## Code Style
 
 ### Formatting

--- a/Makefile
+++ b/Makefile
@@ -397,6 +397,13 @@ ci-clean:
 ci-selftest:
 	./scripts/ci/ci.sh selftest
 
-.PHONY: ci ci-status ci-shell ci-down ci-clean ci-selftest
+# Build and push the production image for HEAD yourself, so CI's build-image
+# job finds it already in the registry and skips ~4 minutes. Requires a clean
+# tree (the image must match the SHA it is tagged with) and `docker login ghcr.io`.
+# Prod is amd64; on Apple Silicon this is Rosetta-emulated, not QEMU.
+deploy-image:
+	./scripts/ci/ci.sh image $(SHA)
+
+.PHONY: ci ci-status ci-shell ci-down ci-clean ci-selftest deploy-image
 
 .PHONY: all test fmt lint fix-lint live-reload kill-live-reload live-reload-cli live-reload-doctests live-test-dev build-chart-cli build-chart-cli-linux tmux-live-reload tmux-live-reload-cli tmux-pin-here tmux-unpin kill-web-components-watch web-components-watch e2e-install test-e2e test-e2e-real test-e2e-ui gen-proto sync-otel-proto update-otel-proto minio-local timefusion-start timefusion-stop test-integration-tf

--- a/README.md
+++ b/README.md
@@ -369,6 +369,7 @@ Real-time metrics and performance monitoring with AI-powered insights.
 - [Configuration](docs/configuration.md)
 - [Kubernetes Guide](docs/kubernetes.md)
 - [Development Guide](docs/DEVELOPMENT.md)
+- [Running CI Locally](docs/local-ci.md)
 
 <br/>
 

--- a/docs/local-ci.md
+++ b/docs/local-ci.md
@@ -85,6 +85,36 @@ Postgres-as-TimeFusion fallback. That is genuinely useful feedback and it is
 exercise. On a Linux/amd64 box the real service starts and the whole suite
 attests.
 
+## Building the deploy image yourself
+
+The image build is the rest of the deploy: with tests cached it is ~4 of the ~4.5
+minutes. It is not fingerprinted like the other checks, because it produces an
+*artifact* rather than a verdict — skipping it would leave nothing to deploy. Its
+cache is the registry, and its fingerprint is the commit SHA:
+
+```bash
+make deploy-image          # build + push ghcr.io/…/monoscope:<HEAD sha>, linux/amd64
+```
+
+Push that commit and CI's `build-image` job finds the tag already there and skips
+the build. The same check makes a re-run, a `workflow_dispatch` of an existing
+commit, or a revert to an already-built SHA into a ~30-second deploy for free.
+
+Two things to know before using it:
+
+- **It refuses a dirty tree.** The image is tagged with a commit SHA and must
+  actually be that commit, or the tag lies about what is running in production.
+- **It records who built it.** An image cannot be re-derived from source to check
+  (a Haskell build is not bit-reproducible), so unlike an attestation there is no
+  way to verify after the fact that a pushed image matches its tag. The deploy job
+  therefore prints `built by: …` in its summary, every deploy, sourced from a
+  `refs/ci-attest/v1/image/<sha>/…` record written at build time. If that line
+  ever names someone unexpected, that is the signal.
+
+Prod is `linux/amd64`. On Apple Silicon that is emulated — but by **Rosetta**, not
+QEMU, so it runs at a useful fraction of native rather than 10× slower. Budget
+~10 GB of free disk for the amd64 deps image the first time.
+
 ## Knobs
 
 | Variable | Effect |

--- a/scripts/ci/ci.sh
+++ b/scripts/ci/ci.sh
@@ -17,6 +17,8 @@
 #   scripts/ci/ci.sh shell                    a shell inside the local CI container
 #   scripts/ci/ci.sh down                     stop the local CI containers (keeps build caches)
 #   scripts/ci/ci.sh clean                    …and delete the cached build volumes
+#   scripts/ci/ci.sh image [sha]              build+push the deploy image for a commit (linux/amd64)
+#   scripts/ci/ci.sh image-who <sha>          who built the deploy image for a commit
 #   scripts/ci/ci.sh gc [days]                delete attestations older than N days (default 30)
 #   scripts/ci/ci.sh selftest                 exercise this script's own logic
 #
@@ -466,6 +468,46 @@ cmd_shell() {
 cmd_down() { compose down --remove-orphans; }
 cmd_clean() { compose down -v --remove-orphans; }
 
+# ---------------------------------------------------------------- deploy image
+
+# The deploy image is keyed by commit SHA, so the REGISTRY is its cache and the
+# tag is its fingerprint — no attestation needed to decide whether to build it.
+# What an attestation does add is provenance: an image is the artifact that runs
+# in production, and unlike a fingerprint it can't be re-derived from source
+# (a Haskell build isn't bit-reproducible), so "who built what's running" has to
+# be recorded at build time or it is unanswerable.
+IMAGE=${MONOSCOPE_IMAGE:-ghcr.io/monoscope-tech/monoscope}
+
+image_exists() { docker manifest inspect "$IMAGE:$1" >/dev/null 2>&1; }
+
+cmd_image() { # [sha] — build and push the production image for a commit
+  local sha date
+  sha=${1:-$(git rev-parse HEAD)}
+  [ -z "$(git status --porcelain)" ] || die "working tree is dirty; the image would not match $sha"
+  git cat-file -e "$sha^{commit}" 2>/dev/null || die "unknown commit $sha"
+  if image_exists "$sha"; then
+    note "$IMAGE:$sha already exists — nothing to do (CI will skip its build)"
+    return 0
+  fi
+  date=$(git show -s --format=%cI "$sha")
+  note "building $IMAGE:$sha for linux/amd64 (prod runs amd64; this is Rosetta-emulated on Apple Silicon)"
+  docker buildx build --platform linux/amd64 -f Dockerfile \
+    --build-arg "GIT_HASH=$sha" --build-arg "GIT_COMMIT_DATE=$date" \
+    --provenance=false --push -t "$IMAGE:$sha" .
+  # Record who built it BEFORE anyone can deploy it.
+  publish_attestation image "$sha" docker linux-amd64
+  note "pushed. Push commit $sha and CI will reuse this image instead of rebuilding."
+}
+
+cmd_image_who() { # <sha> — one line naming who built the image for this commit
+  local ref
+  ref=$(remote_refs | grep "^$NS/image/$1/" | head -1 || true)
+  if [ -z "$ref" ]; then echo "built by: CI (no local-build record)"; return 0; fi
+  git fetch -q "$REMOTE" "$ref" 2>/dev/null \
+    && echo "built by: $(git cat-file commit FETCH_HEAD | sed -n 's/^runner=//p')" \
+    || echo "built by: (record exists but could not be read) $ref"
+}
+
 # ---------------------------------------------------------------- selftest
 
 assert() { # <desc> <expected> <actual>
@@ -553,6 +595,8 @@ case "$cmd" in
   shell)       cmd_shell ;;
   down)        cmd_down ;;
   clean)       cmd_clean ;;
+  image)       cmd_image "$@" ;;
+  image-who)   cmd_image_who "$@" ;;
   gc)          cmd_gc "$@" ;;
   selftest)    cmd_selftest ;;
   checks)      checks_all ;;


### PR DESCRIPTION
Two things, both following from the same measurement: with tests now cached, the deploy is **4m22s — of which 3m52s is the image build**. That's the whole critical path.

## 1. Reuse an image that's already in the registry

The image isn't fingerprinted like the other checks, because it produces an *artifact* rather than a verdict — skip it on a verdict and there's nothing left to deploy. But it doesn't need a fingerprint: it's tagged with the commit SHA, so **the registry is already its cache and the SHA is already its identity**.

So `build-image` probes the registry first and skips when the tag exists. Nothing changes for a genuinely new commit. What it collapses to ~30 seconds is the repeat cases:

- re-running a failed or cancelled deploy (two cancelled on 2026-08-16 alone)
- `workflow_dispatch` of an existing commit
- a revert to an already-built SHA

Skipping re-points `:latest` at the reused image rather than leaving it on an older commit, since `docker-compose.yml` (self-hosters) pulls `:latest`. That's a manifest copy, not a rebuild.

## 2. Optionally build it on a machine bigger than a 4-vCPU runner

`make deploy-image` builds and pushes `linux/amd64` locally; push the commit and CI finds the tag and skips. I'd previously assumed this was impractical on Apple Silicon — that was wrong. Docker Desktop here has `useVirtualizationFrameworkRosetta = True`, so amd64 runs under **Rosetta, not QEMU**; a probe executed `uname -m` → `x86_64` in 0.077s.

This does move the artifact that runs in production outside CI, and unlike an attestation it **cannot be verified after the fact** — a Haskell build isn't bit-reproducible, so CI can't rebuild and compare digests. Two things keep it honest:

- the build **refuses a dirty tree**, so the image is the commit it claims to be;
- it writes a provenance record, and the deploy job prints `built by: …` in its summary on **every** deploy, CI-built or not. If that line ever names someone unexpected, that's the signal.

## 3. Docs

`CONTRIBUTING.md` gets the section a contributor actually needs: the commands, that CI skips what you already proved, and the two caveats that would otherwise surprise them — the first `make ci` is a cold build, and publishing a result needs push access, so **from a fork it's still fast local feedback but CI re-runs the checks itself**. `README.md` links `docs/local-ci.md` alongside the other guides, which now also covers `make deploy-image`.