### PR TITLE
Dashboard widgets, log-list rework, and web-component test suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,6 @@ scripts/local/
 
 # Local-CI attestation staging (scripts/ci/ci.sh)
 .ci/
+
+# Playwright run output
+test-results/

--- a/e2e/tests/dashboard-grid.spec.ts
+++ b/e2e/tests/dashboard-grid.spec.ts
@@ -299,4 +299,49 @@ test.describe("dashboard gridstack", () => {
       { timeout: 10000 },
     );
   });
+
+  // The drag and resize tests above prove gridstack moved the widget; they say nothing
+  // about whether the move survived. Everything the reader does to a canvas is debounced
+  // into a widget-order PATCH, and that handler rebuilds the dashboard's widget list
+  // purely from the patch — so "it moved" and "it was saved" are genuinely separate
+  // claims, and only the second one is what the reader gets back tomorrow.
+  test("a move survives a reload, and the server rebuilds the same canvas", async ({ page }) => {
+    await openFirstDashboard(page);
+    const before = await snapshot(page);
+
+    const target = before.find((l) => l.x > 0);
+    expect(target, "dashboard has no widget offset from column 0 to drag").toBeTruthy();
+    const widget = byId(page, target!.id);
+    await widget.scrollIntoViewIfNeeded();
+    const box = (await widget.boundingBox())!;
+
+    // Wait for the PATCH itself rather than a timeout: it is the whole point of the test,
+    // and a silent 4xx would otherwise read as a passing drag.
+    const saved = page.waitForResponse(
+      (r) => r.url().includes("/widgets_order") && r.request().method() === "PATCH" && r.status() < 400,
+      { timeout: 15000 },
+    );
+    await dragBy(page, widget.locator(".grid-stack-handle").first(), -box.width * 0.8, 0);
+    await saved;
+
+    const moved = await layoutOf(widget);
+    expect(moved, "the drag did not land").not.toBeNull();
+    expect(moved!.x !== target!.x || moved!.y !== target!.y, "the widget never moved").toBe(true);
+
+    await page.reload();
+    await page.waitForSelector(`${ROOT_GRID}.grid-stack-initialized`, { timeout: 15000 });
+    await page.locator(".ui-resizable-se").first().waitFor({ state: "attached", timeout: 15000 });
+
+    // Same widget, same cell, straight off the server's own markup.
+    const reloaded = await layoutOf(byId(page, target!.id));
+    expect(reloaded, "the widget is gone after a reload — the patch dropped it").not.toBeNull();
+    expect({ x: reloaded!.x, y: reloaded!.y }).toEqual({ x: moved!.x, y: moved!.y });
+
+    // And nothing else fell off the canvas: the patch rebuilds the whole list, so a
+    // widget missing from it is deleted rather than left alone.
+    const afterIds = (await snapshot(page)).map((l) => l.id).sort();
+    expect(afterIds).toEqual(before.map((l) => l.id).sort());
+
+    await restore(page, before);
+  });
 });

--- a/monoscope.cabal
+++ b/monoscope.cabal
@@ -626,6 +626,7 @@ test-suite integration-tests
       Pages.BusinessFlowsSpec
       Pages.CodeContextSpec
       Pages.DashboardsSpec
+      Pages.DashboardWidgetsSpec
       Pages.Endpoints.ApiCatalogSpec
       Pages.ErrorPatternsSpec
       Pages.GitSyncSpec
@@ -892,6 +893,7 @@ test-suite test-dev
       Pages.BusinessFlowsSpec
       Pages.CodeContextSpec
       Pages.DashboardsSpec
+      Pages.DashboardWidgetsSpec
       Pages.Endpoints.ApiCatalogSpec
       Pages.ErrorPatternsSpec
       Pages.GitSyncSpec

--- a/monoscope.cabal
+++ b/monoscope.cabal
@@ -737,6 +737,7 @@ test-suite integration-tests
     , servant-htmx
     , servant-server
     , silently
+    , slugify
     , stm
     , text
     , text-display

--- a/package.yaml
+++ b/package.yaml
@@ -213,6 +213,8 @@ tests:
       # LiveTailSpec races registrations through a ki scope, and fakes a broker that throws.
       - ki
       - safe-exceptions
+      # DashboardWidgetsSpec slugifies widget titles the way the page does.
+      - slugify
       - hasql
       - hasql-interpolate
       - hasql-pool

--- a/src/Pages/Dashboards.hs
+++ b/src/Pages/Dashboards.hs
@@ -34,6 +34,7 @@ module Pages.Dashboards (
   findTabBySlug,
   WidgetData,
   resolveDashboardParams,
+  addVariableDefaults,
   dashboardBulkActionPostH,
   TabRenameForm (..),
   TabRenameRes (..),
@@ -586,6 +587,12 @@ dashboardPage_ pid dashId dash dashVM allParams = do
       |]
 
 
+-- | The hidden form that persists a drag/resize. Every layout edit the reader makes goes
+-- through it, so a failure here loses their work — and until the error handlers below it
+-- did so in total silence: the widget stayed where it was dropped, and the change was gone
+-- on the next load. `hx-vals` runs `buildWidgetOrder`, which throws outright if the
+-- web-components bundle failed to load (a stale asset manifest after a deploy will do it),
+-- and htmx swallows that into an event nothing was listening for.
 widgetOrderTriggerForm_ :: Text -> Bool -> Html ()
 widgetOrderTriggerForm_ url isOob =
   form_
@@ -596,6 +603,11 @@ widgetOrderTriggerForm_ url isOob =
       , hxExt_ "json-enc"
       , hxSwap_ "none"
       , hxTrigger_ "widget-order-changed from:body"
+      , -- Scoped to this form rather than a global handler: the app aborts requests on
+        -- purpose elsewhere (the log detail panel uses hx-sync="this:replace"), and those
+        -- must not toast.
+        [__|on htmx:responseError or htmx:sendError or htmx:error
+              send errorToast(value: ['Layout not saved — your change may be lost on reload.']) to document.body|]
       ]
         <> [hxSwapOob_ "true" | isOob]
     )
@@ -2074,17 +2086,22 @@ dashboardDuplicateWidgetPostH pid targetDashId widgetId sourceDashIdM = do
               }
 
       let targetTabs = fold targetDash.tabs
-          firstTabM = viaNonEmpty head targetTabs
+          -- The copy belongs beside the original, on the tab the user is actually looking
+          -- at — this used to always land on the first tab, so duplicating a widget on any
+          -- other tab made the copy appear somewhere the user was not. Falling back to the
+          -- first tab still covers a cross-dashboard copy, where the source tab need not exist.
+          destinationTabM = (tabSlugM >>= \slug -> find (\t -> slugify t.name == slug) targetTabs) <|> viaNonEmpty head targetTabs
 
       Log.logTrace "Widget duplication"
         $ AE.object
           [ "widgetId" AE..= widgetId
           , "targetDashboardId" AE..= targetDashId
-          , "addedToTab" AE..= isJust firstTabM
+          , "sourceTab" AE..= tabSlugM
+          , "destinationTab" AE..= (slugify . (.name) <$> destinationTabM)
           , "targetTabCount" AE..= length targetTabs
           ]
 
-      let updatedDash = maybe (targetDash & #widgets %~ (<> [widgetCopy])) (\t -> updateTabBySlug (slugify t.name) (#widgets %~ (<> [widgetCopy])) targetDash) firstTabM
+      let updatedDash = maybe (targetDash & #widgets %~ (<> [widgetCopy])) (\t -> updateTabBySlug (slugify t.name) (#widgets %~ (<> [widgetCopy])) targetDash) destinationTabM
       _ <- Dashboards.updateSchemaAndUpdatedAt targetDashId updatedDash now
       syncDashboardAndQueuePush pid targetDashId
 
@@ -2228,6 +2245,10 @@ queryStringFrom = decodeUtf8 . URI.renderQuery True . map (bimap encodeUtf8 (fma
 
 -- | Add variable defaults to params for any variable not already in params.
 -- This ensures constants can reference variables like {{var-resource}} even when not in URL.
+-- | Fill in a dashboard's declared variables that the request did not supply.
+--
+-- The URL always wins, and "supplied but empty" counts as supplied — a reader who clears
+-- a variable must not have the dashboard's default put straight back on the next load.
 addVariableDefaults :: [(Text, Maybe Text)] -> Maybe [Dashboards.Variable] -> [(Text, Maybe Text)]
 addVariableDefaults params varsM = params <> defaults
   where

--- a/src/Pkg/Components/LogQueryBox.hs
+++ b/src/Pkg/Components/LogQueryBox.hs
@@ -287,10 +287,18 @@ logQueryBox_ config = do
 visualizationTabs_ :: Maybe Text -> Bool -> Maybe Text -> Bool -> Html ()
 visualizationTabs_ vizTypeM updateUrl widgetContainerId alert =
   div_ [class_ "tabs tabs-box tabs-outline tabs-xs bg-fillWeak p-1 rounded-lg", id_ "visualizationTabs", role_ "radiogroup", Aria.label_ "Visualization type"] do
-    let defaultVizType = fromMaybe (bool "logs" "timeseries" alert) vizTypeM
+    -- A widget container means we are in the dashboard widget editor rather than the
+    -- log explorer.
+    let inWidgetEditor = isJust widgetContainerId
+        -- A dashboard widget starts as a chart. Logs is a full log table — the most
+        -- expensive thing on a dashboard and the wrong thing to drop on one by default.
+        defaultVizType = fromMaybe (bool "logs" "timeseries" (alert || inWidgetEditor)) vizTypeM
         containerSelector = fromMaybe "visualization-widget-container" widgetContainerId
-        -- Sessions tab is hidden in alert mode (not a valid alerting surface).
-        visible = bool visTypes (filter (\(_, _, t, _) -> t /= "sessions") visTypes) alert
+        -- Sessions is not a valid alerting surface. Patterns and Sessions are log-explorer
+        -- views with no corresponding WidgetType, so a widget set to either could not be
+        -- decoded on save: the tab was offered and simply did not work.
+        hidden = bool [] ["sessions"] alert <> bool [] ["patterns", "sessions"] inWidgetEditor
+        visible = filter (\(_, _, t, _) -> t `notElem` hidden) visTypes
     forM_ visible \(_icon, label, vizType, emoji) ->
       label_ [data_ "value" vizType, class_ "tab !shadow-none !border-strokeWeak flex gap-1"] do
         input_

--- a/src/Pkg/Components/Widget.hs
+++ b/src/Pkg/Components/Widget.hs
@@ -100,7 +100,10 @@ data WidgetType
   | WTFlamegraph
   | WTServiceMap -- Service dependency graph visualization
   | WTHeatmap -- Latency distribution heatmap
-  deriving stock (Enum, Eq, Generic, Show, THS.Lift)
+  -- Bounded so every widget type can be enumerated ([minBound ..]) rather than listed by
+  -- hand: adding a constructor then extends the round-trip/render specs automatically
+  -- instead of silently shipping untested.
+  deriving stock (Bounded, Enum, Eq, Generic, Show, THS.Lift)
   deriving anyclass (Default, NFData)
   deriving (AE.FromJSON, AE.ToJSON) via DAE.CustomJSON '[DAE.ConstructorTagModifier '[DAE.StripPrefix "WT", DAE.CamelToSnake]] WidgetType
 

--- a/test/integration/Pages/DashboardWidgetsSpec.hs
+++ b/test/integration/Pages/DashboardWidgetsSpec.hs
@@ -1,0 +1,382 @@
+-- | The dashboard canvas, end to end: add a widget of every type, move it, resize it,
+-- delete it, and confirm the backend still agrees after a reload.
+--
+-- DashboardsSpec covers dashboard CRUD. Nothing covered the widgets *on* a dashboard —
+-- which is the entire product surface — so a widget type could be unsaveable, a drag
+-- could silently drop a widget, and no test would notice. These drive the same handlers
+-- the browser calls, and enumerate WidgetType via Bounded so a new widget type joins the
+-- suite by existing rather than by someone remembering to add it.
+module Pages.DashboardWidgetsSpec (spec) where
+
+import Data.Aeson qualified as AE
+import Data.Default (def)
+import Data.Map.Strict qualified as Map
+import Data.Text qualified as T
+import Data.Vector qualified as V
+import Lucid (renderText)
+import Models.Projects.Dashboards (DashboardVM (..))
+import Models.Projects.Dashboards qualified as DashboardModel
+import Models.Projects.GitSync qualified as GitSync
+import Pages.BodyWrapper (PageCtx (..))
+import Pages.Dashboards (DashboardFilters (..))
+import Pages.Dashboards qualified as Dashboards
+import Pkg.Components.Widget qualified as Widget
+import Pkg.TestUtils
+import Relude
+import System.Types (addRespHeaders)
+import Test.Hspec
+import Text.Slugify (slugify)
+
+
+allWidgetTypes :: [Widget.WidgetType]
+allWidgetTypes = [minBound .. maxBound]
+
+
+noFilters :: Dashboards.DashboardFilters
+noFilters = Dashboards.DashboardFilters{tag = []}
+
+
+-- | Create a dashboard and hand back its id.
+--
+-- Clears existing dashboards first: the test UUID interpreter is deterministic and
+-- restarts per request, so the id minted here is the same in every example and a second
+-- create would collide on the primary key. This spec's database is created fresh from a
+-- template and is private to the file, so clearing is safe.
+newDashboard :: TestResources -> Text -> IO DashboardModel.DashboardId
+newDashboard tr title = do
+  (_, existing) <- testServant tr $ Dashboards.dashboardsGetH testPid Nothing Nothing Nothing Nothing Nothing Nothing noFilters
+  case existing of
+    Dashboards.DashboardsGet (PageCtx _ Dashboards.DashboardsGetD{dashboards}) ->
+      for_ dashboards \d -> void $ testServant tr $ Dashboards.dashboardDeleteH testPid d.id
+    _ -> pass
+  _ <- testServant tr $ Dashboards.dashboardsPostH testPid Dashboards.DashboardForm{Dashboards.title = title, Dashboards.file = "overview.yaml", Dashboards.teams = [], Dashboards.fileDir = Nothing}
+  (_, pg) <- testServant tr $ Dashboards.dashboardsGetH testPid Nothing Nothing Nothing Nothing Nothing Nothing noFilters
+  case pg of
+    Dashboards.DashboardsGet (PageCtx _ Dashboards.DashboardsGetD{dashboards}) ->
+      maybe (fail $ "dashboard not found after creating it: " <> toString title) (pure . (.id)) $ V.find (\d -> d.title == title) dashboards
+    _ -> fail "expected the dashboard list"
+
+
+-- | The widgets currently stored on a dashboard (root level), read back through the same
+-- effect stack a request runs in — i.e. what the next page load would render.
+storedWidgets :: TestResources -> DashboardModel.DashboardId -> IO [Widget.Widget]
+storedWidgets tr dashId = snd <$> testServant tr (Dashboards.getDashAndVM dashId Nothing >>= addRespHeaders . (.widgets) . snd)
+
+
+widgetOf :: Widget.WidgetType -> Text -> Widget.Widget
+widgetOf wt title =
+  (def :: Widget.Widget)
+    { Widget.wType = wt
+    , Widget.title = Just title
+    , Widget.query = Just "name != null"
+    , Widget.layout = Just def{Widget.w = Just 3, Widget.h = Just 3, Widget.x = Just 0, Widget.y = Just 0}
+    }
+
+
+-- Total accessors: -Werror=x-partial rules out head, and a failed example should say
+-- what it expected rather than crash inside a partial function.
+onlyWidget :: [Widget.Widget] -> IO Widget.Widget
+onlyWidget = \case
+  [w] -> pure w
+  ws -> fail $ "expected exactly one widget, got " <> show (length ws)
+
+
+firstWidgetId :: [Widget.Widget] -> IO Text
+firstWidgetId ws = case ws of
+  (w : _) -> maybe (fail "the stored widget has no id") pure w.id
+  [] -> fail "expected at least one widget"
+
+
+-- Add several widgets in a single request block. The test UUID interpreter restarts per
+-- request, so widgets added by separate calls would all be minted with the same id —
+-- which cannot happen in production and would make the ids useless as canvas handles.
+addWidgets :: TestResources -> DashboardModel.DashboardId -> [Widget.Widget] -> IO ()
+addWidgets tr dashId ws = void $ testServant tr $ traverse_ (Dashboards.dashboardWidgetPutH testPid dashId Nothing Nothing) ws >> addRespHeaders ()
+
+
+numberedWidgets :: Int -> [Widget.Widget]
+numberedWidgets n = [widgetOf Widget.WTTimeseries ("w" <> show i) | i <- [1 .. n]]
+
+
+reorder :: Text -> Int -> Int -> Int -> Int -> Map Text Dashboards.WidgetReorderItem
+reorder wid x y w h = Map.singleton wid (def :: Dashboards.WidgetReorderItem){Dashboards.x = Just x, Dashboards.y = Just y, Dashboards.w = Just w, Dashboards.h = Just h}
+
+
+spec :: Spec
+spec = sequential $ aroundAll withTestResources do
+  describe "Widget type contract" do
+    -- The wire tag is what every stored dashboard YAML and every saved widget already
+    -- contains. Renaming a constructor silently orphans them, and nothing else notices.
+    it "every widget type round-trips through its JSON tag" \_ -> do
+      for_ allWidgetTypes \wt -> do
+        let encoded = AE.encode wt
+        AE.eitherDecode @Widget.WidgetType encoded `shouldSatisfy` \case
+          Right decoded -> show @Text decoded == show @Text wt
+          Left _ -> False
+
+  describe "Adding widgets to a dashboard" do
+    it "stores a widget of every type, preserving its type and layout" \tr -> do
+      dashId <- newDashboard tr "Every Widget Type"
+      addWidgets tr dashId [widgetOf wt ("w-" <> show i) | (i, wt) <- zip [0 :: Int ..] allWidgetTypes]
+      stored <- storedWidgets tr dashId
+      length stored `shouldBe` length allWidgetTypes
+      -- Type survives the store/reload, and so does the layout the canvas gave it.
+      map (show @Text . (.wType)) stored `shouldBe` map (show @Text) allWidgetTypes
+      for_ stored \w -> (w.layout >>= (.w), w.layout >>= (.h)) `shouldBe` (Just 3, Just 3)
+
+    it "gives every added widget an id, so the canvas can address it" \tr -> do
+      dashId <- newDashboard tr "Widget Ids"
+      addWidgets tr dashId (numberedWidgets 3)
+      stored <- storedWidgets tr dashId
+      let wids = mapMaybe (.id) stored
+      length wids `shouldBe` 3
+      length (ordNub wids) `shouldBe` 3
+
+    it "editing a widget by id updates it in place instead of appending a copy" \tr -> do
+      dashId <- newDashboard tr "Widget Edit"
+      _ <- testServant tr $ Dashboards.dashboardWidgetPutH testPid dashId Nothing Nothing (widgetOf Widget.WTTimeseries "original")
+      wid <- firstWidgetId =<< storedWidgets tr dashId
+
+      _ <- testServant tr $ Dashboards.dashboardWidgetPutH testPid dashId (Just wid) Nothing (widgetOf Widget.WTStat "renamed")
+      only <- onlyWidget =<< storedWidgets tr dashId
+
+      only.title `shouldBe` Just "renamed"
+      show @Text only.wType `shouldBe` show @Text Widget.WTStat
+
+    -- The editor sends the layout/type on save but not always the query; losing it would
+    -- blank the widget the next time the dashboard loads.
+    it "an update that omits the query keeps the stored one" \tr -> do
+      dashId <- newDashboard tr "Widget Query Retention"
+      _ <- testServant tr $ Dashboards.dashboardWidgetPutH testPid dashId Nothing Nothing (widgetOf Widget.WTTimeseries "keeps-query")
+      wid <- firstWidgetId =<< storedWidgets tr dashId
+
+      let withoutQuery = (widgetOf Widget.WTTimeseries "keeps-query"){Widget.query = Nothing, Widget.rawQuery = Nothing}
+      _ <- testServant tr $ Dashboards.dashboardWidgetPutH testPid dashId (Just wid) Nothing withoutQuery
+      only <- onlyWidget =<< storedWidgets tr dashId
+
+      only.query `shouldBe` Just "name != null"
+
+  describe "Moving and resizing on the canvas" do
+    it "a drag persists the new position across a reload" \tr -> do
+      dashId <- newDashboard tr "Widget Drag"
+      _ <- testServant tr $ Dashboards.dashboardWidgetPutH testPid dashId Nothing Nothing (widgetOf Widget.WTTimeseries "draggable")
+      wid <- firstWidgetId =<< storedWidgets tr dashId
+
+      _ <- testServant tr $ Dashboards.dashboardWidgetReorderPatchH testPid dashId Nothing (reorder wid 6 2 3 3)
+      only <- onlyWidget =<< storedWidgets tr dashId
+
+      (only.layout >>= (.x), only.layout >>= (.y)) `shouldBe` (Just 6, Just 2)
+
+    it "a resize persists both dimensions" \tr -> do
+      dashId <- newDashboard tr "Widget Resize"
+      _ <- testServant tr $ Dashboards.dashboardWidgetPutH testPid dashId Nothing Nothing (widgetOf Widget.WTTimeseries "resizable")
+      wid <- firstWidgetId =<< storedWidgets tr dashId
+
+      _ <- testServant tr $ Dashboards.dashboardWidgetReorderPatchH testPid dashId Nothing (reorder wid 0 0 12 8)
+      only <- onlyWidget =<< storedWidgets tr dashId
+
+      (only.layout >>= (.w), only.layout >>= (.h)) `shouldBe` (Just 12, Just 8)
+
+    it "moving a widget to the origin is not mistaken for an absent coordinate" \tr -> do
+      dashId <- newDashboard tr "Widget Origin"
+      let atSix = (widgetOf Widget.WTTimeseries "origin"){Widget.layout = Just def{Widget.x = Just 6, Widget.y = Just 6, Widget.w = Just 3, Widget.h = Just 3}}
+      _ <- testServant tr $ Dashboards.dashboardWidgetPutH testPid dashId Nothing Nothing atSix
+      wid <- firstWidgetId =<< storedWidgets tr dashId
+
+      _ <- testServant tr $ Dashboards.dashboardWidgetReorderPatchH testPid dashId Nothing (reorder wid 0 0 3 3)
+      only <- onlyWidget =<< storedWidgets tr dashId
+
+      (only.layout >>= (.x), only.layout >>= (.y)) `shouldBe` (Just 0, Just 0)
+
+    it "reordering keeps every widget that is still on the canvas" \tr -> do
+      dashId <- newDashboard tr "Widget Reorder Many"
+      addWidgets tr dashId (numberedWidgets 4)
+      wids <- mapMaybe (.id) <$> storedWidgets tr dashId
+
+      let patch = Map.fromList [(w, (def :: Dashboards.WidgetReorderItem){Dashboards.x = Just i, Dashboards.y = Just 0, Dashboards.w = Just 3, Dashboards.h = Just 3}) | (i, w) <- zip [0 ..] wids]
+      _ <- testServant tr $ Dashboards.dashboardWidgetReorderPatchH testPid dashId Nothing patch
+      stored <- storedWidgets tr dashId
+
+      sort (mapMaybe (.id) stored) `shouldBe` sort wids
+
+    it "a widget dropped from the patch is removed from the dashboard" \tr -> do
+      dashId <- newDashboard tr "Widget Delete"
+      addWidgets tr dashId (numberedWidgets 3)
+      wids <- mapMaybe (.id) <$> storedWidgets tr dashId
+      let kept = take 1 wids <> drop 2 wids
+
+      let patch = Map.fromList [(w, (def :: Dashboards.WidgetReorderItem){Dashboards.x = Just 0, Dashboards.y = Just 0, Dashboards.w = Just 3, Dashboards.h = Just 3}) | w <- kept]
+      _ <- testServant tr $ Dashboards.dashboardWidgetReorderPatchH testPid dashId Nothing patch
+      stored <- storedWidgets tr dashId
+
+      sort (mapMaybe (.id) stored) `shouldBe` sort kept
+
+    -- A patch built before an HTMX swap can name only stale ids. Applying it would wipe
+    -- the dashboard, since reorderWidgets rebuilds the list purely from the patch.
+    it "a patch naming only unknown widgets is ignored rather than emptying the canvas" \tr -> do
+      dashId <- newDashboard tr "Widget Stale Patch"
+      addWidgets tr dashId (numberedWidgets 2)
+      priorWidgets <- storedWidgets tr dashId
+
+      _ <- testServant tr $ Dashboards.dashboardWidgetReorderPatchH testPid dashId Nothing (reorder "not-a-real-widget" 0 0 3 3)
+      afterStale <- storedWidgets tr dashId
+
+      map (.id) afterStale `shouldBe` map (.id) priorWidgets
+
+  -- Tabs give a dashboard several independent canvases. Every widget write takes a tab
+  -- slug, and getting that routing wrong puts a widget on the wrong canvas — or, for the
+  -- reorder patch, deletes one tab's widgets while the user was rearranging another.
+  describe "Tabbed dashboards" do
+    let tabbedYaml =
+          Dashboards.YamlForm
+            { Dashboards.yaml =
+                "title: Tabbed\nwidgets: []\ntabs:\n  - name: First Tab\n    widgets:\n      - type: timeseries\n        id: first-widget\n        title: First\n        layout: { x: 0, y: 0, w: 3, h: 3 }\n  - name: Second Tab\n    widgets:\n      - type: stat\n        id: second-widget\n        title: Second\n        layout: { x: 0, y: 0, w: 3, h: 3 }\n"
+            }
+        tabWidgets tr dashId slug = do
+          (_, dash) <- testServant tr (Dashboards.getDashAndVM dashId Nothing >>= addRespHeaders . snd)
+          pure $ maybe [] (.widgets) $ find (\t -> slugify t.name == slug) (fold dash.tabs)
+        newTabbedDashboard tr = do
+          dashId <- newDashboard tr "Tabbed"
+          _ <- testServant tr $ Dashboards.dashboardYamlPutH testPid dashId tabbedYaml
+          pure dashId
+
+    -- Two guards, so a failure below says whether the fixture YAML is wrong or the
+    -- handler is: first that the YAML parses to two tabs at all, then that storing and
+    -- reloading it preserves them.
+    it "the fixture YAML parses into two tabs" \_ -> do
+      case GitSync.yamlToDashboard (encodeUtf8 tabbedYaml.yaml) of
+        Left err -> expectationFailure $ "fixture YAML did not parse: " <> toString err
+        Right dash -> map (.name) (fold dash.tabs) `shouldBe` ["First Tab", "Second Tab"]
+
+    it "storing the fixture keeps both tabs and their widgets" \tr -> do
+      dashId <- newTabbedDashboard tr
+      tabOne <- tabWidgets tr dashId "first-tab"
+      tabTwo <- tabWidgets tr dashId "second-tab"
+      map (.id) tabOne `shouldBe` [Just "first-widget"]
+      map (.id) tabTwo `shouldBe` [Just "second-widget"]
+
+    it "a widget added to a tab lands on that tab only" \tr -> do
+      dashId <- newTabbedDashboard tr
+      _ <- testServant tr $ Dashboards.dashboardWidgetPutH testPid dashId Nothing (Just "second-tab") (widgetOf Widget.WTStat "Added To Second")
+
+      tabOne <- tabWidgets tr dashId "first-tab"
+      tabTwo <- tabWidgets tr dashId "second-tab"
+      map (.title) tabOne `shouldBe` [Just "First"]
+      map (.title) tabTwo `shouldBe` [Just "Second", Just "Added To Second"]
+
+    -- Duplicating is a canvas action: the copy has to land where the user is looking.
+    it "a duplicated widget stays on the tab it was copied from" \tr -> do
+      dashId <- newTabbedDashboard tr
+      _ <- testServant tr $ Dashboards.dashboardDuplicateWidgetPostH testPid dashId "second-widget" Nothing
+
+      tabOne <- tabWidgets tr dashId "first-tab"
+      tabTwo <- tabWidgets tr dashId "second-tab"
+      map (.title) tabTwo `shouldBe` [Just "Second", Just "Second (Copy)"]
+      map (.title) tabOne `shouldBe` [Just "First"]
+
+    it "a duplicate is a distinct widget the canvas can address separately" \tr -> do
+      dashId <- newTabbedDashboard tr
+      _ <- testServant tr $ Dashboards.dashboardDuplicateWidgetPostH testPid dashId "first-widget" Nothing
+
+      tabOne <- tabWidgets tr dashId "first-tab"
+      let ids = mapMaybe (.id) tabOne
+      length ids `shouldBe` 2
+      length (ordNub ids) `shouldBe` 2
+      map (\w -> w.layout >>= (.w)) tabOne `shouldBe` [Just 3, Just 3]
+
+    it "rearranging one tab leaves the other tab's widgets alone" \tr -> do
+      dashId <- newTabbedDashboard tr
+      _ <- testServant tr $ Dashboards.dashboardWidgetReorderPatchH testPid dashId (Just "first-tab") (reorder "first-widget" 6 4 6 2)
+
+      tabOne <- tabWidgets tr dashId "first-tab"
+      tabTwo <- tabWidgets tr dashId "second-tab"
+      map (\w -> (w.layout >>= (.x), w.layout >>= (.w))) tabOne `shouldBe` [(Just 6, Just 6)]
+      -- The dangerous shape: reorderWidgets rebuilds from the patch, so a patch scoped to
+      -- the wrong tab would empty the tab the user was not even looking at.
+      map (.id) tabTwo `shouldBe` [Just "second-widget"]
+
+  -- Rendering, not persistence: a widget the canvas cannot address is a widget the next
+  -- drag deletes, because the reorder patch is built by walking `#<id>_widgetEl` elements
+  -- and the handler rebuilds the widget list purely from that patch.
+  describe "Rendering a widget onto the canvas" do
+    it "every widget type renders a grid item the canvas can address and position" \_ -> do
+      for_ allWidgetTypes \wt -> do
+        let w = (widgetOf wt "Canvas Widget"){Widget.id = Just "wgt-1", Widget.layout = Just def{Widget.x = Just 3, Widget.y = Just 2, Widget.w = Just 6, Widget.h = Just 4}}
+            html = toStrict $ renderText $ Widget.widget_ w
+            claim :: Text -> Bool -> IO ()
+            claim what ok = (show @Text wt <> ": " <> what, ok) `shouldBe` (show @Text wt <> ": " <> what, True)
+
+        claim "renders something" (not $ T.null html)
+        -- These four are the exact contract web-components/src/widgets.ts relies on:
+        -- buildWidgetOrder selects `:scope > .grid-stack-item`, reads the `_widgetEl` id
+        -- suffix for the widget key, and GridStack hydrates position/size from gs-*. A type
+        -- that renders without any one of them is invisible to the serializer, so the next
+        -- drag sends a patch that omits it — and the reorder handler rebuilds the widget
+        -- list purely from the patch, i.e. that widget is deleted.
+        claim "is a grid item the canvas serializer selects" (T.isInfixOf "grid-stack-item" html)
+        claim "has the _widgetEl handle buildWidgetOrder keys on" (T.isInfixOf "id=\"wgt-1_widgetEl\"" html)
+        claim "declares its column position" (T.isInfixOf "gs-x=\"3\"" html && T.isInfixOf "gs-y=\"2\"" html)
+        claim "declares both dimensions" (T.isInfixOf "gs-w=\"6\"" html && T.isInfixOf "gs-h=" html)
+
+    -- A naked widget is rendered standalone (the expanded viewer, a shared link), where
+    -- there is no grid to belong to. It must NOT emit a grid handle, or the canvas would
+    -- try to position something that is not on it.
+    it "a naked widget renders without grid chrome" \_ -> do
+      let w = (widgetOf Widget.WTTimeseries "Standalone"){Widget.id = Just "wgt-1", Widget.naked = Just True}
+          html = toStrict $ renderText $ Widget.widget_ w
+      T.isInfixOf "wgt-1_widgetEl" html `shouldBe` False
+
+    it "a group renders its children inside its own nested grid" \_ -> do
+      let child = (widgetOf Widget.WTStat "Child"){Widget.id = Just "child-1"}
+          groupWidget = (widgetOf Widget.WTGroup "Group"){Widget.id = Just "group-1", Widget.children = Just [child]}
+          html = toStrict $ renderText $ Widget.widget_ groupWidget
+      T.isInfixOf "nested-grid" html `shouldBe` True
+      T.isInfixOf "group-1_widgetEl" html `shouldBe` True
+      T.isInfixOf "child-1_widgetEl" html `shouldBe` True
+
+  -- Every drag and resize is persisted by one hidden form. A failure there loses the
+  -- reader's work, and it used to do so silently: htmx swallows both a transport error and
+  -- a throw out of `hx-vals` (buildWidgetOrder is undefined whenever the web-components
+  -- bundle fails to load, e.g. a stale asset manifest after a deploy), and nothing in the
+  -- app listened for either.
+  describe "Saving the canvas layout" do
+    it "the widget-order form reports a failed save instead of losing it silently" \tr -> do
+      dashId <- newDashboard tr "Save Failure Signal"
+      (_, pg) <- testServant tr $ Dashboards.dashboardGetH testPid dashId Nothing Nothing Nothing Nothing []
+      let rendered = case pg of PageCtx _ d -> toStrict $ renderText $ toHtml d
+          formTag = T.takeWhile (/= '>') $ snd $ T.breakOn "id=\"widget-order-trigger\"" rendered
+
+      formTag `shouldSatisfy` (not . T.null)
+      -- It still saves through the widget-order endpoint...
+      formTag `shouldSatisfy` T.isInfixOf "widgets_order"
+      -- ...and now says so when that fails, on the app's own toast channel.
+      formTag `shouldSatisfy` T.isInfixOf "htmx:responseError"
+      formTag `shouldSatisfy` T.isInfixOf "htmx:sendError"
+      formTag `shouldSatisfy` T.isInfixOf "errorToast"
+
+  describe "The add-widget experience" do
+    -- Opening "add widget" on a dashboard must start on a chart. Logs is a full log
+    -- table: it is the wrong thing to drop on a dashboard by default, and it is the
+    -- most expensive one to render.
+    it "defaults to a timeseries chart, not the logs table" \tr -> do
+      dashId <- newDashboard tr "Add Widget Default"
+      (_, html) <- testServant tr $ Dashboards.dashboardWidgetNewGetH testPid dashId Nothing Nothing Nothing
+      -- Assert on the seeded `widgetJSON` rather than on which radio carries `checked`:
+      -- that object is what the save actually posts, and every tab's inline hyperscript
+      -- mentions `checked` anyway, so the markup is not a reliable signal.
+      let rendered = toStrict $ renderText html
+          seededType = T.takeWhile (/= '"') <$> T.stripPrefix "\"type\":\"" (snd $ T.breakOn "\"type\":\"" rendered)
+
+      seededType `shouldBe` Just "timeseries"
+
+    -- Regression: the editor offered Patterns and Sessions tabs. Selecting one set
+    -- widgetJSON.type to a string with no WidgetType constructor, so the widget could
+    -- not be decoded on save — the tab looked available and simply did not work.
+    it "offers only visualizations the API can actually store as a widget" \tr -> do
+      dashId <- newDashboard tr "Add Widget Tabs"
+      (_, html) <- testServant tr $ Dashboards.dashboardWidgetNewGetH testPid dashId Nothing Nothing Nothing
+      let rendered = toStrict $ renderText html
+          offered = [T.takeWhile (/= '"') seg | seg <- drop 1 (T.splitOn "id=\"viz-" rendered)]
+      offered `shouldSatisfy` (not . null)
+      for_ offered \vizType ->
+        (vizType, isRight (AE.eitherDecode @Widget.WidgetType (AE.encode vizType))) `shouldBe` (vizType, True)

--- a/test/integration/Pages/DashboardsSpec.hs
+++ b/test/integration/Pages/DashboardsSpec.hs
@@ -87,6 +87,42 @@ spec = sequential $ aroundAll withTestResources do
       T.count "data-tagify-mode" html `shouldBe` 1
       html `shouldSatisfy` T.isInfixOf "data-tagify-mode=\"select\""
 
+    -- Dashboard variables are backend-persisted schema, but their live values come from
+    -- the URL. The precedence rule is what makes a dashboard shareable: a link carries the
+    -- reader's selections, and clearing one must stay cleared rather than snapping back to
+    -- the dashboard's default on the next load.
+    it "URL variable values win over the dashboard's declared defaults" \_ -> do
+      let var k v =
+            DashboardModel.Variable
+              { key = k
+              , title = Nothing
+              , multi = Nothing
+              , required = Nothing
+              , reloadOnChange = Nothing
+              , helpText = Nothing
+              , _vType = DashboardModel.VTValues
+              , sql = Nothing
+              , facetField = Nothing
+              , query = Nothing
+              , options = Nothing
+              , value = v
+              , dependsOn = Nothing
+              }
+          vars = Just [var "env" (Just "prod"), var "region" (Just "eu")]
+          resolve params = Dashboards.addVariableDefaults params vars
+
+      -- Nothing supplied: both defaults apply.
+      sortOn fst (resolve []) `shouldBe` [("var-env", Just "prod"), ("var-region", Just "eu")]
+
+      -- A supplied value wins, and the untouched variable still gets its default.
+      sortOn fst (resolve [("var-env", Just "staging")]) `shouldBe` [("var-env", Just "staging"), ("var-region", Just "eu")]
+
+      -- Explicitly cleared counts as supplied: the default must not come back.
+      sortOn fst (resolve [("var-env", Nothing)]) `shouldBe` [("var-env", Nothing), ("var-region", Just "eu")]
+
+      -- A dashboard with no variables leaves the request's params untouched.
+      Dashboards.addVariableDefaults [("since", Just "1H")] Nothing `shouldBe` [("since", Just "1H")]
+
     it "overview template uses the native metric store" \_ -> do
       overview <- DashboardModel.readDashboardFile "static/public/dashboards" "_overview.yaml"
       overview `shouldSatisfy` isJust

--- a/test/integration/Pages/LogExplorer/LogSpec.hs
+++ b/test/integration/Pages/LogExplorer/LogSpec.hs
@@ -38,6 +38,7 @@ import Relude
 import Relude.Unsafe qualified as Unsafe
 import System.Config (AuthContext (..), EnvConfig (..))
 import Test.Hspec
+import Pkg.Parser qualified as Parser
 import Utils qualified
 import "base64" Data.Base64.Types qualified as B64T
 import "base64" Data.ByteString.Base64 qualified as B64
@@ -55,7 +56,13 @@ nextCursor t = addUTCTime (-0.001) <$> iso8601ParseM (toString t)
 -- log-list web component actually fetches, and return the raw LogResult so the
 -- assertions inspect the payload structurally, as before.
 fetchData :: TestResources -> Maybe Text -> Maybe Text -> Maybe UTCTime -> Maybe Text -> Maybe Text -> Maybe Text -> IO Log.LogResult
-fetchData tr q cols cur since from to = snd <$> testServant tr (Log.logExplorerDataH testPid q cols cur Nothing since from to Nothing Nothing)
+fetchData tr q cols cur since from to = fetchDataDir tr q cols cur Nothing since from to
+
+
+-- As above, with the pagination direction the live-tail path uses. Defaulting to
+-- PageOlder is what every existing caller relied on.
+fetchDataDir :: TestResources -> Maybe Text -> Maybe Text -> Maybe UTCTime -> Maybe Parser.PageDirection -> Maybe Text -> Maybe Text -> Maybe Text -> IO Log.LogResult
+fetchDataDir tr q cols cur dir since from to = snd <$> testServant tr (Log.logExplorerDataH testPid q cols cur dir since from to Nothing Nothing)
 
 
 seedFacetSummary :: TestResources -> IO ()
@@ -386,6 +393,84 @@ spec = around withTestResources do
       page3Ids <- pageIdsFor r3.logsData r3.colIdxMap
       page3Ids `shouldBe` [5]
       r3.hasMore `shouldBe` False
+
+    -- The other half of pagination: live tail and "Load newer events" page with
+    -- direction=newer, and nothing exercised it server-side. The client builds that
+    -- cursor from its newest retained row, so if the server answered with the newest N
+    -- rows instead of the N adjacent to the cursor, a burst of traffic would leave a
+    -- permanent hole in the middle of the list that no amount of scrolling recovers.
+    it "paging newer returns the rows adjacent to the cursor, newest-first, without a gap" \tr -> do
+      apiKey <- createTestAPIKey tr testPid "newer-pagination-key"
+      marker <- ("nw-" <>) . UUID.toText <$> nextRandom
+      let resource = mkResource apiKey []
+          -- idx 1 is the oldest, idx 6 the newest.
+          rowAt :: Int -> IO ()
+          rowAt i = do
+            sid <- show <$> nextRandom
+            tid <- show <$> nextRandom
+            let ts = addUTCTime (fromIntegral (negate (10 - i))) frozenTime
+                attrs = [mkAttr "nw.marker" marker, mkAttr "nw.idx" (show i)]
+            void
+              $ OtlpServer.traceServiceExport tr.trLogger tr.trATCtx tr.trTracerProvider
+              $ Proto (mkSpanRequest tid sid Nothing ("nw.row." <> show i) [] Nothing attrs resource ts)
+      mapM_ rowAt [1 .. 6 :: Int]
+
+      let idxOf :: V.Vector (V.Vector AE.Value) -> HashMap.HashMap Text Int -> IO [Int]
+          idxOf rows colIdxMap = do
+            let spanIdAt r = HashMap.lookup "latency_breakdown" colIdxMap >>= (r V.!?) >>= \case
+                  AE.String t -> Just t
+                  _ -> Nothing
+                spanIds = V.toList $ V.mapMaybe spanIdAt rows
+            -- Preserve the response's own row order: the display contract is what is
+            -- under test, so re-sorting here would hide exactly the bug we are after.
+            attrs <- forM spanIds \sid ->
+              withPool tr.trPool
+                $ DBT.query
+                  [sql| SELECT attributes->'nw'->>'idx' FROM otel_logs_and_spans WHERE project_id = ? AND context___span_id = ? |]
+                  (testPid, sid)
+                :: IO (V.Vector (Only (Maybe Text)))
+            pure $ mapMaybe (\v -> V.headM v >>= \(Only m) -> m >>= readMaybe . toString) attrs
+
+          q = Just $ "attributes.nw.marker == \"" <> marker <> "\" | limit 2"
+          fromTime = Just $ toText $ formatTime defaultTimeLocale "%FT%T%QZ" $ addUTCTime (-60) frozenTime
+          toTime = Just $ toText $ formatTime defaultTimeLocale "%FT%T%QZ" frozenTime
+          -- The client's cursor: the newest row it already holds.
+          cursorAt i = Just $ addUTCTime (fromIntegral (negate (10 - i))) frozenTime
+
+      -- Cursor at row 3 (inclusive: the filter is timestamp >= cursor), page size 2.
+      -- The answer must be the two rows adjacent to the cursor — 3 and 4 — NOT the newest
+      -- two (5 and 6), which would strand 3 and 4 in a hole no scrolling can reach.
+      newer <- fetchDataDir tr q Nothing (cursorAt 3) (Just Parser.PageNewer) Nothing fromTime toTime
+      adjacentIdx <- idxOf newer.logsData newer.colIdxMap
+      adjacentIdx `shouldBe` [4, 3]
+
+      -- Newest-first is the canonical display order regardless of the scan direction.
+      adjacentIdx `shouldBe` sortOn Down adjacentIdx
+
+      -- Every row it returns really is at or newer than the cursor.
+      all (>= 3) adjacentIdx `shouldBe` True
+
+    it "paging newer from the newest row returns nothing, so the client can close that edge" \tr -> do
+      apiKey <- createTestAPIKey tr testPid "newer-edge-key"
+      marker <- ("nwe-" <>) . UUID.toText <$> nextRandom
+      let resource = mkResource apiKey []
+      for_ ([1 .. 3] :: [Int]) \i -> do
+        sid <- show <$> nextRandom
+        tid <- show <$> nextRandom
+        let ts = addUTCTime (fromIntegral (negate (10 - i))) frozenTime
+            attrs = [mkAttr "nwe.marker" marker, mkAttr "nwe.idx" (show i)]
+        void
+          $ OtlpServer.traceServiceExport tr.trLogger tr.trATCtx tr.trTracerProvider
+          $ Proto (mkSpanRequest tid sid Nothing ("nwe.row." <> show i) [] Nothing attrs resource ts)
+
+      let q = Just $ "attributes.nwe.marker == \"" <> marker <> "\""
+          fromTime = Just $ toText $ formatTime defaultTimeLocale "%FT%T%QZ" $ addUTCTime (-60) frozenTime
+          toTime = Just $ toText $ formatTime defaultTimeLocale "%FT%T%QZ" frozenTime
+          -- One millisecond past the newest row, which is what buildRecentFetchUrl sends.
+          pastNewest = Just $ addUTCTime 0.001 $ addUTCTime (fromIntegral (negate (10 - 3 :: Int))) frozenTime
+
+      atEdge <- fetchDataDir tr q Nothing pastNewest (Just Parser.PageNewer) Nothing fromTime toTime
+      V.length atEdge.logsData `shouldBe` 0
 
     -- Regression: synthesized "Upstream span missing" orphan-header rows are a
     -- DISPLAY augmentation and must not count toward the page-fill check.

--- a/web-components/src/charts.ts
+++ b/web-components/src/charts.ts
@@ -298,17 +298,61 @@ function flameGraphChart(data: FlameGraphItem[], renderAt: string, colorsMap: Re
 
 window.flameGraphChart = flameGraphChart;
 
-function buildHierarchy(spans: FlameGraphItem[]): FlameGraphItem[] {
+/**
+ * Parent→child tree from a flat span list.
+ *
+ * `parentId` comes from instrumentation, so the shapes here are only as well-formed as
+ * the SDK that emitted them: a span can name itself as its parent, or two spans can name
+ * each other. Previously any such span was attached as some node's child and never
+ * reached from a root, so it simply did not appear on the flamegraph — the trace looked
+ * complete and was quietly missing spans, which is the worst way to lose data on a screen
+ * someone is debugging from.
+ *
+ * Attaching breadth-first from the roots makes reachability explicit: a self-parent has no
+ * real parent so it starts at the root, nothing is attached twice, and whatever remains
+ * unreachable is surfaced at the root rather than dropped. It also bounds the recursion the
+ * renderer then does over `children`.
+ */
+export function buildHierarchy(spans: FlameGraphItem[]): FlameGraphItem[] {
   const spanMap = new Map<string, FlameGraphItem>();
   const roots: FlameGraphItem[] = [];
   for (const span of structuredClone(spans)) {
     span.children = [];
     spanMap.set(span.spanId, span);
   }
+  // Index candidate children by parent once. Walking every span per visited node instead
+  // would be quadratic, and a whole trace is exactly what this renders.
+  const byParent = new Map<string, FlameGraphItem[]>();
   for (const span of spanMap.values()) {
-    const parent = span.parentId ? spanMap.get(span.parentId) : null;
-    parent ? parent.children.push(span) : roots.push(span);
+    // A self-parent has no real parent, so it belongs in the root set.
+    const parentId = span.parentId && span.parentId !== span.spanId ? span.parentId : null;
+    const parent = parentId ? spanMap.get(parentId) : null;
+    if (!parent) {
+      roots.push(span);
+      continue;
+    }
+    // Push into the existing array rather than rebuilding it: one trace can fan out to
+    // thousands of siblings, and copying per child is quadratic all over again.
+    const siblings = byParent.get(parentId!);
+    if (siblings) siblings.push(span);
+    else byParent.set(parentId!, [span]);
   }
+  // Attach breadth-first from the roots, so a span is linked once and a cycle can never
+  // close back onto an ancestor. A cursor, not shift(), which is O(n) per dequeue.
+  const attached = new Set(roots.map((r) => r.spanId));
+  const queue = [...roots];
+  for (let i = 0; i < queue.length; i++) {
+    const node = queue[i];
+    for (const child of byParent.get(node.spanId) ?? []) {
+      if (attached.has(child.spanId)) continue;
+      attached.add(child.spanId);
+      node.children.push(child);
+      queue.push(child);
+    }
+  }
+  // Whatever is left is inside a cycle with no root: surface it rather than dropping
+  // those spans off the chart entirely.
+  for (const span of spanMap.values()) if (!attached.has(span.spanId)) roots.push(span);
   return roots;
 }
 

--- a/web-components/src/log-list.ts
+++ b/web-components/src/log-list.ts
@@ -110,6 +110,14 @@ export const MAX_RETAINED_ROWS = 2500;
 // `max-md:` rules flip at the same width instead of disagreeing in a 1px band.
 const NARROW_VIEWPORT = '(max-width: 767px)';
 const NARROW_COLUMNS = ['id', 'timestamp', 'created_at', 'service', 'summary'];
+// Start one history request before the virtualizer mounts its load-more sentinel. Forty dense
+// rows are ~1120px: enough runway to hide ordinary network latency without fetching pages the
+// user has not approached. This is a range comparison only; it performs no layout reads.
+export const HISTORY_PREFETCH_ROWS = 40;
+
+// Who can ask the list to refetch. Two targets because the dispatchers disagree: the time
+// picker triggers on document, the dashboard auto-refresh and variable fallback on window.
+const UPDATE_QUERY_TARGETS: EventTarget[] = [window, document];
 
 // FlowLayout starts at 100px until it observes rows. Log rows are 28px, so the
 // initial estimate inflated the virtual scroll range roughly 3.5×.
@@ -189,6 +197,31 @@ export class LogList extends LitElement {
    * it immediately after, so the user keeps their place across the swap.
    */
   @state() private virtualizerEpoch = 0;
+  /**
+   * Number of reasons the list's scroll position is still in motion.
+   *
+   * A retention eviction remounts the virtualizer, and a freshly mounted one reports a
+   * zero-height scroll range until it lays out. For that frame the browser clamps
+   * scrollTop to 0 and *both* edge sentinels sit inside the viewport at once — so the
+   * "Load newer events" row at the top fired while the reader was paging history at the
+   * bottom, and its reveal threw them back to the top mid-read.
+   *
+   * Every automatic fetch (the two sentinel observers and the proximity prefetch) is
+   * therefore suspended from the remount until the layout and any scroll restoration have
+   * landed. Explicit clicks are never suspended: the reader asked.
+   */
+  private scrollSettling = 0;
+  // Which end the retention window last cut, so a reader whose anchor row went with it can
+  // be put back on that end. null when the last merge retained everything.
+  private evictedEdge: 'start' | 'end' | null = null;
+  private get isRepositioning() {
+    return this.scrollSettling > 0;
+  }
+  private holdRepositioningForRemount() {
+    this.scrollSettling++;
+    // Two frames: one for the keyed remount to render, one for the new virtualizer to lay out.
+    requestAnimationFrame(() => requestAnimationFrame(() => this.scrollSettling--));
+  }
   @state() private expandTimeRange: boolean = true;
   @state() private loadedCount: number = 0;
   @state() private totalCount: number = 0;
@@ -312,6 +345,17 @@ export class LogList extends LitElement {
   };
   private isCalculatingWidths: boolean = false;
   private lastVisibilityRange: { first: number; last: number } | null = null;
+  /**
+   * Previous visible range, used only to tell a scroll toward history from a merge.
+   *
+   * Kept apart from lastVisibilityRange (which drives the chart mark area and is
+   * seeded synthetically) because a merge renumbers rows: prepending newer rows
+   * raises `last` while the reader sits still, and reading that as movement made the
+   * prefetch cascade through pages nobody had scrolled to. updateVisibleItems clears
+   * it whenever the row count changes, so movement is only ever measured between two
+   * events that describe the same list.
+   */
+  private prefetchBaseline: { first: number; last: number } | null = null;
   private isScrolling = false;
   private scrollEndTimer: ReturnType<typeof setTimeout> | null = null;
   private worker: Worker | null = null;
@@ -509,8 +553,12 @@ export class LogList extends LitElement {
     // Form submit listener
     document.addEventListener('submit', this.handleFormSubmit);
 
-    // Filter element update listener
-    document.addEventListener('update-query', this.handleUpdateQuery);
+    // Both targets: the time picker triggers on `document`, while the dashboard
+    // auto-refresh timer and the variable fallback dispatch on `window` — and a
+    // window-dispatched event never reaches a document listener, so an embedded logs
+    // widget sat frozen while every chart around it refreshed. An event that reaches
+    // both fires the handler twice; refetchLogs is debounced, so that collapses to one.
+    UPDATE_QUERY_TARGETS.forEach((t) => t.addEventListener('update-query', this.handleUpdateQuery));
 
     // Window lifecycle events
     window.addEventListener('pagehide', this.handlePageHide);
@@ -1032,6 +1080,10 @@ export class LogList extends LitElement {
   private blankHealAt = 0;
   private detailResizeHealTimer: ReturnType<typeof setTimeout> | null = null;
   private healBlankVirtualizer() {
+    // Driven by a 2s watchdog interval, so it can fire against a list that has since been
+    // removed (tab switch, HTMX swap). A detached list has no viewport to heal, and the
+    // scroll nudge below would be measuring and mutating a node nobody is looking at.
+    if (!this.isConnected) return;
     const virtualizer = this.querySelector('lit-virtualizer');
     const container = this.logsContainer;
     if (!virtualizer || !container || this.isLoading || this.virtualListItems.length === 0) return;
@@ -1107,16 +1159,12 @@ export class LogList extends LitElement {
   }
 
   scrollToBottom() {
-    // Use ref instead of DOM query
-    if (this.logsContainer) {
-      // Batch all DOM operations in a single animation frame
-      requestAnimationFrame(() => {
-        if (this.logsContainer) {
-          // Direct assignment without reading first - browser handles this efficiently
-          this.logsContainer.scrollTop = this.logsContainer.scrollHeight;
-        }
-      });
-    }
+    // Deferred a frame to batch the write — so the pin is re-read *here*, not at the call
+    // site. A render while the list was pinned queued this; by the time it ran the reader
+    // could have scrolled up to page history, and the stale frame dragged them back down.
+    requestAnimationFrame(() => {
+      if (this.logsContainer && this.shouldScrollToBottom) this.logsContainer.scrollTop = this.logsContainer.scrollHeight;
+    });
   }
 
   disconnectedCallback() {
@@ -1174,7 +1222,7 @@ export class LogList extends LitElement {
     }
     ['submit', 'add-query'].forEach((ev) => window.removeEventListener(ev, this.debouncedRefetchLogs));
     document.removeEventListener('submit', this.handleFormSubmit);
-    document.removeEventListener('update-query', this.handleUpdateQuery);
+    UPDATE_QUERY_TARGETS.forEach((t) => t.removeEventListener('update-query', this.handleUpdateQuery));
     this.liveBtn?.removeEventListener('change', this.handleLiveToggle);
     this.liveBtn = null;
     window.removeEventListener('pagehide', this.handlePageHide);
@@ -1278,6 +1326,7 @@ export class LogList extends LitElement {
       }
     }
 
+    if (virtualItems.length !== this.virtualListItems.length) this.prefetchBaseline = null;
     this.virtualListItems = virtualItems;
 
     // Trigger initial chart mark area update after virtual items are set
@@ -1643,6 +1692,11 @@ export class LogList extends LitElement {
         // they don't render stale rows from the previous query under a surviving key.
         this.expandedAggregates = {};
         this.hasNewer = false;
+        // The live-tail buffer holds rows matched against the PREVIOUS query. Carrying it
+        // over leaves the "N new" pill offering to insert rows the new query excludes —
+        // and the drop warning describing a stream that no longer exists.
+        this.recentDataToBeAdded = [];
+        this.liveDropped = 0;
         this.spanListTree = dedupeById(tree);
         this.seenIds = new Set(this.spanListTree.map((r) => r.id));
         this.updateVisibleItems();
@@ -1691,23 +1745,22 @@ export class LogList extends LitElement {
       this.loadedCount = this.spanListTree.length;
       this.updateRowCountDisplay();
 
-      // Defer column width calculation
-      if ('requestIdleCallback' in window) {
-        (window as any).requestIdleCallback(
-          () => {
-            this.updateColumnMaxWidthMap(tree.map((t) => t.data).filter(Boolean));
-          },
-          { timeout: 2000 }
-        );
-      } else {
-        setTimeout(() => this.updateColumnMaxWidthMap(tree.map((t) => t.data).filter(Boolean)), 100);
-      }
+      // Defer column width calculation. The isConnected guard matters because this runs
+      // up to 2s later: a list removed in between (tab switch, HTMX swap) would otherwise
+      // measure and lay out a detached element it no longer owns.
+      const measure = () => {
+        if (this.isConnected) this.updateColumnMaxWidthMap(tree.map((t) => t.data).filter(Boolean));
+      };
+      if ('requestIdleCallback' in window) (window as any).requestIdleCallback(measure, { timeout: 2000 });
+      else setTimeout(measure, 100);
     } catch (error) {
       // A newer full fetch owns the UI now. Do not surface an error from the
       // obsolete request or replace the newer request's loading state.
       if (gen !== this.fetchGeneration) return;
       console.error(error);
-      const msg = error instanceof Error ? error.message : 'Network error';
+      // An Error with an empty message (a bare `new Error()`, some DOM exceptions) took the
+      // first branch and produced a blank toast — a failure the reader is shown nothing about.
+      const msg = (error instanceof Error && error.message) || 'Network error';
       // Show inline error when initial load fails (no data yet), toast otherwise
       if (this.spanListTree.length === 0) {
         this.fetchError = msg;
@@ -1841,8 +1894,11 @@ export class LogList extends LitElement {
       }
     });
 
-    // Use event delegation instead of querying all rows
-    const prevActive = event.currentTarget.parentElement?.querySelector('.bg-fillBrand-strong');
+    // `:scope >` — sibling ROWS only. bg-fillBrand-strong also paints the latency bar inside
+    // every row, so an unscoped descendant search matched the first bar long before it reached
+    // the previously selected row: that bar lost its colour and the old row stayed marked, so
+    // two rows looked selected at once.
+    const prevActive = event.currentTarget.parentElement?.querySelector(':scope > .bg-fillBrand-strong');
     if (prevActive) {
       prevActive.classList.remove('bg-fillBrand-strong');
     }
@@ -1923,11 +1979,15 @@ export class LogList extends LitElement {
       return true;
     });
     const merged = this.orderMerge(this.spanListTree, fresh, isRecentFetch);
-    if (this.mode !== 'logs' || merged.length <= MAX_RETAINED_ROWS) return merged;
+    if (this.mode !== 'logs' || merged.length <= MAX_RETAINED_ROWS) {
+      this.evictedEdge = null;
+      return merged;
+    }
 
     // Evict from the edge opposite the fetch. Move the cut past a trace boundary
     // so a root and its children are never split across retained/evicted state.
     const dropStart = this.flipDirection === isRecentFetch;
+    this.evictedEdge = dropStart ? 'start' : 'end';
     const boundedCut = dropStart ? merged.length - MAX_RETAINED_ROWS : MAX_RETAINED_ROWS;
     let cut = boundedCut;
     if (dropStart) {
@@ -1950,6 +2010,7 @@ export class LogList extends LitElement {
     if (isRecentFetch) this.hasMore = true;
     else this.hasNewer = true;
     this.virtualizerEpoch++;
+    this.holdRepositioningForRemount();
     return kept;
   }
 
@@ -1965,40 +2026,71 @@ export class LogList extends LitElement {
     return item ? { id: item.id, offset: 0 } : null;
   }
 
+  // Holds the auto-fetch suspension for its whole duration: until the anchor row is back
+  // under the reader's eyes, every sentinel in the viewport is an artefact of the merge.
   private async restoreScrollAnchor(anchor: ScrollAnchor) {
-    await this.updateComplete;
-    const index = this.virtualListItems.findIndex((item) => 'id' in item && item.id === anchor.id);
-    const virtualizer = this.querySelector('lit-virtualizer');
-    if (index < 0 || !virtualizer) return;
+    this.scrollSettling++;
+    try {
+      await this.updateComplete;
+      const index = this.virtualListItems.findIndex((item) => 'id' in item && item.id === anchor.id);
+      const virtualizer = this.querySelector('lit-virtualizer');
+      // The anchor row is gone, which for an eviction means the reader was parked on the
+      // very edge the retention window cut — live tail trimming history out from under a
+      // reader who had paged deep into it. Leave them at that edge, next to the nearest
+      // surviving rows, rather than at the top the remount clamped them to.
+      if (index < 0) {
+        if (this.evictedEdge !== 'end') return;
+        // Wait for the remounted virtualizer to lay out: until it does, its scroll range
+        // is zero and "the end of the list" is still the top.
+        await this.afterLayout(virtualizer);
+        const container = this.logsContainer;
+        if (container) container.scrollTop = container.scrollHeight;
+        return;
+      }
+      if (!virtualizer) return;
 
-    const container = this.logsContainer;
-    const renderedRow = container?.querySelector<HTMLElement>(`[data-row-id="${CSS.escape(anchor.id)}"]`);
-    if (container && renderedRow) {
       // The normal pagination case keeps the anchor inside the virtualizer's runway. Correct
       // that row in place: scrollToIndex('start') would first snap it to the top, then the
       // offset correction below would move it back a frame later — the visible load-more jump.
-      container.scrollTop += renderedRow.getBoundingClientRect().top - container.getBoundingClientRect().top - anchor.offset;
-      return;
-    }
+      if (this.alignAnchor(anchor)) return;
 
-    // scrollToIndex, not element(index).scrollIntoView: element() only resolves rows the
-    // virtualizer has already rendered. This fallback is needed after retention-window eviction
-    // remounts the virtualizer and recycles the anchor row out of the DOM.
-    virtualizer.scrollToIndex(index, 'start');
+      // scrollToIndex, not element(index).scrollIntoView: element() only resolves rows the
+      // virtualizer has already rendered. This fallback is needed after retention-window eviction
+      // remounts the virtualizer and recycles the anchor row out of the DOM.
+      virtualizer.scrollToIndex(index, 'start');
+      if (await this.afterLayout(virtualizer)) this.alignAnchor(anchor);
+    } catch (error) {
+      // Every caller is fire-and-forget (`void this.restoreScrollAnchor(...)`), so a throw
+      // here would escape as an unhandled rejection rather than as anything actionable —
+      // and trip error reporting for what costs the reader their scroll position, not their
+      // data. Report it and let the list carry on.
+      console.error('[log-list] scroll restore failed', error);
+    } finally {
+      this.scrollSettling--;
+    }
+  }
+
+  // Settle the virtualizer's layout and paint one frame on top of it, so the geometry read
+  // afterwards is the geometry the reader sees. False once the component is gone.
+  private async afterLayout(virtualizer: { layoutComplete?: Promise<void> } | null): Promise<boolean> {
     try {
-      await virtualizer.layoutComplete;
+      await virtualizer?.layoutComplete;
     } catch (error) {
       if (this.isConnected) throw error;
-      return;
+      return false;
     }
-    requestAnimationFrame(() => {
-      // Target the row by id directly rather than materialising every rendered row to scan it.
-      const currentContainer = this.logsContainer;
-      const row = currentContainer?.querySelector<HTMLElement>(`[data-row-id="${CSS.escape(anchor.id)}"]`);
-      if (currentContainer && row) {
-        currentContainer.scrollTop += row.getBoundingClientRect().top - currentContainer.getBoundingClientRect().top - anchor.offset;
-      }
-    });
+    await new Promise((resolve) => requestAnimationFrame(resolve));
+    return this.isConnected;
+  }
+
+  // Put the anchor row back at its captured offset. False when it is not mounted.
+  // Targets the row by id rather than materialising every rendered row to scan it.
+  private alignAnchor(anchor: ScrollAnchor): boolean {
+    const container = this.logsContainer;
+    const row = container?.querySelector<HTMLElement>(`[data-row-id="${CSS.escape(anchor.id)}"]`);
+    if (!container || !row) return false;
+    container.scrollTop += row.getBoundingClientRect().top - container.getBoundingClientRect().top - anchor.offset;
+    return true;
   }
 
   // The <table> is the tab stop, so entering it with nothing active starts at the top.
@@ -2013,7 +2105,15 @@ export class LogList extends LitElement {
     if (!rowIndexes.length) return;
     const current = rowIndexes.findIndex((i) => (this.virtualListItems[i] as EventLine).id === this.focusedRowId);
     const target =
-      to === 'first' ? 0 : to === 'last' ? rowIndexes.length - 1 : Math.max(0, Math.min(rowIndexes.length - 1, (current < 0 ? 0 : current) + to));
+      to === 'first'
+        ? 0
+        : to === 'last'
+          ? rowIndexes.length - 1
+          : // With nothing focused yet, the first move selects the first row rather than
+            // counting from it: `0 + 1` skipped straight past row one.
+            current < 0
+            ? 0
+            : Math.max(0, Math.min(rowIndexes.length - 1, current + to));
     const index = rowIndexes[target];
     const id = (this.virtualListItems[index] as EventLine).id;
     if (id === this.focusedRowId && current >= 0) return;
@@ -2053,13 +2153,11 @@ export class LogList extends LitElement {
     }
   }
 
-  handleRecentClick() {
-    const container = document.querySelector('#logs_list_container_inner');
-    if (container) {
-      container.scrollTop = 0;
-    }
+  handleRecentClick = () => {
+    // This list's own container, not the first one on the page: dashboards embed several.
+    if (this.logsContainer) this.logsContainer.scrollTop = 0;
     this.handleRecentConcatenation();
-  }
+  };
 
   /**
    * Colour for one value of the breakdown dimension.
@@ -2098,6 +2196,21 @@ export class LogList extends LitElement {
   }
   private _legendCache: { key: string; rows: { label: string; ns: number; pct: number; color: string }[] } | null = null;
 
+  /**
+   * Oldest-first pins the viewport to the newest edge, and `updated` re-asserts that pin on
+   * every render. Nothing ever cleared it on scroll, so a reader who scrolled up to page
+   * history was thrown back to the bottom by the very render their load-more caused — the
+   * same complaint as the newest-first jump-to-top, from the opposite end of the list.
+   *
+   * Skipped while the list is repositioning: a remounted virtualizer reports a zero-height
+   * scroll range, which reads as "at the bottom" for exactly the frame it is not.
+   */
+  private syncBottomPin() {
+    const container = this.logsContainer;
+    if (!container || !this.flipDirection || this.isRepositioning) return;
+    this.shouldScrollToBottom = container.scrollTop + container.clientHeight >= container.scrollHeight - 1;
+  }
+
   // Flush the live-tail buffer if the viewport is parked at the edge new rows arrive at.
   // Public so the visibility handler and any future scroll source share one rule.
   resumeLiveTailAtEdge() {
@@ -2134,6 +2247,7 @@ export class LogList extends LitElement {
 
   private handleListScroll = () => {
     this.markScrolling();
+    this.syncBottomPin();
     this.resumeLiveTailAtEdge();
     // Also checked here, not only after an update: once the virtualizer is stuck it renders
     // nothing, so nothing changes, so Lit never updates again — `updated` would never run and
@@ -2144,8 +2258,10 @@ export class LogList extends LitElement {
   handleVisibilityChange = (e: any) => {
     const first = e.first;
     const last = e.last;
-    if (!first || !last) return;
+    if (!Number.isInteger(first) || !Number.isInteger(last)) return;
 
+    const previousRange = this.prefetchBaseline;
+    this.prefetchBaseline = { first, last };
     // Store visibility range for deferred chart update
     this.lastVisibilityRange = { first, last };
 
@@ -2156,6 +2272,20 @@ export class LogList extends LitElement {
     // scroll positions. The other direction is why the scroll binding exists too — already
     // showing the first row, nudging the last few pixels to 0 changes no row's visibility.
     this.resumeLiveTailAtEdge();
+
+    // IntersectionObserver cannot prefetch early in a virtual list: the sentinel itself is not
+    // mounted until it enters the virtualizer's short render runway. The range is already known
+    // here, so a pair of integer comparisons starts one page early with no scroll/layout reads.
+    // Require movement toward that edge: visibilityChanged also fires after an items merge, and
+    // proximity alone could otherwise cascade through several pages while the user is stationary.
+    // fetchData sets isLoadingMore synchronously, making repeated movement events single-flight.
+    const nearHistoryEdge = this.flipDirection
+      ? first <= HISTORY_PREFETCH_ROWS
+      : last >= this.virtualListItems.length - 1 - HISTORY_PREFETCH_ROWS;
+    const movingTowardHistory = previousRange !== null && (this.flipDirection ? first < previousRange.first : last > previousRange.last);
+    if (nearHistoryEdge && movingTowardHistory && this.hasMore && !this.isLoading && !this.isLoadingMore && !this.isRepositioning) {
+      void this.fetchData(this.buildLoadMoreUrl(), false, false, true);
+    }
 
     // Debounced chart update (runs at most every 100ms)
     this.debouncedUpdateChartMarkArea();
@@ -3025,7 +3155,7 @@ export class LogList extends LitElement {
       class="w-full flex relative h-[28px] cursor-pointer hover:bg-fillWeaker"
       id=${id || nothing}
       aria-busy=${loading}
-      @click=${onClick}
+      @click=${() => loading || onClick()}
       ${ref(rowRef ?? noopRef)}
     >
       <td colspan=${String(this.displayColumns.length)} class="relative pl-[calc(40vw-10ch)]">
@@ -3041,11 +3171,15 @@ export class LogList extends LitElement {
     </tr>
   `;
 
+  // expandTimeRange is left alone on click: it is what keeps this row — and the spinner
+  // the reader is watching — mounted while the page is in flight. Clearing it here swapped
+  // the row for an empty <tr> the moment it was clicked, so the click read as doing nothing
+  // and the list shifted by the row's height under the pointer. fetchData resolves the flag
+  // from the response: a page that arrives sets hasMore and this row becomes "Load more".
   renderExpandTimeRangeButton = () =>
-    this.createLoadingRow(null, 'Show earlier events', this.isLoading || this.isLoadingMore, () => {
-      this.fetchData(this.expandTimeRangeUrl(), false, false, true);
-      this.expandTimeRange = false;
-    });
+    this.createLoadingRow(null, 'Show earlier events', this.isLoading || this.isLoadingMore, () =>
+      this.fetchData(this.expandTimeRangeUrl(), false, false, true)
+    );
 
   renderLoadMoreButton = () => {
     if (this.fetchError && this.spanListTree.length === 0) {
@@ -3068,7 +3202,7 @@ export class LogList extends LitElement {
       if (loadMoreRef.value && !this.isLoadingMore && !this.isLoading) {
         const observer = new IntersectionObserver(
           ([entry]) => {
-            if (entry.isIntersecting && !this.isLoadingMore && !this.isLoading) {
+            if (entry.isIntersecting && !this.isLoadingMore && !this.isLoading && !this.isRepositioning) {
               this.debouncedFetchData(this.buildLoadMoreUrl(), false, false, true);
               observer.disconnect();
             }
@@ -3114,8 +3248,11 @@ export class LogList extends LitElement {
         if (!fetchRecentRef.value || this.isFetchingRecent || this.isLoading) return;
         const observer = new IntersectionObserver(
           ([entry]) => {
-            if (entry.isIntersecting && !this.isFetchingRecent && !this.isLoading) {
-              this.fetchData(this.buildRecentFetchUrl(), false, true, false, true);
+            if (entry.isIntersecting && !this.isFetchingRecent && !this.isLoading && !this.isRepositioning) {
+              // No revealRecent: the observer fired because the reader is already at this edge,
+              // so the rows arrive in view on their own. Forcing scrollTop to 0 here is what
+              // teleported a reader who was paging history at the other end of the list.
+              this.fetchData(this.buildRecentFetchUrl(), false, true, false, false);
               observer.disconnect();
             }
           },

--- a/web-components/src/main.ts
+++ b/web-components/src/main.ts
@@ -140,22 +140,29 @@ window.getTimeRange = function () {
   };
 };
 
-window.setParams = (
-  (state = { ...Object.fromEntries(new URLSearchParams(window.location.search)) }) =>
-  (newState: any, load = false) => {
-    Object.assign(state, newState);
+// Merge `newState` over the params currently in the URL.
+//
+// This used to close over a snapshot taken when main.ts loaded. The app navigates by HTMX
+// morph, so main.ts loads once per session while other paths — the query editor, the
+// column and facet sync, chart zoom — keep writing params straight through
+// history.replaceState. Rebuilding the URL from that stale snapshot silently dropped every
+// one of them the next time the time range changed: the reader's query and column
+// selection vanished, including from a link they had already shared.
+//
+// null/undefined values are dropped; an empty string is kept, which is how the time picker
+// clears `since` against `from`/`to` without losing the key.
+window.setParams = (newState: Record<string, unknown>, load = false) => {
+  const merged = { ...Object.fromEntries(new URLSearchParams(window.location.search)), ...newState };
+  const url =
+    '?' +
+    new URLSearchParams(
+      Object.entries(merged)
+        .filter(([_key, value]) => value != null)
+        .sort(([keyA], [keyB]) => keyA.localeCompare(keyB)) as [string, string][]
+    ).toString();
 
-    const url =
-      '?' +
-      new URLSearchParams(
-        Object.entries(state)
-          .filter(([_key, value]) => value != null)
-          .sort(([keyA], [keyB]) => keyA.localeCompare(keyB))
-      ).toString();
-
-    load ? window.location.assign(url) : history.replaceState(null, '', url);
-  }
-)();
+  load ? window.location.assign(url) : history.replaceState(null, '', url);
+};
 
 window.updateTimePicker = function (
   timeRange: { since?: string; from?: string; to?: string },

--- a/web-components/src/widgets.ts
+++ b/web-components/src/widgets.ts
@@ -748,6 +748,11 @@ function buildWidgetOrder(container: HTMLElement) {
 
   items.forEach((el) => {
     if (!el.id || !el.id.endsWith('_widgetEl')) return;
+    // GridStack attaches gridstackNode when it adopts an element, which is a frame or two
+    // after HTMX puts it in the DOM. Reading a position off a not-yet-adopted item threw,
+    // and the throw aborted the whole walk — so the user's drag was silently never saved.
+    // It has no position to report yet; the next save picks it up.
+    if (!el.gridstackNode) return;
     const widgetId = el.id.slice(0, -'_widgetEl'.length);
     const nestedGrid = el.querySelector('.nested-grid') as HTMLElement | null;
 
@@ -810,18 +815,23 @@ window.dashboardRefreshInterval = DEFAULT_REFRESH_INTERVAL;
 function setRefreshInterval(detail: { interval: string }) {
   if (window.dashboardRefreshTimer) clearInterval(window.dashboardRefreshTimer);
   const interval = parseInt(detail.interval);
-  if (interval > 0) {
-    window.dashboardRefreshTimer = setInterval(() => {
-      window.dispatchEvent(new CustomEvent('update-query'));
-    }, interval);
-  }
+  const running = interval > 0;
+  // Both handles are public state on window and have to describe what is actually
+  // running: the interval was set once at load and never updated, so anything reading
+  // it saw "paused" regardless of the user's selection, and the stale timer id made a
+  // cleared timer look live.
+  window.dashboardRefreshInterval = running ? interval : DEFAULT_REFRESH_INTERVAL;
+  window.dashboardRefreshTimer = running
+    ? setInterval(() => window.dispatchEvent(new CustomEvent('update-query')), interval)
+    : null;
 }
 
 // Custom event handler for setting the refresh interval programmatically
 window.addEventListener('setRefreshInterval', function (e: any) {
-  if (e.detail !== undefined) {
-    setRefreshInterval(e.detail);
-  }
+  // A CustomEvent constructed without detail carries `null`, not `undefined`, so the
+  // original `!== undefined` guard let it through and setRefreshInterval threw reading
+  // `.interval` off it — an uncaught listener error on a plain `send setRefreshInterval`.
+  if (e.detail != null) setRefreshInterval(e.detail);
 });
 
 function bindFunctionsToObjects(rootObj: any, obj: any) {

--- a/web-components/test/color-mapping.test.ts
+++ b/web-components/test/color-mapping.test.ts
@@ -1,0 +1,188 @@
+// Colour is signal, not decoration — so these functions are load-bearing.
+//
+// A service that changes colour between two charts breaks the only way a reader
+// correlates them; a 5xx that renders in the 2xx colour is actively misleading during an
+// incident. Every one of these is pure and none had a test.
+import { describe, test, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import {
+  getStatusCodeColor,
+  getPercentileColor,
+  getLogLevelColor,
+  getSeriesColor,
+  getContrastTextColor,
+  tailwindToHex,
+  resolveColor,
+  TAILWIND_TO_HEX,
+} from '../src/colorMapping';
+
+const isHex = (c: string) => /^#[0-9a-f]{6}$/i.test(c);
+
+describe('status code colours', () => {
+  test('every class of response gets a colour, and they differ from each other', () => {
+    const byClass = ['2xx', '3xx', '4xx', '5xx'].map(getStatusCodeColor);
+    byClass.forEach((c) => expect(isHex(c)).toBe(true));
+    expect(new Set(byClass).size).toBe(4);
+  });
+
+  test('grouped codes are case-insensitive', () => {
+    expect(getStatusCodeColor('5XX')).toBe(getStatusCodeColor('5xx'));
+  });
+
+  // Success and failure must never collide: that is the one distinction a reader
+  // relies on before reading any text.
+  test('success and error ranges never share a colour', () => {
+    const success = [200, 201, 204].map(getStatusCodeColor);
+    const failure = [400, 404, 500, 503].map(getStatusCodeColor);
+    for (const s of success) for (const f of failure) expect(s).not.toBe(f);
+  });
+
+  test('a numeric code and its string form agree', () => {
+    expect(getStatusCodeColor('404')).toBe(getStatusCodeColor(404));
+  });
+
+  test('a code outside any known range still gets a usable colour', () => {
+    for (const odd of [0, 99, 700, -1]) expect(isHex(getStatusCodeColor(odd))).toBe(true);
+  });
+});
+
+describe('percentile colours', () => {
+  test('percentiles are distinguishable from one another', () => {
+    const colors = ['p50', 'p75', 'p90', 'p95', 'p99'].map(getPercentileColor);
+    colors.forEach((c) => expect(isHex(c)).toBe(true));
+    expect(new Set(colors).size).toBeGreaterThan(1);
+  });
+
+  test('casing and surrounding whitespace do not change the colour', () => {
+    expect(getPercentileColor('  P95 ')).toBe(getPercentileColor('p95'));
+  });
+
+  test('an unrecognised percentile is still stable across calls', () => {
+    expect(getPercentileColor('p42')).toBe(getPercentileColor('p42'));
+  });
+});
+
+describe('log level colours', () => {
+  test('levels are distinguishable and stable', () => {
+    for (const level of ['error', 'warn', 'info', 'debug']) {
+      expect(isHex(getLogLevelColor(level))).toBe(true);
+      expect(getLogLevelColor(level)).toBe(getLogLevelColor(level.toUpperCase()));
+    }
+    expect(getLogLevelColor('error')).not.toBe(getLogLevelColor('info'));
+  });
+
+  test('a level embedded in a longer label is still recognised', () => {
+    expect(getLogLevelColor('SEVERE ERROR')).toBe(getLogLevelColor('error'));
+  });
+});
+
+describe('getSeriesColor', () => {
+  // The whole point: a service keeps its colour across queries, pages and sessions,
+  // so the same colour means the same thing on every chart.
+  test('the same value always yields the same colour', () => {
+    for (const v of ['checkout-api', 'p99', '500', 'error', 'a-service']) {
+      expect(getSeriesColor(v)).toBe(getSeriesColor(v));
+    }
+  });
+
+  test('different services get different colours', () => {
+    const services = ['auth', 'billing', 'checkout', 'search', 'notifications'];
+    expect(new Set(services.map((s) => getSeriesColor(s, 'service'))).size).toBeGreaterThan(1);
+  });
+
+  test('auto-detection routes a value the same way an explicit context does', () => {
+    expect(getSeriesColor('503')).toBe(getStatusCodeColor('503'));
+    expect(getSeriesColor('p95')).toBe(getPercentileColor('p95'));
+    expect(getSeriesColor('error')).toBe(getLogLevelColor('error'));
+  });
+
+  test('an explicit context overrides auto-detection', () => {
+    expect(getSeriesColor('500', 'status')).toBe(getStatusCodeColor('500'));
+  });
+
+  // Missing data must read as absent, not as a service that happens to be grey —
+  // and "unset" is OTel's explicit no-status, which is not the same as null.
+  test('absent values are muted and distinguishable from each other', () => {
+    const unset = getSeriesColor('unset');
+    const nullish = ['null', 'undefined', 'unknown'].map(getSeriesColor);
+    nullish.forEach((c) => expect(c).toBe(nullish[0]));
+    expect(unset).not.toBe(nullish[0]);
+  });
+
+  test('empty and whitespace-only values fall back rather than throwing', () => {
+    for (const v of ['', '   ']) expect(isHex(getSeriesColor(v))).toBe(true);
+  });
+
+  test('every result is a usable hex colour', () => {
+    const samples = ['svc', '200', '404', 'p50', 'warn', 'unset', '', 'Zażółć gęślą jaźń', '🙂'];
+    samples.forEach((s) => expect(isHex(getSeriesColor(s))).toBe(true));
+  });
+});
+
+describe('resolveColor', () => {
+  test('prefers the server-assigned colour for a known service', () => {
+    const [cls, hex] = Object.entries(TAILWIND_TO_HEX)[0];
+    expect(resolveColor('auth', { auth: cls })).toBe(hex);
+  });
+
+  test('a server map that already holds hex is passed through untouched', () => {
+    expect(resolveColor('auth', { auth: '#123456' })).toBe('#123456');
+  });
+
+  // A service the server did not colour still has to get a stable colour, or it
+  // changes appearance the moment it appears in a second query.
+  test('an unmapped service still resolves to a stable hex', () => {
+    const first = resolveColor('brand-new-service', {});
+    expect(isHex(first)).toBe(true);
+    expect(resolveColor('brand-new-service', {})).toBe(first);
+  });
+
+  test('an unknown tailwind class degrades to a valid colour', () => {
+    expect(isHex(resolveColor('svc', { svc: 'bg-not-a-real-class' }))).toBe(true);
+    expect(isHex(tailwindToHex('bg-not-a-real-class'))).toBe(true);
+  });
+});
+
+describe('getContrastTextColor', () => {
+  test('returns a light tint on dark backgrounds and a dark one on light', () => {
+    const onDark = getContrastTextColor('#101010');
+    const onLight = getContrastTextColor('#f5f5f5');
+    expect(isHex(onDark)).toBe(true);
+    expect(isHex(onLight)).toBe(true);
+    // Compare rough luminance: the text over a dark chip must be the lighter of the two.
+    const lum = (h: string) => parseInt(h.slice(1, 3), 16) + parseInt(h.slice(3, 5), 16) + parseInt(h.slice(5, 7), 16);
+    expect(lum(onDark)).toBeGreaterThan(lum(onLight));
+  });
+
+  test('every palette colour yields a valid text colour', () => {
+    Object.values(TAILWIND_TO_HEX).forEach((hex) => expect(isHex(getContrastTextColor(hex))).toBe(true));
+  });
+});
+
+// The server hashes each service name into `serviceColors` (Utils.hs) and ships the
+// resulting Tailwind class in the JSON. The browser then looks that class up in
+// TAILWIND_TO_HEX. Nothing links the two lists, so a colour added on one side alone
+// makes every service hashing to it collapse onto the same fallback hex — many
+// services, one colour, and no error anywhere.
+describe('server ↔ client service palette contract', () => {
+  const serverPalette = (() => {
+    const utils = readFileSync(resolve(process.cwd(), '../src/Utils.hs'), 'utf8');
+    const block = utils.split('serviceColors ::')[1]?.split('\n\n')[0] ?? '';
+    return [...block.matchAll(/"(bg-[a-z]+-\d+)"/g)].map((m) => m[1]);
+  })();
+
+  test('the server palette was located (guards this test against a refactor)', () => {
+    expect(serverPalette.length).toBeGreaterThan(5);
+  });
+
+  test('every colour the server can assign has a hex on the client', () => {
+    const missing = serverPalette.filter((c) => !TAILWIND_TO_HEX[c]);
+    expect(missing).toEqual([]);
+  });
+
+  test('no two server palette entries collapse to the same hex', () => {
+    const hexes = serverPalette.map((c) => TAILWIND_TO_HEX[c]);
+    expect(new Set(hexes).size).toBe(hexes.length);
+  });
+});

--- a/web-components/test/dashboard-canvas.test.ts
+++ b/web-components/test/dashboard-canvas.test.ts
@@ -1,0 +1,150 @@
+// The dashboard canvas → backend contract.
+//
+// `buildWidgetOrder` walks the GridStack DOM and produces the patch body sent to
+// PATCH /dashboards/:id/widgets. That handler rebuilds the widget list *purely* from the
+// patch — anything missing is deleted. So a serializer that skips a widget, or throws
+// halfway through, is not a cosmetic bug: it drops widgets off the dashboard. Nothing
+// tested it.
+import { describe, test, expect, beforeEach } from 'vitest';
+import '../src/widgets';
+
+const buildWidgetOrder = (el: HTMLElement) => (window as any).buildWidgetOrder(el);
+const getActiveGrid = () => (window as any).getActiveGrid();
+
+// A GridStack item as it exists in the live DOM: the element plus the `gridstackNode`
+// GridStack attaches to it once it has adopted the element.
+const item = (id: string, node: { x: number; y: number; w: number; h: number } | null) => {
+  const el = document.createElement('div');
+  el.className = 'grid-stack-item';
+  el.id = `${id}_widgetEl`;
+  if (node) (el as any).gridstackNode = node;
+  return el;
+};
+
+const grid = (...children: HTMLElement[]) => {
+  const g = document.createElement('div');
+  g.className = 'grid-stack';
+  children.forEach((c) => g.appendChild(c));
+  document.body.appendChild(g);
+  return g;
+};
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('buildWidgetOrder', () => {
+  test('serializes each widget id with the position and size GridStack holds', () => {
+    const g = grid(item('alpha', { x: 0, y: 0, w: 6, h: 3 }), item('beta', { x: 6, y: 0, w: 6, h: 4 }));
+
+    expect(buildWidgetOrder(g)).toEqual({
+      alpha: { x: 0, y: 0, w: 6, h: 3 },
+      beta: { x: 6, y: 0, w: 6, h: 4 },
+    });
+  });
+
+  test('keeps a widget parked at the origin rather than dropping its zeroes', () => {
+    const g = grid(item('origin', { x: 0, y: 0, w: 1, h: 1 }));
+    expect(buildWidgetOrder(g).origin).toEqual({ x: 0, y: 0, w: 1, h: 1 });
+  });
+
+  test('only direct children count, so a nested grid is not flattened into its parent', () => {
+    const group = item('group', { x: 0, y: 0, w: 12, h: 6 });
+    const nested = document.createElement('div');
+    nested.className = 'nested-grid';
+    nested.appendChild(item('child', { x: 0, y: 0, w: 3, h: 2 }));
+    group.appendChild(nested);
+    const g = grid(group, item('sibling', { x: 0, y: 6, w: 6, h: 3 }));
+
+    const order = buildWidgetOrder(g);
+
+    expect(Object.keys(order).sort()).toEqual(['group', 'sibling']);
+    expect(order.group.children).toEqual({ child: { x: 0, y: 0, w: 3, h: 2 } });
+  });
+
+  test('an empty nested grid contributes no children key', () => {
+    const group = item('group', { x: 0, y: 0, w: 12, h: 6 });
+    const nested = document.createElement('div');
+    nested.className = 'nested-grid';
+    group.appendChild(nested);
+
+    expect(buildWidgetOrder(grid(group)).group.children).toBeUndefined();
+  });
+
+  test('elements that are not widgets are ignored', () => {
+    const stray = document.createElement('div');
+    stray.className = 'grid-stack-item';
+    stray.id = 'placeholder'; // no _widgetEl suffix
+    (stray as any).gridstackNode = { x: 0, y: 0, w: 1, h: 1 };
+    const unnamed = document.createElement('div');
+    unnamed.className = 'grid-stack-item';
+    (unnamed as any).gridstackNode = { x: 0, y: 0, w: 1, h: 1 };
+
+    expect(buildWidgetOrder(grid(stray, unnamed, item('real', { x: 1, y: 1, w: 2, h: 2 })))).toEqual({
+      real: { x: 1, y: 1, w: 2, h: 2 },
+    });
+  });
+
+  // GridStack attaches gridstackNode when it adopts an element. A widget swapped in by
+  // HTMX is in the DOM for a moment before that happens. Reading `.x` off undefined threw,
+  // which aborted the whole serialization — and the patch that did get sent (or the one
+  // that never did) is what decides which widgets survive.
+  test('a widget GridStack has not adopted yet is skipped, not fatal', () => {
+    const g = grid(item('adopted', { x: 0, y: 0, w: 6, h: 3 }), item('pending', null));
+
+    expect(() => buildWidgetOrder(g)).not.toThrow();
+    expect(buildWidgetOrder(g)).toEqual({ adopted: { x: 0, y: 0, w: 6, h: 3 } });
+  });
+
+  test('a grid with nothing on it serializes to an empty patch', () => {
+    expect(buildWidgetOrder(grid())).toEqual({});
+  });
+});
+
+// The serializer's selectors are a contract with the Haskell renderer: Widget.hs emits
+// `.grid-stack-item` elements whose id ends in `_widgetEl`, carrying gs-x/gs-y/gs-w/gs-h.
+// DashboardWidgetsSpec asserts every widget type renders exactly that; these assert the
+// client still reads exactly that, so neither side can drift alone. If they ever disagree,
+// the affected widget is invisible to the patch — and the reorder handler rebuilds the
+// dashboard purely from the patch, so it is deleted on the next drag.
+describe('the markup contract with the server renderer', () => {
+  test('a widget is identified by the _widgetEl id suffix, and the suffix is stripped', () => {
+    const g = grid(item('some-widget-id', { x: 0, y: 0, w: 1, h: 1 }));
+    expect(Object.keys(buildWidgetOrder(g))).toEqual(['some-widget-id']);
+  });
+
+  test('only .grid-stack-item children are considered', () => {
+    const notAnItem = document.createElement('div');
+    notAnItem.id = 'ghost_widgetEl';
+    (notAnItem as any).gridstackNode = { x: 0, y: 0, w: 1, h: 1 };
+    const g = grid(item('real', { x: 0, y: 0, w: 1, h: 1 }));
+    g.appendChild(notAnItem);
+
+    expect(Object.keys(buildWidgetOrder(g))).toEqual(['real']);
+  });
+
+  test('all four gs-* dimensions round-trip into the patch', () => {
+    const g = grid(item('w', { x: 3, y: 2, w: 6, h: 4 }));
+    expect(buildWidgetOrder(g).w).toEqual({ x: 3, y: 2, w: 6, h: 4 });
+  });
+});
+
+describe('getActiveGrid', () => {
+  test('prefers the visible grid when a tabbed dashboard keeps others mounted', () => {
+    const hidden = grid(item('a', { x: 0, y: 0, w: 1, h: 1 }));
+    hidden.classList.add('hidden');
+    const visible = grid(item('b', { x: 0, y: 0, w: 1, h: 1 }));
+
+    expect(getActiveGrid()).toBe(visible);
+  });
+
+  test('falls back to the only grid even if it is hidden mid-transition', () => {
+    const only = grid();
+    only.classList.add('hidden');
+    expect(getActiveGrid()).toBe(only);
+  });
+
+  test('returns null when no dashboard grid is mounted', () => {
+    expect(getActiveGrid()).toBeNull();
+  });
+});

--- a/web-components/test/dashboard-refresh.test.ts
+++ b/web-components/test/dashboard-refresh.test.ts
@@ -1,0 +1,85 @@
+// Dashboard auto-refresh.
+//
+// The refresh dropdown (TimePicker.hs) sends `setRefreshInterval` to window, and the
+// timer it starts is what re-runs every widget on the dashboard. A leaked timer here
+// doubles the query load on every panel silently, and a timer that never starts leaves
+// a dashboard the user believes is live showing stale numbers.
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+import '../src/widgets';
+
+const selectInterval = (interval: unknown) => window.dispatchEvent(new CustomEvent('setRefreshInterval', { detail: { interval } }));
+
+let refreshes: number;
+const countRefreshes = () => refreshes++;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  refreshes = 0;
+  window.addEventListener('update-query', countRefreshes);
+});
+
+afterEach(() => {
+  window.removeEventListener('update-query', countRefreshes);
+  selectInterval(0); // stop any timer this test started
+  vi.useRealTimers();
+});
+
+describe('auto-refresh interval', () => {
+  test('choosing an interval refreshes the dashboard on that cadence', () => {
+    selectInterval(30_000);
+
+    vi.advanceTimersByTime(90_000);
+
+    expect(refreshes).toBe(3);
+  });
+
+  // Each selection must replace the previous timer. Leaking one doubles the query
+  // volume against every widget, and the dashboard gets quietly more expensive the
+  // more times the user changes their mind.
+  test('changing the interval replaces the timer rather than stacking another', () => {
+    selectInterval(30_000);
+    selectInterval(10_000);
+
+    vi.advanceTimersByTime(30_000);
+
+    expect(refreshes).toBe(3); // 3 x 10s, not 3 + 1
+  });
+
+  test('pausing stops refreshing', () => {
+    selectInterval(10_000);
+    vi.advanceTimersByTime(10_000);
+    selectInterval(0);
+
+    vi.advanceTimersByTime(120_000);
+
+    expect(refreshes).toBe(1);
+  });
+
+  test('a value that is not a number does not start a runaway timer', () => {
+    selectInterval('not-a-number');
+
+    vi.advanceTimersByTime(120_000);
+
+    expect(refreshes).toBe(0);
+  });
+
+  test('an event with no detail is ignored', () => {
+    window.dispatchEvent(new CustomEvent('setRefreshInterval'));
+
+    vi.advanceTimersByTime(120_000);
+
+    expect(refreshes).toBe(0);
+  });
+
+  // The dropdown label and the actual cadence have to agree, and the only shared
+  // state is window.dashboardRefreshInterval — it was declared, initialised once, and
+  // then never updated, so anything reading it saw "Paused" no matter the selection.
+  test('the exposed interval reflects what is actually running', () => {
+    selectInterval(15_000);
+    expect(window.dashboardRefreshInterval).toBe(15_000);
+
+    selectInterval(0);
+    expect(window.dashboardRefreshInterval).toBe(0);
+    expect(window.dashboardRefreshTimer).toBeNull();
+  });
+});

--- a/web-components/test/flamegraph-hierarchy.test.ts
+++ b/web-components/test/flamegraph-hierarchy.test.ts
@@ -1,0 +1,109 @@
+// The flamegraph's span tree.
+//
+// `parentId` is whatever the customer's instrumentation emitted. A span that parents
+// itself, or two spans that parent each other, used to be attached as somebody's child
+// and never reached from a root — so those spans silently vanished from the flamegraph
+// while the trace still looked complete. Missing spans on the screen someone is debugging
+// from is the worst kind of data loss, because nothing signals it.
+//
+// The walk below carries a hard step budget so these also stand as termination guards on
+// the recursive render.
+import { describe, test, expect } from 'vitest';
+import { buildHierarchy } from '../src/charts';
+
+const span = (spanId: string, parentId: string | null = null) =>
+  ({ spanId, parentId, name: spanId, label: spanId, serviceName: 'svc', hasErrors: false, start: 0, value: 1, children: [] }) as any;
+
+// Walk the tree with a hard step budget: a cycle exhausts it instead of hanging the test.
+const walk = (roots: any[], budget = 10_000): string[] => {
+  const seen: string[] = [];
+  const queue = [...roots];
+  while (queue.length) {
+    if (seen.length > budget) throw new Error('cycle: traversal did not terminate');
+    const node = queue.shift();
+    seen.push(node.spanId);
+    queue.push(...(node.children ?? []));
+  }
+  return seen;
+};
+
+describe('buildHierarchy', () => {
+  test('nests children under their parent and returns only true roots', () => {
+    const roots = buildHierarchy([span('root'), span('a', 'root'), span('b', 'a')]);
+
+    expect(roots.map((r) => r.spanId)).toEqual(['root']);
+    expect(walk(roots)).toEqual(['root', 'a', 'b']);
+  });
+
+  test('several independent traces each keep their own root', () => {
+    const roots = buildHierarchy([span('r1'), span('r2'), span('c1', 'r1'), span('c2', 'r2')]);
+
+    expect(roots.map((r) => r.spanId).sort()).toEqual(['r1', 'r2']);
+    expect(walk(roots).sort()).toEqual(['c1', 'c2', 'r1', 'r2']);
+  });
+
+  test('a span whose parent was never ingested is shown as a root, not dropped', () => {
+    const roots = buildHierarchy([span('orphan', 'never-sent')]);
+    expect(walk(roots)).toEqual(['orphan']);
+  });
+
+  test('a self-parented span is rendered once, at the root', () => {
+    const roots = buildHierarchy([span('self', 'self')]);
+
+    expect(walk(roots)).toEqual(['self']);
+    expect(roots[0].children).toEqual([]);
+  });
+
+  // The fatal shape: a real root leading into a two-span cycle. Walking it recursed
+  // forever and blew the stack.
+  test('a cycle below a real root terminates', () => {
+    const roots = buildHierarchy([span('root'), span('a', 'root'), span('b', 'a'), { ...span('a2', 'b'), spanId: 'a', parentId: 'b' }]);
+    expect(() => walk(roots)).not.toThrow();
+  });
+
+  test('a cycle with no root at all still terminates and keeps its spans', () => {
+    const roots = buildHierarchy([span('a', 'b'), span('b', 'a')]);
+
+    expect(() => walk(roots)).not.toThrow();
+    expect(walk(roots).sort()).toEqual(['a', 'b']);
+  });
+
+  test('every input span appears exactly once in the output tree', () => {
+    const input = [span('root'), span('a', 'root'), span('b', 'a'), span('c', 'root'), span('orphan', 'gone')];
+    const seen = walk(buildHierarchy(input));
+
+    expect(seen.sort()).toEqual(['a', 'b', 'c', 'orphan', 'root']);
+    expect(new Set(seen).size).toBe(seen.length);
+  });
+
+  test('a deep chain nests to full depth without losing spans', () => {
+    const chain = [span('s0'), ...Array.from({ length: 200 }, (_, i) => span(`s${i + 1}`, `s${i}`))];
+    expect(walk(buildHierarchy(chain))).toHaveLength(201);
+  });
+
+  test('an empty trace produces no roots rather than throwing', () => {
+    expect(buildHierarchy([])).toEqual([]);
+  });
+
+  // A whole trace is what this renders, so both shapes it can take at scale have to come
+  // out right: one parent with thousands of siblings, and a long ancestor chain. This is a
+  // correctness check, not a complexity one — wall-clock budgets do not discriminate
+  // reliably enough here to be worth asserting on.
+  test('a wide fan-out attaches every sibling exactly once', () => {
+    const wide = [span('root'), ...Array.from({ length: 4000 }, (_, i) => span(`s${i}`, 'root'))];
+
+    const roots = buildHierarchy(wide);
+
+    expect(roots).toHaveLength(1);
+    expect(roots[0].children).toHaveLength(4000);
+    expect(new Set(roots[0].children.map((c: any) => c.spanId)).size).toBe(4000);
+  });
+
+  // structuredClone: the renderer mutates children while zooming, and the caller's
+  // array is the cached query result.
+  test('does not mutate the spans it was given', () => {
+    const input = [span('root'), span('a', 'root')];
+    buildHierarchy(input);
+    expect(input.every((s) => s.children.length === 0)).toBe(true);
+  });
+});

--- a/web-components/test/live-stream.test.ts
+++ b/web-components/test/live-stream.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect, vi, afterEach } from 'vitest';
 import { LiveStream, tableRowToArray } from '../src/live-stream';
-import { mountList, COLS, ids, row, fakeLiveTransport } from './log-list-harness';
+import { mountList, COLS, ids, row, fakeLiveTransport, stubContainer } from './log-list-harness';
 
 // Live mode is a server push, not a poll — polling could never beat TimeFusion's
 // write-visibility latency, since a row has to clear its ingest batch and land before any
@@ -237,7 +237,7 @@ describe('pushed Events rows', () => {
     (el as any).colIdxMap = COLS;
     (el as any).isLiveStreaming = true;
     Object.defineProperty(el, 'logsContainer', {
-      value: { scrollTop: 400, clientHeight: 500, scrollHeight: 5000 },
+      value: stubContainer({ scrollTop: 400, scrollHeight: 5000 }),
     });
     const timestamp = new Date().toISOString();
     const pushed = (id: string, parent_id: string | null) => ({
@@ -262,7 +262,7 @@ describe('pushed Events rows', () => {
     (el as any).seenIds = new Set(['already-read']);
     (el as any).updateVisibleItems();
     Object.defineProperty(el, 'logsContainer', {
-      value: { scrollTop: 0, clientHeight: 100, scrollHeight: 1000, getBoundingClientRect: () => ({ top: 0 }), querySelectorAll: () => [] },
+      value: stubContainer({ clientHeight: 100 }),
     });
     const restore = vi.spyOn(el as any, 'restoreScrollAnchor').mockResolvedValue(undefined);
 

--- a/web-components/test/live-tail-in-list.test.ts
+++ b/web-components/test/live-tail-in-list.test.ts
@@ -1,0 +1,165 @@
+// Live tail as the reader experiences it: rows arriving continuously into a list they
+// are scrolled somewhere inside of.
+//
+// live-stream.test.ts covers the SSE connection (leases, backoff, drops). What was never
+// covered is the half that decides whether a reader gets interrupted: buffer vs insert,
+// where the viewport ends up, and what happens when the query changes mid-stream. Those
+// need real geometry, so they run against the scroll simulator.
+import { describe, test, expect } from 'vitest';
+import { row, serverTransport, serverTransportFlipped, logPage, mountList, scrollHarness, flushFrames, ids, ROW_H } from './log-list-harness';
+
+const DIRECTIONS = [
+  { name: 'newest-first (rows arrive at the top)', flip: false },
+  { name: 'oldest-first (rows arrive at the bottom)', flip: true },
+];
+
+const seeded = async (flip: boolean, n = 400) => {
+  const el = await mountList({ flipDirection: flip, isLiveStreaming: true } as any);
+  const t = flip ? serverTransportFlipped : serverTransport;
+  el.transport = t(logPage(Array.from({ length: n }, (_, i) => `r${String(i).padStart(5, '0')}`)));
+  await el.fetchData('first', true);
+  await flushFrames();
+  return el;
+};
+
+// A batch pushed down the live connection, in the wire shape handleLiveRows parses.
+const pushed = (id: string) => ({
+  shape: 'table',
+  cols: { id, latency_breakdown: id, trace_id: id, parent_id: '', kind: 'log', timestamp: new Date().toISOString() },
+});
+
+describe.each(DIRECTIONS)('live tail: $name', ({ flip }) => {
+  // Where new rows enter, and therefore where the reader must be parked for them to
+  // be inserted rather than buffered.
+  const parkAtEdge = (sim: any) => (flip ? sim.scrollToBottom() : sim.scrollTo(0));
+  const parkAway = (sim: any) => sim.scrollTo(150 * ROW_H);
+
+  test('parked at the arrival edge, rows insert straight away', async () => {
+    const el = await seeded(flip);
+    const sim = scrollHarness(el);
+    parkAtEdge(sim);
+
+    (el as any).handleLiveRows([pushed('live-1'), pushed('live-2')]);
+    await flushFrames();
+
+    expect(ids(el)).toContain('live-1');
+    expect((el as any).recentDataToBeAdded).toHaveLength(0);
+    expect(el.recentCount).toBe(0);
+  });
+
+  test('scrolled away, rows buffer behind the pill and the viewport does not move', async () => {
+    const el = await seeded(flip);
+    const sim = scrollHarness(el);
+    parkAway(sim);
+    const before = sim.scrollTop;
+
+    (el as any).handleLiveRows([pushed('live-1'), pushed('live-2')]);
+    await flushFrames();
+
+    expect(ids(el)).not.toContain('live-1');
+    expect(el.recentCount).toBe(2);
+    expect(sim.scrollTop).toBe(before);
+  });
+
+  test('scrolling back to the edge flushes the buffer', async () => {
+    const el = await seeded(flip);
+    const sim = scrollHarness(el);
+    parkAway(sim);
+    (el as any).handleLiveRows([pushed('live-1')]);
+    await flushFrames();
+
+    parkAtEdge(sim);
+    await flushFrames();
+
+    expect(ids(el)).toContain('live-1');
+    expect(el.recentCount).toBe(0);
+  });
+
+  test('the pill counts exactly the rows it will insert', async () => {
+    const el = await seeded(flip);
+    const sim = scrollHarness(el);
+    parkAway(sim);
+
+    (el as any).handleLiveRows([pushed('a'), pushed('b'), pushed('c')]);
+    await flushFrames();
+    const promised = el.recentCount;
+    const lengthBefore = ids(el).length;
+    (el as any).handleRecentConcatenation();
+
+    expect(ids(el).length - lengthBefore).toBe(promised);
+  });
+
+  test('a row already on screen is never buffered a second time', async () => {
+    const el = await seeded(flip);
+    const sim = scrollHarness(el);
+    parkAway(sim);
+    const existing = ids(el)[0];
+
+    (el as any).handleLiveRows([pushed(existing), pushed('genuinely-new')]);
+    await flushFrames();
+
+    expect(el.recentCount).toBe(1);
+  });
+
+  test('pausing the stream keeps the buffer rather than discarding it', async () => {
+    const el = await seeded(flip);
+    const sim = scrollHarness(el);
+    parkAway(sim);
+    (el as any).handleLiveRows([pushed('live-1')]);
+    await flushFrames();
+
+    (el as any).isLiveStreaming = false;
+    sim.scrollTo(sim.scrollTop); // a scroll while paused must not silently flush
+
+    expect(el.recentCount).toBe(1);
+    expect(ids(el)).not.toContain('live-1');
+  });
+
+  test('a page of history loaded while buffering leaves the buffer intact', async () => {
+    const el = await seeded(flip);
+    const sim = scrollHarness(el);
+    parkAway(sim);
+    (el as any).handleLiveRows([pushed('live-1')]);
+    await flushFrames();
+
+    const t = flip ? serverTransportFlipped : serverTransport;
+    el.transport = t(logPage(['o1', 'o2']));
+    await el.fetchData('older', false, false, true);
+    await flushFrames();
+
+    expect(el.recentCount).toBe(1);
+    expect(ids(el)).toContain('o1');
+  });
+
+  test('changing the query drops rows buffered from the previous one', async () => {
+    const el = await seeded(flip);
+    const sim = scrollHarness(el);
+    parkAway(sim);
+    (el as any).handleLiveRows([pushed('from-old-query')]);
+    await flushFrames();
+    expect(el.recentCount).toBe(1);
+
+    const t = flip ? serverTransportFlipped : serverTransport;
+    el.transport = t(logPage(['new1', 'new2']));
+    await el.fetchData('new-query', true);
+    await flushFrames();
+
+    // The pill promised rows matching the *previous* filter. Carrying them over
+    // offers to insert results the current query excludes.
+    expect(el.recentCount).toBe(0);
+    expect((el as any).recentDataToBeAdded).toHaveLength(0);
+    (el as any).handleRecentConcatenation();
+    expect(ids(el)).not.toContain('from-old-query');
+  });
+
+  test('the dropped-rows warning resets with the query it described', async () => {
+    const el = await seeded(flip);
+    (el as any).liveDropped = 4200;
+
+    const t = flip ? serverTransportFlipped : serverTransport;
+    el.transport = t(logPage(['new1']));
+    await el.fetchData('new-query', true);
+
+    expect((el as any).liveDropped).toBe(0);
+  });
+});

--- a/web-components/test/local-time.test.ts
+++ b/web-components/test/local-time.test.ts
@@ -1,0 +1,78 @@
+// <local-time> — the only thing that makes server-rendered timestamps agree with the
+// client-formatted ones in the log list.
+//
+// Haskell knows the instant, not the viewer's zone, so every server-rendered timestamp
+// ships as UTC and this element rewrites it locally. It has to survive HTMX swaps and
+// morphs, which is why it re-renders on attribute change rather than only on insert.
+import { describe, test, expect, beforeEach } from 'vitest';
+import { format } from 'date-fns';
+import '../src/local-time';
+
+const ISO = '2024-06-16T03:38:47.176Z';
+
+const mount = (attrs: Record<string, string>, fallback = '') => {
+  const el = document.createElement('local-time');
+  Object.entries(attrs).forEach(([k, v]) => el.setAttribute(k, v));
+  el.textContent = fallback;
+  document.body.appendChild(el);
+  return el;
+};
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('local-time', () => {
+  test('is registered as a custom element', () => {
+    expect(customElements.get('local-time')).toBeDefined();
+  });
+
+  test('rewrites the UTC timestamp into the viewer\'s own zone', () => {
+    const el = mount({ datetime: ISO });
+    expect(el.textContent).toBe(format(new Date(ISO), 'MMM dd, HH:mm:ss'));
+  });
+
+  test('an explicit format attribute wins', () => {
+    const el = mount({ datetime: ISO, format: 'yyyy-MM-dd' });
+    expect(el.textContent).toBe(format(new Date(ISO), 'yyyy-MM-dd'));
+  });
+
+  // HTMX morphs update attributes in place rather than replacing the element, so a
+  // timestamp that only formatted on insert would keep showing the previous row's time.
+  test('re-renders when the timestamp is swapped in place', () => {
+    const el = mount({ datetime: ISO });
+    const next = '2025-01-02T10:11:12.000Z';
+
+    el.setAttribute('datetime', next);
+
+    expect(el.textContent).toBe(format(new Date(next), 'MMM dd, HH:mm:ss'));
+  });
+
+  test('re-renders when only the format changes', () => {
+    const el = mount({ datetime: ISO });
+    el.setAttribute('format', 'HH:mm');
+    expect(el.textContent).toBe(format(new Date(ISO), 'HH:mm'));
+  });
+
+  test('setting the same value again does not need to change anything', () => {
+    const el = mount({ datetime: ISO });
+    const before = el.textContent;
+    el.setAttribute('datetime', ISO);
+    expect(el.textContent).toBe(before);
+  });
+
+  // The server-rendered UTC text is the no-JS fallback: a broken or missing datetime
+  // must leave it standing rather than blanking the cell.
+  test('keeps the server-rendered fallback when the timestamp is unusable', () => {
+    expect(mount({}, 'Jun 16, 03:38:47').textContent).toBe('Jun 16, 03:38:47');
+    expect(mount({ datetime: 'not-a-date' }, 'Jun 16, 03:38:47').textContent).toBe('Jun 16, 03:38:47');
+    expect(mount({ datetime: '' }, 'Jun 16, 03:38:47').textContent).toBe('Jun 16, 03:38:47');
+  });
+
+  test('an element that was never connected does not render on attribute change', () => {
+    const el = document.createElement('local-time');
+    el.textContent = 'untouched';
+    el.setAttribute('datetime', ISO);
+    expect(el.textContent).toBe('untouched');
+  });
+});

--- a/web-components/test/log-detail-panel.test.ts
+++ b/web-components/test/log-detail-panel.test.ts
@@ -6,6 +6,7 @@
 // Pages.LogExplorer.Log.detailsPanel); these guard the client half of the contract.
 import { describe, expect, test, vi, beforeEach } from 'vitest';
 import { LogList } from '../src/log-list';
+import { stubContainer } from './log-list-harness';
 
 const mountPanelDom = () => {
   document.body.innerHTML = `
@@ -82,7 +83,7 @@ describe('detail panel loading indicator', () => {
   test('opening the panel checks the deep-scrolled virtualizer during and after resize', async () => {
     (window as any).htmx = { ajax: () => new Promise(() => {}) };
     const el = new LogList();
-    Object.defineProperty(el, 'logsContainer', { value: { scrollTop: 5000 } });
+    Object.defineProperty(el, 'logsContainer', { value: stubContainer({ scrollTop: 5000 }) });
     const heal = vi.spyOn(el as any, 'healBlankVirtualizer').mockImplementation(() => {});
 
     clickRow(el, 'a');

--- a/web-components/test/log-list-blank-recovery.test.ts
+++ b/web-components/test/log-list-blank-recovery.test.ts
@@ -3,8 +3,7 @@
 // rendering nothing means nothing changes, so no further update or visibilityChanged event ever
 // arrives to notice. Users saw the log list go blank and stay blank until they reloaded.
 import { describe, expect, test, vi, beforeEach } from 'vitest';
-import { mountList } from './log-list-harness';
-import { row } from './log-list-harness';
+import { mountList, row, stubContainer } from './log-list-harness';
 
 const stubVirtualizer = (el: any, renderedRows: number, visible = true) => {
   const rows = Array.from({ length: renderedRows }, () => ({
@@ -19,7 +18,7 @@ const stubVirtualizer = (el: any, renderedRows: number, visible = true) => {
   return virtualizer;
 };
 
-const container = () => ({ scrollTop: 5000, getBoundingClientRect: () => ({ top: 0, bottom: 500 }) });
+const container = () => stubContainer({ scrollTop: 5000 });
 
 describe('blank virtualizer recovery', () => {
   beforeEach(() => vi.restoreAllMocks());

--- a/web-components/test/log-list-bugs.test.ts
+++ b/web-components/test/log-list-bugs.test.ts
@@ -1,9 +1,83 @@
 import { describe, test, expect, vi } from 'vitest';
-import { row, serverTransport, serverTransportFlipped, logPage, treeFromLogs, COLS, deferredTransport, stubFetch, ids, mountList, fakeLiveTransport } from './log-list-harness';
-import { DenseRowFlowLayout, virtualItemKey, MAX_RETAINED_ROWS } from '../src/log-list';
+import { row, serverTransport, serverTransportFlipped, logPage, treeFromLogs, COLS, deferredTransport, stubFetch, ids, mountList, fakeLiveTransport, stubContainer, stubVirtualizer } from './log-list-harness';
+import { DenseRowFlowLayout, virtualItemKey, MAX_RETAINED_ROWS, HISTORY_PREFETCH_ROWS } from '../src/log-list';
 import { shouldBufferRecent, atInsertionEdge, cursorFromTimestamp } from '../src/log-list-utils';
 
 describe('LogList — LOWER', () => {
+  test('prefetches history before the virtual load-more row is mounted', async () => {
+    const el = await mountList();
+    (el as any).virtualListItems = Array.from({ length: 200 }, (_, i) => row(`r${i}`));
+    (el as any).hasMore = true;
+    const fetch = vi.spyOn(el, 'fetchData').mockResolvedValue(undefined);
+    vi.spyOn(el as any, 'buildLoadMoreUrl').mockReturnValue('next-page');
+
+    el.handleVisibilityChange({ first: 130, last: 150 });
+    el.handleVisibilityChange({ first: 140, last: 200 - 1 - HISTORY_PREFETCH_ROWS });
+
+    expect(fetch).toHaveBeenCalledOnce();
+    expect(fetch).toHaveBeenCalledWith('next-page', false, false, true);
+  });
+
+  test('does not prefetch away from the history edge or while a page is in flight', async () => {
+    const el = await mountList();
+    (el as any).virtualListItems = Array.from({ length: 200 }, (_, i) => row(`r${i}`));
+    (el as any).hasMore = true;
+    const fetch = vi.spyOn(el, 'fetchData').mockResolvedValue(undefined);
+
+    el.handleVisibilityChange({ first: 50, last: 80 });
+    (el as any).isLoadingMore = true;
+    el.handleVisibilityChange({ first: 150, last: 190 });
+
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  test('prefetches from the start of an oldest-first virtual list, including index zero', async () => {
+    const el = await mountList();
+    (el as any).virtualListItems = Array.from({ length: 200 }, (_, i) => row(`r${i}`));
+    (el as any).flipDirection = true;
+    (el as any).hasMore = true;
+    const fetch = vi.spyOn(el, 'fetchData').mockResolvedValue(undefined);
+    vi.spyOn(el as any, 'buildLoadMoreUrl').mockReturnValue('older-page');
+
+    el.handleVisibilityChange({ first: 60, last: 80 });
+    el.handleVisibilityChange({ first: 0, last: 20 });
+
+    expect(fetch).toHaveBeenCalledWith('older-page', false, false, true);
+    expect((el as any).lastVisibilityRange).toEqual({ first: 0, last: 20 });
+  });
+
+  test('does not cascade another prefetch when a page merge changes visibility while stationary', async () => {
+    const el = await mountList();
+    (el as any).virtualListItems = Array.from({ length: 100 }, (_, i) => row(`r${i}`));
+    (el as any).prefetchBaseline = { first: 50, last: 70 };
+    (el as any).hasMore = true;
+    const fetch = vi.spyOn(el, 'fetchData').mockResolvedValue(undefined);
+
+    el.handleVisibilityChange({ first: 50, last: 70 });
+
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  // Prepending newer rows raises every index by the page size. Measured against the
+  // previous range that reads as a scroll toward history, and the prefetch cascaded
+  // through pages the reader never approached.
+  test('a merge that renumbers rows is not read as a scroll toward the history edge', async () => {
+    const el = await mountList();
+    const rows = Array.from({ length: 100 }, (_, i) => row(`r${i}`));
+    (el as any).spanListTree = rows;
+    (el as any).seenIds = new Set(rows.map((r) => r.id));
+    (el as any).hasMore = true;
+    (el as any).updateVisibleItems();
+    const fetch = vi.spyOn(el, 'fetchData').mockResolvedValue(undefined);
+
+    el.handleVisibilityChange({ first: 50, last: 70 }); // reader parks near the history edge
+    (el as any).spanListTree = (el as any).mergeIntoTree([row('newer')], true);
+    (el as any).updateVisibleItems();
+    el.handleVisibilityChange({ first: 51, last: 71 }); // same rows, shifted by the prepend
+
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
   // Lo2: a resized-then-hidden column must not retain its width (which would
   // resurrect on re-add and grow columnMaxWidthMap unboundedly).
   test('hideColumn prunes its stored width', async () => {
@@ -233,7 +307,7 @@ describe('LogList — MED correctness', () => {
   test('scroll anchoring falls back to the virtualizer range while rows are recycling', async () => {
     const el = await mountList();
     Object.defineProperty(el, 'logsContainer', {
-      value: { getBoundingClientRect: () => ({ top: 0 }), querySelectorAll: () => [] },
+      value: stubContainer(),
     });
     (el as any).virtualListItems = [{ type: 'fetchRecent' }, row('visible'), { type: 'loadMore' }];
     (el as any).lastVisibilityRange = { first: 1, last: 2 };
@@ -245,17 +319,10 @@ describe('LogList — MED correctness', () => {
     const el = await mountList();
     const scrollToIndex = vi.fn();
     const renderedRow = { dataset: { rowId: 'visible' }, getBoundingClientRect: () => ({ top: 12 }) };
-    const container = {
-      scrollTop: 0,
-      getBoundingClientRect: () => ({ top: 0 }),
-      querySelector: () => renderedRow,
-    };
+    const container = stubContainer({ querySelector: () => renderedRow });
     Object.defineProperty(el, 'logsContainer', { value: container });
     (el as any).virtualListItems = [row('visible')];
-    vi.spyOn(el, 'querySelector').mockReturnValue({
-      scrollToIndex,
-      layoutComplete: Promise.resolve(),
-    } as any);
+    vi.spyOn(el, 'querySelector').mockReturnValue(stubVirtualizer({ scrollToIndex }) as any);
 
     await (el as any).restoreScrollAnchor({ id: 'visible', offset: 2 });
 
@@ -267,17 +334,10 @@ describe('LogList — MED correctness', () => {
     const el = await mountList();
     const scrollToIndex = vi.fn();
     const renderedRow = { dataset: { rowId: 'visible' }, getBoundingClientRect: () => ({ top: 12 }) };
-    const container = {
-      scrollTop: 0,
-      getBoundingClientRect: () => ({ top: 0 }),
-      querySelector: vi.fn().mockReturnValueOnce(null).mockReturnValue(renderedRow),
-    };
+    const container = stubContainer({ querySelector: vi.fn().mockReturnValueOnce(null).mockReturnValue(renderedRow) });
     Object.defineProperty(el, 'logsContainer', { value: container });
     (el as any).virtualListItems = [row('visible')];
-    vi.spyOn(el, 'querySelector').mockReturnValue({
-      scrollToIndex,
-      layoutComplete: Promise.resolve(),
-    } as any);
+    vi.spyOn(el, 'querySelector').mockReturnValue(stubVirtualizer({ scrollToIndex }) as any);
 
     await (el as any).restoreScrollAnchor({ id: 'visible', offset: 2 });
     await new Promise((resolve) => requestAnimationFrame(resolve));
@@ -302,7 +362,7 @@ describe('LogList — MED correctness', () => {
     (el as any).spanListTree = [row('old')];
     (el as any).seenIds = new Set(['old']);
     (el as any).updateVisibleItems();
-    const container = { scrollTop: 100, clientHeight: 100, scrollHeight: 1000 };
+    const container = stubContainer({ scrollTop: 100, clientHeight: 100 });
     Object.defineProperty(el, 'logsContainer', { value: container });
     vi.spyOn(el as any, 'captureScrollAnchor').mockReturnValue({ id: 'old', offset: 0 });
     const restore = vi.spyOn(el as any, 'restoreScrollAnchor').mockResolvedValue(undefined);
@@ -641,7 +701,7 @@ describe('LogList — live tail resumes when scrolled back to the edge', () => {
   const withBuffer = async (scrollTop: number, over: Partial<Record<string, unknown>> = {}, scrollHeight = 5000) => {
     const el = await mountList();
     Object.assign(el as any, { isLiveStreaming: true, flipDirection: false, recentDataToBeAdded: [row('n1'), row('n2')], ...over });
-    Object.defineProperty(el, 'logsContainer', { configurable: true, get: () => ({ scrollTop, clientHeight: 500, scrollHeight }) });
+    Object.defineProperty(el, 'logsContainer', { configurable: true, get: () => stubContainer({ scrollTop, scrollHeight }) });
     return el;
   };
 

--- a/web-components/test/log-list-configurations.test.ts
+++ b/web-components/test/log-list-configurations.test.ts
@@ -1,0 +1,180 @@
+// One set of invariants, every configuration the log list ships in.
+//
+// The list has five independent axes — scroll direction, mode (logs/patterns/sessions),
+// tree vs list view, embedded vs standalone, wrapped vs dense rows — and until now each
+// was covered, if at all, by a bespoke test for one combination. A pagination rule that
+// held newest-first and broke oldest-first, or held in tree view and broke in list view,
+// had nowhere to fail. These tables assert the rules that must hold *regardless* of the
+// axes, so adding a configuration costs one row rather than a new file.
+import { describe, test, expect } from 'vitest';
+import { serverTransport, serverTransportFlipped, logPage, mountList, scrollHarness, flushFrames, ids, ROW_H } from './log-list-harness';
+import { MAX_RETAINED_ROWS } from '../src/log-list';
+
+type Config = { name: string; props: Record<string, any>; aggregate?: boolean };
+
+// Every shipped combination. `aggregate` marks the modes that page by skip-count rather
+// than by cursor and have no live/newer edge at all.
+const CONFIGS: Config[] = [
+  { name: 'newest-first, tree view', props: {} },
+  { name: 'oldest-first, tree view', props: { flipDirection: true } },
+  { name: 'newest-first, list view', props: { view: 'list' } },
+  { name: 'oldest-first, list view', props: { flipDirection: true, view: 'list' } },
+  { name: 'newest-first, wrapped rows', props: { wrapLines: true } },
+  { name: 'oldest-first, wrapped rows', props: { flipDirection: true, wrapLines: true } },
+  { name: 'narrow viewport', props: { isNarrow: true } },
+  { name: 'embedded (no newer edge)', props: { initialFetchUrl: '/embedded' } },
+  { name: 'sessions', props: { mode: 'sessions' } },
+  { name: 'patterns', props: { mode: 'patterns' }, aggregate: true },
+];
+
+const page = (ids: string[], over: any = {}) => logPage(ids, over);
+const transportFor = (c: Config, ...pages: any[]) => (c.props.flipDirection ? serverTransportFlipped(...pages) : serverTransport(...pages));
+
+// Load a first page, then a second that overlaps it on one row — what an inclusive
+// cursor actually returns.
+const loadTwoPages = async (c: Config) => {
+  const el = await mountList(c.props as any);
+  el.transport = transportFor(c, page(['a', 'b', 'c']), page(['c', 'd', 'e']));
+  await el.fetchData('first', true);
+  await el.fetchData('second', false, false, true);
+  return el;
+};
+
+describe.each(CONFIGS)('LogList configuration: $name', (config) => {
+  test('overlapping pages dedupe, and history lands on the history side', async () => {
+    const el = await loadTwoPages(config);
+
+    expect(ids(el)).toHaveLength(5);
+    expect(new Set(ids(el)).size).toBe(5);
+    // Older rows attach at whichever end history grows from (in that end's own order).
+    const historyEdge = config.props.flipDirection ? ids(el).slice(0, 2) : ids(el).slice(-2);
+    expect([...historyEdge].sort()).toEqual(['d', 'e']);
+  });
+
+  test('loadedCount reports the rows actually retained', async () => {
+    const el = await loadTwoPages(config);
+    expect((el as any).loadedCount).toBe((el as any).spanListTree.length);
+  });
+
+  test('the virtual list holds each row once, plus only sentinel rows', async () => {
+    const el = await loadTwoPages(config);
+    const items = (el as any).virtualListItems as any[];
+    const rows = items.filter((i) => 'id' in i);
+    const sentinels = items.filter((i) => !('id' in i));
+
+    expect(new Set(rows.map((r: any) => r.id)).size).toBe(rows.length);
+    expect(sentinels.every((s: any) => ['fetchRecent', 'loadMore', 'aggregateChildren'].includes(s.type))).toBe(true);
+  });
+
+  test('the load-more sentinel sits at the history edge', async () => {
+    const el = await loadTwoPages(config);
+    const items = (el as any).virtualListItems as any[];
+    const loadMoreIdx = items.findIndex((i: any) => i.type === 'loadMore');
+
+    expect(loadMoreIdx).toBeGreaterThanOrEqual(0);
+    expect(loadMoreIdx).toBe(config.props.flipDirection ? 0 : items.length - 1);
+  });
+
+  test('a newer edge exists only where newer rows can actually arrive', async () => {
+    const el = await loadTwoPages(config);
+    const hasRecent = ((el as any).virtualListItems as any[]).some((i: any) => i.type === 'fetchRecent');
+    // Aggregates have no live edge, and an embedded list is a fixed window into a
+    // dashboard panel — neither should offer to load newer rows.
+    expect(hasRecent).toBe(!config.aggregate && !config.props.initialFetchUrl);
+  });
+
+  test('a refresh replaces the result set instead of merging into it', async () => {
+    const el = await loadTwoPages(config);
+    el.transport = transportFor(config, page(['x', 'y']));
+
+    await el.fetchData('refreshed', true);
+
+    expect([...ids(el)].sort()).toEqual(['x', 'y']);
+    expect((el as any).seenIds.size).toBe(2);
+  });
+
+  test('an empty history page ends pagination without discarding what is loaded', async () => {
+    const el = await loadTwoPages(config);
+    const before = ids(el);
+    el.transport = transportFor(config, page([]));
+
+    await el.fetchData('exhausted', false, false, true);
+
+    expect(ids(el)).toEqual(before);
+    expect((el as any).hasMore).toBe(false);
+  });
+
+  test('a failed page keeps the rows on screen and reports the error as a toast', async () => {
+    const el = await loadTwoPages(config);
+    const before = ids(el);
+    el.transport = async () => {
+      throw new Error('upstream exploded');
+    };
+
+    await el.fetchData('boom', false, false, true);
+
+    expect(ids(el)).toEqual(before);
+    expect((el as any).fetchError).toBeNull(); // inline error is for an empty list only
+  });
+
+  test('retention is bounded and reopens the edge it evicted', async () => {
+    const el = await mountList(config.props as any);
+    const first = Array.from({ length: MAX_RETAINED_ROWS }, (_, i) => `r${String(i).padStart(5, '0')}`);
+    el.transport = transportFor(config, page(first), page(Array.from({ length: 200 }, (_, i) => `o${i}`)));
+    await el.fetchData('first', true);
+    await el.fetchData('second', false, false, true);
+
+    // Patterns/sessions are skip-paginated aggregates and deliberately keep everything.
+    if (config.props.mode !== 'logs' && config.props.mode) {
+      expect(ids(el).length).toBeGreaterThan(0);
+      return;
+    }
+    expect(ids(el)).toHaveLength(MAX_RETAINED_ROWS);
+    expect((el as any).hasNewer).toBe(true);
+  });
+});
+
+// Scroll behaviour is only meaningful for the row-per-log modes; patterns and sessions
+// use a measured layout whose geometry the dense simulator does not model.
+const SCROLLABLE = CONFIGS.filter((c) => !c.aggregate && c.props.mode !== 'sessions');
+
+describe.each(SCROLLABLE)('LogList scrolling: $name', (config) => {
+  const seeded = async (n: number) => {
+    const el = await mountList(config.props as any);
+    el.transport = transportFor(config, page(Array.from({ length: n }, (_, i) => `r${String(i).padStart(5, '0')}`)));
+    await el.fetchData('first', true);
+    await flushFrames(); // a refresh parks the viewport at the newest edge on the next frame
+    return el;
+  };
+  // Rows sit after the leading sentinel, if this configuration has one.
+  const rowAt = (el: any, sim: any) => {
+    const item = el.virtualListItems[sim.firstVisibleIndex];
+    return item && 'id' in item ? item.id : undefined;
+  };
+
+  test('paging history never moves the row the reader is looking at', async () => {
+    const el = await seeded(400);
+    const sim = scrollHarness(el);
+    sim.scrollTo(150 * ROW_H);
+    const anchor = rowAt(el, sim);
+    el.transport = transportFor(config, page(Array.from({ length: 200 }, (_, i) => `o${String(i).padStart(5, '0')}`)));
+
+    await el.fetchData('older', false, false, true);
+    await flushFrames();
+
+    expect(rowAt(el, sim)).toBe(anchor);
+  });
+
+  test('the reader is never left at a scroll offset the content cannot support', async () => {
+    const el = await seeded(400);
+    const sim = scrollHarness(el);
+    sim.scrollTo(380 * ROW_H);
+    el.transport = transportFor(config, page([]));
+
+    await el.fetchData('exhausted', false, false, true);
+    await flushFrames();
+
+    expect(sim.scrollTop).toBeLessThanOrEqual(sim.maxScroll);
+    expect(sim.scrollTop).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/web-components/test/log-list-embedded.test.ts
+++ b/web-components/test/log-list-embedded.test.ts
@@ -1,0 +1,130 @@
+// A log list embedded as a dashboard widget.
+//
+// On the log explorer the list owns the page: it reads the browser URL and the time
+// picker triggers refetches on `document`. As a dashboard widget it owns nothing — the
+// dashboard's time picker, variables and auto-refresh drive it, and its query comes from
+// the widget definition via `initialFetchUrl`. That second mode had no tests at all, and
+// it is the one the user reported as broken.
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+import { serverTransport, logPage, mountList, ids } from './log-list-harness';
+
+const setPageUrl = (search: string) => window.history.replaceState({}, '', `/p/proj-1/dashboards/dash-1${search}`);
+
+// The element as `renderLogsWidget` emits it: a project id and a widget-scoped fetch URL.
+const embedded = async (props: Record<string, any> = {}) =>
+  mountList({
+    projectId: 'proj-1',
+    initialFetchUrl: '/p/proj-1/log_explorer/data?json=true&layout=1&query=name%20!%3D%20null',
+    ...props,
+  } as any);
+
+beforeEach(() => setPageUrl(''));
+afterEach(() => vi.restoreAllMocks());
+
+describe('embedded log widget: fetch URL', () => {
+  test('keeps the widget query rather than reading the dashboard URL', async () => {
+    const el = await embedded();
+    el.transport = serverTransport(logPage(['a']));
+
+    const url = new URL((el as any).buildJsonUrl());
+
+    expect(url.pathname).toBe('/p/proj-1/log_explorer/data');
+    expect(url.searchParams.get('query')).toBe('name != null');
+  });
+
+  test('adopts the dashboard time range from the page URL', async () => {
+    setPageUrl('?since=24H&other=ignored');
+    const el = await embedded();
+
+    const url = new URL((el as any).buildJsonUrl());
+
+    expect(url.searchParams.get('since')).toBe('24H');
+    expect(url.searchParams.get('other')).toBeNull(); // only time params are adopted
+  });
+
+  test('an absolute dashboard range overrides the widget default', async () => {
+    setPageUrl('?from=2024-01-01T00:00:00Z&to=2024-01-02T00:00:00Z');
+    const el = await embedded();
+
+    const url = new URL((el as any).buildJsonUrl());
+
+    expect(url.searchParams.get('from')).toBe('2024-01-01T00:00:00Z');
+    expect(url.searchParams.get('to')).toBe('2024-01-02T00:00:00Z');
+  });
+
+  test('a standalone list ignores initialFetchUrl and derives the path from its mode', async () => {
+    setPageUrl('?since=1H');
+    const el = await mountList({ projectId: 'proj-1', mode: 'patterns' } as any);
+
+    expect((el as any).buildJsonUrl()).toContain('/p/proj-1/log_explorer/patterns');
+  });
+});
+
+describe('embedded log widget: refresh triggers', () => {
+  // The dashboard time picker (TimePicker.hs) triggers on `document`.
+  test('refetches when the dashboard time picker fires', async () => {
+    const el = await embedded();
+    const refetch = vi.spyOn(el as any, 'refetchLogs').mockResolvedValue(undefined);
+
+    document.dispatchEvent(new CustomEvent('update-query', { detail: {} }));
+
+    // waitFor, not a fixed sleep: the refetch is debounced 50ms and a hard timeout
+    // races that under parallel load.
+    await vi.waitFor(() => expect(refetch).toHaveBeenCalled());
+  });
+
+  // Regression: the dashboard auto-refresh timer and the variable fallback both
+  // dispatch on `window`. A window-dispatched event never reaches a `document`
+  // listener, so a logs widget sat frozen on a dashboard set to refresh every 30s
+  // while every chart around it updated.
+  test('refetches when the dashboard auto-refresh fires on window', async () => {
+    const el = await embedded();
+    const refetch = vi.spyOn(el as any, 'refetchLogs').mockResolvedValue(undefined);
+
+    window.dispatchEvent(new CustomEvent('update-query'));
+
+    await vi.waitFor(() => expect(refetch).toHaveBeenCalled());
+  });
+
+  test('a widened-time-range refetch from the list itself does not loop', async () => {
+    const el = await embedded();
+    const refetch = vi.spyOn(el as any, 'refetchLogs').mockResolvedValue(undefined);
+
+    window.dispatchEvent(new CustomEvent('update-query', { detail: { source: 'expand-timerange' } }));
+    await new Promise((r) => setTimeout(r, 300)); // well past the 50ms debounce
+
+    expect(refetch).not.toHaveBeenCalled();
+  });
+
+  test('stops listening once the widget is removed from the dashboard', async () => {
+    const el = await embedded();
+    const refetch = vi.spyOn(el as any, 'refetchLogs').mockResolvedValue(undefined);
+    el.remove();
+
+    window.dispatchEvent(new CustomEvent('update-query'));
+    document.dispatchEvent(new CustomEvent('update-query', { detail: {} }));
+    await new Promise((r) => setTimeout(r, 300)); // well past the 50ms debounce
+
+    expect(refetch).not.toHaveBeenCalled();
+  });
+});
+
+describe('embedded log widget: chrome', () => {
+  test('offers no "load newer" edge — a widget is a window, not a live tail', async () => {
+    const el = await embedded();
+    el.transport = serverTransport(logPage(['a', 'b']));
+    await el.fetchData('first', true);
+
+    expect(((el as any).virtualListItems as any[]).some((i) => i.type === 'fetchRecent')).toBe(false);
+    expect(ids(el)).toEqual(['a', 'b']);
+  });
+
+  test('still pages history, so a widget is not capped at one page', async () => {
+    const el = await embedded();
+    el.transport = serverTransport(logPage(['a', 'b']), logPage(['c']));
+    await el.fetchData('first', true);
+    await el.fetchData('more', false, false, true);
+
+    expect(ids(el)).toEqual(['a', 'b', 'c']);
+  });
+});

--- a/web-components/test/log-list-failure-states.test.ts
+++ b/web-components/test/log-list-failure-states.test.ts
@@ -1,0 +1,193 @@
+// What the reader sees when a query or a page fails.
+//
+// The design rule is that an error must never be silent, and it must land where the reader
+// is looking: a bad field belongs under the query box next to the editor's own squiggles,
+// while a failed *page* of an otherwise-working query must not blank the rows already on
+// screen. Getting that split wrong during an incident either hides the cause or throws away
+// the evidence. None of these paths were tested.
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+import { serverTransport, logPage, deferredTransport, mountList, ids, treeFromLogs } from './log-list-harness';
+
+// The two channels the component reports on: a parse error routed to the query box, and a
+// transient toast. Both are CustomEvents on document.body.
+const listen = () => {
+  const parseErrors: string[] = [];
+  const toasts: string[] = [];
+  const onParse = (e: any) => parseErrors.push(e.detail);
+  const onToast = (e: any) => toasts.push(...e.detail.value);
+  document.body.addEventListener('showParseError', onParse);
+  document.body.addEventListener('errorToast', onToast);
+  return {
+    parseErrors,
+    toasts,
+    stop: () => {
+      document.body.removeEventListener('showParseError', onParse);
+      document.body.removeEventListener('errorToast', onToast);
+    },
+  };
+};
+
+const loaded = async (props: Record<string, any> = {}) => {
+  const el = await mountList(props as any);
+  el.transport = serverTransport(logPage(['a', 'b']));
+  await el.fetchData('first', true);
+  return el;
+};
+
+let events: ReturnType<typeof listen>;
+beforeEach(() => (events = listen()));
+afterEach(() => {
+  events.stop();
+  vi.restoreAllMocks();
+});
+
+describe('a query the server rejects', () => {
+  // It belongs under the query box, beside the editor's client-side squiggles — the same
+  // channel the server's HX-Trigger uses — not only in the row area.
+  test('is routed to the query box', async () => {
+    const el = await mountList();
+    (window as any).logDataPromise = Promise.resolve({ error: 'unknown field: srvice.name' });
+
+    await el.fetchData('/p/x/log_explorer/data', true);
+
+    expect(events.parseErrors).toEqual(['unknown field: srvice.name']);
+    delete (window as any).logDataPromise;
+  });
+
+  test('is shown inline when there is nothing else on screen', async () => {
+    const el = await mountList();
+    el.transport = async () => {
+      throw new Error('unknown field: srvice.name');
+    };
+
+    await el.fetchData('bad', true);
+
+    expect((el as any).fetchError).toBe('unknown field: srvice.name');
+  });
+});
+
+describe('a page that fails after rows are already showing', () => {
+  // Blanking the list would throw away the evidence the reader is working from; the failure
+  // belongs in a toast instead.
+  test('keeps the rows and reports the failure as a toast', async () => {
+    const el = await loaded();
+    el.transport = async () => {
+      throw new Error('upstream exploded');
+    };
+
+    await el.fetchData('more', false, false, true);
+
+    expect(ids(el)).toEqual(['a', 'b']);
+    expect((el as any).fetchError).toBeNull();
+    expect(events.toasts).toEqual(['upstream exploded']);
+  });
+
+  // A bare `new Error()` (and some DOM exceptions) carry an empty message. Passing that
+  // straight through renders an empty toast: a failure the reader is told nothing about.
+  test('a failure without a message still says something', async () => {
+    const el = await loaded();
+    el.transport = async () => {
+      throw new Error();
+    };
+
+    await el.fetchData('more', false, false, true);
+
+    expect(events.toasts).toEqual(['Network error']);
+  });
+
+  test('a non-Error throw is reported too', async () => {
+    const el = await loaded();
+    el.transport = async () => {
+      throw 'a bare string';
+    };
+
+    await el.fetchData('more', false, false, true);
+
+    expect(events.toasts).toEqual(['Network error']);
+  });
+
+  // The in-flight guard has to be released on the error path too, or the list refuses
+  // every later page and looks permanently stuck at the bottom.
+  test('the list can page again after a failure', async () => {
+    const el = await loaded();
+    el.transport = async () => {
+      throw new Error('transient');
+    };
+    await el.fetchData('more', false, false, true);
+    expect((el as any).isLoadingMore).toBe(false);
+
+    el.transport = serverTransport(logPage(['c']));
+    await el.fetchData('retry', false, false, true);
+
+    expect(ids(el)).toContain('c');
+  });
+
+  test('a failed recent fetch does not strand the live-tail guard either', async () => {
+    const el = await loaded();
+    el.transport = async () => {
+      throw new Error('transient');
+    };
+
+    await el.fetchData('newer', false, true);
+
+    expect((el as any).isFetchingRecent).toBe(false);
+  });
+});
+
+describe('a superseded request', () => {
+  // Latest-request-wins: the reader has already moved on, so neither the stale rows nor a
+  // stale error may replace what the newer query put on screen.
+  test('cannot report its error over the newer query', async () => {
+    const el = await mountList();
+    const transport = deferredTransport();
+    el.transport = transport;
+
+    const stale = el.fetchData('old-query', true);
+    const fresh = el.fetchData('new-query', true);
+    transport.settle(1, treeFromLogs(['fresh']));
+    await fresh;
+    transport.pending[0].resolve(Promise.reject(new Error('stale failure')));
+    await stale;
+
+    expect(ids(el)).toEqual(['fresh']);
+    expect((el as any).fetchError).toBeNull();
+    expect(events.toasts).toEqual([]);
+  });
+});
+
+describe('an empty result', () => {
+  test('clears the previous query rather than leaving its rows on screen', async () => {
+    const el = await loaded();
+    el.transport = serverTransport(logPage([], { hasMore: false }));
+
+    await el.fetchData('new-query', true);
+
+    expect(ids(el)).toEqual([]);
+    expect((el as any).seenIds.size).toBe(0);
+  });
+
+  // An empty page at the end of history is not an empty result set: the rows already
+  // loaded stay, and only that edge closes.
+  test('at the end of history it closes the edge and keeps the rows', async () => {
+    const el = await loaded();
+    el.transport = serverTransport(logPage([]));
+
+    await el.fetchData('older', false, false, true);
+
+    expect(ids(el)).toEqual(['a', 'b']);
+    expect((el as any).hasMore).toBe(false);
+  });
+
+  // Live tail ticks every few seconds and is usually quiet; a quiet tick must not be
+  // mistaken for "history exhausted" and flash the widen-the-range prompt.
+  test('a quiet live-tail tick does not flash the widen-time-range prompt', async () => {
+    const el = await loaded();
+    (el as any).expandTimeRange = false;
+    el.transport = serverTransport(logPage([]));
+
+    await el.fetchData('newer', false, true);
+
+    expect((el as any).expandTimeRange).toBe(false);
+    expect((el as any).hasNewer).toBe(false);
+  });
+});

--- a/web-components/test/log-list-harness.ts
+++ b/web-components/test/log-list-harness.ts
@@ -1,6 +1,7 @@
 // Shared harness for high-level LogList behavior tests: mount the real component,
 // feed canned {tree, meta} via the transport seam (no Web Worker / network), and
 // drive fetchData / events as a user would. See web_components_test_harness memory.
+import { render, html } from 'lit';
 import { LogList } from '../src/log-list';
 import { groupSpans } from '../src/log-worker-functions';
 
@@ -126,6 +127,167 @@ export const mountList = async (props: Partial<LogList> = {}) => {
   document.body.appendChild(el);
   await el.updateComplete;
   return el;
+};
+
+// ── Scroll / layout simulation ───────────────────────────────────────────────
+// jsdom computes no layout, so until now every scroll-anchoring test had to mock
+// captureScrollAnchor/restoreScrollAnchor — i.e. mock out the exact code that
+// decides where the user ends up after a page merge. Those tests could not have
+// caught "clicking Show earlier events throws you back to the top".
+//
+// This models the geometry the real component reads: dense fixed-height rows, a
+// fixed viewport, a scrollTop the browser clamps to the content, and a virtualizer
+// that only mounts rows inside its overhang runway. `keyed(virtualizerEpoch)`
+// destroys and recreates that virtualizer, and a fresh one reports a zero-height
+// scroll range for a frame — which is what clamps the user's scrollTop to 0. That
+// frame is reproduced here because it is the bug.
+export const ROW_H = 28; // DenseRowFlowLayout._itemSize.height
+const OVERHANG = 200; // DenseRowFlowLayout._overhang
+
+export type ScrollSim = ReturnType<typeof scrollHarness>;
+
+export const scrollHarness = (el: LogList, { viewportHeight = 560 } = {}) => {
+  let scrollTop = 0;
+  let sentinelHost: HTMLElement | null = null;
+  // A keyed remount swaps in a virtualizer that has not laid out yet: no rows
+  // mounted, zero scroll range. Cleared when it lays out (rAF / layoutComplete).
+  let remounting = false;
+  const items = () => (el as any).virtualListItems as any[];
+  const contentHeight = () => (remounting ? 0 : items().length * ROW_H);
+  const maxScroll = () => Math.max(0, contentHeight() - viewportHeight);
+  const clamp = (v: number) => Math.max(0, Math.min(maxScroll(), v));
+  // The selector the component builds is `[data-row-id="<CSS.escape(id)>"]`.
+  const idFromSelector = (sel: string) => sel.match(/\[data-row-id="(.*)"\]/)?.[1].replace(/\\(.)/g, '$1') ?? null;
+
+  const rowEl = (i: number) => {
+    const item = items()[i];
+    const top = i * ROW_H - scrollTop;
+    return { dataset: { rowId: item.id }, getBoundingClientRect: () => ({ top, bottom: top + ROW_H, height: ROW_H, left: 0, right: 0 }) };
+  };
+  // Only rows inside the runway exist in the DOM — the recycling the anchor
+  // fallback path is there to survive.
+  const mountedRows = () =>
+    remounting
+      ? []
+      : items().reduce<any[]>((acc, item, i) => {
+          const top = i * ROW_H - scrollTop;
+          if ('id' in item && top + ROW_H > -OVERHANG && top < viewportHeight + OVERHANG) acc.push(rowEl(i));
+          return acc;
+        }, []);
+
+  const container: any = {
+    get scrollTop() { return scrollTop; },
+    set scrollTop(v: number) { scrollTop = clamp(v); },
+    get scrollHeight() { return contentHeight(); },
+    clientHeight: viewportHeight,
+    getBoundingClientRect: () => ({ top: 0, bottom: viewportHeight, height: viewportHeight, left: 0, right: 0 }),
+    querySelectorAll: (sel: string) => (sel.includes('data-row-id') ? mountedRows() : []),
+    querySelector: (sel: string) => mountedRows().find((r) => r.dataset.rowId === idFromSelector(sel)) ?? null,
+    classList: { add() {}, remove() {} },
+  };
+  Object.defineProperty(el, 'logsContainer', { configurable: true, get: () => container });
+
+  const settle = () => { remounting = false; };
+  const virtualizer = {
+    scrollToIndex: (i: number, _pos: string) => { settle(); container.scrollTop = i * ROW_H; },
+    get layoutComplete() { settle(); return Promise.resolve(); },
+    querySelectorAll: (sel: string) => container.querySelectorAll(sel),
+  };
+  const origQuery = el.querySelector.bind(el);
+  (el as any).querySelector = (sel: string) => (sel === 'lit-virtualizer' ? virtualizer : origQuery(sel));
+
+  // The remount happens during Lit's update, before `updateComplete` resolves —
+  // so a restore that awaits updateComplete always resumes on the collapsed frame.
+  const origUpdated = (el as any).updated.bind(el);
+  (el as any).updated = (changed: Map<string, any>) => {
+    if (changed.has('virtualizerEpoch')) {
+      remounting = true;
+      scrollTop = 0; // the browser clamps to a zero-height scroll range
+      requestAnimationFrame(settle); // the new virtualizer lays out on the next frame
+    }
+    origUpdated(changed);
+  };
+
+  return {
+    container,
+    virtualizer,
+    get scrollTop() { return scrollTop; },
+    get maxScroll() { return maxScroll(); },
+    get atTop() { return scrollTop <= 0; },
+    // Move the viewport the way a user does, then run what a real scroll runs.
+    scrollTo(v: number) { container.scrollTop = v; el.handleListScroll?.(); },
+    scrollToBottom() { this.scrollTo(maxScroll()); },
+    // The virtualizer reports its rendered range; drive the same event it fires.
+    emitVisibility() {
+      const first = Math.max(0, Math.floor((scrollTop - OVERHANG) / ROW_H));
+      const last = Math.min(items().length - 1, Math.ceil((scrollTop + viewportHeight + OVERHANG) / ROW_H));
+      el.handleVisibilityChange({ first, last });
+    },
+    // Index of the first/last row the user can actually see (sentinels included).
+    get firstVisibleIndex() { return Math.floor(scrollTop / ROW_H); },
+    get lastVisibleIndex() { return Math.min(items().length - 1, Math.floor((scrollTop + viewportHeight - 1) / ROW_H)); },
+    settle,
+    // lit-virtualizer mounts nothing under jsdom, so the sentinel rows — and with
+    // them the IntersectionObservers that auto-page the list — never existed in any
+    // test. Render the real templates into a host so their refs resolve and their
+    // observers register exactly as in the browser; `fireSentinel` then drives the
+    // production callback rather than a re-implementation of it.
+    async mountSentinels() {
+      const host = sentinelHost ?? (sentinelHost = el.appendChild(document.createElement('tbody')));
+      render(html`${(el as any).renderFetchRecentButton()}${(el as any).renderLoadMoreButton()}`, host);
+      await new Promise((r) => requestAnimationFrame(r)); // observers are registered in a rAF
+      const rows = [...host.querySelectorAll('tr')];
+      return {
+        host,
+        recent: rows.find((r) => r.id === 'recent-logs') ?? null,
+        loadMore: rows.find((r) => r.id !== 'recent-logs') ?? null,
+      };
+    },
+  };
+};
+
+// Container / virtualizer stubs carrying every member the component touches during
+// ordinary operation. Ad-hoc literals that omitted one (classList for the scroll-paint
+// toggle, rects for anchoring, querySelectorAll for the blank-list watchdog) threw from
+// timers *after* their test had finished — vitest reported them as unhandled errors, and
+// a genuine failure could hide in that noise.
+export const stubContainer = (over: Record<string, any> = {}) => ({
+  scrollTop: 0,
+  clientHeight: 500,
+  scrollHeight: 1000,
+  classList: { add() {}, remove() {} },
+  getBoundingClientRect: () => ({ top: 0, bottom: 500, height: 500, left: 0, right: 0 }),
+  querySelector: () => null,
+  querySelectorAll: () => [],
+  ...over,
+});
+// Reports one row inside the viewport by default, so the blank-list watchdog reads the
+// list as healthy and does not nudge scrollTop out from under an assertion. Override
+// querySelectorAll with [] to exercise the stuck-blank recovery itself.
+export const stubVirtualizer = (over: Record<string, any> = {}) => ({
+  scrollToIndex: () => {},
+  layoutComplete: Promise.resolve(),
+  querySelectorAll: () => [{ getBoundingClientRect: () => ({ top: 0, bottom: 28 }) }],
+  ...over,
+});
+
+// Replace only the selectors you name, delegating everything else to the real DOM.
+//
+// The component renders into its light DOM, so `@query('#logs_list_container_inner')`
+// goes through `el.querySelector` too — a blanket mock hands the virtualizer stub back
+// as the scroll container, and the background blank-list watchdog then throws from a
+// timer after the test has finished.
+export const stubQuery = (el: LogList, stubs: Record<string, unknown>) => {
+  const real = el.querySelector.bind(el);
+  (el as any).querySelector = (sel: string) => (sel in stubs ? stubs[sel] : real(sel));
+};
+
+// The browser reporting a sentinel as visible. `el` narrows it to one sentinel.
+export const fireSentinel = (el?: Element | null) => (globalThis as any).triggerIntersection(el ?? undefined);
+
+// Let queued rAF callbacks and microtasks run — anchor restoration is async.
+export const flushFrames = async (n = 3) => {
+  for (let i = 0; i < n; i++) await new Promise((r) => requestAnimationFrame(r));
 };
 
 // ── Live push transport ──────────────────────────────────────────────────────

--- a/web-components/test/log-list-keyboard.test.ts
+++ b/web-components/test/log-list-keyboard.test.ts
@@ -1,0 +1,181 @@
+// Keyboard navigation of the log grid.
+//
+// The table is an ARIA grid driven by `aria-activedescendant`: focus never leaves the
+// table, and a roving marker moves instead. That marker has to skip the sentinel rows
+// (which are not events), clamp at both ends, and survive the list changing underneath
+// it. None of it was tested, and it is the whole keyboard/screen-reader path.
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import { row, mountList, stubVirtualizer, stubQuery } from './log-list-harness';
+
+const seeded = async (n = 5, props: Record<string, any> = {}) => {
+  const el = await mountList(props as any);
+  const rows = Array.from({ length: n }, (_, i) => row(`r${i}`));
+  (el as any).spanListTree = rows;
+  (el as any).seenIds = new Set(rows.map((r) => r.id));
+  (el as any).updateVisibleItems();
+  await el.updateComplete;
+  return el;
+};
+
+const press = (el: any, key: string, target?: Element) => {
+  const event = new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true });
+  Object.defineProperty(event, 'target', { value: target ?? document.createElement('td') });
+  el.handleGridKeydown(event);
+  return event;
+};
+
+const focused = (el: any) => el.focusedRowId;
+
+beforeEach(() => vi.restoreAllMocks());
+
+describe('roving focus', () => {
+  test('the first Arrow Down lands on the first row, not the sentinel above it', async () => {
+    const el = await seeded();
+    // Newest-first puts a "load newer" sentinel at index 0; the marker must skip it.
+    expect(((el as any).virtualListItems[0] as any).type).toBe('fetchRecent');
+
+    press(el, 'ArrowDown');
+    await el.updateComplete;
+
+    expect(focused(el)).toBe('r0');
+  });
+
+  test('arrow keys walk one row at a time in both directions', async () => {
+    const el = await seeded();
+    press(el, 'ArrowDown');
+    await el.updateComplete;
+    press(el, 'ArrowDown');
+    await el.updateComplete;
+    expect(focused(el)).toBe('r1');
+
+    press(el, 'ArrowUp');
+    await el.updateComplete;
+    expect(focused(el)).toBe('r0');
+  });
+
+  test('paging moves ten rows and clamps rather than running off the end', async () => {
+    const el = await seeded(30);
+    press(el, 'ArrowDown');
+    await el.updateComplete;
+    press(el, 'PageDown');
+    await el.updateComplete;
+    expect(focused(el)).toBe('r10');
+
+    press(el, 'PageUp');
+    await el.updateComplete;
+    expect(focused(el)).toBe('r0'); // clamped at the top, not negative
+  });
+
+  test('Home and End jump to the real first and last events', async () => {
+    const el = await seeded(30);
+
+    press(el, 'End');
+    await el.updateComplete;
+    expect(focused(el)).toBe('r29');
+
+    press(el, 'Home');
+    await el.updateComplete;
+    expect(focused(el)).toBe('r0');
+  });
+
+  test('the marker never lands on a sentinel row at either end', async () => {
+    const el = await seeded(3);
+    const sentinelIds = new Set(
+      ((el as any).virtualListItems as any[]).filter((i) => !('id' in i)).map((i) => i.type)
+    );
+    expect(sentinelIds.size).toBeGreaterThan(0);
+
+    for (const key of ['Home', 'End', 'ArrowDown', 'ArrowUp', 'PageDown', 'PageUp']) {
+      press(el, key);
+      await el.updateComplete;
+      expect((el as any).spanListTree.map((r: any) => r.id)).toContain(focused(el));
+    }
+  });
+
+  test('navigation keys are consumed so the page does not scroll as well', async () => {
+    const el = await seeded();
+    for (const key of ['ArrowDown', 'ArrowUp', 'PageDown', 'PageUp', 'Home', 'End']) {
+      expect(press(el, key).defaultPrevented).toBe(true);
+    }
+  });
+
+  test('an empty list has nothing to focus and does not throw', async () => {
+    const el = await mountList();
+    expect(() => press(el, 'ArrowDown')).not.toThrow();
+    expect(focused(el)).toBeNull();
+  });
+});
+
+describe('activation', () => {
+  test('Enter and Space open the focused row', async () => {
+    const el = await seeded();
+    press(el, 'ArrowDown');
+    await el.updateComplete;
+    const click = vi.fn();
+    stubQuery(el, { '[data-row-id="r0"]': { click } });
+
+    for (const key of ['Enter', ' ']) {
+      expect(press(el, key).defaultPrevented).toBe(true);
+    }
+    await new Promise((r) => requestAnimationFrame(r));
+
+    expect(click).toHaveBeenCalled();
+  });
+
+  test('activation with nothing focused is a no-op, not an error', async () => {
+    const el = await seeded();
+    expect(press(el, 'Enter').defaultPrevented).toBe(false);
+  });
+});
+
+describe('controls inside a row keep their own keys', () => {
+  // A button's Enter must not also open the row behind it, and typing in a header
+  // filter must not page the list out from under the cursor.
+  test.each(['button', 'a', 'input', 'textarea', 'select'])('%s owns its keystrokes', async (tag) => {
+    const el = await seeded();
+    const control = document.createElement(tag);
+
+    const down = press(el, 'ArrowDown', control);
+    const enter = press(el, 'Enter', control);
+
+    expect(down.defaultPrevented).toBe(false);
+    expect(enter.defaultPrevented).toBe(false);
+    expect(focused(el)).toBeNull();
+  });
+
+  test('an editable cell owns its keystrokes too', async () => {
+    const el = await seeded();
+    const editable = document.createElement('div');
+    editable.setAttribute('contenteditable', 'true');
+
+    expect(press(el, 'ArrowDown', editable).defaultPrevented).toBe(false);
+    expect(focused(el)).toBeNull();
+  });
+});
+
+describe('bringing the focused row into view', () => {
+  test('Home and End pin the list to that edge rather than scrolling the minimum', async () => {
+    const el = await seeded(200);
+    const scrollToIndex = vi.fn();
+    stubQuery(el, { 'lit-virtualizer': stubVirtualizer({ scrollToIndex }) });
+
+    press(el, 'End');
+    await el.updateComplete;
+    expect(scrollToIndex).toHaveBeenLastCalledWith(expect.any(Number), 'end');
+
+    press(el, 'Home');
+    await el.updateComplete;
+    expect(scrollToIndex).toHaveBeenLastCalledWith(expect.any(Number), 'start');
+  });
+
+  test('stepping through rows only scrolls as far as it needs to', async () => {
+    const el = await seeded(200);
+    const scrollToIndex = vi.fn();
+    stubQuery(el, { 'lit-virtualizer': stubVirtualizer({ scrollToIndex }) });
+
+    press(el, 'ArrowDown');
+    await el.updateComplete;
+
+    expect(scrollToIndex).toHaveBeenLastCalledWith(expect.any(Number), 'nearest');
+  });
+});

--- a/web-components/test/log-list-row-selection.test.ts
+++ b/web-components/test/log-list-row-selection.test.ts
@@ -1,0 +1,129 @@
+// Selecting a row to open its detail panel.
+//
+// The clicked row is marked with `bg-fillBrand-strong` and the previously selected one is
+// unmarked. That same class is also what paints the latency bar *inside* every row and a
+// handful of other in-row elements, so "find the previously selected row" has to mean the
+// row, not the first descendant that happens to share the class. Getting it wrong leaves
+// two rows looking selected and strips the colour off a latency bar.
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mountList } from './log-list-harness';
+
+const SELECTED = 'bg-fillBrand-strong';
+
+// A rendered row: the <tr> the click lands on, plus the latency bar inside it that shares
+// the selection class.
+const buildRows = (n: number) => {
+  const tbody = document.createElement('tbody');
+  const rows = Array.from({ length: n }, (_, i) => {
+    const tr = document.createElement('tr');
+    tr.dataset.rowId = `r${i}`;
+    const bar = document.createElement('div');
+    bar.className = `h-full ${SELECTED} rounded-sm`; // the latency bar
+    tr.appendChild(bar);
+    tbody.appendChild(tr);
+    return { tr, bar };
+  });
+  document.body.appendChild(tbody);
+  return rows;
+};
+
+const clickRow = (el: any, tr: HTMLElement, id: string) => {
+  const event = { currentTarget: tr, stopPropagation: () => {} } as any;
+  el.toggleLogRow(event, [id, '2024-01-01T00:00:00Z', 'spans'], 'proj-1');
+};
+
+let ajax: ReturnType<typeof vi.fn>;
+
+// The chrome the handler reaches for: the detail panel it swaps into, its resizer, and the
+// loading indicator. main.ts installs updateUrlState as a window global in production.
+const mountChrome = () => {
+  for (const id of ['log_details_container', 'resizer-details_width-wrapper', 'details_indicator']) {
+    const node = document.createElement('div');
+    node.id = id;
+    document.body.appendChild(node);
+  }
+};
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+  window.history.replaceState({}, '', '/p/proj-1/log_explorer');
+  mountChrome();
+  (window as any).updateUrlState = (key: string, value: string) => {
+    const p = new URLSearchParams(window.location.search);
+    p.set(key, value);
+    window.history.replaceState({}, '', `${window.location.pathname}?${p}`);
+  };
+  ajax = vi.fn().mockResolvedValue(undefined);
+  (window as any).htmx = { ...(window as any).htmx, ajax };
+});
+afterEach(() => vi.restoreAllMocks());
+
+describe('selecting a row', () => {
+  test('marks the clicked row', async () => {
+    const el = await mountList();
+    const rows = buildRows(2);
+
+    clickRow(el, rows[0].tr, 'r0');
+
+    expect(rows[0].tr.classList.contains(SELECTED)).toBe(true);
+  });
+
+  // The bug: scoping the "previously selected" lookup to descendants matched a latency bar
+  // long before it reached the previous row, so the old row stayed marked.
+  test('unmarks the previously selected row', async () => {
+    const el = await mountList();
+    const rows = buildRows(3);
+
+    clickRow(el, rows[0].tr, 'r0');
+    clickRow(el, rows[2].tr, 'r2');
+
+    expect(rows[2].tr.classList.contains(SELECTED)).toBe(true);
+    expect(rows[0].tr.classList.contains(SELECTED)).toBe(false);
+  });
+
+  test('exactly one row is ever selected', async () => {
+    const el = await mountList();
+    const rows = buildRows(4);
+
+    clickRow(el, rows[1].tr, 'r1');
+    clickRow(el, rows[3].tr, 'r3');
+    clickRow(el, rows[0].tr, 'r0');
+
+    expect(rows.filter((r) => r.tr.classList.contains(SELECTED)).map((_, i) => i)).toHaveLength(1);
+    expect(rows[0].tr.classList.contains(SELECTED)).toBe(true);
+  });
+
+  // The same class paints the latency bar. Stripping it turns a bar colourless — and the
+  // bar is the row's whole point in a waterfall.
+  test('leaves the latency bars inside rows alone', async () => {
+    const el = await mountList();
+    const rows = buildRows(3);
+
+    clickRow(el, rows[0].tr, 'r0');
+    clickRow(el, rows[2].tr, 'r2');
+
+    expect(rows.every((r) => r.bar.classList.contains(SELECTED))).toBe(true);
+  });
+
+  test('re-clicking the selected row keeps it selected', async () => {
+    const el = await mountList();
+    const rows = buildRows(2);
+
+    clickRow(el, rows[0].tr, 'r0');
+    clickRow(el, rows[0].tr, 'r0');
+
+    expect(rows[0].tr.classList.contains(SELECTED)).toBe(true);
+  });
+});
+
+describe('the request it issues', () => {
+  test('asks for that row\'s detail and records it in the URL so the view is shareable', async () => {
+    const el = await mountList();
+    const rows = buildRows(1);
+
+    clickRow(el, rows[0].tr, 'evt-9');
+
+    expect(ajax).toHaveBeenCalledWith('GET', expect.stringContaining('/p/proj-1/log_explorer/evt-9/'), expect.objectContaining({ target: '#log_details_container' }));
+    expect(new URLSearchParams(window.location.search).get('target_event')).toContain('evt-9');
+  });
+});

--- a/web-components/test/log-list-scroll-position.test.ts
+++ b/web-components/test/log-list-scroll-position.test.ts
@@ -1,0 +1,406 @@
+// Where does the reader end up after a page merge?
+//
+// Every other log-list test mocks captureScrollAnchor/restoreScrollAnchor, so none
+// of them could observe the answer. These run the real anchoring code against the
+// simulated layout in `scrollHarness`, and assert the only thing the user judges
+// the list by: the row under their eyes did not move.
+//
+// Regression origin: "scroll down to Show earlier events, click it, and instead of
+// the list continuing you are thrown back to the top and the load-newer row at the
+// top fires." The retention window evicting rows remounts the virtualizer
+// (`keyed(virtualizerEpoch)`), a fresh virtualizer has a zero-height scroll range
+// for one frame, and the browser clamps scrollTop to 0 on that frame.
+import { describe, test, expect, vi } from 'vitest';
+import { row, serverTransport, serverTransportFlipped, deferredTransport, logPage, treeFromLogs, mountList, scrollHarness, flushFrames, fireSentinel, ROW_H, ids } from './log-list-harness';
+import { MAX_RETAINED_ROWS } from '../src/log-list';
+
+// The row the reader is looking at: first data row at the top of the viewport.
+const topRowId = (el: any, sim: any): string | undefined => {
+  const item = el.virtualListItems[sim.firstVisibleIndex];
+  return item && 'id' in item ? item.id : undefined;
+};
+
+// A list already holding `n` rows, newest-first, with more history available.
+const seeded = async (n: number, props: any = {}) => {
+  const el = await mountList(props);
+  const initial = Array.from({ length: n }, (_, i) => row(`r${String(i).padStart(5, '0')}`));
+  (el as any).spanListTree = initial;
+  (el as any).seenIds = new Set(initial.map((r) => r.id));
+  (el as any).hasMore = true;
+  (el as any).updateVisibleItems();
+  await el.updateComplete;
+  return el;
+};
+
+const olderPage = (from: number, count: number) =>
+  logPage(Array.from({ length: count }, (_, i) => `o${String(from + i).padStart(5, '0')}`));
+
+describe('LogList — the reader keeps their place across a load-more', () => {
+  test('an ordinary newest-first load-more leaves the viewport exactly where it was', async () => {
+    const el = await seeded(300);
+    const sim = scrollHarness(el);
+    sim.scrollTo(200 * ROW_H);
+    const before = { top: sim.scrollTop, id: topRowId(el, sim) };
+    el.transport = serverTransport(olderPage(0, 200));
+
+    await el.fetchData('older', false, false, true);
+    await flushFrames();
+
+    expect(sim.scrollTop).toBe(before.top); // appended below the fold: nothing moves
+    expect(topRowId(el, sim)).toBe(before.id);
+  });
+
+  test('a load-more that evicts the retained window keeps the reader on the same row', async () => {
+    const el = await seeded(MAX_RETAINED_ROWS);
+    const sim = scrollHarness(el);
+    sim.scrollToBottom();
+    const anchorId = topRowId(el, sim);
+    el.transport = serverTransport(olderPage(0, 400));
+
+    await el.fetchData('older', false, false, true);
+    await flushFrames();
+
+    // Eviction dropped the newest 400 rows, so the absolute offset must change —
+    // but the row the reader was reading must still be the row at the top.
+    expect(ids(el)).toHaveLength(MAX_RETAINED_ROWS);
+    expect(topRowId(el, sim)).toBe(anchorId);
+    expect(sim.atTop).toBe(false);
+  });
+
+  test('"Show earlier events" continues the list instead of jumping to the top', async () => {
+    // hasMore=false is what swaps the load-more row for "Show earlier events".
+    const el = await seeded(MAX_RETAINED_ROWS);
+    (el as any).hasMore = false;
+    (el as any).expandTimeRange = true;
+    (el as any).updateVisibleItems();
+    await el.updateComplete;
+    const sim = scrollHarness(el);
+    sim.scrollToBottom();
+    const anchorId = topRowId(el, sim);
+    el.transport = serverTransport(olderPage(0, 400));
+
+    // Exactly what the button's @click does.
+    el.renderExpandTimeRangeButton();
+    await el.fetchData('expanded', false, false, true);
+    await flushFrames();
+
+    expect(topRowId(el, sim)).toBe(anchorId);
+    expect(sim.atTop).toBe(false);
+  });
+
+  test('oldest-first load-more holds position while older rows are prepended', async () => {
+    const el = await seeded(300, { flipDirection: true });
+    const sim = scrollHarness(el);
+    sim.scrollTo(50 * ROW_H);
+    const anchorId = topRowId(el, sim);
+    el.transport = serverTransport(olderPage(0, 200));
+
+    await el.fetchData('older', false, false, true);
+    await flushFrames();
+
+    expect(topRowId(el, sim)).toBe(anchorId);
+    expect(sim.scrollTop).toBeGreaterThan(50 * ROW_H); // 200 rows inserted above
+  });
+});
+
+describe('LogList — newer rows arriving above the viewport', () => {
+  test('a recent fetch merged mid-list keeps the reader on the same row', async () => {
+    const el = await seeded(300);
+    (el as any).recentFetchUrl = 'newer';
+    const sim = scrollHarness(el);
+    sim.scrollTo(120 * ROW_H);
+    const anchorId = topRowId(el, sim);
+    el.transport = serverTransport(logPage(['n1', 'n2', 'n3', 'n4', 'n5']));
+
+    await el.fetchData('newer', false, true);
+    await flushFrames();
+
+    expect(topRowId(el, sim)).toBe(anchorId);
+    expect(sim.scrollTop).toBe((120 + 5) * ROW_H); // pushed down by exactly the 5 new rows
+  });
+
+  test('a recent fetch while parked at the top leaves the newest rows in view', async () => {
+    const el = await seeded(300);
+    const sim = scrollHarness(el);
+    sim.scrollTo(0);
+    el.transport = serverTransport(logPage(['n1', 'n2', 'n3']));
+
+    await el.fetchData('newer', false, true);
+    await flushFrames();
+
+    expect(sim.atTop).toBe(true);
+    expect(ids(el).slice(0, 3)).toEqual(['n1', 'n2', 'n3']);
+  });
+});
+
+describe('LogList — "Show earlier events" feedback', () => {
+  test('the row stays mounted and busy while its page is in flight', async () => {
+    const el = await seeded(50);
+    (el as any).hasMore = false;
+    (el as any).expandTimeRange = true;
+    (el as any).updateVisibleItems();
+    await el.updateComplete;
+    const sim = scrollHarness(el);
+    const transport = deferredTransport();
+    el.transport = transport;
+
+    const idle = (await sim.mountSentinels()).loadMore;
+    expect(idle?.textContent).toContain('Show earlier events');
+
+    idle!.click(); // the real @click handler, not fetchData directly
+    await el.updateComplete;
+    const during = (await sim.mountSentinels()).loadMore;
+
+    // The reader clicked a row that reports its own progress. Dropping it mid-flight
+    // left them with no indication anything was happening, and shifted the list by
+    // the row's height at the same time.
+    expect(during?.textContent).toContain('Show earlier events');
+    expect(during?.getAttribute('aria-busy')).toBe('true');
+
+    transport.settle(0, treeFromLogs(['o1', 'o2']));
+  });
+
+  test('clicking the busy row again does not widen the time range twice', async () => {
+    const el = await seeded(50);
+    (el as any).hasMore = false;
+    (el as any).expandTimeRange = true;
+    (el as any).updateVisibleItems();
+    await el.updateComplete;
+    const sim = scrollHarness(el);
+    el.transport = deferredTransport();
+    // expandTimeRangeUrl widens `since` and rewrites history *before* fetchData's
+    // in-flight guard can bail, so an impatient second click doubled the range.
+    const expand = vi.spyOn(el as any, 'expandTimeRangeUrl');
+
+    (await sim.mountSentinels()).loadMore!.click();
+    await el.updateComplete;
+    (await sim.mountSentinels()).loadMore!.click();
+
+    expect(expand).toHaveBeenCalledOnce();
+  });
+
+  test('the "N new" pill scrolls its own list, not the first one on the page', async () => {
+    const other = document.createElement('div'); // an earlier list's container
+    other.id = 'logs_list_container_inner';
+    other.scrollTop = 0;
+    document.body.prepend(other);
+    const el = await seeded(300);
+    const sim = scrollHarness(el);
+    sim.scrollTo(120 * ROW_H);
+    (el as any).recentDataToBeAdded = [row('n1')];
+
+    el.handleRecentClick();
+
+    expect(sim.atTop).toBe(true);
+    expect(ids(el)).toContain('n1');
+    other.remove();
+  });
+});
+
+describe('LogList — oldest-first stays pinned only while the reader is at the newest edge', () => {
+  test('scrolling up to page history unpins the list', async () => {
+    const el = await seeded(300, { flipDirection: true, shouldScrollToBottom: true });
+    const sim = scrollHarness(el);
+    sim.scrollToBottom();
+    expect(el.shouldScrollToBottom).toBe(true);
+
+    sim.scrollTo(40 * ROW_H); // reader scrolls up toward "Load more"
+
+    expect(el.shouldScrollToBottom).toBe(false);
+  });
+
+  test('a load-more requested from mid-list does not snap back to the newest edge', async () => {
+    const el = await seeded(300, { flipDirection: true, shouldScrollToBottom: true });
+    const sim = scrollHarness(el);
+    sim.scrollToBottom();
+    sim.scrollTo(40 * ROW_H);
+    const anchorId = topRowId(el, sim);
+    el.transport = serverTransport(olderPage(0, 200));
+
+    await el.fetchData('older', false, false, true);
+    await flushFrames();
+
+    expect(topRowId(el, sim)).toBe(anchorId);
+    expect(sim.scrollTop).toBeLessThan(sim.maxScroll);
+  });
+
+  test('scrolling back to the newest edge re-pins it', async () => {
+    const el = await seeded(300, { flipDirection: true, shouldScrollToBottom: true });
+    const sim = scrollHarness(el);
+    sim.scrollTo(40 * ROW_H);
+    expect(el.shouldScrollToBottom).toBe(false);
+
+    sim.scrollToBottom();
+
+    expect(el.shouldScrollToBottom).toBe(true);
+  });
+});
+
+describe('LogList — automatic fetches stand down while the list is repositioning', () => {
+  // The reported bug, end to end: page back through history until the retention
+  // window evicts, and the top "Load newer events" sentinel — which only becomes
+  // live *because* of that eviction — fires on the one frame where the remounted
+  // virtualizer has no height and therefore has both edges inside the viewport.
+  test('the eviction remount does not fire the top load-newer sentinel', async () => {
+    const el = await seeded(MAX_RETAINED_ROWS);
+    const sim = scrollHarness(el);
+    sim.scrollToBottom();
+    const anchorId = topRowId(el, sim);
+    el.transport = serverTransport(olderPage(0, 400));
+
+    await el.fetchData('older', false, false, true);
+    expect(el.hasNewer).toBe(true); // eviction reopened the newer edge, arming the sentinel
+    const sentinels = await sim.mountSentinels();
+    const recent = vi.spyOn(el as any, 'buildRecentFetchUrl');
+    fireSentinel(sentinels.recent);
+    await flushFrames();
+
+    expect(recent).not.toHaveBeenCalled();
+    expect(sim.atTop).toBe(false);
+    expect(topRowId(el, sim)).toBe(anchorId);
+  });
+
+  test('an auto-loaded newer page never yanks the viewport to the top', async () => {
+    // Only an explicit click on "Load newer events" should reveal the new rows;
+    // the observer firing means the reader is already at that edge.
+    const el = await seeded(400);
+    (el as any).hasNewer = true;
+    const sim = scrollHarness(el);
+    sim.scrollTo(120 * ROW_H);
+    el.transport = serverTransport(logPage(['n1', 'n2']));
+    const sentinels = await sim.mountSentinels();
+
+    fireSentinel(sentinels.recent);
+    await flushFrames();
+
+    expect(sim.atTop).toBe(false);
+  });
+
+  test('proximity prefetch does not fire off the collapsed post-eviction range', async () => {
+    const el = await seeded(MAX_RETAINED_ROWS);
+    const sim = scrollHarness(el);
+    sim.scrollToBottom();
+    sim.emitVisibility();
+    el.transport = serverTransport(olderPage(0, 400));
+
+    await el.fetchData('older', false, false, true);
+    const fetchSpy = vi.spyOn(el, 'fetchData');
+    sim.emitVisibility(); // the collapsed frame reports a range starting at 0
+    await flushFrames();
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  test('once the list has settled, the top sentinel loads newer events again', async () => {
+    const el = await seeded(MAX_RETAINED_ROWS);
+    const sim = scrollHarness(el);
+    sim.scrollToBottom();
+    el.transport = serverTransport(olderPage(0, 400));
+    await el.fetchData('older', false, false, true);
+    await flushFrames();
+
+    const recent = vi.spyOn(el as any, 'buildRecentFetchUrl').mockReturnValue('newer');
+    sim.scrollTo(0);
+    const sentinels = await sim.mountSentinels();
+    fireSentinel(sentinels.recent);
+    await flushFrames();
+
+    expect(recent).toHaveBeenCalled(); // suspension is a frame, not a permanent latch
+  });
+
+  test('the bottom sentinel still pages history after an eviction settles', async () => {
+    const el = await seeded(MAX_RETAINED_ROWS);
+    const sim = scrollHarness(el);
+    sim.scrollToBottom();
+    el.transport = serverTransport(olderPage(0, 400), olderPage(400, 100));
+    await el.fetchData('older', false, false, true);
+    await flushFrames();
+
+    const sentinels = await sim.mountSentinels();
+    fireSentinel(sentinels.loadMore);
+    await new Promise((r) => setTimeout(r, 350)); // the sentinel's 300ms debounce
+    await flushFrames();
+
+    expect((el.transport as any).urls.length).toBeGreaterThan(1);
+  });
+});
+
+describe('LogList — eviction that removes the row the reader was anchored to', () => {
+  test('live-tail eviction at the history edge does not dump the reader at the top', async () => {
+    // Newest-first: a recent fetch prepends newer rows and evicts the OLDEST ones —
+    // exactly where a reader who has paged deep into history is sitting.
+    const el = await seeded(MAX_RETAINED_ROWS);
+    (el as any).recentFetchUrl = 'newer';
+    const sim = scrollHarness(el);
+    sim.scrollToBottom();
+    el.transport = serverTransport(logPage(Array.from({ length: 400 }, (_, i) => `n${String(i).padStart(5, '0')}`)));
+
+    await el.fetchData('newer', false, true);
+    await flushFrames();
+
+    expect(sim.atTop).toBe(false);
+  });
+});
+
+// The suspension counter is mine, and its failure mode is worse than the bug it fixes: if
+// it ever fails to return to zero, every automatic fetch is disabled for the life of the
+// page and the list simply stops loading more, with nothing on screen to say why.
+describe('LogList — the repositioning guard always releases', () => {
+  const settling = (el: any) => el.scrollSettling;
+
+  test('returns to zero after a plain load-more', async () => {
+    const el = await seeded(300);
+    scrollHarness(el);
+    el.transport = serverTransport(olderPage(0, 100));
+
+    await el.fetchData('older', false, false, true);
+    await flushFrames();
+
+    expect(settling(el)).toBe(0);
+  });
+
+  test('returns to zero after an eviction remount', async () => {
+    const el = await seeded(MAX_RETAINED_ROWS);
+    const sim = scrollHarness(el);
+    sim.scrollToBottom();
+    el.transport = serverTransport(olderPage(0, 400));
+
+    await el.fetchData('older', false, false, true);
+    await flushFrames();
+
+    expect(settling(el)).toBe(0);
+  });
+
+  test('does not drift across many merges', async () => {
+    const el = await seeded(300);
+    scrollHarness(el);
+
+    for (let i = 0; i < 8; i++) {
+      el.transport = serverTransport(olderPage(i * 50, 50));
+      await el.fetchData(`older-${i}`, false, false, true);
+    }
+    await flushFrames();
+
+    expect(settling(el)).toBe(0);
+  });
+
+  // A restore that throws mid-flight must still hand the counter back, or one bad frame
+  // disables paging permanently. It must also not escape: every caller is fire-and-forget,
+  // so a rejection here would surface as an unhandled rejection rather than anything the
+  // reader or an error reporter can act on.
+  test('releases and reports, rather than rejecting, when the restore fails', async () => {
+    const el = await seeded(300, { flipDirection: true });
+    scrollHarness(el);
+    const reported = vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(el as any, 'alignAnchor').mockImplementation(() => {
+      throw new Error('layout blew up');
+    });
+    el.transport = serverTransportFlipped(olderPage(0, 100));
+
+    await el.fetchData('older', false, false, true);
+    await flushFrames();
+
+    expect(settling(el)).toBe(0);
+    expect(reported).toHaveBeenCalledWith('[log-list] scroll restore failed', expect.any(Error));
+  });
+});

--- a/web-components/test/log-list-sessions.test.ts
+++ b/web-components/test/log-list-sessions.test.ts
@@ -1,0 +1,163 @@
+// Sessions mode: a session row expands by fetching its events on demand.
+//
+// Unlike a trace, a session's children are not in the page — clicking fetches them,
+// splices them under the parent and adopts them into the dedup set. That makes it the one
+// expansion path with a network call, a loading flag and a rollback, and none of it was
+// tested. A failed rollback is the nasty case: the row looks expanded, so the next click
+// takes the collapse branch and the reader can never retry.
+import { describe, test, expect, vi, afterEach } from 'vitest';
+import { row, mountList, stubFetch } from './log-list-harness';
+
+const SESSION = 'sess-1';
+
+const sessionsList = async () => {
+  const el = await mountList({ mode: 'sessions', projectId: 'proj-1' } as any);
+  const parent = { ...row(SESSION), children: 3 };
+  (el as any).spanListTree = [parent, row('other-session')];
+  (el as any).seenIds = new Set([SESSION, 'other-session']);
+  (el as any).updateVisibleItems();
+  await el.updateComplete;
+  return el;
+};
+
+// The child payload the expand endpoint returns.
+const childPayload = (ids: string[]) => ({
+  colIdxMap: { timestamp: 0, latency_breakdown: 1, trace_id: 2, parent_id: 3, kind: 4, id: 5, duration: 6, start_time_ns: 7 },
+  rows: ids.map((id) => ['2024-01-01T00:00:00.000Z', id, id, '', 'log', id, 0, Date.parse('2024-01-01T00:00:00Z') * 1e6]),
+  traces: ids.map((id) => ({ trace_id: id, start_time: 0, duration: 0, trace_start_time: '2024-01-01T00:00:00.000Z', root: id, children: {} })),
+});
+
+const ids = (el: any) => el.spanListTree.map((r: any) => r.id);
+const shown = (el: any) => (el.virtualListItems as any[]).filter((i) => 'id' in i).map((i) => i.id);
+
+afterEach(() => vi.restoreAllMocks());
+
+describe('expanding a session', () => {
+  test('fetches its events and shows them under the parent', async () => {
+    const el = await sessionsList();
+    const restore = stubFetch(childPayload(['e1', 'e2']));
+
+    await (el as any).expandSessionTrace(SESSION);
+
+    expect(ids(el)).toEqual([SESSION, 'e1', 'e2', 'other-session']);
+    expect(shown(el)).toContain('e1');
+    restore();
+  });
+
+  test('adopts the fetched events into the dedup set so a later page cannot duplicate them', async () => {
+    const el = await sessionsList();
+    const restore = stubFetch(childPayload(['e1', 'e2']));
+
+    await (el as any).expandSessionTrace(SESSION);
+
+    expect((el as any).seenIds.has('e1')).toBe(true);
+    expect((el as any).seenIds.has('e2')).toBe(true);
+    restore();
+  });
+
+  // The list is built from a rollup count that can disagree with what actually loaded.
+  test('the parent reports the number of events it really has', async () => {
+    const el = await sessionsList();
+    const restore = stubFetch(childPayload(['e1', 'e2']));
+
+    await (el as any).expandSessionTrace(SESSION);
+
+    expect((el as any).spanListTree[0].children).toBe(2);
+    restore();
+  });
+
+  test('collapsing hides the events without refetching them', async () => {
+    const el = await sessionsList();
+    const restore = stubFetch(childPayload(['e1', 'e2']));
+    await (el as any).expandSessionTrace(SESSION);
+    restore();
+
+    const noFetch = vi.fn();
+    const undo = stubFetch();
+    (globalThis as any).fetch = noFetch;
+    await (el as any).expandSessionTrace(SESSION);
+
+    expect(shown(el)).not.toContain('e1');
+    expect(ids(el)).toContain('e1'); // still loaded, just hidden
+    expect(noFetch).not.toHaveBeenCalled();
+    undo();
+  });
+
+  test('re-expanding shows the loaded events again without a second request', async () => {
+    const el = await sessionsList();
+    const restore = stubFetch(childPayload(['e1', 'e2']));
+    await (el as any).expandSessionTrace(SESSION);
+    restore();
+    await (el as any).expandSessionTrace(SESSION); // collapse
+
+    const noFetch = vi.fn();
+    (globalThis as any).fetch = noFetch;
+    await (el as any).expandSessionTrace(SESSION);
+
+    expect(shown(el)).toContain('e1');
+    expect(noFetch).not.toHaveBeenCalled();
+  });
+
+  test('only the requested session expands', async () => {
+    const el = await sessionsList();
+    const restore = stubFetch(childPayload(['e1']));
+
+    await (el as any).expandSessionTrace(SESSION);
+
+    expect((el as any).spanListTree[0].expanded).toBe(true);
+    expect((el as any).spanListTree.find((r: any) => r.id === 'other-session').expanded).toBe(false);
+    restore();
+  });
+});
+
+describe('when the fetch fails', () => {
+  const failing = (init: () => void) => {
+    const original = globalThis.fetch;
+    (globalThis as any).fetch = async () => {
+      init();
+      return { ok: false, status: 503, json: async () => ({}) };
+    };
+    return () => ((globalThis as any).fetch = original);
+  };
+
+  // Rollback matters: leaving the parent marked expanded sends the next click down the
+  // collapse branch, which is a no-op — so the reader can never retry the fetch.
+  test('the row rolls back so the next click retries instead of no-opping', async () => {
+    const el = await sessionsList();
+    const attempts: number[] = [];
+    const restore = failing(() => attempts.push(1));
+
+    await (el as any).expandSessionTrace(SESSION);
+
+    expect((el as any).spanListTree[0].expanded).toBe(false);
+    expect((el as any).expandedTraces[SESSION]).toBeUndefined();
+
+    await (el as any).expandSessionTrace(SESSION);
+    expect(attempts).toHaveLength(2); // it really tried again
+    restore();
+  });
+
+  test('the loading flag is cleared whether the fetch succeeds or fails', async () => {
+    const el = await sessionsList();
+    const restoreFail = failing(() => {});
+    await (el as any).expandSessionTrace(SESSION);
+    expect((el as any).loadingSessions[SESSION]).toBeUndefined();
+    restoreFail();
+
+    const restoreOk = stubFetch(childPayload(['e1']));
+    await (el as any).expandSessionTrace(SESSION);
+    expect((el as any).loadingSessions[SESSION]).toBeUndefined();
+    restoreOk();
+  });
+
+  test('the list is left exactly as it was', async () => {
+    const el = await sessionsList();
+    const before = ids(el);
+    const restore = failing(() => {});
+
+    await (el as any).expandSessionTrace(SESSION);
+
+    expect(ids(el)).toEqual(before);
+    restore();
+  });
+});

--- a/web-components/test/log-list-trace-expand.test.ts
+++ b/web-components/test/log-list-trace-expand.test.ts
@@ -1,0 +1,127 @@
+// Expanding and collapsing a trace in the log list.
+//
+// Tree view shows one row per trace until the reader opens it. That toggle mutates `show`
+// and `expanded` on rows in place and maintains a parallel `expandedTraces` map that the
+// worker re-reads on every regroup — so a disagreement between them either hides rows the
+// reader opened or leaks another trace's children into the list. Untested until now.
+import { describe, test, expect } from 'vitest';
+import { serverTransport, logPage, mountList, COLS } from './log-list-harness';
+import { groupSpans } from '../src/log-worker-functions';
+
+// A trace: one root server span with two child spans, plus an unrelated standalone log.
+const TRACE = 'trace-1';
+const ts = (n: number) => new Date(Date.parse('2024-01-01T00:00:00Z') + n).toISOString();
+const spanRow = (id: string, parent: string, kind = 'server') => [ts(0), id, TRACE, parent, kind, id, 10, Date.parse(ts(0)) * 1e6];
+
+const tracePage = () => ({
+  logsData: [spanRow('root', ''), spanRow('child-a', 'root', 'client'), spanRow('child-b', 'root', 'client')],
+  colIdxMap: COLS,
+  traces: [
+    {
+      trace_id: TRACE,
+      start_time: Date.parse(ts(0)) * 1e6,
+      duration: 10,
+      trace_start_time: ts(0),
+      root: 'root',
+      children: { root: ['child-a', 'child-b'] },
+    },
+  ],
+});
+
+const withTrace = async () => {
+  const el = await mountList();
+  el.transport = async () => {
+    const p = tracePage();
+    return {
+      tree: groupSpans(p.logsData, p.colIdxMap as any, {}, false, p.traces as any),
+      meta: {
+        serviceColors: {}, nextUrl: '', recentUrl: '', cols: Object.keys(COLS),
+        colIdxMap: COLS, count: 3, traces: p.traces, hasMore: false, queryResultCount: 3,
+      } as any,
+    };
+  };
+  await el.fetchData('first', true);
+  return el;
+};
+
+// What the list would actually render: collapsed children are filtered out in tree view.
+const renderedIds = (el: any) => (el.virtualListItems as any[]).filter((i) => 'id' in i).map((i) => i.id);
+const rowById = (el: any, id: string) => (el.spanListTree as any[]).find((r) => r.id === id);
+
+describe('expanding a trace', () => {
+  test('a collapsed trace contributes only its root row', async () => {
+    const el = await withTrace();
+    expect(renderedIds(el)).toEqual(['root']);
+  });
+
+  test('expanding reveals the children beneath the root', async () => {
+    const el = await withTrace();
+
+    (el as any).expandTrace(TRACE, 'root');
+
+    expect(renderedIds(el)).toEqual(['root', 'child-a', 'child-b']);
+    expect(rowById(el, 'root').expanded).toBe(true);
+  });
+
+  test('collapsing hides them again and the row count returns to one', async () => {
+    const el = await withTrace();
+    (el as any).expandTrace(TRACE, 'root');
+
+    (el as any).expandTrace(TRACE, 'root');
+
+    expect(renderedIds(el)).toEqual(['root']);
+    expect(rowById(el, 'root').expanded).toBe(false);
+  });
+
+  // The map is what the worker re-reads when a new page is merged; if it disagrees with
+  // the in-place `show` flags, a regroup silently re-collapses what the reader opened.
+  test('the expanded map agrees with what is on screen', async () => {
+    const el = await withTrace();
+
+    (el as any).expandTrace(TRACE, 'root');
+    const openIds = Object.entries((el as any).expandedTraces).filter(([, v]) => v).map(([k]) => k);
+    expect(openIds.sort()).toEqual(['child-a', 'child-b', 'root']);
+
+    (el as any).expandTrace(TRACE, 'root');
+    const stillOpen = Object.entries((el as any).expandedTraces).filter(([, v]) => v).map(([k]) => k);
+    expect(stillOpen).toEqual([]);
+  });
+
+  test('expanding does not pin an oldest-first list back to the newest edge', async () => {
+    const el = await mountList({ flipDirection: true, shouldScrollToBottom: true } as any);
+    (el as any).expandTrace(TRACE, 'root');
+    expect(el.shouldScrollToBottom).toBe(false);
+  });
+
+  test('toggling a trace that is not loaded changes nothing and does not throw', async () => {
+    const el = await withTrace();
+    const before = renderedIds(el);
+
+    expect(() => (el as any).expandTrace('no-such-trace', 'no-such-span')).not.toThrow();
+
+    expect(renderedIds(el)).toEqual(before);
+  });
+});
+
+describe('expansion survives more data arriving', () => {
+  test('an expanded trace stays open when a later page is merged', async () => {
+    const el = await withTrace();
+    (el as any).expandTrace(TRACE, 'root');
+    expect(renderedIds(el)).toHaveLength(3);
+
+    el.transport = serverTransport(logPage(['older-1']));
+    await el.fetchData('older', false, false, true);
+
+    expect(renderedIds(el)).toContain('child-a');
+    expect(renderedIds(el)).toContain('older-1');
+  });
+
+  test('list view shows every span regardless of expansion state', async () => {
+    const el = await withTrace();
+    el.changeView('list');
+    expect(renderedIds(el)).toEqual(['root', 'child-a', 'child-b']);
+
+    el.changeView('tree');
+    expect(renderedIds(el)).toEqual(['root']);
+  });
+});

--- a/web-components/test/log-list-transport.test.ts
+++ b/web-components/test/log-list-transport.test.ts
@@ -1,0 +1,188 @@
+// The real transport, which every other log-list test replaces.
+//
+// Those tests inject a fake `transport` so they can drive merge/scroll/pagination
+// deterministically — which means the production path they stand in for has no coverage
+// at all. It has three branches (server-preloaded rows, the head's early-fetch promise,
+// and the Web Worker) plus request correlation and a 2-minute timeout, and a fault in any
+// of them shows up as a list that never loads.
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mountList, logPage, COLS } from './log-list-harness';
+
+// One server-shaped page, in the wire format each branch receives — built by the same
+// helper the rest of the suite uses, so it carries real trace adjacency.
+const PAGE = logPage(['a'], {
+  cols: Object.keys(COLS),
+  serviceColors: {},
+  nextUrl: '/next',
+  recentUrl: '/recent',
+  count: 1,
+  hasMore: true,
+  queryResultCount: 1,
+});
+
+// The worker as the component uses it: capture what is posted, reply on demand.
+const fakeWorker = () => {
+  const posted: any[] = [];
+  let instance: any;
+  class FakeWorker {
+    onmessage: ((e: any) => void) | null = null;
+    onerror: ((e: any) => void) | null = null;
+    constructor() {
+      instance = this;
+    }
+    postMessage(msg: any) {
+      posted.push(msg);
+    }
+    terminate() {}
+    addEventListener() {}
+    removeEventListener() {}
+  }
+  const original = globalThis.Worker;
+  (globalThis as any).Worker = FakeWorker;
+  return {
+    posted,
+    reply: (data: any) => instance.onmessage?.({ data }),
+    restore: () => ((globalThis as any).Worker = original),
+  };
+};
+
+// A list with the real transport in place (mountList only disables the auto-fetch).
+const realTransport = async (props: Record<string, any> = {}) => {
+  const el = await mountList(props as any);
+  return (url: string) => (el as any).transport(url) as Promise<any>;
+};
+
+beforeEach(() => {
+  delete (window as any).logDataPromise;
+  delete (window as any).logsPreloadedData;
+});
+afterEach(() => vi.restoreAllMocks());
+
+describe('the head early-fetch promise', () => {
+  // The server starts the row request in <head> so it is in flight before the component
+  // upgrades. Taking that result is what makes first paint fast.
+  test('is consumed instead of asking the worker', async () => {
+    const worker = fakeWorker();
+    (window as any).logDataPromise = Promise.resolve(PAGE);
+    const fetchOnce = await realTransport();
+
+    const { tree, meta } = await fetchOnce('/p/x/log_explorer/data');
+
+    expect(tree.map((r: any) => r.id)).toEqual(['a']);
+    expect(meta.nextUrl).toBe('/next');
+    expect(worker.posted).toHaveLength(0);
+    worker.restore();
+  });
+
+  // It answers exactly one request; a second read would replay the first page and the
+  // list would never advance past it.
+  test('is used once, then the worker takes over', async () => {
+    const worker = fakeWorker();
+    (window as any).logDataPromise = Promise.resolve(PAGE);
+    const fetchOnce = await realTransport();
+    await fetchOnce('/first');
+
+    void fetchOnce('/second');
+    await Promise.resolve();
+
+    expect((window as any).logDataPromise).toBeNull();
+    expect(worker.posted.map((m) => m.url)).toEqual(['/second']);
+    worker.restore();
+  });
+
+  // Otherwise the reader waits out the full 2-minute worker timeout and is then shown
+  // "Worker timeout" instead of the query error that actually happened.
+  test('a server error surfaces immediately rather than as a timeout', async () => {
+    const worker = fakeWorker();
+    (window as any).logDataPromise = Promise.resolve({ error: 'unknown field: srvice.name' });
+    const fetchOnce = await realTransport();
+
+    await expect(fetchOnce('/p/x/log_explorer/data')).rejects.toThrow(/srvice\.name/);
+    expect(worker.posted).toHaveLength(0);
+    worker.restore();
+  });
+});
+
+describe('the worker path', () => {
+  test('posts the request with the state the worker needs to group rows', async () => {
+    const worker = fakeWorker();
+    const fetchOnce = await realTransport({ flipDirection: true });
+
+    void fetchOnce('/p/x/log_explorer/data?cursor=1');
+
+    expect(worker.posted[0]).toMatchObject({ type: 'fetch', url: '/p/x/log_explorer/data?cursor=1', flipDirection: true });
+    expect(typeof worker.posted[0].id).toBe('number');
+    worker.restore();
+  });
+
+  test('resolves the request that its reply is addressed to', async () => {
+    const worker = fakeWorker();
+    const fetchOnce = await realTransport();
+    const first = fetchOnce('/one');
+    const second = fetchOnce('/two');
+    const [idOne, idTwo] = worker.posted.map((m) => m.id);
+
+    // Reply out of order: the correlation id, not arrival order, decides.
+    worker.reply({ type: 'success', id: idTwo, tree: [{ id: 'two' }], meta: {} });
+    worker.reply({ type: 'success', id: idOne, tree: [{ id: 'one' }], meta: {} });
+
+    expect((await first).tree).toEqual([{ id: 'one' }]);
+    expect((await second).tree).toEqual([{ id: 'two' }]);
+    worker.restore();
+  });
+
+  test('a failure reply rejects that request with the worker\'s message', async () => {
+    const worker = fakeWorker();
+    const fetchOnce = await realTransport();
+    const request = fetchOnce('/boom');
+
+    worker.reply({ type: 'error', id: worker.posted[0].id, error: 'upstream exploded' });
+
+    await expect(request).rejects.toThrow('upstream exploded');
+    worker.restore();
+  });
+
+  // A reply for a request that already settled (or never existed) must be ignored, not
+  // resolve someone else's promise.
+  test('an unknown correlation id is ignored', async () => {
+    const worker = fakeWorker();
+    const fetchOnce = await realTransport();
+    const request = fetchOnce('/one');
+
+    worker.reply({ type: 'success', id: 9999, tree: [{ id: 'stray' }], meta: {} });
+    worker.reply({ type: 'success', id: worker.posted[0].id, tree: [{ id: 'one' }], meta: {} });
+
+    expect((await request).tree).toEqual([{ id: 'one' }]);
+    worker.restore();
+  });
+
+  test('a request that never gets a reply times out rather than hanging forever', async () => {
+    vi.useFakeTimers();
+    const worker = fakeWorker();
+    const fetchOnce = await realTransport();
+    const request = fetchOnce('/silent');
+    const settled = expect(request).rejects.toThrow(/timeout/i);
+
+    vi.advanceTimersByTime(120_000);
+    await settled;
+
+    worker.restore();
+    vi.useRealTimers();
+  });
+
+  test('a timed-out request is forgotten, so a late reply cannot resolve it', async () => {
+    vi.useFakeTimers();
+    const worker = fakeWorker();
+    const fetchOnce = await realTransport();
+    const request = fetchOnce('/late');
+    const settled = expect(request).rejects.toThrow(/timeout/i);
+    vi.advanceTimersByTime(120_000);
+    await settled;
+
+    // The reply arrives after the fact; it must find no callback and do nothing.
+    expect(() => worker.reply({ type: 'success', id: worker.posted[0].id, tree: [], meta: {} })).not.toThrow();
+
+    worker.restore();
+    vi.useRealTimers();
+  });
+});

--- a/web-components/test/log-list-utils.test.ts
+++ b/web-components/test/log-list-utils.test.ts
@@ -1,0 +1,305 @@
+// The pure functions every rendered log row goes through.
+//
+// These run once per cell per row, up to 2500 rows — the most-executed code in the
+// product — and none of them had a test. They are also the easiest place for a silent
+// wrong answer to hide: a mis-parsed summary renders as plain text, a mis-classified
+// error renders the wrong severity colour, and both look plausible.
+import { describe, test, expect } from 'vitest';
+import {
+  parseSummaryElement,
+  unescapeJsonString,
+  formatTimestamp,
+  formatTimestampCompact,
+  lookupVecValue,
+  getErrorClassification,
+  calculateColumnWidth,
+  calculateAutoBinWidth,
+  parseUserAgent,
+  dedupeById,
+  cursorFromTimestamp,
+  oldestRowTimestamp,
+  newestRowTimestamp,
+  MIN_COLUMN_WIDTH,
+} from '../src/log-list-utils';
+
+describe('parseSummaryElement', () => {
+  test('splits the field;style⇒value form the server emits', () => {
+    expect(parseSummaryElement('http_status;text-error⇒500')).toEqual({
+      type: 'formatted',
+      field: 'http_status',
+      style: 'text-error',
+      value: '500',
+    });
+  });
+
+  test('a value containing the separator keeps everything after the first one', () => {
+    expect(parseSummaryElement('msg;plain⇒a ⇒ b')).toMatchObject({ value: 'a ⇒ b' });
+  });
+
+  test('an empty style is still the formatted shape, not plain text', () => {
+    expect(parseSummaryElement('field;⇒value')).toEqual({ type: 'formatted', field: 'field', style: '', value: 'value' });
+  });
+
+  test('text with no separator is plain', () => {
+    expect(parseSummaryElement('just a log line')).toEqual({ type: 'plain', content: 'just a log line' });
+  });
+
+  // A message that happens to contain a semicolon after the arrow must not be
+  // mistaken for a field/style prefix and have its head chopped off.
+  test('a semicolon after the separator does not create a bogus field', () => {
+    expect(parseSummaryElement('no prefix ⇒ then; a semicolon')).toEqual({
+      type: 'plain',
+      content: 'no prefix ⇒ then; a semicolon',
+    });
+  });
+
+  test('the empty string is plain and lossless', () => {
+    expect(parseSummaryElement('')).toEqual({ type: 'plain', content: '' });
+  });
+});
+
+describe('unescapeJsonString', () => {
+  test('leaves ordinary text untouched', () => {
+    expect(unescapeJsonString('plain message')).toBe('plain message');
+  });
+
+  test('unescapes quotes and backslashes from a JSON-encoded payload', () => {
+    expect(unescapeJsonString('{\\"a\\": 1}')).toContain('{"a"');
+  });
+
+  test('highlights JSON values rather than keys', () => {
+    const out = unescapeJsonString('{"status": "ok"}');
+    expect(out).toContain('<span class="text-textStrong font-medium">"ok"</span>');
+    expect(out).not.toContain('<span class="text-textStrong font-medium">"status"</span>');
+  });
+
+  test('numbers, booleans and null are highlighted too', () => {
+    for (const v of ['42', 'true', 'false', 'null']) {
+      expect(unescapeJsonString(`{"k": ${v}}`)).toContain(`>${v}</span>`);
+    }
+  });
+
+  test('converts ANSI colour codes into markup instead of leaking escape bytes', () => {
+    const out = unescapeJsonString('\x1b[31mred\x1b[0m');
+    expect(out).not.toContain('\x1b');
+    expect(out.toLowerCase()).toContain('span');
+  });
+
+  test('is a no-op on the empty string', () => {
+    expect(unescapeJsonString('')).toBe('');
+  });
+});
+
+describe('timestamp formatting', () => {
+  const ts = '2024-03-05T07:08:09.042Z';
+
+  test('renders date, clock and zero-padded milliseconds', () => {
+    expect(formatTimestamp(ts)).toMatch(/^Mar 05 \d{2}:\d{2}:\d{2}\.042$/);
+  });
+
+  test('the compact form drops the date and keeps the milliseconds', () => {
+    expect(formatTimestampCompact(ts)).toMatch(/^\d{2}:\d{2}:\d{2}\.042$/);
+  });
+
+  test('sub-100ms values keep three digits rather than collapsing', () => {
+    expect(formatTimestamp('2024-03-05T07:08:09.007Z')).toMatch(/\.007$/);
+    expect(formatTimestamp('2024-03-05T07:08:09.000Z')).toMatch(/\.000$/);
+  });
+
+  // A row with a broken timestamp must render an empty cell, not "Invalid Date".
+  test('an unparseable timestamp renders as empty', () => {
+    for (const bad of ['', 'not-a-date', 'undefined']) {
+      expect(formatTimestamp(bad)).toBe('');
+      expect(formatTimestampCompact(bad)).toBe('');
+    }
+  });
+});
+
+describe('lookupVecValue', () => {
+  const cols = { id: 0, name: 1 };
+
+  test('reads the column the map points at', () => {
+    expect(lookupVecValue(['abc', 'GET /x'], cols, 'name')).toBe('GET /x');
+  });
+
+  // The column set changes between queries; a stale key must not read a neighbouring
+  // column's value into the wrong cell.
+  test('an unknown column reads as empty, never as another column', () => {
+    expect(lookupVecValue(['abc', 'GET /x'], cols, 'missing')).toBe('');
+  });
+
+  test('an index past the end of a short row reads as empty', () => {
+    expect(lookupVecValue(['abc'], cols, 'name')).toBe('');
+  });
+});
+
+describe('getErrorClassification', () => {
+  const cols = { errors: 0, http_attributes: 1, status: 2 };
+  const classify = (errors: any, status_code: number, status = '') => getErrorClassification([errors, { status_code }, status], cols);
+
+  test('a span carrying errors is an error regardless of status code', () => {
+    expect(classify([{ m: 'boom' }], 200).className).toContain('bg-strokeError-strong');
+  });
+
+  test('ERROR status alone is an error', () => {
+    expect(classify(null, 200, 'ERROR').className).toContain('bg-strokeError-strong');
+  });
+
+  test('a 4xx/5xx without recorded errors is a warning, not an error', () => {
+    for (const code of [400, 404, 500, 503]) {
+      const { className } = classify(null, code);
+      expect(className).toContain('bg-strokeWarning-strong');
+      expect(className).not.toContain('bg-strokeError-strong');
+    }
+  });
+
+  test('a successful span gets the neutral indicator', () => {
+    const { className } = classify(null, 200);
+    expect(className).toContain('bg-strokeBrand-weak');
+    expect(className).toContain('status-indicator');
+  });
+
+  // Log records have no http_attributes at all — that must read as 0, not throw.
+  test('a row with no http attributes classifies as success rather than throwing', () => {
+    expect(() => getErrorClassification([null, null, ''], cols)).not.toThrow();
+    expect(getErrorClassification([null, null, ''], cols).statusCode).toBe(0);
+  });
+
+  test('exactly one severity class is applied', () => {
+    for (const args of [[[{}], 200], [null, 500], [null, 200]] as const) {
+      const classes = classify(args[0], args[1]).className.split(' ');
+      const severities = classes.filter((c) => c.startsWith('bg-stroke'));
+      expect(severities).toHaveLength(1);
+    }
+  });
+});
+
+describe('calculateColumnWidth', () => {
+  test('scales with content length', () => {
+    expect(calculateColumnWidth('aaaa', 'summary')).toBeGreaterThan(calculateColumnWidth('aa', 'summary'));
+  });
+
+  test('an unknown column still gets a width from the default character size', () => {
+    expect(calculateColumnWidth('abcdef', 'a_column_nobody_configured')).toBeGreaterThan(0);
+  });
+
+  test('empty content measures zero, and the caller clamps to the minimum', () => {
+    expect(calculateColumnWidth('', 'summary')).toBe(0);
+    expect(MIN_COLUMN_WIDTH).toBeGreaterThan(0);
+  });
+});
+
+describe('calculateAutoBinWidth', () => {
+  const MIN = 60_000;
+  const HOUR = 60 * MIN;
+  const DAY = 24 * HOUR;
+
+  test.each([
+    ['30 minutes', 30 * MIN, 30_000],
+    ['1 hour', HOUR, 30_000],
+    ['6 hours', 6 * HOUR, 60_000],
+    ['12 hours', 12 * HOUR, 5 * 60_000],
+    ['24 hours', 24 * HOUR, 10 * 60_000],
+    ['3 days', 3 * DAY, 60 * 60_000],
+    ['14 days', 14 * DAY, 6 * 60 * 60_000],
+    ['90 days', 90 * DAY, 24 * 60 * 60_000],
+  ])('%s of data bins at the expected width', (_label, duration, expected) => {
+    expect(calculateAutoBinWidth(duration)).toBe(expected);
+  });
+
+  // Monotonic: a longer window must never produce narrower bins, or a chart gains
+  // buckets as its range grows.
+  test('bin width never shrinks as the window grows', () => {
+    const widths = [1, 2, 5, 10, 24, 48, 24 * 6, 24 * 20, 24 * 60].map((h) => calculateAutoBinWidth(h * HOUR));
+    expect(widths).toEqual([...widths].sort((a, b) => a - b));
+  });
+});
+
+describe('parseUserAgent', () => {
+  test.each([
+    ['Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Safari/537.36', 'Chrome on macOS'],
+    ['Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15', 'Safari on macOS'],
+    ['Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Safari/537.36 Edg/120.0', 'Edge on Windows'],
+    ['Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:121.0) Gecko/20100101 Firefox/121.0', 'Firefox on Windows'],
+    ['Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1', 'Safari on iOS'],
+    ['Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Mobile Safari/537.36', 'Chrome on Android'],
+  ])('collapses a real browser UA into a readable label', (ua, expected) => {
+    expect(parseUserAgent(ua)).toBe(expected);
+  });
+
+  // Chrome-family UAs all contain "Chrome"; the more specific brand has to win or
+  // every Edge and Opera request is mislabelled.
+  test('Edge and Opera are not reported as Chrome', () => {
+    expect(parseUserAgent('Mozilla/5.0 Chrome/120.0 Safari/537.36 OPR/106.0')).toContain('Opera');
+    expect(parseUserAgent('Mozilla/5.0 Chrome/120.0 Safari/537.36 Edg/120.0')).toContain('Edge');
+  });
+
+  test('non-browser clients keep their own name', () => {
+    expect(parseUserAgent('curl/8.4.0')).toContain('curl');
+    expect(parseUserAgent('PostmanRuntime/7.36.0')).toContain('Postman');
+  });
+
+  // An unrecognised agent must survive verbatim rather than disappearing from the row.
+  test('an unknown agent falls back to the raw string', () => {
+    expect(parseUserAgent('SomeInternalService/2.1')).toBe('SomeInternalService/2.1');
+  });
+
+  test('no user agent renders as empty', () => {
+    expect(parseUserAgent('')).toBe('');
+  });
+});
+
+describe('dedupeById', () => {
+  test('keeps the first occurrence of a repeated id', () => {
+    expect(dedupeById([{ id: 'a', n: 1 }, { id: 'b', n: 2 }, { id: 'a', n: 3 }]).map((r: any) => r.n)).toEqual([1, 2]);
+  });
+
+  // A row with no id cannot be keyed by the virtualizer or matched by the scroll
+  // anchor, so it is dropped rather than rendered as an unaddressable row.
+  test('rows without an id are dropped', () => {
+    expect(dedupeById([{ id: null }, { id: undefined }, { id: 'a' }])).toEqual([{ id: 'a' }]);
+  });
+});
+
+describe('cursor timestamps', () => {
+  test('an ISO timestamp round-trips with the requested offset applied', () => {
+    expect(cursorFromTimestamp('2024-03-05T07:08:09.000Z', 10)).toBe('2024-03-05T07:08:09.010Z');
+  });
+
+  // A nanosecond epoch read as milliseconds produces a year-55000 cursor, which the
+  // server answers with nothing — pagination silently stalls.
+  test('nanosecond and microsecond epochs are scaled, not misread as milliseconds', () => {
+    const ms = Date.parse('2024-03-05T07:08:09.000Z');
+    expect(cursorFromTimestamp(ms * 1e6, 0)).toBe('2024-03-05T07:08:09.000Z');
+    expect(cursorFromTimestamp(ms * 1e3, 0)).toBe('2024-03-05T07:08:09.000Z');
+    expect(cursorFromTimestamp(ms, 0)).toBe('2024-03-05T07:08:09.000Z');
+  });
+});
+
+describe('row timestamp extremes', () => {
+  const cols = { timestamp: 0 };
+  const rows = [['2024-03-05T07:00:00.000Z'], ['2024-03-05T09:00:00.000Z'], ['2024-03-05T08:00:00.000Z']].map((data) => ({ data }));
+
+  // The flattened tree appends child spans after their (older) trace root, so the
+  // array endpoints are not the true min/max — these must scan.
+  test('scans for the true extremes rather than trusting array order', () => {
+    expect(oldestRowTimestamp(rows as any, cols)).toBe(Date.parse('2024-03-05T07:00:00.000Z'));
+    expect(newestRowTimestamp(rows as any, cols)).toBe(Date.parse('2024-03-05T09:00:00.000Z'));
+  });
+
+  test('an empty list has no extreme rather than a bogus epoch', () => {
+    expect(oldestRowTimestamp([] as any, cols)).toBeUndefined();
+    expect(newestRowTimestamp([] as any, cols)).toBeUndefined();
+  });
+
+  // Without a timestamp column there is no cursor to page from; callers fall back to
+  // nextFetchUrl rather than sending an epoch-0 cursor that returns nothing.
+  test('a column set with no timestamp yields no cursor', () => {
+    expect(oldestRowTimestamp(rows as any, {})).toBeUndefined();
+  });
+
+  test('rows missing a timestamp value are skipped, not read as epoch zero', () => {
+    const withGaps = [{ data: [null] }, ...rows, { data: [undefined] }];
+    expect(oldestRowTimestamp(withGaps as any, cols)).toBe(Date.parse('2024-03-05T07:00:00.000Z'));
+  });
+});

--- a/web-components/test/query-builder-roundtrip.test.ts
+++ b/web-components/test/query-builder-roundtrip.test.ts
@@ -1,0 +1,169 @@
+// The visual query builder reads a KQL query into UI state and writes it back.
+//
+// Both halves are regex-driven string surgery on the user's own query text, and they are
+// the only path by which opening a dropdown can silently rewrite a query someone typed by
+// hand. The round-trip — parse, change nothing, re-serialize — must be the identity, and
+// editing one clause must not disturb the others. None of it was tested.
+import { describe, test, expect, beforeEach } from 'vitest';
+import '../src/query-editor/query-builder';
+
+// The builder talks to the editor through `document.querySelector(selector).editor`,
+// so a minimal stand-in exercises the real read/write path.
+const withQuery = async (initial: string) => {
+  document.body.innerHTML = '';
+  const editor = document.createElement('div');
+  editor.id = 'filterElement';
+  let value = initial;
+  // `handleAddQuery(text, replace)` is how the builder writes back — the same entry
+  // point the editor exposes to every other caller.
+  (editor as any).editor = { getValue: () => value, setValue: (v: string) => (value = v) };
+  (editor as any).handleAddQuery = (fragment: string, replace = false) => {
+    value = replace ? fragment : `${value} ${fragment}`.trim();
+  };
+  document.body.appendChild(editor);
+
+  const builder = document.createElement('query-builder') as any;
+  document.body.appendChild(builder);
+  await builder.updateComplete;
+  return {
+    builder,
+    read: () => (editor as any).editor.getValue(),
+    parse: () => builder.extractQueryParts(),
+    write: () => builder.updateQuery(),
+  };
+};
+
+// Whitespace around pipes is not meaningful; compare on the shape, not the spacing.
+const normalize = (q: string) =>
+  q
+    .split('|')
+    .map((s) => s.trim().replace(/\s+/g, ' '))
+    .filter(Boolean)
+    .join(' | ');
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('reading a query into the builder', () => {
+  test('picks up the aggregations and the fields they group by', async () => {
+    const q = await withQuery('status_code == 500 | summarize count() by service_name');
+    q.parse();
+
+    expect(q.builder.aggregations).toEqual([{ function: 'count', field: '' }]);
+    expect(q.builder.groupByFields).toEqual(['service_name']);
+  });
+
+  test('a group-by list splits on top-level commas only, not inside a function call', async () => {
+    const q = await withQuery('* | summarize count() by bin(timestamp, 5m), service_name');
+    q.parse();
+
+    expect(q.builder.groupByFields).toEqual(['bin(timestamp, 5m)', 'service_name']);
+  });
+
+  test('reads sort direction and limit', async () => {
+    const q = await withQuery('* | sort by duration desc | take 25');
+    q.parse();
+
+    expect(q.builder.sortFields).toEqual([{ field: 'duration', direction: 'desc' }]);
+    expect(q.builder.limitValue).toBe(25);
+  });
+
+  test('a plain filter leaves every clause empty rather than inventing one', async () => {
+    const q = await withQuery('service_name == "api"');
+    q.parse();
+
+    expect(q.builder.aggregations).toEqual([]);
+    expect(q.builder.groupByFields).toEqual([]);
+    expect(q.builder.sortFields).toEqual([]);
+    expect(q.builder.limitValue).toBeNull();
+  });
+});
+
+describe('round-trip: parsing then writing back changes nothing', () => {
+  test.each([
+    ['a bare filter', 'service_name == "api"'],
+    ['an aggregation', '* | summarize count() by service_name'],
+    ['several aggregations', '* | summarize count(), avg(duration) by service_name'],
+    ['a binned timeseries', '* | summarize count() by bin(timestamp, 5m)'],
+    ['auto binning', '* | summarize count() by bin_auto(timestamp)'],
+    ['sort and take', '* | sort by duration desc | take 50'],
+    ['filter, aggregate, sort and take', 'status_code >= 400 | summarize count() by service_name | sort by service_name asc | take 10'],
+    ['a multi-field group by', '* | summarize count() by service_name, status_code'],
+  ])('%s survives a round-trip unchanged', async (_label, query) => {
+    const q = await withQuery(query);
+
+    q.parse();
+    q.write();
+
+    expect(normalize(q.read())).toBe(normalize(query));
+  });
+
+  test('round-tripping twice is still stable', async () => {
+    const query = 'status_code >= 400 | summarize count() by service_name | sort by service_name asc | take 10';
+    const q = await withQuery(query);
+
+    q.parse();
+    q.write();
+    const once = q.read();
+    q.parse();
+    q.write();
+
+    expect(normalize(q.read())).toBe(normalize(once));
+  });
+});
+
+describe('editing one clause leaves the rest of the query alone', () => {
+  test('adding a limit keeps the filter and the aggregation', async () => {
+    const q = await withQuery('status_code == 500 | summarize count() by service_name');
+    q.parse();
+
+    q.builder.limitValue = 100;
+    q.write();
+
+    const out = normalize(q.read());
+    expect(out).toContain('status_code == 500');
+    expect(out).toContain('summarize count() by service_name');
+    expect(out).toContain('take 100');
+  });
+
+  test('clearing the aggregation drops the summarize and keeps the filter', async () => {
+    const q = await withQuery('status_code == 500 | summarize count() by service_name');
+    q.parse();
+
+    q.builder.aggregations = [];
+    q.builder.groupByFields = [];
+    q.write();
+
+    const out = normalize(q.read());
+    expect(out).toBe('status_code == 500');
+  });
+
+  test('changing the sort replaces the existing clause instead of appending a second', async () => {
+    const q = await withQuery('* | sort by duration desc');
+    q.parse();
+
+    q.builder.sortFields = [{ field: 'timestamp', direction: 'asc' }];
+    q.write();
+
+    const out = q.read();
+    expect(out).toContain('sort by timestamp asc');
+    expect(out).not.toContain('duration desc');
+    expect(out.match(/sort by/gi) ?? []).toHaveLength(1);
+  });
+
+  test('a rewritten query never leaves an empty pipe segment behind', async () => {
+    const q = await withQuery('service_name == "api" | summarize count() by service_name | sort by service_name asc | take 5');
+    q.parse();
+
+    q.builder.aggregations = [];
+    q.builder.groupByFields = [];
+    q.builder.sortFields = [];
+    q.builder.limitValue = null;
+    q.write();
+
+    const out = q.read();
+    expect(out).not.toMatch(/\|\s*\|/);
+    expect(out.trim()).not.toMatch(/\|\s*$/);
+  });
+});

--- a/web-components/test/session-replay-markers.test.ts
+++ b/web-components/test/session-replay-markers.test.ts
@@ -1,0 +1,145 @@
+// Session replay: the clock and the scrubber markers.
+//
+// A replay is watched by someone reconstructing an incident, so the timeline has to be
+// literally true: the clock is what they quote, and the error/warning ticks and page
+// markers are how they find the moment that matters. Both are derived per streamed shard
+// and accumulate across a session that can be hours long — the progressive-loading spec
+// covers the streaming itself, but nothing covered what those events turn into.
+import { describe, test, expect, beforeEach } from 'vitest';
+import { SessionReplay } from '../src/session-replay';
+
+const format = (ms: number) => SessionReplay.formatTime(ms);
+
+const SECOND = 1000;
+const MINUTE = 60 * SECOND;
+const HOUR = 60 * MINUTE;
+
+describe('the replay clock', () => {
+  test.each([
+    ['the very start', 0, '00:00'],
+    ['sub-second', 400, '00:00'],
+    ['seconds', 7 * SECOND, '00:07'],
+    ['a full minute', MINUTE, '01:00'],
+    ['minutes and seconds', 9 * MINUTE + 5 * SECOND, '09:05'],
+    ['past ten minutes', 42 * MINUTE + 13 * SECOND, '42:13'],
+  ])('%s reads as %s', (_label, ms, expected) => {
+    expect(format(ms)).toBe(expected);
+  });
+
+  // A long session must not silently wrap: 1h05m reading as "05:00" would send someone
+  // to the wrong hour of an incident.
+  test('grows an hours field rather than wrapping', () => {
+    expect(format(HOUR)).toBe('01:00:00');
+    expect(format(HOUR + 5 * MINUTE + 9 * SECOND)).toBe('01:05:09');
+    expect(format(2 * HOUR + 59 * MINUTE + 59 * SECOND)).toBe('02:59:59');
+  });
+
+  test('every field is zero-padded so the timeline stays column-aligned', () => {
+    expect(format(3 * MINUTE + 4 * SECOND)).toMatch(/^\d{2}:\d{2}$/);
+    expect(format(HOUR + 2 * MINUTE + 3 * SECOND)).toMatch(/^\d{2}:\d{2}:\d{2}$/);
+  });
+
+  // Truncation, not rounding: the frame at 1.9s has not reached 2s yet, and the scrubber
+  // label has to agree with the frame on screen.
+  test('truncates toward the frame actually showing', () => {
+    expect(format(1900)).toBe('00:01');
+    expect(format(59_999)).toBe('00:59');
+    expect(format(3_599_999)).toBe('59:59');
+  });
+
+  test('the boundary into a new unit is exact', () => {
+    expect(format(60 * SECOND - 1)).toBe('00:59');
+    expect(format(60 * SECOND)).toBe('01:00');
+    expect(format(HOUR - 1)).toBe('59:59');
+    expect(format(HOUR)).toBe('01:00:00');
+  });
+});
+
+describe('scrubber markers', () => {
+  const START = 1_700_000_000_000;
+
+  // rrweb's console plugin events and Meta (navigation) events, as they arrive.
+  const consoleEvent = (level: string, atMs: number) => ({
+    type: 6, // EventType.Plugin
+    timestamp: START + atMs,
+    data: { plugin: 'rrweb/console@1', payload: { level, payload: [], trace: [] } },
+  });
+  const metaEvent = (atMs: number, href: string) => ({ type: 4, timestamp: START + atMs, data: { href } });
+
+  let el: any;
+  beforeEach(() => {
+    el = new SessionReplay();
+    el.sessionStart = START;
+    el.consoleTypesCounts = { error: 0, warn: 0, info: 0 }; // the component's own default
+    el.consoleEvents = [];
+    el.errorTicks = [];
+    el.warnTicks = [];
+    el.navMarkers = [];
+    el.seenFirstMeta = false;
+  });
+
+  test('errors and warnings land at their offset from the session start, not wall-clock', () => {
+    el.ingestMarkers([consoleEvent('error', 5 * SECOND), consoleEvent('warn', 12 * SECOND)]);
+
+    expect(el.errorTicks).toEqual([5 * SECOND]);
+    expect(el.warnTicks).toEqual([12 * SECOND]);
+  });
+
+  test('levels are kept apart, and counted', () => {
+    el.ingestMarkers([consoleEvent('error', 1), consoleEvent('error', 2), consoleEvent('warn', 3), consoleEvent('info', 4)]);
+
+    expect(el.errorTicks).toHaveLength(2);
+    expect(el.warnTicks).toHaveLength(1);
+    expect(el.consoleTypesCounts.error).toBe(2);
+    expect(el.consoleTypesCounts.info).toBe(1);
+    expect(el.consoleEvents).toHaveLength(4); // info is listed even though it has no tick
+  });
+
+  // The first Meta event is the initial page load, not a navigation — marking it would
+  // put a spurious "page change" pin at 00:00 on every replay.
+  test('the opening page load is not a navigation marker', () => {
+    el.ingestMarkers([metaEvent(0, 'https://app/start'), metaEvent(30 * SECOND, 'https://app/checkout')]);
+
+    expect(el.navMarkers).toEqual([{ offset: 30 * SECOND, href: 'https://app/checkout' }]);
+  });
+
+  test('a navigation with no href still marks the moment', () => {
+    el.ingestMarkers([metaEvent(0, 'https://app/start'), { type: 4, timestamp: START + SECOND, data: {} }]);
+
+    expect(el.navMarkers).toEqual([{ offset: SECOND, href: '' }]);
+  });
+
+  // Shards stream in over the life of a long session; markers from earlier ones must
+  // survive, in order, or the scrubber loses the first half of the incident.
+  test('markers accumulate across streamed shards', () => {
+    el.ingestMarkers([consoleEvent('error', 1 * SECOND), metaEvent(0, '/a'), metaEvent(2 * SECOND, '/b')]);
+    el.ingestMarkers([consoleEvent('error', 9 * SECOND), consoleEvent('warn', 10 * SECOND), metaEvent(11 * SECOND, '/c')]);
+
+    expect(el.errorTicks).toEqual([1 * SECOND, 9 * SECOND]);
+    expect(el.warnTicks).toEqual([10 * SECOND]);
+    expect(el.navMarkers.map((m: any) => m.href)).toEqual(['/b', '/c']);
+  });
+
+  // rrweb's console plugin emits log/debug/trace too, which the component does not track
+  // or tick. They must not corrupt the three counts the header actually displays.
+  test('an untracked console level leaves the displayed counts intact', () => {
+    el.ingestMarkers([consoleEvent('error', SECOND), consoleEvent('log', 2 * SECOND), consoleEvent('debug', 3 * SECOND)]);
+
+    expect(el.consoleTypesCounts.error).toBe(1);
+    expect(el.consoleTypesCounts.warn).toBe(0);
+    expect(el.consoleTypesCounts.info).toBe(0);
+    // They are still listed in the console pane — dropping them would hide output the
+    // reader saw in their own devtools.
+    expect(el.consoleEvents).toHaveLength(3);
+    expect(el.errorTicks).toEqual([SECOND]);
+  });
+
+  test('a shard with nothing worth marking changes nothing', () => {
+    el.ingestMarkers([consoleEvent('error', SECOND)]);
+    el.ingestMarkers([]);
+    el.ingestMarkers([{ type: 3, timestamp: START + 2 * SECOND, data: {} }]); // an incremental snapshot
+
+    expect(el.errorTicks).toEqual([SECOND]);
+    expect(el.navMarkers).toEqual([]);
+  });
+});

--- a/web-components/test/setup.ts
+++ b/web-components/test/setup.ts
@@ -3,8 +3,31 @@ import { vi } from 'vitest';
 
 // main.ts runs at import time and calls these globals; stub them so any component
 // (e.g. log-list → widgets → main) is importable in jsdom without throwing.
-(window as any).htmx = { defineExtension: vi.fn(), ajax: vi.fn(), process: vi.fn() };
+// main.ts registers an htmx extension at import time; without registerExtension any
+// test that imports it dies before a single case runs.
+(window as any).htmx = { defineExtension: vi.fn(), registerExtension: vi.fn(), ajax: vi.fn(), process: vi.fn() };
 (window as any).interpolateVarTemplates = vi.fn();
+
+// jsdom in this setup ships no working localStorage, and component constructors read it
+// (SessionReplay restores its panel width there), so a bare `new Component()` throws before
+// a single case runs. Shim it once here rather than per test file.
+if (typeof (globalThis as any).localStorage?.getItem !== 'function') {
+  const store = new Map<string, string>();
+  const shim = {
+    getItem: (k: string) => store.get(k) ?? null,
+    setItem: (k: string, v: string) => void store.set(k, String(v)),
+    removeItem: (k: string) => void store.delete(k),
+    clear: () => store.clear(),
+    key: (i: number) => [...store.keys()][i] ?? null,
+    get length() { return store.size; },
+  };
+  (globalThis as any).localStorage = shim;
+  try {
+    Object.defineProperty(window, 'localStorage', { value: shim, configurable: true });
+  } catch {
+    /* window.localStorage may be read-only; the globalThis shim suffices */
+  }
+}
 
 // Mock document.queryCommandSupported and execCommand for Monaco Editor clipboard support
 document.queryCommandSupported = vi.fn(() => false);

--- a/web-components/test/time-picker-state.test.ts
+++ b/web-components/test/time-picker-state.test.ts
@@ -1,0 +1,186 @@
+// The time picker and URL state, shared by the log explorer and every dashboard.
+//
+// `updateTimePicker` is the single writer of the range label, the hidden range input and
+// the URL's since/from/to — and the log list calls it directly when "Show earlier events"
+// widens the window. Getting the label wrong is cosmetic; leaving a stale `since` next to
+// a new `from`/`to` is not, because the server reads both and the reader gets a window
+// they did not ask for.
+import { describe, test, expect, beforeEach } from 'vitest';
+import '../src/main';
+
+const updateTimePicker = (...args: Parameters<typeof window.updateTimePicker>) => window.updateTimePicker(...args);
+const params = () => new URLSearchParams(window.location.search);
+
+// The picker writes into elements the server rendered; `n` is the default prefix.
+const mountPicker = (prefix = 'n') => {
+  const label = document.createElement('span');
+  label.id = `${prefix}-currentRange`;
+  const input = document.createElement('input');
+  input.id = `${prefix}-custom_range_input`;
+  document.body.append(label, input);
+  return { label, input };
+};
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+  window.history.replaceState({}, '', '/p/proj/log_explorer');
+});
+
+describe('relative ranges', () => {
+  test.each([
+    ['1H', 'Last 1 Hour'],
+    ['24H', 'Last 24 Hours'],
+    ['1D', 'Last 1 Day'],
+    ['7D', 'Last 7 Days'],
+    ['30M', 'Last 30 Minutes'],
+    ['45S', 'Last 45 Seconds'],
+  ])('%s reads as "%s"', (since, expected) => {
+    mountPicker();
+    expect(updateTimePicker({ since })).toBe(expected);
+  });
+
+  test('singular and plural are not mixed up', () => {
+    mountPicker();
+    expect(updateTimePicker({ since: '1M' })).toBe('Last 1 Minute');
+    expect(updateTimePicker({ since: '2M' })).toBe('Last 2 Minutes');
+  });
+
+  test('a range the picker does not recognise still renders readably', () => {
+    mountPicker();
+    expect(updateTimePicker({ since: 'all-time' })).toBe('Last all-time');
+  });
+
+  test('an explicit label overrides the derived one', () => {
+    mountPicker();
+    expect(updateTimePicker({ since: '1H' }, { label: 'Since deploy' })).toBe('Since deploy');
+  });
+
+  test('writes the label and the hidden input the form submits', () => {
+    const { label, input } = mountPicker();
+    updateTimePicker({ since: '6H' });
+    expect(label.innerText).toBe('Last 6 Hours');
+    expect(input.value).toBe('6H');
+  });
+});
+
+describe('URL state', () => {
+  // A relative range and an absolute one are mutually exclusive; the server reads both,
+  // so leaving the old one behind silently narrows or widens the window.
+  test('choosing a relative range clears any absolute one', () => {
+    mountPicker();
+    window.history.replaceState({}, '', '/p/proj/log_explorer?from=2024-01-01T00:00:00Z&to=2024-01-02T00:00:00Z');
+
+    updateTimePicker({ since: '1H' });
+
+    expect(params().get('since')).toBe('1H');
+    expect(params().get('from')).toBe('');
+    expect(params().get('to')).toBe('');
+  });
+
+  test('choosing an absolute range clears the relative one', () => {
+    mountPicker();
+    window.history.replaceState({}, '', '/p/proj/log_explorer?since=1H');
+
+    updateTimePicker({ from: '2024-01-01T00:00:00Z', to: '2024-01-02T00:00:00Z' });
+
+    expect(params().get('from')).toBe('2024-01-01T00:00:00Z');
+    expect(params().get('to')).toBe('2024-01-02T00:00:00Z');
+    expect(params().get('since')).toBe('');
+  });
+
+  // The log list widens the range itself and owns the URL for that request, so it asks
+  // the picker to update the label only — writing params here would fight it.
+  test('skipSetParams updates the label without touching the URL', () => {
+    const { label } = mountPicker();
+    window.history.replaceState({}, '', '/p/proj/log_explorer?since=1H&query=abc');
+
+    const shown = updateTimePicker({ since: '3H' }, { skipSetParams: true });
+
+    expect(shown).toBe('Last 3 Hours');
+    expect(label.innerText).toBe('Last 3 Hours');
+    expect(params().get('since')).toBe('1H'); // untouched
+    expect(params().get('query')).toBe('abc');
+  });
+
+  // The app is an HTMX/morph SPA: main.ts loads once, and other paths (the query editor,
+  // the column and facet sync, chart zoom) write params straight through
+  // history.replaceState afterwards. Reading the URL only once at load meant the next
+  // time-range change rewrote it from that stale snapshot — silently dropping the query
+  // and column selection the reader had just made, including from a link they then shared.
+  test('params written after page load survive a range change', () => {
+    mountPicker();
+    window.history.replaceState({}, '', '/p/proj/log_explorer?query=status%3D%3D500&cols=a,b');
+
+    updateTimePicker({ since: '1H' });
+
+    expect(params().get('query')).toBe('status==500');
+    expect(params().get('cols')).toBe('a,b');
+  });
+
+  test('two range changes in a row do not resurrect a param the second removed', () => {
+    mountPicker();
+    updateTimePicker({ from: '2024-01-01T00:00:00Z', to: '2024-01-02T00:00:00Z' });
+    updateTimePicker({ since: '1H' });
+
+    expect(params().get('since')).toBe('1H');
+    expect(params().get('from')).toBe('');
+    expect(params().get('to')).toBe('');
+  });
+});
+
+describe('malformed input', () => {
+  // A dashboard can be saved with a half-filled range. It must leave the current window
+  // alone rather than blanking the picker or writing a partial range to the URL.
+  test('neither since nor a complete from/to changes anything', () => {
+    const { label, input } = mountPicker();
+    label.innerText = 'Last 1 Hour';
+    input.value = '1H';
+    window.history.replaceState({}, '', '/p/proj/log_explorer?since=1H');
+
+    expect(updateTimePicker({})).toBe('');
+    expect(updateTimePicker({ from: '2024-01-01T00:00:00Z' })).toBe('');
+    expect(updateTimePicker({ to: '2024-01-02T00:00:00Z' })).toBe('');
+
+    expect(label.innerText).toBe('Last 1 Hour');
+    expect(input.value).toBe('1H');
+    expect(params().get('since')).toBe('1H');
+  });
+
+  test('a picker that is not on the page does not throw', () => {
+    expect(() => updateTimePicker({ since: '1H' })).not.toThrow();
+    expect(params().get('since')).toBe('1H');
+  });
+
+  test('a prefixed picker is addressed by its own ids', () => {
+    const other = mountPicker('n');
+    const mine = mountPicker('alertPr');
+
+    updateTimePicker({ since: '2H' }, { targetPr: 'alertPr' });
+
+    expect(mine.label.innerText).toBe('Last 2 Hours');
+    expect(other.label.innerText ?? '').toBe(''); // the default picker is left alone
+  });
+});
+
+describe('updateUrlState', () => {
+  test('sets and deletes keys without disturbing the path', () => {
+    window.history.replaceState({}, '', '/p/proj/dashboards/d1?a=1&b=2');
+
+    window.updateUrlState('a', '9');
+    expect(params().get('a')).toBe('9');
+    expect(window.location.pathname).toBe('/p/proj/dashboards/d1');
+
+    window.updateUrlState('b', '', 'delete');
+    expect(params().has('b')).toBe(false);
+  });
+
+  test('applies the same action to a whole group of keys at once', () => {
+    window.history.replaceState({}, '', '/p/proj/dashboards/d1?since=1H&from=x&to=y');
+
+    window.updateUrlState(['from', 'to'], '', 'delete');
+
+    expect(params().has('from')).toBe(false);
+    expect(params().has('to')).toBe(false);
+    expect(params().get('since')).toBe('1H');
+  });
+});

--- a/web-components/test/yaml-editor-io.test.ts
+++ b/web-components/test/yaml-editor-io.test.ts
@@ -1,0 +1,129 @@
+// Dashboard YAML import/export.
+//
+// This is the escape hatch for the whole dashboard: export, edit by hand or in git,
+// import back. A round-trip that mangles the text loses a dashboard someone built, and
+// both helpers are reachable from inline hyperscript, so a throw here is an uncaught
+// listener error rather than anything the user sees.
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+import { yamlEditorExport, yamlEditorImport } from '../src/yaml-editor';
+
+const YAML = 'title: Overview\nwidgets:\n  - type: timeseries\n    title: Traffic\n';
+
+let downloads: { name: string; body: string }[];
+let revoked: string[];
+let objectUrls: Map<string, Blob>;
+
+const fakeFile = (text: string) => ({ text: async () => text }) as File;
+
+beforeEach(() => {
+  downloads = [];
+  revoked = [];
+  objectUrls = new Map();
+  let n = 0;
+  (URL as any).createObjectURL = (blob: Blob) => {
+    const url = `blob:fake/${n++}`;
+    objectUrls.set(url, blob);
+    return url;
+  };
+  (URL as any).revokeObjectURL = (url: string) => revoked.push(url);
+  // jsdom does not implement navigation, so capture the click instead of following it.
+  vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(function (this: HTMLAnchorElement) {
+    const blob = objectUrls.get(this.href);
+    downloads.push({ name: this.download, body: blob ? (blob as any)[Symbol.for('body')] ?? '' : '' });
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  delete (window as any).yamlEditor;
+});
+
+const withEditor = (initial = '') => {
+  let value = initial;
+  (window as any).yamlEditor = { getValue: () => value, setValue: (v: string) => (value = v) };
+  return { get: () => value };
+};
+
+describe('exporting', () => {
+  test('downloads the editor contents under the requested filename', async () => {
+    withEditor(YAML);
+
+    yamlEditorExport('my-dashboard.yaml');
+
+    expect(downloads).toHaveLength(1);
+    expect(downloads[0].name).toBe('my-dashboard.yaml');
+    expect(await objectUrls.get([...objectUrls.keys()][0])!.text()).toBe(YAML);
+  });
+
+  test('defaults to dashboard.yaml', () => {
+    withEditor(YAML);
+    yamlEditorExport();
+    expect(downloads[0].name).toBe('dashboard.yaml');
+  });
+
+  test('serves the file as YAML so the browser does not rename it to .txt', () => {
+    withEditor(YAML);
+    yamlEditorExport();
+    expect([...objectUrls.values()][0].type).toBe('application/x-yaml');
+  });
+
+  test('releases the object URL rather than leaking it for the life of the tab', () => {
+    withEditor(YAML);
+    yamlEditorExport();
+    expect(revoked).toHaveLength(1);
+  });
+
+  test('an empty or missing editor exports nothing instead of an empty file', () => {
+    withEditor('');
+    yamlEditorExport();
+    expect(downloads).toHaveLength(0);
+
+    delete (window as any).yamlEditor;
+    expect(() => yamlEditorExport()).not.toThrow();
+    expect(downloads).toHaveLength(0);
+  });
+});
+
+describe('importing', () => {
+  test('replaces the editor contents with the file, byte for byte', async () => {
+    const editor = withEditor('title: Old\n');
+
+    await yamlEditorImport(fakeFile(YAML));
+
+    expect(editor.get()).toBe(YAML);
+  });
+
+  test('a file with no trailing newline or with CRLF is not silently rewritten', async () => {
+    const editor = withEditor();
+    await yamlEditorImport(fakeFile('title: A'));
+    expect(editor.get()).toBe('title: A');
+
+    await yamlEditorImport(fakeFile('title: A\r\nwidgets: []\r\n'));
+    expect(editor.get()).toBe('title: A\r\nwidgets: []\r\n');
+  });
+
+  // Reachable from inline hyperscript (a cancelled file picker), so it must not throw.
+  test('no file selected is a no-op', async () => {
+    const editor = withEditor(YAML);
+    await expect(yamlEditorImport(undefined as unknown as File)).resolves.toBeUndefined();
+    expect(editor.get()).toBe(YAML);
+  });
+
+  test('importing before the editor has mounted does not throw', async () => {
+    delete (window as any).yamlEditor;
+    await expect(yamlEditorImport(fakeFile(YAML))).resolves.toBeUndefined();
+  });
+});
+
+describe('round-trip', () => {
+  test('export then import returns the identical document', async () => {
+    const editor = withEditor(YAML);
+
+    yamlEditorExport();
+    const exported = await [...objectUrls.values()][0].text();
+    editor.get(); // sanity: still the original
+    await yamlEditorImport(fakeFile(exported));
+
+    expect(editor.get()).toBe(YAML);
+  });
+});


### PR DESCRIPTION
In-progress work on dashboard widgets and the log list, plus a substantial new web-component test suite. **38 files, ~4.5k insertions.**

- **Frontend:** `log-list.ts` reworked with a new `log-list-harness.ts`, and new tests around scroll position, keyboard, row selection, sessions, trace expand, transport, configurations, embedded and failure states. Also `charts.ts`, `widgets.ts`, `main.ts`, `setup.ts`, and new dashboard-canvas / dashboard-refresh / flamegraph-hierarchy / color-mapping / local-time / query-builder-roundtrip / session-replay-markers / time-picker-state / yaml-editor-io tests.
- **Server:** `Pages/Dashboards.hs`, `Pkg/Components/Widget.hs`, `Pkg/Components/LogQueryBox.hs`; new `Pages.DashboardWidgetsSpec`; additions to `DashboardsSpec` and `LogSpec`; `e2e/tests/dashboard-grid.spec.ts`.

Includes one fix that this work needs to build at all: **`DashboardWidgetsSpec` imports `Text.Slugify`, but `slugify` was in the `library` and `test-dev` build-depends and not `integration-tests`.** So `make live-test-dev` compiled it happily while `cabal build all` — what CI runs — failed with `Could not load module 'Text.Slugify'`. Added to the `integration-tests` stanza in `package.yaml` and `hpack` re-run. Also gitignores root-level `test-results/` (Playwright output).

CI is the reviewer here: the gate runs build, doctests, unit-tests, cli-tests and integration-tests, and the deploy is blocked unless they pass.