### PR TITLE
fix(test): import toHtml in DashboardWidgetsSpec

### DIFF
--- a/test/integration/Pages/DashboardWidgetsSpec.hs
+++ b/test/integration/Pages/DashboardWidgetsSpec.hs
@@ -13,7 +13,7 @@ import Data.Default (def)
 import Data.Map.Strict qualified as Map
 import Data.Text qualified as T
 import Data.Vector qualified as V
-import Lucid (renderText)
+import Lucid (renderText, toHtml)
 import Models.Projects.Dashboards (DashboardVM (..))
 import Models.Projects.Dashboards qualified as DashboardModel
 import Models.Projects.GitSync qualified as GitSync
@@ -155,6 +155,32 @@ spec = sequential $ aroundAll withTestResources do
       only <- onlyWidget =<< storedWidgets tr dashId
 
       only.query `shouldBe` Just "name != null"
+
+  -- The full canvas lifecycle, once per widget type, in one example: add it, drag it,
+  -- resize it, then re-read the dashboard the way the next page load does. Every type goes
+  -- through the same three handlers, so looping is what makes "every single kind of widget"
+  -- cheap to assert — and a type that silently fails to persist shows up as its own line in
+  -- the diff rather than as one opaque failure.
+  it "every widget type survives add, move, resize and reload" \tr -> do
+    dashId <- newDashboard tr "Widget Lifecycle"
+    addWidgets tr dashId [widgetOf wt (show @Text wt) | wt <- allWidgetTypes]
+    added <- storedWidgets tr dashId
+    map (show @Text . (.wType)) added `shouldBe` map (show @Text) allWidgetTypes
+
+    -- Move and resize every one to a position and size unique to its index, so a widget
+    -- landing on another's coordinates cannot pass.
+    let placed = [(wid, (i * 2) `mod` 12, i, 1 + (i `mod` 4), 2 + (i `mod` 3)) | (i, wid) <- zip [0 ..] (mapMaybe (.id) added)]
+        patch = fromList [(wid, (def :: Dashboards.WidgetReorderItem){Dashboards.x = Just x, Dashboards.y = Just y, Dashboards.w = Just w, Dashboards.h = Just h}) | (wid, x, y, w, h) <- placed]
+    _ <- testServant tr $ Dashboards.dashboardWidgetReorderPatchH testPid dashId Nothing patch
+
+    -- The reload: read it back through the same path a fresh request renders from.
+    reloaded <- storedWidgets tr dashId
+    let geometryOf w = (w.id, w.layout >>= (.x), w.layout >>= (.y), w.layout >>= (.w), w.layout >>= (.h))
+        expected = sort [(Just wid, Just x, Just y, Just w, Just h) | (wid, x, y, w, h) <- placed]
+    sort (map geometryOf reloaded) `shouldBe` expected
+    -- And nothing changed identity along the way: same types, same count, no duplicates.
+    sort (map (show @Text . (.wType)) reloaded) `shouldBe` sort (map (show @Text) allWidgetTypes)
+    length (ordNub (mapMaybe (.id) reloaded)) `shouldBe` length allWidgetTypes
 
   describe "Moving and resizing on the canvas" do
     it "a drag persists the new position across a reload" \tr -> do

--- a/web-components/src/log-list.ts
+++ b/web-components/src/log-list.ts
@@ -284,6 +284,11 @@ export class LogList extends LitElement {
   // aria-activedescendant plus the active outline: lit-virtualizer recycles row nodes, so
   // DOM focus placed on a row dies with the node as soon as the list scrolls.
   @state() private focusedRowId: string | null = null;
+  // The row whose detail panel is open. Rendered from state rather than by adding a class
+  // in the click handler: the virtualizer destroys a row's element when it scrolls out of
+  // the runway, so an imperative class was lost the moment the reader scrolled away and
+  // back — during an incident, losing track of which row you are reading.
+  @state() private openRowId: string | null = null;
   private barChart: any = null;
   private lineChart: any = null;
   private initChartsTimer: ReturnType<typeof setTimeout> | null = null;
@@ -1894,15 +1899,10 @@ export class LogList extends LitElement {
       }
     });
 
-    // `:scope >` — sibling ROWS only. bg-fillBrand-strong also paints the latency bar inside
-    // every row, so an unscoped descendant search matched the first bar long before it reached
-    // the previously selected row: that bar lost its colour and the old row stayed marked, so
-    // two rows looked selected at once.
-    const prevActive = event.currentTarget.parentElement?.querySelector(':scope > .bg-fillBrand-strong');
-    if (prevActive) {
-      prevActive.classList.remove('bg-fillBrand-strong');
-    }
-    event.currentTarget.classList.add('bg-fillBrand-strong');
+    // One assignment, and the template does the rest. The previous approach searched the
+    // DOM for the last marked row, which also matched the latency bar *inside* a row (same
+    // class) — stripping its colour while leaving the old row marked — and could not
+    // survive the virtualizer recycling the row's element.
     // Re-query rather than reuse a cached ref: the indicator is rendered *inside* the container
     // this request innerHTML-swaps, so every response replaces the node. A ref captured on an
     // earlier click points at a detached element, and clearing that leaves the live one spinning.
@@ -1910,6 +1910,7 @@ export class LogList extends LitElement {
     showIndicator(true);
 
     const [rdId, rdCreatedAt, source] = targetInfo;
+    this.openRowId = rdId;
     const url = `/p/${pid}/log_explorer/${rdId}/${rdCreatedAt}/detailed?source=${source}`;
     updateUrlState('target_event', `${rdId}/${rdCreatedAt}/detailed?source=${source}`);
     // Only the newest click owns the indicator: #log_details_container carries
@@ -3403,6 +3404,7 @@ export class LogList extends LitElement {
         // and only summary is forced onto its own line below them.
         this.isNarrow ? 'flex-wrap items-center gap-x-2 py-1.5 px-1 border-b border-strokeWeak' : 'whitespace-nowrap',
         rowData.id === this.focusedRowId && 'outline outline-2 -outline-offset-2 outline-strokeBrand-strong',
+        rowData.id === this.openRowId && 'bg-fillBrand-strong',
         rowHoverBg,
         !ov && 'contain-layout-style',
         isPatterns && (this.wrapsLines ? 'items-start' : 'items-center'),

--- a/web-components/test/live-tail.test.ts
+++ b/web-components/test/live-tail.test.ts
@@ -162,3 +162,129 @@ describe('Live Tail reconnection', () => {
     expect(posted.at(-1)).toMatchObject(selectors);
   });
 });
+
+// The connection state machine and what a restart resets. Live tail is watched during an
+// incident, so "is this still receiving?" has to be answerable from the screen — a stream
+// that stopped while showing its last rows is indistinguishable from a quiet service.
+describe('Live Tail connection state', () => {
+  test('only connecting, live and reconnecting count as running', async () => {
+    const el = await mount();
+    for (const [state, isRunning] of [
+      ['idle', false],
+      ['connecting', true],
+      ['live', true],
+      ['reconnecting', true],
+      ['stopped', false],
+      ['expired', false],
+    ] as const) {
+      el.streamState = state;
+      expect([state, el.running]).toEqual([state, isRunning]);
+    }
+  });
+
+  // The status line is what the reader checks. A state change that left the previous
+  // state's message behind would describe a connection that no longer exists.
+  test('the status message belongs to the current state', async () => {
+    const el = await mount();
+    el.restart();
+    const stream = (el as any).stream;
+
+    stream.opts.onState('reconnecting', 'lost the connection');
+    await el.updateComplete;
+    expect([el.streamState, el.statusMessage]).toEqual(['reconnecting', 'lost the connection']);
+
+    stream.opts.onState('live', undefined);
+    await el.updateComplete;
+    expect([el.streamState, el.statusMessage]).toEqual(['live', '']);
+  });
+
+  test('server-side drops are reported as a total, not accumulated twice', async () => {
+    const el = await mount();
+    el.restart();
+    const stream = (el as any).stream;
+
+    stream.opts.onState('live', undefined);
+    stream.opts.onDropped(12);
+    stream.opts.onDropped(30); // the server reports a running total
+    await el.updateComplete;
+
+    expect(el.droppedServer).toBe(30);
+  });
+});
+
+describe('Live Tail restart', () => {
+  // Restarting means a new filter: rows matched against the old one are not results for
+  // the new one, and carrying over a drop count would attribute them to the wrong query.
+  test('clears the rows and drop counts from the previous filter', async () => {
+    const el = await mount();
+    el.restart();
+    el.appendRows(pushed(0, 5).map((r: any) => r.log));
+    (el as any).droppedServer = 7;
+    (el as any).droppedClient = 3;
+    await el.updateComplete;
+
+    el.restart();
+    await el.updateComplete;
+
+    expect(el.rows).toEqual([]);
+    expect(el.buffer).toEqual([]);
+    expect(el.droppedServer).toBe(0);
+    expect(el.droppedClient).toBe(0);
+  });
+
+  test('replaces the old connection rather than leaving two open', async () => {
+    const el = await mount();
+    el.restart();
+    const first = (el as any).stream;
+
+    el.restart();
+
+    expect((el as any).stream).not.toBe(first);
+    expect(first.isRunning).toBe(false);
+  });
+
+  // A plain /live_tail link must stay plain: only a filter the reader actually chose
+  // belongs in the URL they might copy.
+  test('writes only the filters that differ from the defaults into the URL', async () => {
+    const el = await mount();
+    window.history.replaceState({}, '', '/p/p1/live_tail');
+    const param = (k: string) => new URLSearchParams(window.location.search).get(k);
+
+    el.service = 'checkout';
+    el.environment = 'prod';
+    el.kind = 'spans';
+    el.restart();
+    expect([param('service'), param('env'), param('kind')]).toEqual(['checkout', 'prod', 'spans']);
+
+    // Cleared filters are removed rather than left as empty keys, and `logs` is the
+    // default kind so it never appears — a plain /live_tail link stays plain.
+    el.service = '';
+    el.environment = '';
+    el.kind = 'logs';
+    el.restart();
+    expect([param('service'), param('env'), param('kind')]).toEqual([null, null, null]);
+  });
+
+  test('the registration body carries the chosen filters', async () => {
+    const el = await mount();
+    el.service = 'checkout';
+    el.environment = 'prod';
+    el.query = 'level == "error"';
+
+    el.restart();
+    const body = (el as any).stream.opts.body();
+
+    expect(body).toMatchObject({ service: 'checkout', environment: 'prod', query: 'level == "error"' });
+  });
+
+  test('an unset filter is sent as null, not an empty string', async () => {
+    const el = await mount();
+    el.service = '';
+    el.environment = '';
+    el.query = '';
+
+    el.restart();
+
+    expect((el as any).stream.opts.body()).toMatchObject({ service: null, environment: null, query: null });
+  });
+});

--- a/web-components/test/log-list-row-selection.test.ts
+++ b/web-components/test/log-list-row-selection.test.ts
@@ -1,10 +1,11 @@
 // Selecting a row to open its detail panel.
 //
-// The clicked row is marked with `bg-fillBrand-strong` and the previously selected one is
-// unmarked. That same class is also what paints the latency bar *inside* every row and a
-// handful of other in-row elements, so "find the previously selected row" has to mean the
-// row, not the first descendant that happens to share the class. Getting it wrong leaves
-// two rows looking selected and strips the colour off a latency bar.
+// The open row used to be marked by adding `bg-fillBrand-strong` in the click handler and
+// searching the DOM to unmark the previous one. That search also matched the latency bar
+// *inside* a row (same class), so it stripped a bar's colour while leaving the old row
+// marked — two rows looking selected at once. And because the virtualizer destroys a row's
+// element when it scrolls out of the runway, the mark did not survive scrolling away and
+// back. Selection is now state the template renders, so both problems are unrepresentable.
 import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
 import { mountList } from './log-list-harness';
 
@@ -59,29 +60,18 @@ beforeEach(() => {
 afterEach(() => vi.restoreAllMocks());
 
 describe('selecting a row', () => {
-  test('marks the clicked row', async () => {
+  test('records the clicked row as the open one', async () => {
     const el = await mountList();
     const rows = buildRows(2);
 
     clickRow(el, rows[0].tr, 'r0');
 
-    expect(rows[0].tr.classList.contains(SELECTED)).toBe(true);
+    expect((el as any).openRowId).toBe('r0');
   });
 
-  // The bug: scoping the "previously selected" lookup to descendants matched a latency bar
-  // long before it reached the previous row, so the old row stayed marked.
-  test('unmarks the previously selected row', async () => {
-    const el = await mountList();
-    const rows = buildRows(3);
-
-    clickRow(el, rows[0].tr, 'r0');
-    clickRow(el, rows[2].tr, 'r2');
-
-    expect(rows[2].tr.classList.contains(SELECTED)).toBe(true);
-    expect(rows[0].tr.classList.contains(SELECTED)).toBe(false);
-  });
-
-  test('exactly one row is ever selected', async () => {
+  // Exactly one row can be open, because it is a single value rather than a class the
+  // handler has to remember to remove from somewhere.
+  test('opening another row replaces the first', async () => {
     const el = await mountList();
     const rows = buildRows(4);
 
@@ -89,12 +79,10 @@ describe('selecting a row', () => {
     clickRow(el, rows[3].tr, 'r3');
     clickRow(el, rows[0].tr, 'r0');
 
-    expect(rows.filter((r) => r.tr.classList.contains(SELECTED)).map((_, i) => i)).toHaveLength(1);
-    expect(rows[0].tr.classList.contains(SELECTED)).toBe(true);
+    expect((el as any).openRowId).toBe('r0');
   });
 
-  // The same class paints the latency bar. Stripping it turns a bar colourless — and the
-  // bar is the row's whole point in a waterfall.
+  // The same class paints the latency bar inside every row. The old DOM search stripped it.
   test('leaves the latency bars inside rows alone', async () => {
     const el = await mountList();
     const rows = buildRows(3);
@@ -105,14 +93,28 @@ describe('selecting a row', () => {
     expect(rows.every((r) => r.bar.classList.contains(SELECTED))).toBe(true);
   });
 
-  test('re-clicking the selected row keeps it selected', async () => {
+  // The virtualizer destroys and recreates row elements as they leave and re-enter its
+  // runway. State survives that; a class added to the element did not.
+  test('the open row survives the list re-rendering around it', async () => {
+    const el = await mountList();
+    const rows = buildRows(2);
+    clickRow(el, rows[0].tr, 'r0');
+
+    document.body.innerHTML = ''; // every row element is gone
+    buildRows(2); // ...and rebuilt, as the virtualizer would
+    await el.updateComplete;
+
+    expect((el as any).openRowId).toBe('r0');
+  });
+
+  test('re-clicking the open row keeps it open', async () => {
     const el = await mountList();
     const rows = buildRows(2);
 
     clickRow(el, rows[0].tr, 'r0');
     clickRow(el, rows[0].tr, 'r0');
 
-    expect(rows[0].tr.classList.contains(SELECTED)).toBe(true);
+    expect((el as any).openRowId).toBe('r0');
   });
 });
 


### PR DESCRIPTION
This is what blocked the deploy of `b052d6cf4`:

```
test/integration/Pages/DashboardWidgetsSpec.hs:346:72: error: [GHC-88464]
    Variable not in scope: toHtml :: Dashboards.DashboardGet -> Html a0
    Suggested fix: Add ‘toHtml’ to the import list in the import of ‘Lucid’
```

Line 16 imported only `renderText`. The fix already existed in the working tree and had simply never been committed, so master received the broken version.

Worth noting how long it took to *see* that error: the `doctests` step was recompiling all 184 modules (because `build` and the test steps disagreed on `ghc-options` — fixed in #495), and on a 4-vCPU runner that recompile was OOM-killed before GHC could print anything. The log went straight from `[182 of 184] Compiling …` to a failed step with no message. Once the recompile was removed, the step failed in 1 minute with the actual error.

Carries the rest of the in-flight work: `log-list.ts` changes, a new live-tail test, and a reworked log-list-row-selection test.