### PR TITLE
ci: run local CI from a snapshot, so editing ci.sh mid-run is safe

### DIFF
--- a/docs/local-ci.md
+++ b/docs/local-ci.md
@@ -65,6 +65,11 @@ Two deliberate differences from your normal `make test`:
 - **Your `.env` is not visible.** `ci/compose.yml` mounts an empty file over it.
   A local secret — or a `DATABASE_URL` pointing at production — changing the
   result is exactly what makes "passes locally, fails in CI" happen.
+- **Editing `ci.sh` mid-run is safe.** The container runs from a copy, because
+  bash reads a script incrementally by file offset — editing the original while
+  it runs would otherwise make the running shell resume at a stale offset and die
+  with `syntax error near unexpected token`. A run lasts tens of minutes, so
+  editing it meanwhile is normal, not a mistake.
 - **Build directories are container-private.** `dist-newstyle` and both
   `node_modules` are named volumes; your host's are macOS/arm64 artifacts and
   sharing them corrupts both. The volumes persist, so the second `make ci` is

--- a/scripts/ci/ci.sh
+++ b/scripts/ci/ci.sh
@@ -455,9 +455,14 @@ cmd_local() {
   local rc=0
   # --rm so a failed run leaves nothing behind; the caches live in named volumes.
   # Forward the run's knobs; `compose run` only passes what it is told to.
+  # Run from a COPY inside the container, not from the bind mount. bash reads a
+  # script incrementally by file offset, so editing scripts/ci/ci.sh while a run
+  # is in flight makes the running shell resume at a stale offset and die with
+  # "syntax error near unexpected token". A `make ci` lasts tens of minutes —
+  # long enough that editing it meanwhile is a normal thing to do, not a mistake.
   compose run --rm \
     -e "CI_ALLOW_DEGRADED=${CI_ALLOW_DEGRADED:-}" -e "CI_FORCE=${CI_FORCE:-}" -e "CI_KEEP_GOING=${CI_KEEP_GOING:-}" \
-    runner scripts/ci/ci.sh run "$@" || rc=$?
+    runner sh -c 'cp scripts/ci/ci.sh /tmp/ci-run.sh && exec bash /tmp/ci-run.sh run "$@"' ci-run "$@" || rc=$?
   # Publish whatever passed even if a later check failed — a green check is green.
   cmd_publish .ci/attest.tsv
   [ "$rc" -eq 0 ] || note "local CI failed (exit $rc); services left up for debugging — \`make ci-down\` to clean up"


### PR DESCRIPTION
bash reads a script incrementally by file offset. The container ran `ci.sh` straight off the bind mount, so editing it while a run was in flight made the running shell resume at a stale offset and die with `syntax error near unexpected token ';;'`.

The check itself had already passed and been attested — only the wrapper died. That is the third instance today of a passing check reported as failing because something around it broke. A `make ci` lasts tens of minutes, so editing the script meanwhile is normal, not user error.

Fix: copy the script into the container and exec the copy.