### PR TITLE
Fix embedding requests constructed from root and trailing-slash URLs

### DIFF
--- a/monoscope.cabal
+++ b/monoscope.cabal
@@ -174,6 +174,7 @@ extra-source-files:
     static/migrations/0143_error_group_reviews.sql
     static/migrations/0144_learned_error_masks.sql
     static/migrations/0145_error_patterns_recent_trace_at.sql
+    static/migrations/0146_rum_panel_cache.sql
     static/migrations/0147_error_patterns_first_trace_at.sql
 
 source-repository head
@@ -1210,6 +1211,7 @@ test-suite unit-tests
   other-modules:
       BackgroundJobs.SpikeDetectionSpec
       Data.Effectful.HasqlSpec
+      Data.Effectful.LLMSpec
       Models.DashboardTemplatesSpec
       Models.Telemetry.DeterministicIdSpec
       Models.Telemetry.MetricServiceNameSpec
@@ -1269,6 +1271,7 @@ test-suite unit-tests
     , hspec
     , http-client
     , http-types
+    , langchain-hs
     , lens
     , log-base
     , log-effectful

--- a/package.yaml
+++ b/package.yaml
@@ -292,6 +292,7 @@ tests:
       - base # System.ServerSpec imports Control.Concurrent/Exception directly (not via relude)
       - hs-opentelemetry-instrumentation-auto
       - hspec
+      - langchain-hs
       - relude >= 1.2.0.0
       - aeson
       # Pkg.WidgetLazySpec builds a Widget and renders it

--- a/src/BackgroundJobs.hs
+++ b/src/BackgroundJobs.hs
@@ -3878,11 +3878,7 @@ embedAndMerge pid ctx cfg = unless (null cfg.items) do
 
 
 embeddingConfig :: Config.AuthContext -> Langchain.Embeddings.OpenAI.OpenAIEmbeddings
-embeddingConfig ctx =
-  Langchain.Embeddings.OpenAI.defaultOpenAIEmbeddings
-    { Langchain.Embeddings.OpenAI.apiKey = ctx.config.openaiApiKey
-    , Langchain.Embeddings.OpenAI.baseUrl = if T.null ctx.config.openaiBaseUrl then Just "https://api.openai.com/v1" else Just (toString ctx.config.openaiBaseUrl)
-    }
+embeddingConfig ctx = ELLM.openAIEmbeddings ctx.config.openaiApiKey ctx.config.openaiBaseUrl
 
 
 -- Endpoint template discovery ---------------------------------------------------

--- a/src/Data/Effectful/LLM.hs
+++ b/src/Data/Effectful/LLM.hs
@@ -3,6 +3,7 @@ module Data.Effectful.LLM (
   callLLM,
   callAgenticChat,
   embedDocuments,
+  openAIEmbeddings,
   callOpenAIAPI,
   modelAndEffort,
   runLLMReal,
@@ -57,6 +58,20 @@ type instance DispatchOf LLM = 'Dynamic
 
 
 makeEffect ''LLM
+
+
+-- | Configure the embedding client from the application settings. Langchain
+-- appends /embeddings verbatim, so the base must have no trailing slash.
+-- Accept the official host root as its versioned API base; custom proxy paths
+-- are already API bases and must retain their path.
+openAIEmbeddings :: Text -> Text -> EmbOAI.OpenAIEmbeddings
+openAIEmbeddings apiKey baseUrl =
+  EmbOAI.defaultOpenAIEmbeddings
+    { EmbOAI.apiKey = apiKey
+    , EmbOAI.baseUrl = Just $ if T.null baseUrl || normalized == "https://api.openai.com" then "https://api.openai.com/v1" else toString normalized
+    }
+  where
+    normalized = T.dropWhileEnd (== '/') baseUrl
 
 
 -- | Real interpreter that makes actual OpenAI API calls

--- a/test/unit/Data/Effectful/LLMSpec.hs
+++ b/test/unit/Data/Effectful/LLMSpec.hs
@@ -1,0 +1,25 @@
+module Data.Effectful.LLMSpec (spec) where
+
+import Data.Effectful.LLM (openAIEmbeddings)
+import Langchain.Embeddings.OpenAI qualified as EmbOAI
+import Relude
+import Test.Hspec
+
+
+spec :: Spec
+spec = describe "embedding endpoint configuration" do
+  let cases :: [(Text, String)]
+      cases =
+        [ ("", "https://api.openai.com/v1")
+        , ("https://api.openai.com/", "https://api.openai.com/v1")
+        , ("https://api.openai.com", "https://api.openai.com/v1")
+        , ("https://api.openai.com/v1/", "https://api.openai.com/v1")
+        , ("https://api.openai.com/v1", "https://api.openai.com/v1")
+        , ("https://proxy.example/openai/v1/", "https://proxy.example/openai/v1")
+        , ("https://proxy.example/api", "https://proxy.example/api")
+        ]
+  forM_ cases \(configured, expected) ->
+    it ("resolves " <> show configured) do
+      let client = openAIEmbeddings "test-key" configured
+      EmbOAI.baseUrl client `shouldBe` Just expected
+      EmbOAI.apiKey client `shouldBe` "test-key"


### PR DESCRIPTION
Production configures OPENAI_BASE_URL=https://api.openai.com/, while the embedding client appends /embeddings verbatim. Background embedding jobs therefore request //embeddings and receive HTTP 404.

Normalize trailing slashes and resolve the official OpenAI root to its /v1 API base when constructing the embedding client. Preserve explicit custom proxy paths and the API key. Move this construction into the existing LLM module so tests exercise the actual client configuration used by BackgroundJobs.

Validation: seven regression cases produced four failures before the repair and all pass afterward. Targeted HLint, formatting, and diff checks pass. No production deployment or successful live embedding job has been verified yet.

Rebased onto master after #507 merged. Regenerating the Cabal manifest also includes the already-existing 0146 migration that its prior generated list omitted.
