### PR TITLE
fix: bound embedding requests and preserve long patterns

### DIFF
--- a/src/BackgroundJobs.hs
+++ b/src/BackgroundJobs.hs
@@ -3481,7 +3481,7 @@ newEndpointAlertsPerHour = 10
 runHostRetentionSweep :: Config.AuthContext -> Projects.ProjectId -> ATBackgroundCtx ()
 runHostRetentionSweep authCtx pid = do
   now <- Time.currentTime
-  traffic <- Endpoints.hostTrafficSince authCtx.env.enableTimefusionReads pid (addUTCTime (-48 * 3600) now)
+  traffic <- Endpoints.hostTrafficSince authCtx.env.enableTimefusionReads pid (addUTCTime (-(48 * 3600)) now)
   (unarchivedRaw, archivedCount) <- Endpoints.hostRetentionSweep pid traffic
   let unarchived = ordNub $ V.toList unarchivedRaw
   when (archivedCount > 0) $ Log.logInfo "Hosts auto-archived after 30 idle days" ("project_id", pid.toText, "count", archivedCount)

--- a/src/Data/Effectful/LLM.hs
+++ b/src/Data/Effectful/LLM.hs
@@ -20,6 +20,7 @@ import Data.ByteString qualified as BS
 import Data.Effectful.Wreq (withGoldenCache)
 import Data.IntMap.Strict qualified as IntMap
 import Data.Text qualified as T
+import Data.Text.Foreign qualified as TextForeign
 import Data.Vector qualified as V
 import Data.Vector.Unboxed qualified as VU
 import Effectful
@@ -83,7 +84,7 @@ openAIEmbeddings apiKey baseUrl =
 
 -- | Apply the embedding provider's per-input and batch limits without losing text.
 -- UTF-8 byte length is an upper bound on cl100k_base token count. Keep inputs
--- under 8192 bytes; four bytes per code point bounds even non-ASCII chunks.
+-- under 8192 bytes, preserving UTF-8 boundaries when splitting chunks.
 -- A batch of at most 36 such chunks stays below the 300,000-token request limit.
 -- Long documents use a byte-length-weighted mean, normalized for cosine search.
 embedDocumentsBounded :: Monad m => ([DocLoader.Document] -> m (Either Text [[Float]])) -> [DocLoader.Document] -> m (Either Text [[Float]])
@@ -93,15 +94,23 @@ embedDocumentsBounded request docs
       means <- go mempty chunks
       traverse (finish means) [0 .. length docs - 1]
   where
+    maxInputBytes = 8191 :: Int
+    maxBatchChunks = 300000 `div` maxInputBytes
+    -- takeWord8/dropWord8 advance together by up to three bytes to finish a
+    -- code point. Reserve those bytes so even that final character fits.
+    chunkBytes = fromIntegral (maxInputBytes - 3)
+    splitText txt
+      | T.null txt = []
+      | otherwise = TextForeign.takeWord8 chunkBytes txt : splitText (TextForeign.dropWord8 chunkBytes txt)
     chunks = concat $ zipWith splitDocument [0 :: Int ..] docs
     splitDocument docId doc =
       let txt = toStrict $ DocLoader.pageContent doc
-          parts = if byteLength txt < 8192 then [txt] else T.chunksOf (8191 `div` 4) txt
+          parts = if byteLength txt <= maxInputBytes then [txt] else splitText txt
        in map (\part -> (docId, byteLength part, doc{DocLoader.pageContent = toLazy part})) parts
     byteLength = BS.length . encodeUtf8
     go means [] = pure means
     go means remaining = do
-      let (batch, rest) = splitAt 36 remaining
+      let (batch, rest) = splitAt maxBatchChunks remaining
       vectors <- ExceptT $ request $ map (\(_, _, doc) -> doc) batch
       when (length vectors /= length batch) $ throwError "Embedding response count does not match request"
       updated <- foldM add means $ zip batch vectors

--- a/src/Data/Effectful/LLM.hs
+++ b/src/Data/Effectful/LLM.hs
@@ -4,6 +4,7 @@ module Data.Effectful.LLM (
   callAgenticChat,
   embedDocuments,
   openAIEmbeddings,
+  embedDocumentsBounded,
   callOpenAIAPI,
   modelAndEffort,
   runLLMReal,
@@ -11,11 +12,16 @@ module Data.Effectful.LLM (
 ) where
 
 import Control.Lens ((^?))
+import Control.Monad (foldM)
+import Control.Monad.Except (throwError)
 import Data.Aeson qualified as AE
 import Data.Aeson.Lens (key)
+import Data.ByteString qualified as BS
 import Data.Effectful.Wreq (withGoldenCache)
+import Data.IntMap.Strict qualified as IntMap
 import Data.Text qualified as T
 import Data.Vector qualified as V
+import Data.Vector.Unboxed qualified as VU
 import Effectful
 import Effectful.Dispatch.Dynamic
 import Effectful.TH
@@ -27,6 +33,7 @@ import Langchain.LLM.OpenAI qualified as OpenAI
 import OpenAI.V1.Chat.Completions qualified as OpenAIV1
 import OpenAI.V1.Models qualified as Models
 import Relude
+import Relude.Extra.Bifunctor (firstF)
 
 
 -- Generic-derived JSON for LLMCore.Message (record field names match the prior
@@ -74,6 +81,59 @@ openAIEmbeddings apiKey baseUrl =
     normalized = T.dropWhileEnd (== '/') baseUrl
 
 
+-- | Apply the embedding provider's per-input and batch limits without losing text.
+-- UTF-8 byte length is an upper bound on cl100k_base token count. Keep inputs
+-- under 8192 bytes; four bytes per code point bounds even non-ASCII chunks.
+-- A batch of at most 36 such chunks stays below the 300,000-token request limit.
+-- Long documents use a byte-length-weighted mean, normalized for cosine search.
+embedDocumentsBounded :: Monad m => ([DocLoader.Document] -> m (Either Text [[Float]])) -> [DocLoader.Document] -> m (Either Text [[Float]])
+embedDocumentsBounded request docs
+  | any (T.null . toStrict . DocLoader.pageContent) docs = pure $ Left "Cannot embed an empty document"
+  | otherwise = runExceptT do
+      means <- go mempty chunks
+      traverse (finish means) [0 .. length docs - 1]
+  where
+    chunks = concat $ zipWith splitDocument [0 :: Int ..] docs
+    splitDocument docId doc =
+      let txt = toStrict $ DocLoader.pageContent doc
+          parts = if byteLength txt < 8192 then [txt] else T.chunksOf (8191 `div` 4) txt
+       in map (\part -> (docId, byteLength part, doc{DocLoader.pageContent = toLazy part})) parts
+    byteLength = BS.length . encodeUtf8
+    go means [] = pure means
+    go means remaining = do
+      let (batch, rest) = splitAt 36 remaining
+      vectors <- ExceptT $ request $ map (\(_, _, doc) -> doc) batch
+      when (length vectors /= length batch) $ throwError "Embedding response count does not match request"
+      updated <- foldM add means $ zip batch vectors
+      go updated rest
+    add means ((docId, weight, _), values)
+      | null values || any (\v -> isNaN v || isInfinite v) values = throwError "Embedding response contains an invalid vector"
+      | otherwise = do
+          let !vector = VU.fromList $ map realToFrac values
+          next <- case IntMap.lookup docId means of
+            Nothing -> pure $ EmbeddingMean 1 weight vector
+            Just (EmbeddingMean count total mean)
+              | VU.length mean /= VU.length vector -> throwError "Embedding response dimensions do not match"
+              | otherwise ->
+                  let fraction = fromIntegral weight / fromIntegral (total + weight)
+                      !combined = VU.zipWith (\a b -> a + fraction * (b - a)) mean vector
+                   in pure $ EmbeddingMean (count + 1) (total + weight) combined
+          pure $ IntMap.insert docId next means
+    finish means docId = case IntMap.lookup docId means of
+      Nothing -> throwError "Embedding response is missing a document"
+      Just (EmbeddingMean count _ mean)
+        | count == 1 -> pure $ map realToFrac $ VU.toList mean
+        | otherwise ->
+            let norm = sqrt $ VU.sum $ VU.map (\v -> v * v) mean :: Double
+             in if norm == 0
+                  then throwError "Chunk embeddings have a zero-length mean"
+                  else pure $ map (realToFrac . (/ norm)) $ VU.toList mean
+
+
+-- Strict fields keep chunk accumulation from retaining previous batch vectors.
+data EmbeddingMean = EmbeddingMean !Int !Int !(VU.Vector Double)
+
+
 -- | Real interpreter that makes actual OpenAI API calls
 runLLMReal :: IOE :> es => Eff (LLM ': es) a -> Eff es a
 runLLMReal = interpret $ \_ -> \case
@@ -82,7 +142,7 @@ runLLMReal = interpret $ \_ -> \case
     let openAI = OpenAI.OpenAI{apiKey, callbacks = [], baseUrl = Nothing}
     result <- LLMCore.chat openAI history (Just params)
     pure $ first show result
-  EmbedDocuments config docs -> liftIO $ first show <$> EmbCore.embedDocuments config docs
+  EmbedDocuments config docs -> liftIO $ embedDocumentsBounded (firstF show . EmbCore.embedDocuments config) docs
 
 
 -- | Golden test interpreter that caches responses
@@ -221,7 +281,7 @@ data EmbeddingCache = EmbeddingCache
 getOrCreateEmbeddingGoldenResponse :: FilePath -> EmbOAI.OpenAIEmbeddings -> [DocLoader.Document] -> IO (Either Text [[Float]])
 getOrCreateEmbeddingGoldenResponse goldenDir config docs =
   withGoldenCache goldenDir (cacheKey <> ".json") ("Failed to decode embedding cache from: " <>) (.result) $ do
-    result <- first show <$> EmbCore.embedDocuments config docs
+    result <- embedDocumentsBounded (firstF show . EmbCore.embedDocuments config) docs
     pure (EmbeddingCache{texts, result}, result)
   where
     texts = map (toStrict . DocLoader.pageContent) docs

--- a/test/unit/Data/Effectful/LLMSpec.hs
+++ b/test/unit/Data/Effectful/LLMSpec.hs
@@ -1,25 +1,77 @@
 module Data.Effectful.LLMSpec (spec) where
 
-import Data.Effectful.LLM (openAIEmbeddings)
+import Data.ByteString qualified as BS
+import Data.Effectful.LLM (embedDocumentsBounded, openAIEmbeddings)
+import Data.Text qualified as T
+import Langchain.DocumentLoader.Core qualified as Doc
 import Langchain.Embeddings.OpenAI qualified as EmbOAI
 import Relude
 import Test.Hspec
 
 
 spec :: Spec
-spec = describe "embedding endpoint configuration" do
-  let cases :: [(Text, String)]
-      cases =
-        [ ("", "https://api.openai.com/v1")
-        , ("https://api.openai.com/", "https://api.openai.com/v1")
-        , ("https://api.openai.com", "https://api.openai.com/v1")
-        , ("https://api.openai.com/v1/", "https://api.openai.com/v1")
-        , ("https://api.openai.com/v1", "https://api.openai.com/v1")
-        , ("https://proxy.example/openai/v1/", "https://proxy.example/openai/v1")
-        , ("https://proxy.example/api", "https://proxy.example/api")
-        ]
-  forM_ cases \(configured, expected) ->
-    it ("resolves " <> show configured) do
-      let client = openAIEmbeddings "test-key" configured
-      EmbOAI.baseUrl client `shouldBe` Just expected
-      EmbOAI.apiKey client `shouldBe` "test-key"
+spec = do
+  describe "embedding endpoint configuration" do
+    let cases :: [(Text, String)]
+        cases =
+          [ ("", "https://api.openai.com/v1")
+          , ("https://api.openai.com/", "https://api.openai.com/v1")
+          , ("https://api.openai.com", "https://api.openai.com/v1")
+          , ("https://api.openai.com/v1/", "https://api.openai.com/v1")
+          , ("https://api.openai.com/v1", "https://api.openai.com/v1")
+          , ("https://proxy.example/openai/v1/", "https://proxy.example/openai/v1")
+          , ("https://proxy.example/api", "https://proxy.example/api")
+          ]
+    forM_ cases \(configured, expected) ->
+      it ("resolves " <> show configured) do
+        let client = openAIEmbeddings "test-key" configured
+        EmbOAI.baseUrl client `shouldBe` Just expected
+        EmbOAI.apiKey client `shouldBe` "test-key"
+
+  describe "bounded embedding requests" do
+    it "preserves long Unicode documents and keeps every request inside provider limits" do
+      seen <- newIORef []
+      let texts = ["short", T.replicate 100000 "🌍", T.replicate 400000 "abc "]
+          request batch = do
+            let inputs = map (toStrict . Doc.pageContent) batch
+                sizes = map (BS.length . encodeUtf8) inputs
+            modifyIORef' seen (<> inputs)
+            pure
+              $ if all (\n -> n > 0 && n < 8192) sizes && sum sizes <= 300000
+                then Right (replicate (length inputs) [1, 0])
+                else Left "provider input limit exceeded"
+      result <- embedDocumentsBounded request (map (\t -> Doc.Document (toLazy t) mempty) texts)
+      result `shouldBe` Right [[1, 0], [1, 0], [1, 0]]
+      (mconcat <$> readIORef seen) `shouldReturn` mconcat texts
+
+    it "rejects missing provider vectors instead of shifting document assignments" do
+      embedDocumentsBounded (\_ -> pure $ Right []) [Doc.Document "hello" mempty]
+        `shouldReturn` Left "Embedding response count does not match request"
+
+    it "does not call the provider for an empty input list" do
+      embedDocumentsBounded (\_ -> expectationFailure "unexpected request" $> Left "called") []
+        `shouldReturn` Right []
+
+    it "combines all chunks by length and preserves document ordering" do
+      let long = T.replicate 8188 "a" <> T.replicate 2047 "b"
+          inputs = map (\t -> Doc.Document (toLazy t) mempty) ["first", long, "last"]
+          vector doc = case toStrict $ Doc.pageContent doc of
+            "first" -> [0, 1]
+            "last" -> [-1, 0]
+            t | T.all (== 'a') t -> [1, 0]
+            _ -> [0, 1]
+      result <- embedDocumentsBounded (pure . Right . map vector) inputs
+      case result of
+        Right [firstVector, [x, y], lastVector] -> do
+          firstVector `shouldBe` [0, 1]
+          lastVector `shouldBe` [-1, 0]
+          abs (x - 4 / sqrt 17) `shouldSatisfy` (< 0.000001)
+          abs (y - 1 / sqrt 17) `shouldSatisfy` (< 0.000001)
+        _ -> expectationFailure $ show result
+
+    it "stops after a provider failure" do
+      calls <- newIORef (0 :: Int)
+      let request _ = modifyIORef' calls (+ 1) $> Left "rate limited"
+      embedDocumentsBounded request [Doc.Document (toLazy $ T.replicate 100000 "🌍") mempty]
+        `shouldReturn` Left "rate limited"
+      readIORef calls `shouldReturn` 1

--- a/test/unit/Data/Effectful/LLMSpec.hs
+++ b/test/unit/Data/Effectful/LLMSpec.hs
@@ -75,3 +75,20 @@ spec = do
       embedDocumentsBounded request [Doc.Document (toLazy $ T.replicate 100000 "🌍") mempty]
         `shouldReturn` Left "rate limited"
       readIORef calls `shouldReturn` 1
+
+    it "fills byte-sized chunks for ASCII text" do
+      calls <- newIORef (0 :: Int)
+      let request batch = modifyIORef' calls (+ 1) $> Right (replicate (length batch) [1, 0])
+      embedDocumentsBounded request [Doc.Document (toLazy $ T.replicate 50000 "abc ") mempty]
+        `shouldReturn` Right [[1, 0]]
+      readIORef calls `shouldReturn` 1
+
+    it "combines distinct vectors across request boundaries" do
+      let input = T.replicate (8188 * 40) "a" <> T.replicate 8188 "b"
+          vector doc = if T.all (== 'a') (toStrict $ Doc.pageContent doc) then [1, 0] else [0, 1]
+      result <- embedDocumentsBounded (pure . Right . map vector) [Doc.Document (toLazy input) mempty]
+      case result of
+        Right [[x, y]] -> do
+          abs (x - 40 / sqrt 1601) `shouldSatisfy` (< 0.000001)
+          abs (y - 1 / sqrt 1601) `shouldSatisfy` (< 0.000001)
+        _ -> expectationFailure $ show result


### PR DESCRIPTION
Large error messages and log patterns cause OpenAI to reject an entire 500-pattern embedding request. After the endpoint URL fix, production logs reproduced HTTP 400 errors for inputs over 8192 tokens in both job paths.

Split oversized documents without discarding text, bound requests by a conservative UTF-8 byte ceiling, and combine chunk vectors using a normalized, byte-length-weighted mean. Accumulate one strict vector per document so large messages do not retain every chunk response. Preserve document ordering and reject missing, empty, nonfinite, or inconsistent chunk vectors. Both real and golden interpreters use the same bounded path.

Validation: three regression cases failed against the original unbounded call. All 14 embedding tests and the full 298-test unit suite pass; targeted hlint and formatting pass. A live OpenAI request with synthetic text reproduced the 8192-token error before the change; the bounded implementation returned one 1536-dimensional vector for that same text. Production deployment and backlog verification remain pending.

The byte ceiling is deliberately conservative: it guarantees the token limits for UTF-8 byte-pair encoding without adding a tokenizer dependency. Chunks use byte offsets adjusted to Unicode boundaries, so ASCII inputs fill the available byte budget. Long-document means use byte counts as weights, rather than exact token counts. See [API limits](https://developers.openai.com/api/reference/resources/embeddings/methods/create) and [long-input embedding guidance](https://developers.openai.com/cookbook/examples/embedding_long_inputs).
