### PR TITLE
fix: return requested aggregates and columns in summary tables

### DIFF
--- a/observability/monitors/timefusion-unsorted.yaml
+++ b/observability/monitors/timefusion-unsorted.yaml
@@ -1,6 +1,6 @@
 active: true
 alert_recovery_threshold: null
-alert_threshold: 0.0
+alert_threshold: 1.0
 check_interval_mins: 5
 email_all: false
 emails:

--- a/src/Models/Apis/LogQueries.hs
+++ b/src/Models/Apis/LogQueries.hs
@@ -269,7 +269,7 @@ validateSqlQuery query =
 selectLogTable :: (DB es, Labeled "timefusion" Hasql :> es, Log :> es, Time.Time :> es, Tracing :> es) => Bool -> Projects.ProjectId -> [Section] -> Text -> Maybe PageCursor -> (Maybe UTCTime, Maybe UTCTime) -> [Text] -> Maybe Sources -> Maybe Text -> Maybe Text -> Eff es (Either Text (V.Vector (V.Vector AE.Value), [Text], Int))
 selectLogTable useTimefusion pid queryAST queryText cursorM dateRange projectedColsByUser source targetSpansM environment = do
   now <- Time.currentTime
-  let (q, queryComponents) = queryASTToComponents ((defSqlQueryCfg pid now source targetSpansM){cursorM, dateRange, projectedColsByUser, source, targetSpansM, environment}) queryAST
+  let (q, queryComponents) = queryASTToComponents ((defSqlQueryCfg pid now source targetSpansM){cursorM, dateRange, projectedColsByUser, source, targetSpansM, environment, metricJsonAsVariant = useTimefusion}) queryAST
       canonicalOrder = case cursorM of Just (PageCursor PageNewer _) -> V.reverse; _ -> identity
 
   Log.logTrace

--- a/src/Pkg/Parser.hs
+++ b/src/Pkg/Parser.hs
@@ -352,6 +352,11 @@ sqlFromQueryComponents sqlCfg qc =
     -- groups (or aggregates the whole set, where a bare HAVING is still valid).
     havingClause = nq.nqHaving
     sortOrder = nq.nqOrderBy
+    groupedAggregateCols = map (resolveExtendedColumn (Map.fromList nq.nqExtendedColumns)) qc.groupByClause <> qc.aggregations
+    tableColumns = case qc.finalSummarizeQuery of
+      Just _ -> "timestamp" : filter (not . T.isInfixOf "time_bucket") (if null qc.aggregations then qc.select else qc.aggregations)
+      Nothing -> if null qc.aggregations then nq.nqSelectCols else groupedAggregateCols
+    aggregateSortOrder = if null qc.groupByClause && isNothing qc.sortFields then "" else sortOrder
     limitClause = nq.nqLimit
     whereCondition = nq.nqWhere
 
@@ -395,10 +400,10 @@ sqlFromQueryComponents sqlCfg qc =
                 , True
                 )
           Nothing
-            | not (null qc.aggregations) && not (null qc.groupByClause) ->
-                ( [fmt|SELECT {wrap (T.intercalate "," (colsNoAsClause qc.aggregations) <> ", " <> countOver)} FROM {fromTable}
+            | not (null qc.aggregations) ->
+                ( [fmt|SELECT {wrap (T.intercalate "," (colsNoAsClause groupedAggregateCols) <> ", " <> countOver)} FROM {fromTable}
                    WHERE {buildWhere}
-                   {groupByClause} {havingClause} {sortOrder} {limitClause} |]
+                   {groupByClause} {havingClause} {aggregateSortOrder} {limitClause} |]
                 , True
                 )
             | otherwise ->
@@ -513,7 +518,7 @@ sqlFromQueryComponents sqlCfg qc =
    in
     ( finalSqlQuery
     , qc
-        { finalColumns = listToColNames nq.nqSelectCols
+        { finalColumns = listToColNames tableColumns
         , finalSqlQuery = finalSqlQuery
         , hasCountOver = countOverIncluded
         , whereClause = Just whereCondition

--- a/test/integration/Pages/LogExplorer/LogSpec.hs
+++ b/test/integration/Pages/LogExplorer/LogSpec.hs
@@ -604,6 +604,22 @@ spec = around withTestResources do
       length seen `shouldBe` 5
       length (ordNub seen) `shouldBe` 5
 
+    it "metric table summaries preserve scalar values and group labels" \tr -> do
+      pid <- createTestProject tr "metric-table-summary"
+      apiKey <- createTestAPIKey tr pid "metric-table-summary-key"
+      now <- getCurrentTime
+      ingestMetric tr apiKey [] [] "summary.pressure" 28 (addUTCTime (-2) now)
+      ingestMetric tr apiKey [] [] "summary.pressure" 80 (addUTCTime (-1) now)
+      let fromTime = Just $ toText $ iso8601Show $ addUTCTime (-60) now
+          toTime = Just $ toText $ iso8601Show $ addUTCTime 60 now
+          query suffix = runAsBase tr $ Log.queryEvents pid (Just $ "metrics | summarize peak=max(value)" <> suffix) Nothing fromTime toTime Nothing Nothing Nothing Nothing
+      scalar <- query ""
+      scalar.cols `shouldBe` ["peak"]
+      scalar.logsData `shouldBe` V.singleton (V.singleton $ AE.Number 80)
+      grouped <- query " by metric_name"
+      grouped.cols `shouldBe` ["metric_name", "peak"]
+      grouped.logsData `shouldBe` V.singleton (V.fromList [AE.String "summary.pressure", AE.Number 80])
+
     -- v1/CLI events API (queryEvents): --with-children must not silently truncate.
     it "events API with-children pagination visits every matched root (no silent truncation)" \tr -> do
       apiKey <- createTestAPIKey tr testPid "events-children-key"

--- a/test/unit/Pkg/ParserSpec.hs
+++ b/test/unit/Pkg/ParserSpec.hs
@@ -80,6 +80,17 @@ spec = do
       let (_, c) = fromRight' $ parseQueryToComponents (defSqlQueryCfg defPid fixedUTCTime Nothing Nothing) "summarize count(*)"
       fromMaybe "" c.finalSummarizeQuery `shouldNotSatisfy` T.isInfixOf "::text"
 
+    it "table summaries return aggregate columns rather than default event fields" do
+      let parse q = fromRight' $ parseQueryToComponents (defSqlQueryCfg defPid fixedUTCTime Nothing Nothing) q
+          (scalarSql, scalar) = parse "metrics | summarize peak=max(value)"
+          (groupedSql, grouped) = parse "metrics | summarize peak=max(value) by metric_name"
+      scalarSql `shouldSatisfy` T.isInfixOf "max((value)::float)"
+      scalarSql `shouldNotSatisfy` T.isInfixOf "context___trace_id"
+      scalarSql `shouldNotSatisfy` T.isInfixOf "ORDER BY timestamp"
+      scalar.toColNames `shouldBe` ["peak"]
+      groupedSql `shouldSatisfy` T.isInfixOf "jsonb_build_array(metric_name,max((value)::float)"
+      grouped.toColNames `shouldBe` ["metric_name", "peak"]
+
     it "grouped summarize casts to text and projects the group column" do
       let (_, c) = fromRight' $ parseQueryToComponents (defSqlQueryCfg defPid fixedUTCTime Nothing Nothing) "summarize count(*) by name"
           sql = fromMaybe "" c.finalSummarizeQuery
@@ -107,7 +118,7 @@ SELECT extract(epoch from time_bucket('1 days', timestamp))::integer, 'value', c
       -- ORDER BY uses GROUP BY column (kind) since timestamp is not in GROUP BY
       let expected =
             [text|
-      SELECT jsonb_build_array(count(*)::float, count(*) OVER()) FROM otel_logs_and_spans WHERE project_id='00000000-0000-0000-0000-000000000000' and ((timestamp >= NOW() - INTERVAL '7 days')) GROUP BY kind ORDER BY kind desc limit 500 |]
+      SELECT jsonb_build_array(kind,count(*)::float, count(*) OVER()) FROM otel_logs_and_spans WHERE project_id='00000000-0000-0000-0000-000000000000' and ((timestamp >= NOW() - INTERVAL '7 days')) GROUP BY kind ORDER BY kind desc limit 500 |]
       normT query `shouldBe` normT expected
     it "summarize with sort by and take" do
       let (query, _) = fromRight' $ parseQueryToComponents (defSqlQueryCfg defPid fixedUTCTime Nothing Nothing) "name==\"GET\" | summarize sum(attributes.client) by attributes.client, bin(timestamp, 60) | sort by parent_id asc | take 1000"


### PR DESCRIPTION
Scalar table summaries fell through to ordinary span columns, causing metric summaries to fail with unknown context___trace_id. Grouped summaries omitted their grouping values and labeled aggregate values with the ordinary span columns.

Build table projections and response columns from the requested grouping keys and aggregates, including summaries with no group key. Enable the TimeFusion metric JSON representation in the table query path. Also persist the production unsorted-flush monitor correction: alert at one occurrence, since its comparison is inclusive and zero is healthy.

Validation: the parser regression failed before the fix and all 129 parser tests passed afterward. The integration regression checks scalar and grouped metric table results, including numeric values and the metric-name label; it passed against the fixed local TimeFusion server. TimeFusion PR #210 is now deployed and its production JSON query returns numeric values. Targeted hlint passed. Monoscope production deployment remains pending.
