### PR TITLE
fix: keep ingestion parameters out of database exception logs

### DIFF
--- a/src/BackgroundJobs.hs
+++ b/src/BackgroundJobs.hs
@@ -3481,7 +3481,7 @@ newEndpointAlertsPerHour = 10
 runHostRetentionSweep :: Config.AuthContext -> Projects.ProjectId -> ATBackgroundCtx ()
 runHostRetentionSweep authCtx pid = do
   now <- Time.currentTime
-  traffic <- Endpoints.hostTrafficSince authCtx.env.enableTimefusionReads pid (addUTCTime (-48 * 3600) now)
+  traffic <- Endpoints.hostTrafficSince authCtx.env.enableTimefusionReads pid (addUTCTime (-(48 * 3600)) now)
   (unarchivedRaw, archivedCount) <- Endpoints.hostRetentionSweep pid traffic
   let unarchived = ordNub $ V.toList unarchivedRaw
   when (archivedCount > 0) $ Log.logInfo "Hosts auto-archived after 30 idle days" ("project_id", pid.toText, "count", archivedCount)

--- a/src/Data/Effectful/Hasql.hs
+++ b/src/Data/Effectful/Hasql.hs
@@ -53,6 +53,7 @@ import OpenTelemetry.Attributes (Attribute)
 import OpenTelemetry.Instrumentation.Hasql (TracedPool)
 import OpenTelemetry.Instrumentation.Hasql qualified as OHasql
 import Relude
+import Text.Show (showString, showsPrec)
 import UnliftIO qualified
 
 
@@ -85,13 +86,29 @@ type instance DispatchOf Hasql = 'Dynamic
 
 
 newtype HasqlException = HasqlException UsageError
-  deriving stock (Show)
+
+
+-- Parameter values can contain an entire ingestion batch. Keep the typed error
+-- for classification, but render its SQL template and diagnostics without them.
+instance Show HasqlException where
+  showsPrec _ = showString . displayException
 
 
 instance Exception HasqlException where
   displayException (HasqlException ue) = case ue of
     AcquisitionTimeoutUsageError -> "Hasql: pool acquisition timeout"
     ConnectionUsageError e -> "Hasql connection error: " <> toString (toDetailedText e)
+    SessionUsageError (StatementSessionError total index template _ prepared err) ->
+      "Hasql statement error (statement "
+        <> show (index + 1)
+        <> "/"
+        <> show total
+        <> ", prepared="
+        <> show prepared
+        <> "):\n"
+        <> toString template
+        <> "\n"
+        <> toString (toDetailedText err)
     SessionUsageError e -> "Hasql session error: " <> toString (toDetailedText e)
 
 

--- a/test/unit/Data/Effectful/HasqlSpec.hs
+++ b/test/unit/Data/Effectful/HasqlSpec.hs
@@ -1,6 +1,7 @@
 module Data.Effectful.HasqlSpec (spec) where
 
 import Data.Effectful.Hasql qualified as EHasql
+import Data.Text qualified as T
 import Hasql.Errors qualified as HE
 import Hasql.Pool qualified as HP
 import Relude
@@ -63,6 +64,20 @@ spec = describe "isTransientException" $ do
     EHasql.isLockTimeout (EHasql.HasqlException lockTimeoutError) `shouldBe` True
     EHasql.isLockTimeout (EHasql.HasqlException realSqlStateError) `shouldBe` False -- 23505
     EHasql.isLockTimeout (EHasql.HasqlException deadlockError) `shouldBe` False -- 40P01
+  it "keeps database diagnostics without serializing ingestion parameters" do
+    let payload = T.replicate 100000 "private-batch-value"
+        err =
+          EHasql.HasqlException
+            $ HP.SessionUsageError
+            $ HE.StatementSessionError 2 1 "INSERT INTO events SELECT * FROM unnest($1)" [payload] True
+            $ HE.ServerStatementError
+            $ HE.ServerError "57P03" "database is draining" (Just "retry after recovery") Nothing Nothing
+    for_ [show @String err, displayException err, show @String $ toException err] \rendered -> do
+      rendered `shouldNotContain` "private-batch-value"
+      rendered `shouldContain` "57P03"
+      rendered `shouldContain` "database is draining"
+      rendered `shouldContain` "retry after recovery"
+      rendered `shouldContain` "INSERT INTO events"
   where
     allConnectionErrors =
       [ HE.NetworkingConnectionError "ECONNREFUSED"


### PR DESCRIPTION
A failed telemetry write serialized every SQL parameter into its exception log. Ingestion parameters contain entire batches, so individual error messages reached several megabytes and entered the pattern-embedding backlog.

Render statement exceptions with the SQL template, pipeline position, prepared flag, and original server or decoder diagnostics. Omit parameter values from both Show and displayException, including SomeException rendering. The original typed UsageError remains intact for retry and error classification.

Validation: a synthetic large-parameter regression failed before the change and passes afterward across all three rendering paths. All 8 Hasql tests and the full 292-test unit suite pass; targeted hlint and formatting pass. No live error was deliberately induced. Production deployment and log verification remain pending.
