### PR TITLE
Fix CLI severity filters that hide matching errors

### DIFF
--- a/cli/CLI/Commands.hs
+++ b/cli/CLI/Commands.hs
@@ -799,8 +799,8 @@ buildSearchParams opts =
 -- @body has "POISON_ROW_DROPPED" or summary has "POISON_ROW_DROPPED"@,
 -- matching what a developer naturally types.
 --
--- --level normalizes to upper-case (B2) so @--level error@ and @--level
--- ERROR@ both match the canonical OTel severity strings.
+-- --level uses the stored severity field and normalizes its enum value to
+-- lower-case, so @--level error@ and @--level ERROR@ select the same rows.
 --
 -- >>> foldFiltersIntoQuery "" [] Nothing
 -- ""
@@ -810,10 +810,10 @@ buildSearchParams opts =
 -- "resource.service.name==\"web\""
 -- >>> foldFiltersIntoQuery "" ["web", "worker"] Nothing
 -- "resource.service.name in (\"web\", \"worker\")"
--- >>> foldFiltersIntoQuery "" [] (Just "warn")
--- "severity.text==\"WARN\""
+-- >>> map (foldFiltersIntoQuery "" []) [Just "warn", Just "WARN"]
+-- ["severity.severity_text==\"warn\"","severity.severity_text==\"warn\""]
 -- >>> foldFiltersIntoQuery "errors > 0" ["web"] (Just "error")
--- "resource.service.name==\"web\" and severity.text==\"ERROR\" and (errors > 0)"
+-- "resource.service.name==\"web\" and severity.severity_text==\"error\" and (errors > 0)"
 -- >>> foldFiltersIntoQuery "POISON_ROW_DROPPED" [] Nothing
 -- "body has \"POISON_ROW_DROPPED\" or summary has \"POISON_ROW_DROPPED\""
 foldFiltersIntoQuery :: Text -> [Text] -> Maybe Text -> Text
@@ -828,7 +828,7 @@ foldFiltersIntoQuery query services mLevel
       [] -> Nothing
       [s] -> Just (eq "resource.service.name" s)
       ss -> Just ("resource.service.name in (" <> T.intercalate ", " (map q ss) <> ")")
-    filters = catMaybes [serviceFilter, eq "severity.text" . T.toUpper <$> mLevel]
+    filters = catMaybes [serviceFilter, eq "severity.severity_text" . T.toLower <$> mLevel]
     prefix = T.intercalate " and " filters
     rewritten = rewriteBareQuery (T.strip query)
 

--- a/cli/CLI/Main.hs
+++ b/cli/CLI/Main.hs
@@ -311,7 +311,7 @@ eventsSearchParser =
     <*> optional (strOption (long "to" <> metavar "TIMESTAMP" <> help "End time (ISO 8601)"))
     <*> optional (strOption (long "kind" <> metavar "KIND" <> help "log|trace|span"))
     <*> many (strOption (long "service" <> metavar "SERVICE" <> help "Filter by service (repeatable: --service api --service worker → in (api, worker))"))
-    <*> optional (strOption (long "level" <> metavar "LEVEL" <> help "Shorthand for severity.text=='LEVEL'"))
+    <*> optional (strOption (long "level" <> metavar "LEVEL" <> help "Filter by severity (case-insensitive input)"))
     <*> optional (option auto (long "limit" <> short 'n' <> metavar "N" <> help "Max results"))
     <*> optional (strOption (long "fields" <> metavar "FIELDS" <> help "Comma-separated fields to keep"))
     <*> optional (strOption (long "cursor" <> metavar "CURSOR" <> help "Pagination cursor from a prior response"))
@@ -334,7 +334,7 @@ eventsSearchExamples :: [Text]
 eventsSearchExamples =
   [ "Examples:"
   , "  monoscope logs search POISON_ROW_DROPPED --since 24h   # bare strings = full-text"
-  , "  monoscope events search 'severity.text==\"ERROR\"' --since 1h"
+  , "  monoscope events search 'severity.severity_text==\"error\"' --since 1h"
   , "  monoscope logs search --service checkout-api --level error --limit 50"
   , "  monoscope events search 'attributes.http.response.status_code >= 500' --since 1h"
   , "  monoscope traces search --since 30m --first --id-only   # one trace id"
@@ -474,7 +474,7 @@ facetsExamples =
   [ "Examples:"
   , "  monoscope facets                         # all faceted fields"
   , "  monoscope facets resource.service.name   # values for one field"
-  , "  monoscope facets severity.text --top 5"
+  , "  monoscope facets severity.severity_text --top 5"
   , "  monoscope facets resource.service.name | jq -r '.[\"resource.service.name\"][].value'"
   , "  monoscope facets --since 7d              # widen the lookback"
   , ""
@@ -604,7 +604,7 @@ openExamples =
   , "  monoscope open trace a1b2c3d4                      # the trace waterfall, in the browser"
   , "  monoscope open issue <issue-id>"
   , "  monoscope open dashboard <dashboard-id>"
-  , "  monoscope open logs 'severity.text==\"ERROR\"' --since 6h"
+  , "  monoscope open logs 'severity.severity_text==\"error\"' --since 6h"
   , "  monoscope open project --print                     # just print the link, e.g. to paste in Slack"
   , ""
   , "The host comes from the server (/api/v1/me), so self-hosted installs work."


### PR DESCRIPTION
`events search --level error` returned no rows because the CLI queried `severity.text` with an uppercase value. Stored severities use `severity.severity_text` and lowercase enum values. The shorthand now uses that field, normalizes input case, and the help examples match the stored schema.

Verified against a fixed production window: both `--level error` and `--level ERROR` exactly match the explicit severity query; the released binary returned zero rows before this fix. All 55 command doctests and 16 CLI tests pass. Source HLint and formatting checks pass.
