### PR TITLE
Avoid mobile sidebar errors on pages without a project

### DIFF
--- a/src/Pages/BodyWrapper.hs
+++ b/src/Pages/BodyWrapper.hs
@@ -387,7 +387,8 @@ bodyWrapper bcfg child = do
           -- Command palette (shell rendered inline, dynamic items lazy-loaded)
           whenJust bcfg.currProject \p -> CommandPalette.paletteShell_ p.id
           -- Mobile nav toggle (CSS-only sidebar control, only rendered when sidebar exists)
-          input_ [type_ "checkbox", class_ "hidden", id_ "mobile-nav-toggle", [__|on load if window.innerWidth < 768 then set #sidenav-toggle.checked to true|]]
+          when (isJust bcfg.currProject)
+            $ input_ [type_ "checkbox", class_ "hidden", id_ "mobile-nav-toggle", [__|on load if window.innerWidth < 768 then set #sidenav-toggle.checked to true|]]
           section_ [class_ "flex flex-row grow-0 h-screen overflow-hidden"] do
             foldMap (\project -> sideNav sess project (fromMaybe bcfg.pageTitle bcfg.prePageTitle) (if bcfg.isSettingsPage then Just "Settings" else bcfg.menuItem)) bcfg.currProject
             section_ [class_ "h-full overflow-y-hidden grow flex flex-col"] do
@@ -425,7 +426,8 @@ bodyWrapper bcfg child = do
                     $ replicateM_ 3 (div_ [class_ "skeleton h-16 w-full"] "")
 
       -- Mobile nav backdrop (at body level, after section, so it paints on top)
-      label_ [term "for" "mobile-nav-toggle", class_ "fixed inset-0 bg-black/50 backdrop-blur-xs z-40 hidden group-has-[#mobile-nav-toggle:checked]/pg:max-md:block cursor-default", Aria.label_ "Close menu"] ""
+      when (isJust bcfg.sessM && isJust bcfg.currProject)
+        $ label_ [term "for" "mobile-nav-toggle", class_ "fixed inset-0 bg-black/50 backdrop-blur-xs z-40 hidden group-has-[#mobile-nav-toggle:checked]/pg:max-md:block cursor-default", Aria.label_ "Close menu"] ""
       when isProd $ externalHeadScripts_ bcfg.config
       globalTemplates_
       when isProd $ script_ [async_ "true", src_ "https://www.googletagmanager.com/gtag/js?id=AW-11285541899"] ("" :: Text)

--- a/test/integration/Pages/Projects/ProjectsSpec.hs
+++ b/test/integration/Pages/Projects/ProjectsSpec.hs
@@ -1,7 +1,10 @@
 module Pages.Projects.ProjectsSpec (spec) where
 
 import Data.Generics.Labels ()
+import Data.Text qualified as T
+import Data.Text.Lazy qualified as LT
 import Data.Vector qualified as V
+import Lucid qualified
 import Models.Projects.ProjectMembers qualified as ProjectMembers
 import Models.Projects.Projects qualified as Projects
 import Pages.BodyWrapper
@@ -12,7 +15,6 @@ import Pkg.TestUtils
 import Relude
 import Relude.Unsafe qualified as Unsafe
 import Test.Hspec
-
 
 
 spec :: Spec
@@ -45,7 +47,9 @@ spec = around withTestResources do
       length projects `shouldBe` 2
       let projectIds = map (.id.toText) (V.toList projects)
       projectIds `shouldContain` [testPid.toText] -- test project from testSessionHeader
-      -- TODO: add more checks for the info we we display on list page
+      let html = LT.toStrict $ Lucid.renderText $ Lucid.toHtml pg
+      html `shouldSatisfy` (not . T.isInfixOf "id=\"mobile-nav-toggle\"")
+      html `shouldSatisfy` (not . T.isInfixOf "for=\"mobile-nav-toggle\"")
     it "Should update project with new details and verify in list" \tr -> do
       -- Section 1: Update the project
       let createPForm =


### PR DESCRIPTION
On mobile, the authenticated projects page rendered a checkbox whose load handler dereferenced `#sidenav-toggle`, although that page has no sidebar. This matches the reported null-element error. The page wrapper now renders the mobile toggle and backdrop only when their sidebar exists.

The projects-page regression fails before the fix because the orphan controls are present, then passes afterward. All three projects-page integration tests pass; HLint and formatting checks pass.
