### PR TITLE
fix: align severity schema and examples with stored fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ SVC=$(monoscope facets resource.service.name --top 1 \
         | jq -r '.["resource.service.name"][0].value')
 
 # 2. Grab one error event from that service — id only, ready to chain.
-ID=$(monoscope logs search 'severity.text=="error"' \
+ID=$(monoscope logs search 'severity.severity_text=="error"' \
         --service "$SVC" --first --id-only)
 
 # 3. Pull the surrounding 5 minutes of traffic, with a per-trace summary

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -157,7 +157,7 @@ chart — an unavailable panel and a quiet one are not the same thing.
 monoscope open trace a1b2c3d4                    # the trace waterfall in the UI
 monoscope open issue <issue-id>
 monoscope open dashboard <dashboard-id>
-monoscope open logs 'severity.text=="ERROR"' --since 6h
+monoscope open logs 'severity.severity_text=="error"' --since 6h
 monoscope open monitors
 monoscope open project --print                   # print the link, don't launch
 ```
@@ -207,7 +207,7 @@ Options:
 | `--to <timestamp>` | End time (ISO 8601) |
 | `--kind log\|trace` | Filter by event kind (mapped to the `source` query param) |
 | `--service <name>` | Shorthand for `resource.service.name=="<name>"`. **Repeatable** — `--service a --service b` expands to `in (a, b)` |
-| `--level <level>` | Shorthand for `severity.text=="<LEVEL>"` (auto-uppercased) |
+| `--level <level>` | Shorthand for `severity.severity_text=="<level>"` (converted to lowercase) |
 | `--limit/-n <N>` | Max results to return |
 | `--fields <f1,f2>` | Comma-separated columns to keep in JSON / table output |
 | `--cursor <value>` | Pagination: pass the `cursor` field from a previous response |
@@ -644,7 +644,7 @@ monoscope facets
 
 # Drill into a single field
 monoscope facets resource.service.name
-monoscope facets severity.text --top 5
+monoscope facets severity.severity_text --top 5
 
 # Widen the lookback (default 24h)
 monoscope facets --since 7d
@@ -664,7 +664,7 @@ Response shape:
     { "value": "payments",     "count":  812 },
     ...
   ],
-  "severity.text": [...],
+  "severity.severity_text": [...],
   "attributes.http.response.status_code": [...]
 }
 ```
@@ -855,7 +855,7 @@ JSON is the default when stdout is not a TTY or `CI` is set. Use `jq` for script
 
 ```bash
 # Error-rate gate in CI (count of error-level events in the last 30 min)
-monoscope metrics query 'summarize count() | where severity.text=="error"' --since 30m --assert '< 100'
+monoscope metrics query 'where severity.severity_text=="error" | summarize count()' --since 30m --assert '< 100'
 
 # Get open issue count
 monoscope issues list --status open -o json | jq '.data | length'

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -100,7 +100,7 @@ curl -s https://api.monoscope.tech/api/v1/mcp \
     "params": {
       "name": "search_events",
       "arguments": {
-        "body": { "query": "severity.text==\"error\"", "since": "1h" }
+        "body": { "query": "severity.severity_text==\"error\"", "since": "1h" }
       }
     }
   }' | jq

--- a/shared/src/Models/Telemetry/Schema.hs
+++ b/shared/src/Models/Telemetry/Schema.hs
@@ -53,7 +53,7 @@ telemetrySchema =
           , ("kind", FieldInfo "string" "Type of telemetry data (logs, span, request)" (Just ["logs", "span", "request"]))
           , ("status_code", FieldInfo "string" "Status code of the span" (Just ["OK", "ERROR", "UNSET"]))
           , ("status_message", FieldInfo "string" "Status message" Nothing)
-          , ("level", FieldInfo "string" "Log level (same as severity text)" (Just ["TRACE", "DEBUG", "INFO", "WARN", "ERROR", "FATAL"]))
+          , ("level", FieldInfo "string" "Log level (same as severity text)" (Just ["trace", "debug", "info", "warn", "error", "fatal"]))
           , ("body", FieldInfo "object" "Body content of the log/span" Nothing)
           , ("duration", FieldInfo "duration" "Duration of the span in nanoseconds" Nothing)
           , ("start_time", FieldInfo "string" "Start time of the span" Nothing)
@@ -64,8 +64,8 @@ telemetrySchema =
           , ("date", FieldInfo "string" "Date" Nothing)
           , -- Severity fields (flattened)
             ("severity", FieldInfo "object" "Severity information" Nothing)
-          , ("severity.text", FieldInfo "string" "Text representation of severity" (Just ["TRACE", "DEBUG", "INFO", "WARN", "ERROR", "FATAL"]))
-          , ("severity.number", FieldInfo "string" "Numeric representation of severity" Nothing)
+          , ("severity.severity_text", FieldInfo "string" "Text representation of severity" (Just ["trace", "debug", "info", "warn", "error", "fatal"]))
+          , ("severity.severity_number", FieldInfo "number" "Numeric representation of severity" Nothing)
           , -- Context fields (flattened)
             ("context", FieldInfo "object" "Context information" Nothing)
           , ("context.trace_id", FieldInfo "string" "Unique identifier for the trace" Nothing)
@@ -296,6 +296,12 @@ popularOtelQueriesJson = AE.toJSON popularOtelQueries
 -- >>> let advertises f = Map.member f (deriveSchema mempty).fields
 -- >>> map advertises ["summary", "errors", "message_size_bytes", "service", "span_name", "url_path"]
 -- [True,True,True,True,True,True]
+--
+-- Severity metadata describes the actual storage fields and lowercase values:
+-- >>> Map.lookup "severity.severity_text" telemetrySchema.fields >>= (.examples)
+-- Just ["trace","debug","info","warn","error","fatal"]
+-- >>> (.fieldType) <$> Map.lookup "severity.severity_number" telemetrySchema.fields
+-- Just "number"
 --
 -- A dotted hand-coded entry with no matching live column is still dropped:
 -- >>> map advertises ["severity.text", "attribute"]

--- a/shared/src/Models/Telemetry/Schema.hs
+++ b/shared/src/Models/Telemetry/Schema.hs
@@ -53,7 +53,7 @@ telemetrySchema =
           , ("kind", FieldInfo "string" "Type of telemetry data (logs, span, request)" (Just ["logs", "span", "request"]))
           , ("status_code", FieldInfo "string" "Status code of the span" (Just ["OK", "ERROR", "UNSET"]))
           , ("status_message", FieldInfo "string" "Status message" Nothing)
-          , ("level", FieldInfo "string" "Log level (same as severity text)" (Just ["trace", "debug", "info", "warn", "error", "fatal"]))
+          , ("level", FieldInfo "string" "Log level (uppercase)" (Just ["TRACE", "DEBUG", "INFO", "WARN", "ERROR", "FATAL"]))
           , ("body", FieldInfo "object" "Body content of the log/span" Nothing)
           , ("duration", FieldInfo "duration" "Duration of the span in nanoseconds" Nothing)
           , ("start_time", FieldInfo "string" "Start time of the span" Nothing)
@@ -297,7 +297,9 @@ popularOtelQueriesJson = AE.toJSON popularOtelQueries
 -- >>> map advertises ["summary", "errors", "message_size_bytes", "service", "span_name", "url_path"]
 -- [True,True,True,True,True,True]
 --
--- Severity metadata describes the actual storage fields and lowercase values:
+-- Severity metadata distinguishes the uppercase level from the lowercase enum:
+-- >>> Map.lookup "level" telemetrySchema.fields >>= (.examples)
+-- Just ["TRACE","DEBUG","INFO","WARN","ERROR","FATAL"]
 -- >>> Map.lookup "severity.severity_text" telemetrySchema.fields >>= (.examples)
 -- Just ["trace","debug","info","warn","error","fatal"]
 -- >>> (.fieldType) <$> Map.lookup "severity.severity_number" telemetrySchema.fields

--- a/shared/src/Pkg/Parser/Stats.hs
+++ b/shared/src/Pkg/Parser/Stats.hs
@@ -1166,9 +1166,9 @@ extractPercentilesInfo secs = listToMaybe $ mapMaybe pcts [agg | SummarizeComman
 -- as @Text@. Lives here rather than in "Pkg.Parser" so the CLI can validate
 -- queries client-side without pulling in the DB-bound half of the parser.
 --
--- >>> isRight (parseQueryToAST "severity.text==\"ERROR\"")
+-- >>> isRight (parseQueryToAST "severity.severity_text==\"error\"")
 -- True
--- >>> isLeft (parseQueryToAST "severity.text ==")
+-- >>> isLeft (parseQueryToAST "severity.severity_text ==")
 -- True
 -- >>> parseQueryToAST "attribute contains \"x\""
 -- Left "Unknown field \"attribute\". Did you mean \"attributes\"?"

--- a/test/integration/CLI/CLILifecycleSpec.hs
+++ b/test/integration/CLI/CLILifecycleSpec.hs
@@ -81,7 +81,7 @@ spec = around withTestResources do
       writeFileText yamlPath
         $ unlines
           [ "title: Lifecycle error-rate alert"
-          , "query: 'severity.text == \"ERROR\"'"
+          , "query: 'severity.severity_text == \"error\"'"
           , "alert_threshold: 10"
           , "trigger_less_than: false"
           , "check_interval_mins: 5"


### PR DESCRIPTION
The advertised severity fields and examples used nonexistent `severity.text` / `severity.number` names and uppercase values. This aligns schema metadata, CLI and MCP examples, and the monitor fixture with the stored `severity.severity_text` / `severity.severity_number` fields and lowercase levels. The aggregate example also filters before summarizing.

Validation: all 118 schema doctests pass, including distinct uppercase `level` and lowercase severity enum assertions; HLint and Fourmolu checks pass. The corresponding CLI filter was verified against a fixed production window in #514.
