### PR TITLE
fix(cli): preserve pipelines when adding shorthand filters

### DIFF
--- a/cli/CLI/Commands.hs
+++ b/cli/CLI/Commands.hs
@@ -825,6 +825,8 @@ buildSearchParams opts =
 -- True
 -- >>> withError "body has \"a|b\" | summarize count()" == parseQueryToAST "severity.severity_text==\"error\" | body has \"a|b\" | summarize count()"
 -- True
+-- >>> and [withError ("| " <> stage) == parseQueryToAST ("severity.severity_text==\"error\" | " <> stage) | stage <- ["take 10", "sort by timestamp"]]
+-- True
 foldFiltersIntoQuery :: Text -> [Text] -> Maybe Text -> Text
 foldFiltersIntoQuery query services mLevel
   | T.null prefix = rewritten
@@ -847,8 +849,8 @@ foldFiltersIntoQuery query services mLevel
 -- previous behaviour parsed the bareword as a column reference, producing a
 -- useless @column "X" does not exist@ error.
 --
--- A query containing any of @== != >= <= > < has and or " (@ is passed
--- through unchanged.
+-- A query starting with @|@ or containing any of @== != >= <= > < has and or " (@
+-- is passed through unchanged.
 --
 -- >>> rewriteBareQuery ""
 -- ""
@@ -879,7 +881,8 @@ rewriteBareQuery t
     -- Operators / grouping disable the rewrite; multi-word phrases ("foo
     -- bar") are still rewritten so a phrase search Just Works.
     hasOperator x =
-      any (`T.isInfixOf` x) ["==", "!=", ">=", "<=", " has ", " and ", " or "]
+      T.isPrefixOf "|" x
+        || any (`T.isInfixOf` x) ["==", "!=", ">=", "<=", " has ", " and ", " or "]
         || T.any (`elem` ("><\"(" :: [Char])) x
 
 

--- a/cli/CLI/Commands.hs
+++ b/cli/CLI/Commands.hs
@@ -813,14 +813,23 @@ buildSearchParams opts =
 -- >>> map (foldFiltersIntoQuery "" []) [Just "warn", Just "WARN"]
 -- ["severity.severity_text==\"warn\"","severity.severity_text==\"warn\""]
 -- >>> foldFiltersIntoQuery "errors > 0" ["web"] (Just "error")
--- "resource.service.name==\"web\" and severity.severity_text==\"error\" and (errors > 0)"
+-- "resource.service.name==\"web\" and severity.severity_text==\"error\" | errors > 0"
 -- >>> foldFiltersIntoQuery "POISON_ROW_DROPPED" [] Nothing
 -- "body has \"POISON_ROW_DROPPED\" or summary has \"POISON_ROW_DROPPED\""
+--
+-- Shorthand filters must run before the user's pipeline, including a leading pipe.
+-- >>> import Pkg.Parser.Stats (parseQueryToAST)
+-- >>> let withError q = parseQueryToAST (foldFiltersIntoQuery q [] (Just "error"))
+-- >>> let expected = parseQueryToAST "severity.severity_text==\"error\" | summarize count()"
+-- >>> map withError ["summarize count()", "| summarize count()"] == replicate 2 expected && isRight expected
+-- True
+-- >>> withError "body has \"a|b\" | summarize count()" == parseQueryToAST "severity.severity_text==\"error\" | body has \"a|b\" | summarize count()"
+-- True
 foldFiltersIntoQuery :: Text -> [Text] -> Maybe Text -> Text
 foldFiltersIntoQuery query services mLevel
   | T.null prefix = rewritten
   | T.null rewritten = prefix
-  | otherwise = prefix <> " and (" <> rewritten <> ")"
+  | otherwise = prefix <> " | " <> T.stripStart (fromMaybe rewritten $ T.stripPrefix "|" rewritten)
   where
     q v = "\"" <> T.replace "\"" "\\\"" v <> "\""
     eq field val = field <> "==" <> q val


### PR DESCRIPTION
Combining `--level` or `--service` with a query pipeline enclosed the pipeline in parentheses and produced invalid KQL. Shorthand predicates now form a separate leading stage, preserving the user query and accepting its optional leading pipe. Operator-free stages such as `| take 10` and `| sort by timestamp` also remain query stages instead of becoming search text.

Validation: both failures reproduced with doctests; all 61 Commands doctests and 16 CLI tests pass. The rebuilt binary queried production with `events search "| summarize count()" --level error` for a fixed window and returned the expected count of 7. Formatting and diff checks pass.
