### PR TITLE
fix: include project ID in dashboard variable refreshes

### DIFF
--- a/src/Pages/Dashboards.hs
+++ b/src/Pages/Dashboards.hs
@@ -292,6 +292,7 @@ dashboardPage_ pid dashId dash dashVM allParams = do
             $ [ type_ "text"
               , name_ var.key
               , class_ "dash-variable-input"
+              , data_ "project-id" pidText
               , data_ "tagify" ""
               , data_ "tagify-whitelist" whitelist
               , data_ "tagify-enforce-whitelist" ""

--- a/web-components/src/main.ts
+++ b/web-components/src/main.ts
@@ -564,6 +564,7 @@ function reloadVarWhitelist(input: HTMLElement, background = false): Promise<voi
   if (!tgfy) return Promise.resolve();
   const params = new URLSearchParams({
     ...Object.fromEntries(new URLSearchParams(location.search)),
+    pid: input.dataset.projectId || '',
     query,
     query_sql: querySql,
     data_type: 'text',

--- a/web-components/test/dashboard-variable-refresh.test.ts
+++ b/web-components/test/dashboard-variable-refresh.test.ts
@@ -42,6 +42,18 @@ test('ticks keep options and selection usable, coalesce requests and append only
   expect(tagify.settings.whitelist).toBe(merged);
 });
 
+test('variable refresh uses the rendered project instead of URL query parameters', async () => {
+  const { input } = mount();
+  input.dataset.projectId = '87576849-4941-49d3-a15d-680fef88a1a8';
+  history.replaceState({}, '', '/p/87576849-4941-49d3-a15d-680fef88a1a8/dashboards/overview?pid=stale&since=6h');
+  const fetch = vi.fn<typeof globalThis.fetch>().mockResolvedValue(response([]));
+  vi.stubGlobal('fetch', fetch);
+  await reload(input);
+  const params = new URL(fetch.mock.calls[0][0], location.origin).searchParams;
+  expect(params.get('pid')).toBe(input.dataset.projectId);
+  expect(params.get('since')).toBe('6h');
+});
+
 test.each(['offline', 'http', 'query'])('%s failure preserves options and permits a later retry', async (failure) => {
   const { input, tagify } = mount();
   vi.spyOn(console, 'error').mockImplementation(() => {});


### PR DESCRIPTION
Dashboard variable refreshes called `/chart_data` without its required `pid` parameter, causing HTTP400 when the project was present only in the page path. Each rendered selector now carries its project ID, and refresh requests pass that ID explicitly instead of inheriting a missing or stale URL parameter.

Validation: request regression fails before/passes after; all931 frontend tests pass, production Vite build passes, and Haskell formatting/HLint checks pass. This addresses the production database-selector error recorded on September6.
