### PR TITLE
fix: avoid quadratic suffix scans during error normalization

### DIFF
--- a/src/Utils.hs
+++ b/src/Utils.hs
@@ -1272,7 +1272,7 @@ replaceAllFormats !input = toText . TLB.toLazyText $ go Nothing (replacePrePass 
     scanMons !prev !deferred !t
       -- End of input: flush deferred and remaining text
       | T.null t = flushDef deferred
-      | T.length t < 3 = flushDef deferred <> TLB.fromText t
+      | T.compareLength t 3 == LT = flushDef deferred <> TLB.fromText t
       -- Check for month abbreviation
       | let mon = T.take 3 t
       , HS.member mon monthSet
@@ -1297,7 +1297,7 @@ replaceAllFormats !input = toText . TLB.toLazyText $ go Nothing (replacePrePass 
       , not (T.null r)
       , T.head r == '-'
       , let afterDash = T.drop 1 r
-      , T.length afterDash >= 3
+      , T.compareLength afterDash 3 /= LT
       , HS.member (T.take 3 afterDash) monthSet
       , maybe True (not . isAlphaNum) prev =
           scanMons (Just '-') (Just (mempty, ds <> "-")) afterDash
@@ -1451,7 +1451,7 @@ replaceAllFormats !input = toText . TLB.toLazyText $ go Nothing (replacePrePass 
     scanDigit :: Text -> TLB.Builder
     scanDigit !txt
       -- 0x hex literal
-      | T.length txt >= 2 && T.head txt == '0' && T.index txt 1 == 'x' =
+      | T.compareLength txt 2 /= LT && T.head txt == '0' && T.index txt 1 == 'x' =
           let (hexRun, rest) = T.span isHexDigit' (T.drop 2 txt)
            in if T.null hexRun then "{integer}" <> go (Just '}') (T.drop 1 txt) else "{hex}" <> go (Just '}') rest
       | otherwise =


### PR DESCRIPTION
Pattern embedding jobs time out while normalizing large error messages. The date scanner counted the entire remaining Text at every character to test whether three characters remained, making the scan quadratic; the digit scanner had another full-suffix length check. These checks now use bounded `Text.compareLength` without truncating input or changing normalization rules.

Production evidence: the next 500 unembedded errors contain 93 MB in their first lines, 24 first lines exceed 1 MB, and the largest is 7.43 MB. The embedding job records a ten-minute TimeoutException before saving vectors.

Validation: all 647 Utils/ErrorFingerprint/PatternMerge doctests and all 300 unit tests pass, as do formatting and HLint. A synthetic 100k/200k-character normalization probe changes from 0.107/0.391 seconds to 0.0055/0.011 seconds; the candidate processes 5.4 MB of JSON-like input in 0.376 seconds. Baseline used the previous test build, candidate the default library build; the scaling trend, rather than an exact speedup factor, is the useful comparison.
