### PR TITLE
fix: preserve queued jobs when background workers are disabled

### DIFF
--- a/src/BackgroundJobs.hs
+++ b/src/BackgroundJobs.hs
@@ -3112,7 +3112,7 @@ dispatchTeamNotifications team alert projectId projectTitle monitorUrl subj rend
 
 
 jobsWorkerInit :: Logger -> Config.AuthContext -> TracerProvider -> IO ()
-jobsWorkerInit logger appCtx tp = do
+jobsWorkerInit logger appCtx tp = when appCtx.config.enableBackgroundJobs do
   when appCtx.config.enableDailyJobScheduling do
     ensureDailyJobScheduled appCtx
     void $ async $ forever do

--- a/src/System/Server.hs
+++ b/src/System/Server.hs
@@ -462,7 +462,7 @@ runServer appLogger env tp = do
           -- replicas dropped their listener every ~10-50min with nothing in the logs).
           guard (not consumerOnly) $> async ((runSettings warpSettings wrappedServer >> logExc "warp" "runSettings returned cleanly") `Safe.withException` \(e :: SomeException) -> logExc "warp" ("runSettings threw: " <> show e))
         , guard env.config.enablePubsubService $> async (supervise logExc "pubsub" $ Queue.pubsubService appLogger env tp env.config.requestPubsubTopics processMessages)
-        , guard (not consumerOnly) $> async (supervise logExc "background-jobs" bgJobWorker)
+        , guard (not consumerOnly && env.config.enableBackgroundJobs) $> async (supervise logExc "background-jobs" bgJobWorker)
         , guard (not consumerOnly && env.config.enableOtlpGrpcService) $> async (supervise logExc "otlp-grpc" $ OtlpServer.runServer appLogger env tp)
         , -- TWO identical ingest consumers per node, on purpose (commit 4ee5350a, "Extra
           -- kafka processor fiber per node"): they join the same consumer group, so the

--- a/test/integration/BackgroundJobs/DailyScheduleSpec.hs
+++ b/test/integration/BackgroundJobs/DailyScheduleSpec.hs
@@ -12,6 +12,8 @@ import Database.PostgreSQL.Simple qualified as PGS
 import Database.PostgreSQL.Simple.SqlQQ (sql)
 import Pkg.TestUtils
 import Relude
+import System.Config qualified as Config
+import System.Timeout qualified as Timeout
 import Test.Hspec (Spec, around, describe, it, shouldBe)
 
 
@@ -59,3 +61,11 @@ spec = around withTestResources do
       queueAt tr "DailyJob" "9 hours"
       BackgroundJobs.ensureDailyJobScheduled tr.trATCtx
       countTag tr "DailyJob" >>= (`shouldBe` 1)
+
+  describe "disabled background worker" do
+    it "leaves queued jobs untouched and does not start a runner" \tr -> do
+      queueAt tr "DailyJob" "-1 hour"
+      let ctx = tr.trATCtx{Config.config = tr.trATCtx.config{Config.enableBackgroundJobs = False, Config.enableDailyJobScheduling = False}}
+      result <- Timeout.timeout 1_000_000 $ BackgroundJobs.jobsWorkerInit tr.trLogger ctx tr.trTracerProvider
+      remaining <- countTag tr "DailyJob"
+      (result, remaining) `shouldBe` (Just (), 1)


### PR DESCRIPTION
When ENABLE_BACKGROUND_JOBS is false, the worker still starts and can consume queued jobs whose handlers then skip their work. Gate both worker initialization and supervisor startup on the setting so disabled processes leave the queue untouched.

Validation: reproduced a queued DailyJob disappearing before the fix; the regression now confirms the worker returns and preserves the job. All three DailySchedule integration tests pass against PostgreSQL, plus HLint and Fourmolu. This is a confirmed isolation bug; it is not established as the cause of the production embedding backlog.
