### PR TITLE
fix: avoid repeated suffix copies during pattern normalization

### DIFF
--- a/src/Utils.hs
+++ b/src/Utils.hs
@@ -1248,6 +1248,14 @@ getAlertStatusColor = \case
 --
 -- >>> map replaceAllFormats ["code 1A2B3C", "code 4D5E6F"]
 -- ["code {integer}A{integer}B{integer}C","code {integer}D{integer}E{integer}F"]
+--
+-- Failed JWT candidates remain text, including nested prefixes; later valid tokens still match.
+-- >>> replaceAllFormats "eyJeyJeyJ! eyJabc..bad eyJgood.payload.signature user@example.com next@other.org"
+-- "eyJeyJeyJ! eyJabc..bad {jwt} {email} {email}"
+-- >>> map replaceAllFormats ["λcode1", "λcode2"] == ["λcode{integer}", "λcode{integer}"]
+-- True
+-- >>> replaceAllFormats (T.replicate 1000 "9") == replaceAllFormats (T.replicate 1001 "9")
+-- True
 replaceAllFormats :: Text -> Text
 replaceAllFormats !input = toText . TLB.toLazyText $ go Nothing (replacePrePass input)
   where
@@ -1292,8 +1300,9 @@ replaceAllFormats !input = toText . TLB.toLazyText $ go Nothing (replacePrePass 
       -- Detect "D-" or "DD-" that might precede a month: defer it
       | isNothing deferred
       , isDigit (T.head t)
-      , let (ds, r) = T.span isDigit t
+      , let ds = T.takeWhile isDigit $ T.take 3 t
       , T.length ds <= 2
+      , let r = T.drop (T.length ds) t
       , not (T.null r)
       , T.head r == '-'
       , let afterDash = T.drop 1 r
@@ -1332,14 +1341,16 @@ replaceAllFormats !input = toText . TLB.toLazyText $ go Nothing (replacePrePass 
       pure r5
 
     replaceEmails :: Text -> Text
-    replaceEmails !txt =
-      let (before, after) = T.breakOn "@" txt
-          afterAt = T.drop 1 after
-          (localRev, prefixRev) = T.span isLocalChar (T.reverse before)
-          keepAt = before <> "@" <> replaceEmails afterAt
-       in if T.null after
-            then txt
-            else maybe keepAt (\rest -> T.reverse prefixRev <> "{email}" <> replaceEmails rest) (guard (not $ T.null localRev) >> tryEmailDomain afterAt)
+    replaceEmails = toText . TLB.toLazyText . emails
+      where
+        emails !txt =
+          let (before, after) = T.breakOn "@" txt
+              afterAt = T.drop 1 after
+              (localRev, prefixRev) = T.span isLocalChar (T.reverse before)
+              keepAt = TLB.fromText before <> "@" <> emails afterAt
+           in if T.null after
+                then TLB.fromText txt
+                else maybe keepAt (\rest -> TLB.fromText (T.reverse prefixRev) <> "{email}" <> emails rest) (guard (not $ T.null localRev) >> tryEmailDomain afterAt)
 
     isLocalChar :: Char -> Bool
     isLocalChar c = isAlphaNum c || c `elem` ("._%+-" :: [Char])
@@ -1354,12 +1365,19 @@ replaceAllFormats !input = toText . TLB.toLazyText $ go Nothing (replacePrePass 
       pure rest
 
     replaceJWTs :: Text -> Text
-    replaceJWTs !txt =
-      let (before, after) = T.breakOn "eyJ" txt
-          rest3 = T.drop 3 after
-       in if T.null after
-            then txt
-            else maybe (before <> "eyJ" <> replaceJWTs rest3) (\r3 -> before <> "{jwt}" <> replaceJWTs r3) (jwtTail rest3)
+    replaceJWTs = toText . TLB.toLazyText . jwts
+      where
+        jwts !txt =
+          let (before, after) = T.breakOn "eyJ" txt
+              rest3 = T.drop 3 after
+              -- A failed candidate cannot hide a valid JWT inside this same
+              -- header run: every suffix would encounter the same separators.
+              -- Advance past it once instead of rescanning each nested "eyJ".
+              (header, rest) = T.span isBase64Url rest3
+              keepHeader = "eyJ" <> TLB.fromText header <> jwts rest
+           in if T.null after
+                then TLB.fromText txt
+                else TLB.fromText before <> maybe keepHeader (\r3 -> "{jwt}" <> jwts r3) (jwtTail rest3)
 
     -- Two more non-empty base64url segments, each dot-separated, after the "eyJ" header.
     jwtTail :: Text -> Maybe Text
@@ -1388,7 +1406,7 @@ replaceAllFormats !input = toText . TLB.toLazyText $ go Nothing (replacePrePass 
                   else -- Digit trigger: check for hex-alpha suffix to peel
                     case peelHexSuffix safe of
                       (safePre, hexPart)
-                        | not (T.null hexPart) -> TLB.fromText safePre <> scanHexDigit (hexPart <> rest)
+                        | not (T.null hexPart) -> TLB.fromText safePre <> scanHexDigit (T.drop (T.length safePre) txt)
                       _ -> TLB.fromText safe <> scanDigit rest
 
     trigger :: Char -> Bool

--- a/test/bench/UtilsBenchSpec.hs
+++ b/test/bench/UtilsBenchSpec.hs
@@ -6,6 +6,7 @@ import Relude
 import Test.Hspec
 import Utils (replaceAllFormats)
 
+
 -- Realistic log lines covering all pattern types the scanner should handle
 sampleLines :: [Text]
 sampleLines =
@@ -16,39 +17,40 @@ sampleLines =
   , "Hash: a94a8fe5ccb19ba61c4c0873d391e987982fbbd3, Status: 403, Port: :8443"
   , "Connected to 10.0.0.1:443 and 192.168.1.100:22"
   , "Server started on :8080 with PID 12345"
-  -- Timestamps (ISO, MySQL, standalone time)
-  , "2024-01-15T14:30:00.123Z INFO Processing request 123456"
+  , -- Timestamps (ISO, MySQL, standalone time)
+    "2024-01-15T14:30:00.123Z INFO Processing request 123456"
   , "2023-10-14 10:29:38 ERROR: Connection refused to 10.0.0.5:3306"
   , "[2024-03-01T08:15:22+05:30] WARN Rate limit exceeded client=172.16.0.1"
   , "SELECT * FROM users WHERE id = 42 AND created_at > 2024-01-15 10:30:00"
-  -- JWT, email, URL
-  , "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.signature sent to user@example.com"
+  , -- JWT, email, URL
+    "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.signature sent to user@example.com"
   , "Webhook delivery to https://example.com/hook/abc123 failed with 502"
   , "Authentication failed for admin@company.org from IP 10.0.0.5"
-  -- JSON-like structures (colon handling)
-  , "{\"status_code\":200,\"duration\":45.67,\"user_id\":\"550e8400-e29b-41d4-a716-446655440000\"}"
+  , -- JSON-like structures (colon handling)
+    "{\"status_code\":200,\"duration\":45.67,\"user_id\":\"550e8400-e29b-41d4-a716-446655440000\"}"
   , "{\"http\":{\"request\":{\"method\":\"GET\"},\"response\":{\"status_code\":200}},\"url\":{\"full\":\"http://frontend-proxy:8080/\"}}"
   , "{\"rpc\":{\"grpc\":{\"status_code\":0},\"method\":\"GetCart\",\"service\":\"oteldemo.CartService\"}}"
-  -- gRPC/OTEL-style structured logs
-  , "outgoing 200 GET GET {\"http\":{\"request\":{\"method\":\"GET\"},\"response\":{\"status_code\":200}},\"url\":{\"full\":\"http://frontend-proxy:8080/\"}}"
+  , -- gRPC/OTEL-style structured logs
+    "outgoing 200 GET GET {\"http\":{\"request\":{\"method\":\"GET\"},\"response\":{\"status_code\":200}},\"url\":{\"full\":\"http://frontend-proxy:8080/\"}}"
   , "INFO \"Product Found\" {\"app\":{\"product\":{\"id\":\"1YMWWN1N1O\",\"name\":\"Eclipsmart Travel Refractor Telescope\"}}}"
   , "internal user_flood_home {\"flood\":{\"count\":5}}"
-  -- Kafka, database, k8s
-  , "Kafka offset 987654321 partition 3 topic events-production"
+  , -- Kafka, database, k8s
+    "Kafka offset 987654321 partition 3 topic events-production"
   , "Database query took 123ms for table users_sessions with 5000 rows"
   , "pod/api-server-7b8f6c9d4-x2k9m restarted 3 times in namespace production"
-  -- MAC, hex, floats, mixed
-  , "MAC 00:1A:2B:3C:4D:5E on VLAN 100 with latency 12.5ms"
+  , -- MAC, hex, floats, mixed
+    "MAC 00:1A:2B:3C:4D:5E on VLAN 100 with latency 12.5ms"
   , "Memory usage 1048576 bytes, CPU 95.2%, uptime 86400 seconds"
   , "Transaction 0xDEADBEEF failed with hash a94a8fe5ccb19ba61c4c0873d391e987982fbbd3"
-  -- Longer log lines (~200+ chars)
-  , "[2024-01-15T14:30:00.123Z] [ERROR] Connection to db-master.region.rds.amazonaws.com:5432 failed: timeout after 30000ms (attempt 3/5) trace_id=c73bcdcc-2669-4bf6-81d3-e4ae73fb11fd"
+  , -- Longer log lines (~200+ chars)
+    "[2024-01-15T14:30:00.123Z] [ERROR] Connection to db-master.region.rds.amazonaws.com:5432 failed: timeout after 30000ms (attempt 3/5) trace_id=c73bcdcc-2669-4bf6-81d3-e4ae73fb11fd"
   , "Request from 172.16.0.1 forwarded to 10.0.0.5:3000 via proxy at 192.168.1.1:8080 with X-Request-ID: 507f1f77bcf86cd799439011 in 45.67ms"
-  -- Short lines
-  , "Responses: 200, 301, 404, 500"
+  , -- Short lines
+    "Responses: 200, 301, 404, 500"
   , "OK"
   , ""
   ]
+
 
 spec :: Spec
 spec = describe "replaceAllFormats benchmark" $ do
@@ -66,16 +68,28 @@ spec = describe "replaceAllFormats benchmark" $ do
     putStrLn $ "\n  20k rows: " <> showMs elapsed <> "  (" <> showPerRow elapsed 20000 <> "/row)"
     elapsed `shouldSatisfy` (< 5.0)
 
+  forM_ ([("hex suffix", "code1 "), ("email", "user@example.com "), ("JWT header", "eyJ"), ("digit run", "9")] :: [(String, Text)]) $ \(label, token) ->
+    it ("reports long-message scaling for " <> label)
+      $ forM_ ([5000, 10000, 20000] :: [Int])
+      $ \n -> do
+        let input = T.replicate n token
+        evaluateNF_ input
+        elapsed <- bench [input]
+        putStrLn $ "\n  " <> label <> ": " <> show n <> " repetitions, " <> showMs elapsed
+
+
 bench :: [Text] -> IO Double
 bench rows = do
   start <- getCurrentTime
   let results = map replaceAllFormats rows
-  void $ evaluateNF $ foldl' (\acc t -> acc + T.length t) 0 results
+  evaluateNF_ $ foldl' (\acc t -> acc + T.length t) 0 results
   end <- getCurrentTime
   pure $ realToFrac (diffUTCTime end start)
 
+
 showMs :: Double -> String
 showMs s = show (round (s * 1000) :: Int) <> "ms"
+
 
 showPerRow :: Double -> Int -> String
 showPerRow s n = show (round (s / fromIntegral n * 1_000_000) :: Int) <> "μs"


### PR DESCRIPTION
Large error messages spend seconds in normalization before embedding can start. The main scanner copies the whole remaining message whenever a digit follows hexadecimal letters. Email/JWT prepasses also concatenate strict Text repeatedly, and month detection rescans long digit runs.

Reuse a slice of the original input in the scanner, build email/JWT output with Text builders, advance past failed JWT headers once, and bound day-of-month lookahead to three digits. Normalized text stays unchanged.

Validation: full library build, all650 relevant doctests,300 unit tests, and all6 normalization benchmarks pass, along with HLint and formatting. Full-library normalization of two captured large messages drops from roughly23s/12s to0.64s/0.49s, with byte-identical output. Synthetic hex/email/JWT/digit scaling cases are included in the repository benchmark; they report measurements without new timing thresholds. Eight isolated scanner comparisons and five final-library comparisons also match byte for byte. Private message contents are excluded from the repository.
