### PR TITLE
fix: save completed embedding documents before later requests fail

### DIFF
--- a/src/BackgroundJobs.hs
+++ b/src/BackgroundJobs.hs
@@ -3807,16 +3807,17 @@ data MergeConfig k a = MergeConfig
 
 embedAndMerge :: Ord k => Projects.ProjectId -> Config.AuthContext -> MergeConfig k a -> ATBackgroundCtx ()
 embedAndMerge pid ctx cfg = unless (null cfg.items) do
-  let docs = map (\item -> Langchain.DocumentLoader.Core.Document (toLazy $ cfg.normalizeEmb $ cfg.itemText item) mempty) cfg.items
-  embedResult <- ELLM.embedDocuments (embeddingConfig ctx) docs
+  let docs = map (\item -> (cfg.toId item, Langchain.DocumentLoader.Core.Document (toLazy $ cfg.normalizeEmb $ cfg.itemText item) mempty)) cfg.items
+      save batch = do
+        count <- cfg.updateEmbs batch
+        Log.logInfo "Saved pattern embeddings" $ AE.object ["project_id" AE..= pid, "pattern_type" AE..= cfg.label, "saved" AE..= count]
+  embedResult <- ELLM.embedDocumentsWithProgress (ELLM.embedDocuments $ embeddingConfig ctx) save docs
   case embedResult of
     Left err -> Log.logAttention ("Failed to embed " <> cfg.label <> " patterns") (pid, err)
-    Right embeddingsList -> do
-      void $ cfg.updateEmbs $ zipWith (\item emb -> (cfg.toId item, emb)) cfg.items embeddingsList
+    Right newWithEmbs -> do
       allCentroids <- cfg.getCentroids
       let newIds = S.fromList $ map cfg.toId cfg.items
           centroids = filter (\(cid, _) -> not $ S.member cid newIds) allCentroids
-          newWithEmbs = zip (map cfg.toId cfg.items) embeddingsList
           !(autoMerges, ambiguous) = PatternMerge.assignToCentroids centroids newWithEmbs
       let newTextMap = Map.fromList $ map (\item -> (cfg.toId item, cfg.itemText item)) cfg.items
           neededIds = ordNub $ map snd autoMerges <> map snd ambiguous

--- a/src/Data/Effectful/LLM.hs
+++ b/src/Data/Effectful/LLM.hs
@@ -5,6 +5,7 @@ module Data.Effectful.LLM (
   embedDocuments,
   openAIEmbeddings,
   embedDocumentsBounded,
+  embedDocumentsWithProgress,
   callOpenAIAPI,
   modelAndEffort,
   runLLMReal,
@@ -94,8 +95,6 @@ embedDocumentsBounded request docs
       means <- go mempty chunks
       traverse (finish means) [0 .. length docs - 1]
   where
-    maxInputBytes = 8191 :: Int
-    maxBatchChunks = 300000 `div` maxInputBytes
     -- takeWord8/dropWord8 advance together by up to three bytes to finish a
     -- code point. Reserve those bytes so even that final character fits.
     chunkBytes = fromIntegral (maxInputBytes - 3)
@@ -137,6 +136,43 @@ embedDocumentsBounded request docs
              in if norm == 0
                   then throwError "Chunk embeddings have a zero-length mean"
                   else pure $ map (realToFrac . (/ norm)) $ VU.toList mean
+
+
+maxInputBytes, maxBatchChunks :: Int
+maxInputBytes = 8191
+maxBatchChunks = 300000 `div` maxInputBytes
+
+
+-- | Save completed documents between bounded groups of provider requests.
+-- A document spanning more than one request stays whole: partial chunk means
+-- must never be persisted as that document's embedding.
+embedDocumentsWithProgress
+  :: Monad m
+  => ([DocLoader.Document] -> m (Either Text [[Float]]))
+  -> ([(a, [Float])] -> m ())
+  -> [(a, DocLoader.Document)]
+  -> m (Either Text [(a, [Float])])
+embedDocumentsWithProgress request save docs = runExceptT $ concat . reverse <$> foldM store [] (groups docs)
+  where
+    chunks (_, doc) =
+      let bytes = BS.length $ encodeUtf8 $ toStrict $ DocLoader.pageContent doc
+       in if bytes <= maxInputBytes then 1 else 1 + (bytes - 1) `div` (maxInputBytes - 3)
+    groups [] = []
+    groups (doc : rest) =
+      let (following, remaining) = fill (maxBatchChunks - chunks doc) rest
+       in (doc : following) : groups remaining
+    fill _ [] = ([], [])
+    fill budget pending@(doc : rest)
+      | chunks doc > budget = ([], pending)
+      | otherwise =
+          let (following, remaining) = fill (budget - chunks doc) rest
+           in (doc : following, remaining)
+    store completed batch = do
+      vectors <- ExceptT $ request $ map snd batch
+      when (length vectors /= length batch) $ throwError "Embedding response count does not match request"
+      let pairs = zip (map fst batch) vectors
+      lift $ save pairs
+      pure (pairs : completed)
 
 
 -- Strict fields keep chunk accumulation from retaining previous batch vectors.

--- a/test/unit/Data/Effectful/LLMSpec.hs
+++ b/test/unit/Data/Effectful/LLMSpec.hs
@@ -1,7 +1,7 @@
 module Data.Effectful.LLMSpec (spec) where
 
 import Data.ByteString qualified as BS
-import Data.Effectful.LLM (embedDocumentsBounded, openAIEmbeddings)
+import Data.Effectful.LLM (embedDocumentsBounded, embedDocumentsWithProgress, openAIEmbeddings)
 import Data.Text qualified as T
 import Langchain.DocumentLoader.Core qualified as Doc
 import Langchain.Embeddings.OpenAI qualified as EmbOAI
@@ -11,6 +11,31 @@ import Test.Hspec
 
 spec :: Spec
 spec = do
+  describe "durable embedding progress" do
+    let cases :: [(String, [Int], [(Int, [Float])])]
+        cases = [("completed documents survive a later failure", [36, 36], [(1, [1, 0])]), ("an unfinished document is never saved", [72], [])]
+    forM_ cases \(label, sizes, expected) ->
+      it label do
+        saved <- newIORef []
+        calls <- newIORef (0 :: Int)
+        let docs = zip [1 :: Int ..] $ map (\n -> Doc.Document (toLazy $ T.replicate (8188 * n) "a") mempty) sizes
+            request batch = do
+              modifyIORef' calls (+ 1)
+              call <- readIORef calls
+              pure $ if call == 2 then Left "provider unavailable" else Right (replicate (length batch) [1, 0])
+        embedDocumentsWithProgress (embedDocumentsBounded request) (modifyIORef' saved . flip (<>)) docs
+          `shouldReturn` Left "provider unavailable"
+        readIORef saved `shouldReturn` expected
+        readIORef calls `shouldReturn` 2
+
+    it "returns and saves all document identities in input order" do
+      saved <- newIORef []
+      let docs = [(i, Doc.Document (toLazy $ T.replicate 8191 "a") mempty) | i <- [1 :: Int .. 80]]
+          request batch = pure $ Right $ replicate (length batch) [1, 0]
+          expected = [(i, [1, 0]) | i <- [1 :: Int .. 80]]
+      embedDocumentsWithProgress (embedDocumentsBounded request) (modifyIORef' saved . flip (<>)) docs `shouldReturn` Right expected
+      readIORef saved `shouldReturn` expected
+
   describe "embedding endpoint configuration" do
     let cases :: [(Text, String)]
         cases =


### PR DESCRIPTION
A pattern-embedding job currently saves nothing until all 500 documents finish. The observed large batch needs over 15,800 provider chunks; a later request failure discards completed documents from that attempt. A reproduction with two documents and a failure on the second provider request leaves zero saved vectors.

Save complete documents between groups bounded by the existing provider chunk budget. Documents spanning multiple requests remain indivisible, and the existing chunk-weighted embedding calculation is unchanged. Successful runs retain document order and the existing centroid-assignment flow. Log the actual saved count after each database update.

Validation: all 303 unit tests passed, including completed-document durability, refusal to save an unfinished document, and identity/order preservation. HLint and formatting pass. The final unit rerun, including the saved-count log, also passes all 303 tests. CI is required before merge.
