### PR TITLE
Retry temporary embedding provider rate limits

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -114,7 +114,7 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/tonyalaribe/langchain-hs
-  tag: 030ac14a6cb6c20e9dca8576cff8d2f0df5efd4a
+  tag: 5595b365639676702c52c4fd2f15e5815d4bc330
   subdir: .
 
 source-repository-package


### PR DESCRIPTION
Production embedding jobs stop on temporary OpenAI token rate limits: four HTTP 429 responses requested delays of 101–604ms, but the transport returned each error immediately. Pin the owned Langchain fork to retry these responses while preserving the incremental saves added in #523.

The transport retries only known temporary 429 error codes, at most twice, with no retry starting after 30 seconds. It honors Retry-After seconds or HTTP dates, uses exponential backoff with jitter when the header is missing or invalid, and returns terminal responses unchanged. Quota, input, unknown errors, and streaming request bodies are not retried; cancellation and transport exceptions propagate.

Validation: two real HTTP regression cases fail before the fix. All twelve HTTP cases pass afterward, covering identical POST replay, the retry bound, minimum delays, fallback backoff, HTTP dates, and terminal errors. HLint passes for the new transport and tests. The application builds successfully against the pinned fork, and all 303 application unit tests pass. The fork keeps package version 0.0.3.0, matching the existing freeze file.

Fork change: https://github.com/tonyalaribe/langchain-hs/commit/5595b365639676702c52c4fd2f15e5815d4bc330
