### PR TITLE
Preserve OpenAI cancellation at background job deadlines

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -114,7 +114,7 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/tonyalaribe/langchain-hs
-  tag: 5595b365639676702c52c4fd2f15e5815d4bc330
+  tag: ad74fb7f1663349993238d5da99ca05e3bf68334
   subdir: .
 
 source-repository-package


### PR DESCRIPTION
When a pattern merge job reaches its deadline during an OpenAI call, Langchain catches `AsyncCancelled` and returns a provider error. The job can then continue into later steps after cancellation. Production recorded this in the log-pattern judgment step after all 1,000 selected embeddings had been saved.

Pin the client fix that lets asynchronous cancellation escape both generation and chat calls. Synchronous provider failures still return `LangchainError`; the existing bounded embedding retries are unchanged. The job runner retains its existing ten-minute deadline.

Validation: both local HTTP cancellation regressions fail before the fix and pass after it. The tests also check ordinary HTTP 500 failures remain provider errors. All 14 OpenAI HTTP tests pass, and HLint reports no hints. Application CI build, weeder, doctests, unit tests, CLI tests and integration tests pass. End-to-end CI is finishing. The dependency fix and its HTTP regressions are in [ad74fb7](https://github.com/tonyalaribe/langchain-hs/commit/ad74fb7f1663349993238d5da99ca05e3bf68334).
