### PR TITLE
Avoid union allocation in Drain Jaccard comparisons

### DIFF
--- a/src/Pkg/PatternMerge.hs
+++ b/src/Pkg/PatternMerge.hs
@@ -300,7 +300,8 @@ contentTokens = S.fromList . filter (not . isPlaceholderToken) . words
 jaccardOnSets :: S.Set Text -> S.Set Text -> Double
 jaccardOnSets tokA tokB =
   let inter = S.size $ S.intersection tokA tokB
-      union_ = S.size $ S.union tokA tokB
+      -- Cardinality needs no union tree: |A union B| = |A| + |B| - |A intersect B|.
+      union_ = S.size tokA + S.size tokB - inter
    in if union_ == 0 then 1.0 else fromIntegral inter / fromIntegral union_
 
 


### PR DESCRIPTION
Drain flush CPU profiles show repeated set union and intersection allocation under `mergeByJaccard`. The union is used only for its size. Compute that size from the two input sizes and their already-computed intersection size, preserving the score, threshold, representative, frequencies and event membership.

Validation: exhaustive comparison of all 65,536 pairs of subsets of an eight-token universe produced identical scores, including empty sets. An optimized GHC 9.12.2 benchmark using the production helper over 499,500 comparisons of 20-token sets with ten shared tokens reduced allocation from 1,251,894,624 to 472,532,736 bytes (62%) and CPU time from 0.441 to 0.227 seconds. HLint, formatting and diff checks pass. Application checks will run in CI.

This removes a measured allocation hotspot; it is not yet evidence that the separately observed container OOMs are resolved.
