### PR TITLE
Fix query editor deployment test contracts and runner discovery

### DIFF
--- a/test/integration/Pages/LogExplorer/LogSpec.hs
+++ b/test/integration/Pages/LogExplorer/LogSpec.hs
@@ -744,11 +744,15 @@ spec = around withTestResources do
         `shouldSatisfy` maybe False (T.isInfixOf "overflow-hidden")
 
   describe "Query editor skeleton" do
-    it "apiLogH_rendersAnEmptyQueryAsAMutedPlaceholder" \tr -> do
+    it "apiLogH_rendersAnEmptyQueryAsANativePlaceholder" \tr -> do
       (_, page) <- testServant tr $ Log.apiLogH testPid Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing
       let html = toText $ Lucid.renderText $ Lucid.toHtml page
-      find (T.isInfixOf "level ==") (T.splitOn "<" html)
-        `shouldSatisfy` maybe False (T.isInfixOf "opacity-60")
+      let input = find (T.isInfixOf "data-query-input") (T.splitOn "<" html)
+      input `shouldSatisfy` maybe False (T.isPrefixOf "textarea ")
+      input `shouldSatisfy` maybe False (T.isInfixOf "placeholder=\"level == &quot;ERROR&quot;\"")
+      -- The example belongs in the placeholder, never in the editable value
+      -- that the query editor adopts when its JavaScript loads.
+      input `shouldSatisfy` maybe False (T.isSuffixOf ">")
   describe "Trace Tree" do
     -- Regression: startNs was folded with a 0 seed, so every synthetic orphan
     -- header started at 0 and its duration spanned from the epoch to the last span.

--- a/web-components/vitest.config.ts
+++ b/web-components/vitest.config.ts
@@ -1,7 +1,9 @@
-import { defineConfig } from 'vitest/config';
+import { configDefaults, defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
+    // Browser benchmarks run through bench/playwright.config.ts.
+    exclude: [...configDefaults.exclude, 'bench/**'],
     // jsdom has better compatibility with Monaco Editor
     environment: 'jsdom',
     globals: true,


### PR DESCRIPTION
Deployment checks fail after the query editor update for two test-runner mismatches: an integration test expects the old skeleton opacity class, and Vitest discovers a browser benchmark written for Playwright.

Check the native textarea placeholder and empty editable value, protecting the value adopted when JavaScript loads. Keep Playwright benchmarks under their existing dedicated configuration and out of Vitest discovery, preserving Vitest's default exclusions.

Validation: all 55 Vitest suites / 911 tests pass locally with Node 25. Formatting and diff checks pass. HLint reports existing hints elsewhere in the integration module, none in the changed test. CI validates the integration suite.
