### PR TITLE
Refresh cached report PNGs after the renderer update

### DIFF
--- a/plans/weekly-report-redesign.md
+++ b/plans/weekly-report-redesign.md
@@ -269,3 +269,9 @@ The first production browser check opened saved report
 `447647ba-f56e-47dd-9de1-0773c908fe86` in 0.607 seconds, verified both logo themes,
 and confirmed the explicit live action displays its waiting state. Final PNG and
 hover verification follows the packaging/preload rollout.
+
+The CDN confirmed a HIT on old PNGs with a one-year immutable lifetime. Chart
+URLs now carry `render=2`. Publish this URL revision after every replica has the
+newly compiled renderer, so mixed-version rollout cannot cache an old image
+under the new URL. All seven report tests pass with this revision and the hover
+preloading regression.

--- a/src/Pkg/EmailTemplates.hs
+++ b/src/Pkg/EmailTemplates.hs
@@ -1004,7 +1004,8 @@ chartBlock label url = do
   p_ [style_ "margin: 20px 0 8px; font-size: 14px; font-weight: 600; color: #57606a;"] $ toHtml label
   themedImages (appearance "light") (appearance "dark") [class_ "report-chart", alt_ $ label <> " chart", width_ "600", style_ "width:100%;max-width:600px;box-sizing:border-box;height:auto;display:block;border:1px solid #dee2e7; border-radius: 8px;"]
   where
-    appearance mode = url <> (if "?" `T.isInfixOf` url then "&" else "?") <> "appearance=" <> mode
+    -- PNG responses are immutable in the CDN; a renderer revision needs fresh URLs.
+    appearance mode = url <> (if "?" `T.isInfixOf` url then "&" else "?") <> "appearance=" <> mode <> "&render=2"
 
 
 -- Separate wrappers keep Outlook's inline fallback and dark-mode CSS predictable.

--- a/test/integration/Pages/ReportsSpec.hs
+++ b/test/integration/Pages/ReportsSpec.hs
@@ -288,7 +288,7 @@ spec = around withTestResources do
       map (.query) charts `shouldBe` replicate 4 Nothing
       map (fmap (.source) . (.dataset)) charts
         `shouldBe` concatMap (replicate 2 . Just) [[aesonQQ|[["Time","Events"],[1735689600000,100]]|], [aesonQQ|[["Time","Errors"],[1735689600000,7]]|]]
-      email `shouldContainAll` ["appearance=light", "appearance=dark", "logo-white-ink.png", "email-image-dark", "View 25 more service comparisons", "&lt;script&gt;", "View 8 more monitors", "View 25 more endpoints"]
+      email `shouldContainAll` ["appearance=light", "appearance=dark", "render=2", "logo-white-ink.png", "email-image-dark", "View 25 more service comparisons", "&lt;script&gt;", "View 8 more monitors", "View 25 more endpoints"]
       email `shouldSatisfy` (not . T.isInfixOf "<script>")
       BS.length (encodeUtf8 email) `shouldSatisfy` (< 80000)
       full `shouldSatisfy` (not . T.isInfixOf "View 25 more service comparisons")


### PR DESCRIPTION
Report PNGs have a one-year immutable CDN lifetime. Early requests cached the old renderer's white images, so changing the deployed binary alone does not refresh those URLs.

Add `render=2` to the shared email chart URLs. Publish this change only after renderer packaging commit `115795d67` is running on all application replicas; that avoids caching an old renderer's output under the new URL during rollout.

Validation: all seven report integration tests pass, including the unchanged 80 KB email limit and the live-link preloading regression. Fourmolu and HLint pass. The standalone compiled renderer produces the corrected light/dark PNGs. Production PNG verification follows the renderer rollout.

Renderer rollout verified: all three application replicas run `115795d67`. Four fresh production PNGs (two charts × light/dark) returned 200 at 900×300 with the expected background pixels; their plot spacing was visually inspected. The production browser opened the saved report in 1.241 seconds, verified both logo themes, confirmed hover does not generate a report, and confirmed click shows the live waiting state. The staged publication condition is satisfied; final PR CI remains pending.
