### PR TITLE
Let log embeddings progress during slow error embedding

### DIFF
--- a/monoscope.cabal
+++ b/monoscope.cabal
@@ -749,6 +749,7 @@ test-suite integration-tests
     , kafka-effectful
     , ki
     , ki-effectful
+    , langchain-hs
     , lens
     , lens-aeson
     , lucid

--- a/monoscope.cabal
+++ b/monoscope.cabal
@@ -676,6 +676,7 @@ test-suite integration-tests
       Pages.ServiceMapSpec
       Pages.ShareSpec
       Pages.TelemetrySpec
+      Pkg.EmbeddingFairnessSpec
       Pkg.KafkaConsumerSpec
       ProcessMessageSpec
       ReplaySpec
@@ -962,6 +963,7 @@ test-suite test-dev
       Pages.ServiceMapSpec
       Pages.ShareSpec
       Pages.TelemetrySpec
+      Pkg.EmbeddingFairnessSpec
       Pkg.KafkaConsumerSpec
       ProcessMessageSpec
       ReplaySpec

--- a/package.yaml
+++ b/package.yaml
@@ -200,6 +200,8 @@ tests:
       - monoscope
       - monoscope-cli
       - monoscope-shared
+      # EmbeddingFairnessSpec inspects documents passed to the LLM effect.
+      - langchain-hs
       # AuthSpec builds a Set-Cookie header the way a browser round-trips it.
       - cookie
       # CLI.Harness drives the real CLI parser and captures its stdout.

--- a/src/BackgroundJobs.hs
+++ b/src/BackgroundJobs.hs
@@ -43,7 +43,7 @@ import Database.PostgreSQL.Simple qualified as SimplePG
 import Database.PostgreSQL.Simple.SqlQQ (sql)
 import Database.PostgreSQL.Simple.Types
 import Effectful (Eff, IOE, (:>))
-import Effectful.Concurrent.Async (forConcurrently)
+import Effectful.Concurrent.Async (concurrently_, forConcurrently)
 import Effectful.Ki qualified as Ki
 import Effectful.Labeled (Labeled)
 import Effectful.Log (Log)
@@ -3733,9 +3733,12 @@ patternEmbeddingAndMerge pid = do
   ctx <- ask @Config.AuthContext
   if T.null ctx.config.openaiApiKey
     then Log.logAttention "OpenAI API key not configured, skipping pattern embedding" pid
-    else do
-      tryStep "errorPatternEmbedding" $ embedAndMergeErrors pid ctx
-      tryStep "logPatternEmbedding" $ embedAndMergeLogPatterns pid ctx
+    -- Each stage saves completed batches independently. A large error backlog
+    -- can consume the whole job timeout; log patterns must still make progress.
+    else
+      concurrently_
+        (tryStep "errorPatternEmbedding" $ embedAndMergeErrors pid ctx)
+        (tryStep "logPatternEmbedding" $ embedAndMergeLogPatterns pid ctx)
 
 
 embedAndMergeErrors :: Projects.ProjectId -> Config.AuthContext -> ATBackgroundCtx ()

--- a/test/integration/Pkg/EmbeddingFairnessSpec.hs
+++ b/test/integration/Pkg/EmbeddingFairnessSpec.hs
@@ -1,6 +1,7 @@
 module Pkg.EmbeddingFairnessSpec (spec) where
 
 import BackgroundJobs qualified
+import Control.Exception (SomeAsyncException)
 import Data.Effectful.LLM qualified as LLM
 import Data.Pool (withResource)
 import Data.Text qualified as T
@@ -12,7 +13,7 @@ import Pkg.TestUtils
 import Relude
 import System.Timeout (timeout)
 import Test.Hspec
-import UnliftIO.Async (withAsync)
+import UnliftIO.Async (cancel, waitCatch, withAsync)
 import UnliftIO.Concurrent (threadDelay)
 
 
@@ -54,8 +55,12 @@ spec = aroundAll withTestResources do
               SELECT embedding IS NOT NULL FROM apis.log_patterns WHERE pattern_hash = 'embedding-stage-ready'|]
             pure ready
           waitSaved = saved >>= \ready -> unless ready (threadDelay 10000 >> waitSaved)
-      withAsync (runTestBg frozenTime tr $ provider $ BackgroundJobs.patternEmbeddingAndMerge testPid) \_ ->
+      withAsync (runTestBg frozenTime tr $ provider $ BackgroundJobs.patternEmbeddingAndMerge testPid) \worker -> do
         timeout 3000000 waitSaved `shouldReturn` Just ()
+        cancel worker
+        waitCatch worker >>= \case
+          Left err -> isJust (fromException err :: Maybe SomeAsyncException) `shouldBe` True
+          Right _ -> expectationFailure "A cancelled embedding job must not report success"
       saved `shouldReturn` True
       withResource tr.trPool \conn -> do
         [PG.Only untouched] <-

--- a/test/integration/Pkg/EmbeddingFairnessSpec.hs
+++ b/test/integration/Pkg/EmbeddingFairnessSpec.hs
@@ -1,0 +1,66 @@
+module Pkg.EmbeddingFairnessSpec (spec) where
+
+import BackgroundJobs qualified
+import Data.Effectful.LLM qualified as LLM
+import Data.Pool (withResource)
+import Data.Text qualified as T
+import Database.PostgreSQL.Simple qualified as PG
+import Database.PostgreSQL.Simple.SqlQQ (sql)
+import Effectful.Dispatch.Dynamic (interpose)
+import Langchain.DocumentLoader.Core qualified as Doc
+import Pkg.TestUtils
+import Relude
+import System.Timeout (timeout)
+import Test.Hspec
+import UnliftIO.Async (withAsync)
+import UnliftIO.Concurrent (threadDelay)
+
+
+spec :: Spec
+spec = aroundAll withTestResources do
+  describe "Pattern embedding stage fairness" do
+    it "saves log embeddings while error embedding is blocked, and preserves them on cancellation" \tr -> do
+      withResource tr.trPool \conn -> do
+        void $ PG.execute_ conn [sql|UPDATE apis.error_patterns SET merge_override = TRUE|]
+        void $ PG.execute_ conn [sql|UPDATE apis.log_patterns SET merge_override = TRUE|]
+        void
+          $ PG.execute_
+            conn
+            [sql|
+          INSERT INTO apis.error_patterns (project_id, error_type, message, stacktrace, hash)
+          VALUES ('00000000-0000-0000-0000-000000000000', 'EmbeddingStageBlockedError', 'blocked', '', 'embedding-stage-blocked')|]
+        void
+          $ PG.execute_
+            conn
+            [sql|
+          INSERT INTO apis.log_patterns (project_id, log_pattern, pattern_hash)
+          VALUES ('00000000-0000-0000-0000-000000000000', 'ready log stage', 'embedding-stage-ready')|]
+      errorStarted <- newEmptyMVar
+      releaseError <- newEmptyMVar
+      let provider = interpose @LLM.LLM \_ -> \case
+            LLM.EmbedDocuments _ docs
+              | any (T.isInfixOf "EmbeddingStageBlockedError" . toStrict . Doc.pageContent) docs ->
+                  liftIO $ putMVar errorStarted () >> takeMVar releaseError
+              | otherwise -> do
+                  readMVar errorStarted
+                  pure $ Right $ map (const [1, 0]) docs
+            LLM.CallLLM{} -> pure $ Left "No merge judge is needed for this fixture"
+            LLM.CallAgenticChat{} -> pure $ Left "No agent is needed for this fixture"
+          saved = withResource tr.trPool \conn -> do
+            [PG.Only ready] <-
+              PG.query_
+                conn
+                [sql|
+              SELECT embedding IS NOT NULL FROM apis.log_patterns WHERE pattern_hash = 'embedding-stage-ready'|]
+            pure ready
+          waitSaved = saved >>= \ready -> unless ready (threadDelay 10000 >> waitSaved)
+      withAsync (runTestBg frozenTime tr $ provider $ BackgroundJobs.patternEmbeddingAndMerge testPid) \_ ->
+        timeout 3000000 waitSaved `shouldReturn` Just ()
+      saved `shouldReturn` True
+      withResource tr.trPool \conn -> do
+        [PG.Only untouched] <-
+          PG.query_
+            conn
+            [sql|
+          SELECT embedding IS NULL FROM apis.error_patterns WHERE hash = 'embedding-stage-blocked'|]
+        untouched `shouldBe` True


### PR DESCRIPTION
A slow error-pattern embedding pass can consume the entire ten-minute background-job limit before log-pattern embedding starts. In production, one scheduled run saved 459 of 500 error patterns over that window and left the log backlog untouched.

Run the independent error and log stages concurrently within the existing job lifetime. Completed batches remain durable, and cancellation stops both stages. This allows up to two provider requests concurrently per job; request-size limits and the existing retry policy still apply.

Validation: a regression using the real test database and a controlled LLM effect blocks error embedding, then requires a log embedding to be persisted and survive cancellation. It also checks that the cancelled job returns an async exception instead of success. It failed before the change and passes afterward. The focused regression passes through both test-dev and the actual integration-tests target. The integration target explicitly declares the existing langchain-hs dependency used by the test. Compilation, HLint, formatting, and diff checks pass.
