### PR TITLE
Avoid production restarts for changes confined to plans

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -4,6 +4,10 @@ on:
   workflow_dispatch:
   push:
     branches: [master]
+    # Investigation notes do not change the application; avoid restarting
+    # consumers just to publish a checkpoint. Mixed code/plan pushes still run.
+    paths-ignore:
+      - 'plans/**'
 
 env:
   LANG: C.UTF-8


### PR DESCRIPTION
Commits containing only investigation notes currently rebuild and roll all production replicas. For example, 8dcc58a changed only a plan document but replaced the running consumers, adding another rebalance and interrupting memory observations.

Exclude pushes confined to `plans/**` from the automatic Deploy workflow. Pushes that also change application files still deploy, and `workflow_dispatch` remains available. This deliberately does not exclude other Markdown or documentation that might be application inputs.

Validation: parsed the workflow YAML and checked that the master branch trigger, manual trigger, and deployment job conditions remain intact. Diff checks pass. The filter follows [GitHub's documented paths-ignore semantics](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#onpushpull_requestpull_request_targetpathspaths-ignore).
