### PR TITLE
Support trace IDs in timestamped CLI lookups

### DIFF
--- a/cli/CLI/Commands.hs
+++ b/cli/CLI/Commands.hs
@@ -64,7 +64,7 @@ import Data.Aeson.Key qualified as AK
 import Data.Aeson.KeyMap qualified as KM
 import Data.Aeson.Lens qualified as AL
 import Data.ByteString qualified as BS
-import Data.Char (isAsciiLower, isAsciiUpper, isDigit)
+import Data.Char (isAsciiLower, isAsciiUpper, isDigit, isHexDigit)
 import Data.Default (def)
 import Data.Effectful.Wreq (HTTP, runHTTPWreq)
 import Data.HashMap.Strict qualified as HM
@@ -589,8 +589,8 @@ validateEventsOpts opts = do
 
 
 -- | 'events get ID' — fetch one event (or full trace tree with --tree).
--- When --at TIMESTAMP is given, uses GET /api/v1/events/{id}/time/{ts} for an
--- O(1) timeseries point lookup. Without --at, falls back to a KQL search over
+-- When --at TIMESTAMP is given, event UUIDs use the point lookup endpoint;
+-- trace IDs use a search restricted to the exact timestamp. Without --at, searches
 -- --since (default 90d).
 -- An unparseable --at value is rejected up front so the user gets an immediate
 -- error instead of a slow range-scan fallback that hides the typo.
@@ -598,12 +598,13 @@ runEventsGet :: (Environment :> es, HTTP :> es, IOE :> es) => CLIConfig -> Event
 runEventsGet cfg opts mode = do
   validateDurationOrDie "--since" opts.since
   case opts.at of
-    Nothing -> rangeScan
+    Nothing -> rangeScan Nothing
     Just raw -> case iso8601ParseM (toString raw) :: Maybe UTCTime of
       Nothing -> printError "--at: invalid ISO-8601 timestamp" >> liftIO exitFailure
       Just t
         | T.any (`elem` ("/?#%" :: [Char])) opts.eventId ->
             printError "event id must not contain any of '/', '?', '#', '%'" >> liftIO exitFailure
+        | isTraceId -> rangeScan (Just t)
         | otherwise -> do
             -- Direct O(1) lookup: both id and timestamp known → single-partition query.
             -- Returns raw OtelLogsAndSpans JSON; always rendered as JSON (table view
@@ -611,13 +612,17 @@ runEventsGet cfg opts mode = do
             let path = "/api/v1/events/" <> opts.eventId <> "/time/" <> toText (iso8601Show t)
             withAPIResult cfg path [] (renderJSON . applyProjection opts)
   where
-    rangeScan = do
+    isTraceId = T.length opts.eventId == 32 && T.all isHexDigit opts.eventId
+    rangeScan at = do
       -- Fallback scan, also matching trace_id so bare trace IDs work.
       let eid = T.replace "\"" "\\\"" (T.replace "\\" "\\\\" opts.eventId)
           q
             | opts.showTree = "context.trace_id==\"" <> eid <> "\""
             | otherwise = "(id==\"" <> eid <> "\") or (context.trace_id==\"" <> eid <> "\")"
-          params = [("query", q), ("since", fromMaybe "90d" opts.since)] <> [("with_children", "true") | opts.showTree]
+          bounds = case at of
+            Nothing -> [("since", fromMaybe "90d" opts.since)]
+            Just t -> [("from", toText $ iso8601Show t), ("to", toText $ iso8601Show t)]
+          params = [("query", q)] <> bounds <> [("with_children", "true") | opts.showTree]
       withAPIResult cfg "/api/v1/events" params $ \val ->
         if opts.showTree
           then renderTraceTree val

--- a/test/integration/CLI/CLILifecycleSpec.hs
+++ b/test/integration/CLI/CLILifecycleSpec.hs
@@ -147,13 +147,29 @@ spec = around withTestResources do
       (ecG, getOut) <- runCLILifecycle tr ["--json", "events", "get", toString eid]
       ecG `shouldBe` ExitSuccess
       gv <- jsonOut getOut
-      ts <- case gv of
+      (ts, traceIDText) <- case gv of
         AE.Object o
           | Just (AE.Array evs) <- KM.lookup "events" o
           , Just (AE.Object e0) <- evs V.!? 0
-          , Just (AE.String t) <- KM.lookup "timestamp" e0 ->
-              pure t
+          , Just (AE.String t) <- KM.lookup "timestamp" e0
+          , Just (AE.String tid) <- KM.lookup "trace_id" e0 ->
+              pure (t, tid)
         _ -> expectationFailure ("no events[0].timestamp in events get output: " <> take 300 (toString getOut)) >> error "unreachable"
+
+      -- A trace ID is not an event UUID: --at must still find the same span.
+      forM_ [(ts, [Just (AE.String eid)]), (toText $ iso8601Show $ addUTCTime 3600 frozenTime, [])] \(lookupAt, expectedIds) -> do
+        (ecAt, atOut) <- runCLILifecycle tr ["--json", "traces", "get", toString traceIDText, "--at", toString lookupAt, "--since", "90d"]
+        ecAt `shouldBe` ExitSuccess
+        atValue <- jsonOut atOut
+        case atValue of
+          AE.Object o
+            | Just (AE.Array evs) <- KM.lookup "events" o ->
+                [KM.lookup "id" e | AE.Object e <- V.toList evs] `shouldBe` expectedIds
+          _ -> expectationFailure ("no events in timestamped trace lookup: " <> take 300 (toString atOut))
+
+      (ecUuid, uuidOut) <- runCLILifecycle tr ["--json", "events", "get", toString eid, "--at", toString ts, "--field", "id"]
+      ecUuid `shouldBe` ExitSuccess
+      jsonOut uuidOut `shouldReturn` AE.object ["id" AE..= eid]
 
       -- temporal context with per-trace summary (skill step 4)
       (ecCx, cxOut) <- runCLILifecycle tr ["--json", "events", "context", "--at", toString ts, "--window", "5m", "--summary"]


### PR DESCRIPTION
A trace ID passed to `traces get --at` was sent to the event UUID endpoint and failed with HTTP 400. Route 32-character hexadecimal identifiers through the existing search endpoint with both time bounds set to the requested timestamp. Event UUIDs keep their point lookup and response format.

The existing CLI investigation lifecycle now checks a timestamped trace lookup, an unmatched timestamp even when `--since 90d` is also supplied, and the UUID lookup with field projection. The focused integration test passes through the real parser, handlers, and test database. The rebuilt CLI also passes all three read-only production checks; the original trace lookup returned 400 before this change.

Compilation, formatting, and diff checks pass. HLint reports the same four pre-existing hints on the base and changed files, with no new hints.
