### PR TITLE
Measure native Kafka fetch queue memory

### DIFF
--- a/monoscope.cabal
+++ b/monoscope.cabal
@@ -1230,6 +1230,7 @@ test-suite unit-tests
       Pkg.DrainSpec
       Pkg.GitSpec
       Pkg.IngestBudgetSpec
+      Pkg.KafkaMetricsSpec
       Pkg.ParserSpec
       Pkg.QueryCacheSpec
       Pkg.WidgetLazySpec

--- a/src/Pkg/Queue.hs
+++ b/src/Pkg/Queue.hs
@@ -4,6 +4,7 @@ module Pkg.Queue (
   KafkaRole (..),
   decoupledLoop,
   pollKafkaBatch,
+  parseKafkaFetchQueues,
   ConsumerEff,
   publishJSONToKafka,
   publishToDeadLetterQueue,
@@ -28,6 +29,8 @@ import Control.Lens ((^?), _Just)
 import Control.Lens qualified as L
 import Control.Monad.Trans.Resource (runResourceT)
 import Data.Aeson qualified as AE
+import Data.Aeson.KeyMap qualified as AKM
+import Data.Aeson.Types qualified as AET
 import Data.Annotation (toAnnotation)
 import Data.ByteString.Char8 qualified as BC
 import Data.ByteString.Lazy.Base64 qualified as LB64
@@ -480,6 +483,9 @@ kafkaService appLogger appCtx tp role label dlqBase kafkaTopics batchSize fn = c
         <> K.groupId (K.ConsumerGroupId groupId)
         <> K.clientId (K.ClientId clientId)
         <> foldMap (uncurry K.extraProp) (kafkaSaslExtraProps cfg)
+        -- Native fetch queues are outside the application byte budget and GHC heap.
+        <> K.extraProp "statistics.interval.ms" "30000"
+        <> K.setCallback (K.statsCallback (logKafkaFetchQueues appLogger clientId))
         <> K.extraProp "session.timeout.ms" "45000"
         <> K.extraProp "heartbeat.interval.ms" "3000"
         -- 30 min: backlog-drain batches can legitimately process for >5 min
@@ -505,6 +511,40 @@ kafkaService appLogger appCtx tp role label dlqBase kafkaTopics batchSize fn = c
         -- member never rejoins in-process — the group sat at 0 members while
         -- the supervised thread looked alive. Dynamic members just rejoin.
         <> K.logLevel K.KafkaLogInfo
+
+
+-- | Aggregate only queue sizes, without logging topic names or broker metadata.
+-- A malformed sample is reported separately instead of being mistaken for zero.
+logKafkaFetchQueues :: Logger -> Text -> ByteString -> IO ()
+logKafkaFetchQueues logger clientId raw = runLogT "kafka-service" logger LogInfo
+  $ case parseKafkaFetchQueues raw of
+    Left _ -> LogBase.logAttention "kafka.consumer.native_metrics_invalid" (AE.object ["client_id" AE..= clientId])
+    Right (sampleTime, queueBytes, queueMessages, partitions) ->
+      LogBase.logInfo "kafka.consumer.native_metrics"
+        $ AE.object
+          [ "client_id" AE..= clientId
+          , "sample_time" AE..= sampleTime
+          , "fetch_queue_bytes" AE..= queueBytes
+          , "fetch_queue_messages" AE..= queueMessages
+          , "partitions" AE..= partitions
+          ]
+
+
+-- | Decode a native sample into timestamp, byte count, message count, and partition count.
+parseKafkaFetchQueues :: ByteString -> Either String (Int64, Natural, Natural, Int)
+parseKafkaFetchQueues raw = do
+  (sampleTime, queues) <- AE.eitherDecodeStrict' raw >>= AET.parseEither parseFetchQueues
+  pure (sampleTime, sum (fst <$> queues), sum (snd <$> queues), length queues)
+  where
+    parseFetchQueues :: AE.Value -> AET.Parser (Int64, [(Natural, Natural)])
+    parseFetchQueues = AE.withObject "Kafka statistics" \obj -> do
+      sampleTime <- obj AE..: "time"
+      topics <- obj AE..: "topics"
+      queues <- forM (AKM.elems topics) $ AE.withObject "Kafka topic statistics" \topic -> do
+        partitions <- topic AE..: "partitions"
+        forM (AKM.elems partitions) $ AE.withObject "Kafka partition statistics" \partition ->
+          (,) <$> partition AE..: "fetchq_size" <*> partition AE..: "fetchq_cnt"
+      pure (sampleTime, concat queues)
 
 
 -- | The consumer loop's effect stack: ATBackgroundCtx plus the kafka-effectful

--- a/test/unit/Pkg/KafkaMetricsSpec.hs
+++ b/test/unit/Pkg/KafkaMetricsSpec.hs
@@ -1,0 +1,22 @@
+module Pkg.KafkaMetricsSpec (spec) where
+
+import Pkg.Queue (parseKafkaFetchQueues)
+import Relude
+import Test.Hspec
+
+
+spec :: Spec
+spec = describe "native Kafka fetch queue statistics" do
+  it "sums every partition across topics and preserves the sample time" do
+    parseKafkaFetchQueues "{\"time\":42,\"topics\":{\"first\":{\"partitions\":{\"0\":{\"fetchq_size\":1048576,\"fetchq_cnt\":2},\"1\":{\"fetchq_size\":7,\"fetchq_cnt\":1}}},\"second\":{\"partitions\":{\"3\":{\"fetchq_size\":9,\"fetchq_cnt\":4}}}},\"brokers\":{\"private-host\":{}}}"
+      `shouldBe` Right (42, 1048592, 7, 3)
+    parseKafkaFetchQueues "{\"time\":43,\"topics\":{}}" `shouldBe` Right (43, 0, 0, 0)
+
+  it "rejects malformed or incomplete samples instead of reporting empty queues" do
+    forM_
+      [ "not json"
+      , "{\"time\":42}"
+      , "{\"time\":42,\"topics\":{\"t\":{\"partitions\":{\"0\":{\"fetchq_size\":7}}}}}"
+      , "{\"time\":42,\"topics\":{\"t\":{\"partitions\":{\"0\":{\"fetchq_size\":-1,\"fetchq_cnt\":2}}}}}"
+      ]
+      \sample -> parseKafkaFetchQueues sample `shouldSatisfy` isLeft


### PR DESCRIPTION
The ingestion byte budget measures application payloads, while librdkafka retains native fetch buffers outside the GHC heap. Production OOMs persist after bounding ingestion, and the existing metrics cannot distinguish native queue memory from other allocations.

Emit aggregate fetch-queue bytes, message count, partition count, and sample time every 30 seconds through librdkafka’s supported statistics callback. Log only the configured client ID and numeric totals. Invalid samples produce a distinct diagnostic instead of a misleading zero.

Validation: library and unit-test build, formatting, all 308 unit tests, and a bounded local probe using the real librdkafka callback passed. Parser tests cover multiple topics/partitions, empty queues, missing fields, malformed JSON, and negative sizes.
