### PR TITLE
Prevent overdue background jobs from starving behind new arrivals

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -23,8 +23,8 @@ source-repository-package
 
 source-repository-package
   type: git
-  location: https://github.com/saurabhnanda/odd-jobs.git
-  tag: d6d37e2eabafcb1e286a190d98d73c4d12ff6e53
+  location: https://github.com/tonyalaribe/odd-jobs.git
+  tag: dfdca4ad4d6fca09944d8a29af393186c37917c4
   subdir: .
 
 source-repository-package

--- a/src/BackgroundJobs.hs
+++ b/src/BackgroundJobs.hs
@@ -88,7 +88,7 @@ import Network.HTTP.Types (urlEncode)
 import Network.Wreq (defaults, header, postWith, responseBody)
 import Network.Wreq qualified as Wreq
 import OddJobs.ConfigBuilder (mkConfig)
-import OddJobs.Job (ConcurrencyControl (..), Job (..), LogEvent, LogLevel, createJob, scheduleJob, startJobRunner, throwParsePayload)
+import OddJobs.Job (ConcurrencyControl (..), Config (cfgJobOrdering), Job (..), JobOrdering (EarliestRunAtFirst), LogEvent, LogLevel, createJob, scheduleJob, startJobRunner, throwParsePayload)
 import OpenTelemetry.Attributes qualified as OA
 import OpenTelemetry.Trace (TracerProvider)
 import Pages.Replay qualified as Replay
@@ -3119,7 +3119,7 @@ jobsWorkerInit logger appCtx tp = when appCtx.config.enableBackgroundJobs do
       threadDelay (30 * 60 * 1_000_000) -- 30 minutes
       ensureDailyJobScheduled appCtx
   startJobRunner
-    $ mkConfig jobLogger "background_jobs" appCtx.jobsPool (MaxConcurrentJobs appCtx.config.maxConcurrentJobs) (jobsRunner logger appCtx tp) id
+    $ mkConfig jobLogger "background_jobs" appCtx.jobsPool (MaxConcurrentJobs appCtx.config.maxConcurrentJobs) (jobsRunner logger appCtx tp) (\cfg -> cfg{cfgJobOrdering = EarliestRunAtFirst})
   where
     jobLogger :: OddJobs.Job.LogLevel -> LogEvent -> IO ()
     jobLogger logLevel logEvent = runLogT "OddJobs" logger LogAttention $ LogLegacy.logInfo "Background jobs ping." (show @Text logLevel, show @Text logEvent)

--- a/static/migrations/0150_background_job_notification_channel.sql
+++ b/static/migrations/0150_background_job_notification_channel.sql
@@ -1,0 +1,11 @@
+-- Match odd-jobs pgEventName for the public background_jobs table.
+CREATE OR REPLACE FUNCTION public.notify_job_monitor_for_background_jobs()
+RETURNS trigger AS $$
+BEGIN
+  PERFORM pg_notify(
+    'jobs_created_background_jobs',
+    json_build_object('id', NEW.id, 'run_at', NEW.run_at, 'locked_at', NEW.locked_at)::text
+  );
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;

--- a/test/integration/BackgroundJobs/DailyScheduleSpec.hs
+++ b/test/integration/BackgroundJobs/DailyScheduleSpec.hs
@@ -7,9 +7,12 @@
 module BackgroundJobs.DailyScheduleSpec (spec) where
 
 import BackgroundJobs qualified
+import Control.Exception (bracket_)
 import Data.Pool (withResource)
 import Database.PostgreSQL.Simple qualified as PGS
+import Database.PostgreSQL.Simple.Notification qualified as PGN
 import Database.PostgreSQL.Simple.SqlQQ (sql)
+import OddJobs.Types (pgEventName)
 import Pkg.TestUtils
 import Relude
 import System.Config qualified as Config
@@ -61,6 +64,17 @@ spec = around withTestResources do
       queueAt tr "DailyJob" "9 hours"
       BackgroundJobs.ensureDailyJobScheduled tr.trATCtx
       countTag tr "DailyJob" >>= (`shouldBe` 1)
+
+  describe "background job wakeups" do
+    it "notifies the channel used by the installed job listener" \tr ->
+      withResource tr.trPool \listener ->
+        bracket_
+          (PGS.execute listener "LISTEN ?" (PGS.Only $ pgEventName "background_jobs"))
+          (PGS.execute listener "UNLISTEN ?" (PGS.Only $ pgEventName "background_jobs"))
+          do
+            queueAt tr "DailyJob" "-1 hour"
+            event <- Timeout.timeout 5_000_000 $ PGN.getNotification listener
+            fmap PGN.notificationChannel event `shouldBe` Just "jobs_created_background_jobs"
 
   describe "disabled background worker" do
     it "leaves queued jobs untouched and does not start a runner" \tr -> do


### PR DESCRIPTION
Background jobs with an earlier scheduled time can remain stuck behind a continuous stream of first-attempt jobs. This also delays reclaiming expired locks left by OOM-killed workers. Opt Monoscope into earliest-eligible-run ordering, including the notification dispatch path, using the pinned odd-jobs fork.

Replace the existing notification function so it emits the channel used by the installed listener (`jobs_created_background_jobs`). The original application migration emits `background_jobs`; the fork also fixes SQL identifier quoting in its trigger factory. Existing job eligibility, retry backoff, and concurrency limits remain in force.

Validation:
- Reproduced retry starvation and notification bypass against the previous behavior.
- All 25 odd-jobs tests passed, including overdue retries, expired locks, actual LISTEN/NOTIFY dispatch, and the library's default ordering.
- Built the Monoscope integration test target with GHC 9.12.2; all four DailySchedule integration examples passed against actual migrated PostgreSQL.
- Tested the original and replacement migration in a disposable database: the original did not notify the listener channel; the replacement did.
- Fourmolu and diff checks passed. No warning suppressions or weakened types added.

Fork: https://github.com/tonyalaribe/odd-jobs/commit/dfdca4ad4d6fca09944d8a29af393186c37917c4

Review verification: `pgEventName :: TableName -> PGS.Identifier` already returns an SQL identifier (OddJobs.Types), so the LISTEN/UNLISTEN regression binds the correct type directly. The four real database tests passed; wrapping the result in another Identifier would be a type error.
