### PR TITLE
Back off background job polling when worker slots are full

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -24,7 +24,7 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/tonyalaribe/odd-jobs.git
-  tag: dfdca4ad4d6fca09944d8a29af393186c37917c4
+  tag: eccaca05da4234571839e0dd808c7760065ec171
   subdir: .
 
 source-repository-package


### PR DESCRIPTION
When all background-job slots are occupied, the odd-jobs poller immediately repeats its capacity check without waiting. Pin the library fix that waits for the configured polling interval when saturated, matching the existing empty-queue behavior. The database connection is released before waiting.

A real queued job occupying the only worker slot reproduced 1,007,764 checks in 200ms; the fixed regression observes one. All 26 odd-jobs tests passed with two-test concurrency. The initial unrestricted run exhausted local PostgreSQL connections; no tests were removed or weakened. Application integration target built successfully. All four BackgroundJobs.DailySchedule integration examples passed against migrated PostgreSQL in 59.15 seconds, including notification wakeups and disabled-worker behavior. Full CI is running.

This fixes demonstrated CPU/allocation churn. Its contribution to production OOMs remains unproven and will be measured after rollout.

Fork commit: https://github.com/tonyalaribe/odd-jobs/commit/eccaca05da4234571839e0dd808c7760065ec171

Reviewed fork diff: https://github.com/tonyalaribe/odd-jobs/compare/dfdca4ad4d6fca09944d8a29af393186c37917c4...eccaca05da4234571839e0dd808c7760065ec171
