### PR TITLE
Update log baselines without scanning every pattern

### DIFF
--- a/src/BackgroundJobs.hs
+++ b/src/BackgroundJobs.hs
@@ -5036,23 +5036,14 @@ calculateLogPatternBaselines pid = do
   Log.logTrace "Calculating log pattern baselines" pid
   now <- Time.currentTime
   allStats <- LogPatterns.getBatchPatternStats pid now baselineWindowHours
-  let statsMap = HM.fromList $ map (\s -> ((s.sourceField, s.patternHash), s)) allStats
-      go offset totalProcessed totalEstablished = do
-        patterns <- LogPatterns.getLogPatterns pid baselinePageSize offset
-        let ageDays lp = realToFrac (diffUTCTime now (zonedTimeToUTC lp.firstSeenAt)) / 86400 :: Double
-            updates = V.fromList $ flip mapMaybe patterns \lp ->
-              HM.lookup (lp.sourceField, lp.patternHash) statsMap <&> \stats ->
-                let est = stats.hourlyMedian > minMedianForEstablished || ageDays lp >= minAgeDaysForEstablished
-                 in (lp.sourceField, lp.patternHash, bool BSLearning BSEstablished est, stats.hourlyMedian, stats.hourlyMADScaled, stats.totalHours)
-            established = V.length $ V.filter (\(_, _, s, _, _, _) -> s == BSEstablished) updates
-        void $ LogPatterns.updateBaselineBatch pid updates
-        let newTotal = totalProcessed + length patterns
-            newEstablished = totalEstablished + established
-        if length patterns == baselinePageSize
-          then go (offset + baselinePageSize) newTotal newEstablished
-          else pure (newTotal, newEstablished)
-  (total, established) <- go 0 0 0
-  Log.logTrace "Finished calculating log pattern baselines" ("patterns" :: Text, total, "established" :: Text, established)
+  establishedCounts <- forM (chunksOf baselinePageSize allStats) \statsBatch -> do
+    let updates = V.fromList $ flip map statsBatch \stats ->
+          let ageDays = realToFrac (diffUTCTime now stats.firstSeenAt) / 86400 :: Double
+              established = stats.hourlyMedian > minMedianForEstablished || ageDays >= minAgeDaysForEstablished
+           in (stats.sourceField, stats.patternHash, bool BSLearning BSEstablished established, stats.hourlyMedian, stats.hourlyMADScaled, stats.totalHours)
+    void $ LogPatterns.updateBaselineBatch pid updates
+    pure $ V.length $ V.filter (\(_, _, baselineState, _, _, _) -> baselineState == BSEstablished) updates
+  Log.logTrace "Finished calculating log pattern baselines" ("patterns" :: Text, length allStats, "established" :: Text, sum establishedCounts)
 
 
 -- | Pure spike/drop detection for a single pattern.

--- a/src/Models/Apis/LogPatterns.hs
+++ b/src/Models/Apis/LogPatterns.hs
@@ -304,7 +304,8 @@ upsertHourlyStatBatch rows =
     deduped = Map.fromListWith (+) [((pid, sf, ph, truncateHour hb), ec) | (pid, sf, ph, hb, ec) <- rows]
 
 
--- | Batch: computes median + MAD for all patterns in one query.
+-- | Baseline inputs for unmerged patterns with recent hourly statistics.
+-- Includes first-seen time so callers never need to paginate full pattern records.
 -- Joins on (source_field, pattern_hash) — pattern_hash alone is NOT unique across source fields.
 data BatchPatternStats = BatchPatternStats
   { sourceField :: Text
@@ -313,6 +314,7 @@ data BatchPatternStats = BatchPatternStats
   , hourlyMADScaled :: Double
   , totalHours :: Int
   , totalEvents :: Int64
+  , firstSeenAt :: UTCTime
   }
   deriving stock (Generic, Show)
   deriving anyclass (HI.DecodeRow)
@@ -341,10 +343,13 @@ getBatchPatternStats pid now hoursBack =
         )
         -- 1.4826 = consistency factor (1/Φ⁻¹(3/4)) to convert MAD to std-dev equivalent under normality
         SELECT mc.source_field, mc.pattern_hash, COALESCE(mc.median_val, 0)::FLOAT, COALESCE(mad.mad_val * 1.4826, 0)::FLOAT,
-          t.total_hours, t.total_events
+          t.total_hours, t.total_events, lp.first_seen_at
         FROM median_calc mc
         JOIN mad_calc mad ON mc.source_field = mad.source_field AND mc.pattern_hash = mad.pattern_hash
         JOIN totals t ON mc.source_field = t.source_field AND mc.pattern_hash = t.pattern_hash
+        JOIN apis.log_patterns lp ON lp.project_id = #{pid}
+          AND lp.source_field = mc.source_field AND lp.pattern_hash = mc.pattern_hash
+          AND lp.canonical_id IS NULL
       |]
 
 

--- a/test/integration/Lifecycle/LogPatternIncidentSpec.hs
+++ b/test/integration/Lifecycle/LogPatternIncidentSpec.hs
@@ -29,6 +29,49 @@ pid = UUIDId UUID.nil
 spec :: Spec
 spec = around withTestResources do
   describe "Log Pattern Incident Lifecycle" do
+    it "updates baselines across batches without touching merged or inactive patterns" \tr -> do
+      runTestBg frozenTime tr pass
+      withResource tr.trPool \conn -> do
+        void
+          $ PGS.execute
+            conn
+            [sql| INSERT INTO apis.log_patterns (project_id, log_pattern, pattern_hash, source_field, first_seen_at)
+                SELECT ?, 'baseline fixture', 'batch-' || n, 'summary', ? FROM generate_series(1,1001) n |]
+            (pid, frozenTime)
+        void
+          $ PGS.execute
+            conn
+            [sql| INSERT INTO apis.log_patterns (project_id, log_pattern, pattern_hash, source_field, first_seen_at)
+                SELECT ?, 'baseline fixture', hash, field, ? FROM
+                (VALUES ('batch-1','body'), ('no-stats','summary'), ('expired','summary'), ('merged','summary')) v(hash,field) |]
+            (pid, frozenTime)
+        void
+          $ PGS.execute
+            conn
+            [sql| UPDATE apis.log_patterns SET canonical_id =
+                (SELECT id FROM apis.log_patterns WHERE project_id = ? AND pattern_hash='batch-1' AND source_field='summary')
+                WHERE project_id = ? AND pattern_hash='merged' |]
+            (pid, pid)
+        void
+          $ PGS.execute
+            conn
+            [sql| INSERT INTO apis.log_pattern_hourly_stats (project_id, source_field, pattern_hash, hour_bucket, event_count)
+                SELECT project_id, source_field, pattern_hash,
+                  ?::timestamptz - CASE WHEN pattern_hash='expired' THEN interval '49 hours' ELSE interval '1 hour' END,
+                  CASE WHEN source_field='body' THEN 100 ELSE 600 END
+                FROM apis.log_patterns WHERE project_id = ? AND pattern_hash <> 'no-stats' |]
+            (frozenTime, pid)
+      runTestBg frozenTime tr $ BackgroundJobs.calculateLogPatternBaselines pid
+      actual <- withResource tr.trPool \conn ->
+        PGS.query
+          conn
+          [sql| SELECT source_field, baseline_state, baseline_volume_hourly_mean, baseline_samples, count(*)::bigint
+                FROM apis.log_patterns WHERE project_id = ?
+                GROUP BY 1,2,3,4 ORDER BY 1,2,3 NULLS LAST |]
+          (Only pid)
+          :: IO [(Text, Text, Maybe Double, Int, Int64)]
+      actual `shouldBe` [("body", "learning", Just 100, 1, 1), ("summary", "established", Just 600, 1, 1001), ("summary", "learning", Nothing, 0, 3)]
+
     it "ingest -> baseline -> spike -> notify -> ack for 24h -> re-spike suppressed -> ack expires -> re-spike fires" \tr -> do
       runTestBg frozenTime tr pass
 
@@ -37,14 +80,30 @@ spec = around withTestResources do
           uid = (Servant.getResponse tr.trSessAndHeader).user.id
 
       -- 1. Seed pattern + 50h of stable baseline at 600/hr
-      void $ runTestBg frozenTime tr $ LogPatterns.upsertLogPattern LogPatterns.UpsertPattern
-        { projectId = pid, logPattern = "Lifecycle <*> pattern", hash = patHash
-        , sourceField = srcField, serviceName = Just "test-svc", logLevel = Just "ERROR"
-        , traceId = Nothing, sampleMessage = Just "lifecycle pattern", eventCount = 600
-        , isError = True }
+      void
+        $ runTestBg frozenTime tr
+        $ LogPatterns.upsertLogPattern
+          LogPatterns.UpsertPattern
+            { projectId = pid
+            , logPattern = "Lifecycle <*> pattern"
+            , hash = patHash
+            , sourceField = srcField
+            , serviceName = Just "test-svc"
+            , logLevel = Just "ERROR"
+            , traceId = Nothing
+            , sampleMessage = Just "lifecycle pattern"
+            , eventCount = 600
+            , isError = True
+            }
       forM_ ([-50 .. -1] :: [Int]) \h ->
-        void $ runTestBg frozenTime tr $ LogPatterns.upsertHourlyStat pid srcField patHash
-          (addUTCTime (fromIntegral h * 3600) frozenTime) 600
+        void
+          $ runTestBg frozenTime tr
+          $ LogPatterns.upsertHourlyStat
+            pid
+            srcField
+            patHash
+            (addUTCTime (fromIntegral h * 3600) frozenTime)
+            600
       runTestBg frozenTime tr $ BackgroundJobs.calculateLogPatternBaselines pid
 
       -- 2. Spike in the current hour: raw 600 -> projected 600*4 = 2400 vs baseline ~600
@@ -53,12 +112,14 @@ spec = around withTestResources do
       runTestBg frozenTime tr $ BackgroundJobs.detectLogPatternSpikes pid frozenTime tr.trATCtx
 
       issues1 <- withResource tr.trPool \conn ->
-        PGS.query conn
+        PGS.query
+          conn
           [sql| SELECT id FROM apis.issues
                 WHERE project_id = ? AND target_hash = ? AND issue_type = 'log_pattern_rate_change'
                   AND acknowledged_at IS NULL
                 ORDER BY created_at DESC LIMIT 1 |]
-          (pid, patHash) :: IO [Only Issues.IssueId]
+          (pid, patHash)
+          :: IO [Only Issues.IssueId]
       let issueId = case issues1 of (Only iid : _) -> iid; _ -> error "no issue fired on initial spike"
 
       -- 3. Acknowledge for 24h -> silenced for exactly that window
@@ -115,7 +176,8 @@ spec = around withTestResources do
 
       void $ runTestBg frozenTime tr $ Monitors.queryMonitorUpsert monitor
       void $ withResource tr.trPool \conn ->
-        PGS.execute conn
+        PGS.execute
+          conn
           [sql|
             UPDATE projects.teams
             SET pagerduty_services = ARRAY['deleted-project-test'],
@@ -136,7 +198,8 @@ spec = around withTestResources do
       reportNotifs `shouldBe` []
       countReports tr `shouldReturn` reportsBefore
       void $ withResource tr.trPool \conn ->
-        PGS.execute conn
+        PGS.execute
+          conn
           [sql|UPDATE monitors.query_monitors
                 SET current_status = 'normal', alert_last_triggered = NULL,
                     notification_count = 0, last_evaluated = '2020-01-01'
@@ -148,7 +211,9 @@ spec = around withTestResources do
 
 
 countOpenIssues :: TestResources -> Text -> IO Int
-countOpenIssues tr h = countQuery tr
+countOpenIssues tr h =
+  countQuery
+    tr
     [sql| SELECT COUNT(*)::INT FROM apis.issues
           WHERE project_id = ? AND target_hash = ? AND issue_type = 'log_pattern_rate_change'
             AND acknowledged_at IS NULL |]
@@ -156,7 +221,9 @@ countOpenIssues tr h = countQuery tr
 
 
 countLogs :: TestResources -> Text -> IO Int
-countLogs tr marker = countQuery tr
+countLogs tr marker =
+  countQuery
+    tr
     [sql| SELECT COUNT(*)::INT FROM otel_logs_and_spans
           WHERE project_id = ? AND body::text LIKE '%' || ? || '%' |]
     (pid, marker)


### PR DESCRIPTION
Hourly baseline calculation pages through every unmerged log pattern, loading full records and embeddings although only patterns with recent statistics can change. OFFSET pages ordered by non-unique last_seen_at also skip eligible rows: the regression updated only 997 of 1,001 patterns before this fix.

Join recent statistics to their unmerged pattern using project, source field and hash, including the first-seen timestamp needed for establishment. Update those inputs in batches of 1,000 without full-pattern pagination. Median/MAD calculation, age and volume thresholds, and no-history behavior are preserved.

Validation: the same regression now updates all 1,001 eligible summary patterns and preserves source-field separation, merged patterns and missing/expired history. All 24 log-pattern integration examples passed against PostgreSQL. Application integration target builds; HLint, formatting and diff checks pass. Production evidence shows concurrent full-pattern pagination; the affected project has 36,178 recent-statistic keys versus an estimated 2.74 million unmerged patterns. Runtime improvement still needs rollout verification.
