### PR TITLE
perf: count Jaccard intersections without temporary sets

### DIFF
--- a/src/Pkg/PatternMerge.hs
+++ b/src/Pkg/PatternMerge.hs
@@ -296,10 +296,20 @@ contentTokens :: Text -> S.Set Text
 contentTokens = S.fromList . filter (not . isPlaceholderToken) . words
 
 
--- | Jaccard similarity on pre-computed token sets.
+-- | Jaccard similarity on pre-computed token sets. Count common tokens without
+-- allocating an intersection tree for every candidate pair.
+--
+-- Exhaustive small-set comparison with the set-algebra definition:
+--
+-- >>> import Data.List (subsequences)
+-- >>> let sets = map S.fromList (subsequences (["a", "b", "c", "d"] :: [Text]))
+-- >>> let reference a b = if S.null (S.union a b) then 1 else fromIntegral (S.size (S.intersection a b)) / fromIntegral (S.size (S.union a b))
+-- >>> and [jaccardOnSets a b == reference a b | a <- sets, b <- sets]
+-- True
 jaccardOnSets :: S.Set Text -> S.Set Text -> Double
 jaccardOnSets tokA tokB =
-  let inter = S.size $ S.intersection tokA tokB
+  let (smaller, larger) = if S.size tokA <= S.size tokB then (tokA, tokB) else (tokB, tokA)
+      inter = S.foldl' (\count token -> if S.member token larger then count + 1 else count) 0 smaller
       -- Cardinality needs no union tree: |A union B| = |A| + |B| - |A intersect B|.
       union_ = S.size tokA + S.size tokB - inter
    in if union_ == 0 then 1.0 else fromIntegral inter / fromIntegral union_


### PR DESCRIPTION
Pattern merging constructs a temporary Set for every Jaccard intersection, then immediately discards it after reading its size. A production CPU sample from a replica above 11 GB shows PatternMerge and Set intersection/splitting among the hot functions. Count common tokens by folding over the smaller set and checking membership in the larger set, preserving the same Jaccard score.

An optimized GHC 9.12.2 benchmark using the actual before/after function bodies and 1.96 million 24-token comparisons produced the same checksum. Measured allocation fell from 5,886,825,288 bytes to 1,128 bytes; elapsed time fell from 2.72 to 2.27 seconds. These are local benchmark results, not a claim that production memory is resolved.

Validation: all 1,530 doctests passed, including exhaustive small-set comparison against the intersection/union definition; five extraction-worker integration tests passed against local PostgreSQL, covering merged frequencies, event membership, and persisted tags. HLint, fourmolu, and diff checks passed. After deployment, compare allocation rates, heap/RSS, queue throughput, and OOM events over a sustained window.
