### PR TITLE
perf: avoid intermediate allocations during centroid matching

### DIFF
--- a/src/Pkg/PatternMerge.hs
+++ b/src/Pkg/PatternMerge.hs
@@ -26,7 +26,6 @@ import Control.Lens ((^..), (^?))
 import Data.Aeson qualified as AE
 import Data.Aeson.Lens (key, _Array, _String)
 import Data.Aeson.Types (parseMaybe)
-import Data.List (maximumBy)
 import Data.Map.Strict qualified as Map
 import Data.Sequence qualified as Seq
 import Data.Set qualified as S
@@ -67,7 +66,12 @@ cosineSimWithNorms (xs, normA) (ys, normB)
   | normA == 0 || normB == 0 = 0.0
   | otherwise = fromIntegral (round (dotP / (normA * normB) * 100 :: Float) :: Int) / 100
   where
-    dotP = VU.sum $ VU.zipWith (*) xs ys
+    -- Keep the accumulation strict without constructing a product vector.
+    -- Length equality is checked above; both indexed reads stay in bounds.
+    dotP = go 0 0
+    go !i !acc
+      | i == VU.length xs = acc
+      | otherwise = go (i + 1) (acc + (xs VU.! i) * (ys VU.! i))
 
 
 vecNorm :: VU.Vector Float -> Float
@@ -92,6 +96,16 @@ ambiguousThreshold = 0.75
 --
 -- >>> assignToCentroids [("c1", [1,0,0])] [("n1", [0,1,0])]
 -- ([],[])
+--
+-- Equal scores keep the last centroid, including scores tied by rounding.
+-- >>> assignToCentroids [("first", [1,0]), ("last", [1,0])] [("new", [1,0])]
+-- ([("new","last")],[])
+--
+-- >>> assignToCentroids [("zero", [0,0]), ("short", [1])] [("new", [1,0])]
+-- ([],[])
+--
+-- >>> assignToCentroids [("c", [1,0])] [("new", [0.8,0.6])]
+-- ([],[("new","c")])
 assignToCentroids :: [(a, [Float])] -> [(a, [Float])] -> ([(a, a)], [(a, a)])
 assignToCentroids centroids = foldl' classify ([], [])
   where
@@ -104,9 +118,15 @@ assignToCentroids centroids = foldl' classify ([], [])
               | sim >= autoMergeThreshold -> ((newId, centId) : merges, ambiguous)
               | sim >= ambiguousThreshold -> (merges, (newId, centId) : ambiguous)
             _ -> (merges, ambiguous)
-    bestMatch newNormed cs = case mapMaybe (\(cid, cemb, cnorm) -> let s = cosineSimWithNorms newNormed (cemb, cnorm) in bool Nothing (Just (cid, s)) (s >= ambiguousThreshold)) cs of
-      [] -> Nothing
-      matches -> Just $ maximumBy (comparing snd) matches
+    bestMatch newNormed = foldl' choose Nothing
+      where
+        choose best (cid, cemb, cnorm)
+          | sim >= ambiguousThreshold = case best of
+              Just (_, bestSim) | sim < bestSim -> best
+              _ -> Just (cid, sim)
+          | otherwise = best
+          where
+            sim = cosineSimWithNorms newNormed (cemb, cnorm)
 
 
 -- | Indices of the input pairs the judge answered @MERGE@ for. Pairs it declined,

--- a/src/Pkg/PatternMerge.hs
+++ b/src/Pkg/PatternMerge.hs
@@ -66,7 +66,7 @@ cosineSimWithNorms (xs, normA) (ys, normB)
   | normA == 0 || normB == 0 = 0.0
   | otherwise = fromIntegral (round (dotP / (normA * normB) * 100 :: Float) :: Int) / 100
   where
-    -- Keep the accumulation strict without constructing a product vector.
+    -- Keep accumulation strict without allocating intermediate stream steps.
     -- Length equality is checked above; both indexed reads stay in bounds.
     dotP = go 0 0
     go !i !acc


### PR DESCRIPTION
Pattern centroid assignment repeatedly allocates intermediate cosine stream steps and candidate lists. Read-only production profiling identified this path as a major allocator during pattern embedding and merging.

Use a strict dot-product loop with checked vector indexing and retain only the best matching centroid. Preserve vector-length and zero-norm checks, Float accumulation order, rounding, thresholds, output order, and the existing last-centroid-wins tie rule.

Validation so far:
- Exact extracted production function, 2,000 centroids × 1,000 patterns × 64 dimensions: allocation fell from 7,394,777,152 to 34,521,152 bytes; runtime from 0.812 to 0.171 seconds. Both produced 1,000 merges, no ambiguous pairs, and the same assignment checksum.
- Compared the final candidate against the original over 901 centroid groups and 450 varied vectors; all assignment results matched.
- Added doctests for tied centroids, zero or mismatched vectors, and ambiguous matches.
- HLint, Fourmolu, all 1,533 application doctests, and all 308 unit tests, and all five extraction integration tests passed.

Production memory improvement remains unverified until deployment and observation. Other allocation sources, including regex normalization, remain under investigation.

Compiler investigation: the original benchmark reproduces the allocation without AutoInstrument. GHC 9.12.2 fires vector stream/unstream fusion rules, but simplified Core retains an existential Stream step function and boxed Yield/Skip values inside the dot-product traversal. A diagnostic build with full-laziness disabled reduces the original to 226,521,152 bytes; the local strict-loop candidate uses 34,521,152 bytes under normal -O2. No global compiler flags or unchecked indexing are introduced.
