### PR TITLE
perf: use boolean regex matching for format classification

### DIFF
--- a/src/ProcessMessage.hs
+++ b/src/ProcessMessage.hs
@@ -87,8 +87,8 @@ import System.Config (AuthContext (..), EnvConfig (..))
 import System.Logging qualified as Log
 import System.Tracing (Tracing, batchSpanAttrs, withSpan_)
 import System.Types (DB)
-import Text.RE.Replace (matched)
-import Text.RE.TDFA (RE, re, (?=~))
+import Text.RE.TDFA (RE, re, reRegex)
+import Text.Regex.TDFA qualified as TDFA
 import Utils (b64ToJson, freeTierDailyMaxEvents, jsonToMap, nestedJsonFromDotNotation, replaceAllFormats, toXXHash)
 
 
@@ -888,7 +888,7 @@ commonFormatPatterns =
 -- >>> map valueToFormatStr ["v1"]
 --
 valueToFormatStr :: Text -> Maybe Text
-valueToFormatStr val = snd <$> find (\(regex, _) -> matched (val ?=~ regex)) commonFormatPatterns
+valueToFormatStr val = snd <$> find (\(regex, _) -> TDFA.matchTest (reRegex regex) val) commonFormatPatterns
 
 
 -- | Detect dynamic URL segments and replace them with named parameters.


### PR DESCRIPTION
Format classification only needs to know whether a regex matches, but it currently constructs a match result and capture metadata. Use the public TDFA boolean matcher on the same compiled regex. Pattern definitions, flags, order, and labels remain unchanged.

Production allocation profiling identified valueToFormatStr as a hot path. An exact-pattern benchmark over 20,000 varied values reduced allocation from 5,236,370,104 to 1,159,996,424 bytes and runtime from 0.861 to 0.229 seconds, with identical classification results. Another 21,156 Unicode, multiline, null-character, and format-boundary cases matched the original.

Validation: all 1,530 doctests, 308 unit tests, and five extraction integration tests passed. HLint, Fourmolu, and diff checks passed. Production memory improvement remains to be measured after deployment.
