### PR TITLE
Fix HTTP Stats response filters and latency query

### DIFF
--- a/static/public/dashboards/http-stats.yaml
+++ b/static/public/dashboards/http-stats.yaml
@@ -16,7 +16,7 @@ widgets:
       - type: 'timeseries_stat'
         title: 'Requests'
         icon: list-tree
-        query: summarize count(*) by bin_auto(timestamp)
+        query: kind == "server" AND attributes.http.response.status_code != null | summarize count(*) by bin_auto(timestamp)
         unit: reqs
         eager: true
         layout: { w: 7, h: 2 }
@@ -27,7 +27,7 @@ widgets:
 
   - type: 'timeseries'
     title: 'All requests'
-    query: summarize count(*) by bin_auto(timestamp), status_code
+    query: kind == "server" AND attributes.http.response.status_code != null | summarize count(*) by bin_auto(timestamp), attributes.http.response.status_code
     unit: reqs
     layout: { w: 6, h: 4 }
 
@@ -38,32 +38,30 @@ widgets:
     # query: timechart p50(duration_ns) as p50, p75(duration_ns) as p75, p90(duration_ns) as p90, p95(duration_ns) as p95 by duration_ns
     summarize_by: max
     sql: |
-      SELECT timeB, value, quantile
-      FROM (
+      WITH bucket_digests AS (
         SELECT extract(epoch from time_bucket('1h', timestamp))::integer AS timeB,
-               ARRAY[
-                 (approx_percentile(0.50, percentile_agg(duration)) / 1000000.0)::float,
-                 (approx_percentile(0.75, percentile_agg(duration)) / 1000000.0)::float,
-                 (approx_percentile(0.90, percentile_agg(duration)) / 1000000.0)::float,
-                 (approx_percentile(0.95, percentile_agg(duration)) / 1000000.0)::float
-               ] AS values,
-               ARRAY['p50', 'p75', 'p90', 'p95'] AS quantiles
+               percentile_agg(duration) AS digest
         FROM otel_logs_and_spans
         WHERE project_id='{{project_id}}'
-          AND name = 'monoscope.http' AND kind = 'SERVER'
+          AND attributes___http___response___status_code IS NOT NULL AND kind = 'server'
           {{time_filter_sql}}
         GROUP BY timeB
-      ) s,
-      LATERAL unnest(s.values, s.quantiles) AS u(value, quantile);
+      )
+      SELECT b.timeB,
+             (approx_percentile(q.percentile, b.digest) / 1000000.0)::float AS value,
+             q.quantile
+      FROM bucket_digests b
+      CROSS JOIN (VALUES ('p50', 0.50), ('p75', 0.75), ('p90', 0.90), ('p95', 0.95))
+        AS q(quantile, percentile);
     layout: { w: 6, h: 4 }
 
   - type: 'timeseries'
     title: 'Errors'
     theme: 'roma'
-    query: status_code >= 300.0 | summarize count(*) by bin_auto(timestamp), status_code
+    query: kind == "server" AND attributes.http.response.status_code >= 400 | summarize count(*) by bin_auto(timestamp), attributes.http.response.status_code
     layout: { w: 6, h: 4 }
 
   - type: 'timeseries'
     title: 'Requests by Endpoint'
-    query: summarize count(*) by bin_auto(timestamp), method, url_path
+    query: kind == "server" AND attributes.http.response.status_code != null | summarize count(*) by bin_auto(timestamp), method, url_path
     layout: { w: 6, h: 4 }


### PR DESCRIPTION
The HTTP Stats dashboard grouped the textual OpenTelemetry status code and compared it with a number, causing cast failures on values such as INFO. Its latency query also used uppercase SERVER and an unsupported table-form unnest, so the chart could not run.

Use the numeric HTTP response status for grouping and errors (400+), and consistently select server spans with an HTTP response across request widgets. Compute each latency bucket digest once and expand the four percentiles with a VALUES join supported by TimeFusion.

Validation: loaded the YAML and parsed/field-validated all four KQL queries through the application parser. Executed their rendered filters and the actual latency SQL against a read-only TimeFusion VALUES fixture containing 200/302/400/500 responses, a client 503 span, and an unrelated server span. Request filters include only the four incoming responses; errors include 400/500; latency returns p50/p75/p90/p95 at 2.5/3.25/3.7/3.85 ms. Original queries reproduce the INFO numeric cast failure and unsupported unnest error. git diff --check passes.
