### PR TITLE
Reduce format classifier allocations by sharing regex input

### DIFF
--- a/src/ProcessMessage.hs
+++ b/src/ProcessMessage.hs
@@ -890,7 +890,10 @@ commonFormatPatterns =
 -- >>> map valueToFormatStr ["v1"]
 --
 valueToFormatStr :: Text -> Maybe Text
-valueToFormatStr val = snd <$> find (\(regex, _) -> TDFA.matchTest (reRegex regex) val) commonFormatPatterns
+valueToFormatStr val = snd <$> find (\(regex, _) -> TDFA.matchTest (reRegex regex) chars) commonFormatPatterns
+  where
+    -- Share the input across patterns instead of unpacking Text for every match.
+    chars = toString val
 
 
 -- | Detect dynamic URL segments and replace them with named parameters.


### PR DESCRIPTION
Format detection tests a value against an ordered list of regex patterns. The Text regex instance unpacks that value for each attempted pattern, making this classifier a major allocation source during ingestion. Share one lazy String conversion across those tests while preserving every pattern and its precedence.

A production profile attributed about 139.9 MB/s of allocation to `valueToFormatStr`. In a standalone mixed-input benchmark, allocations fell from 1,159,996,424 to 24,456,824 bytes (97.9%); elapsed time fell from 0.231 to 0.178 seconds. These are local measurements, not a promised production reduction.

Validation:
- 41,156 parity cases passed, including Unicode, control characters, and pattern boundaries.
- Final application build, HLint, Fourmolu, and diff checks passed.
- Final source passed all 1,533 doctests, 308 unit tests, and five database-backed extraction checks.
