### PR TITLE
Maintain background job modification timestamps

### DIFF
--- a/static/migrations/0151_background_job_updated_at.sql
+++ b/static/migrations/0151_background_job_updated_at.sql
@@ -1,0 +1,5 @@
+-- Job claims, retries, and terminal status changes must advance updated_at.
+-- Use the same change-sensitive trigger as the other application tables.
+CREATE TRIGGER set_updated_at
+BEFORE UPDATE ON public.background_jobs
+FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();


### PR DESCRIPTION
Background job status and retry updates leave `updated_at` at its insertion time. Production failures had September 7 retry times but midnight timestamps, making recent-failure queries unreliable. The job library does not maintain this column, and production has only the insert-notification trigger.

Add the existing application `set_updated_at` trigger to `public.background_jobs`. Changed rows receive the transaction timestamp; no-op updates and explicitly supplied timestamps retain the shared trigger's existing semantics. Historical timestamps are not reconstructed.

Validated in an isolated local PostgreSQL database with the actual shared function and new migration: reproduced the unchanged timestamp before the migration; five claim/retry/terminal status transitions advanced it afterward. No-op updates and explicit timestamps were preserved. The test database was removed after validation. Production inspection was read-only; CI and deployment remain pending.
