### PR TITLE
Use stored telemetry kinds in query suggestions

### DIFF
--- a/shared/src/Models/Telemetry/Schema.hs
+++ b/shared/src/Models/Telemetry/Schema.hs
@@ -50,7 +50,7 @@ telemetrySchema =
           , ("parent_id", FieldInfo "string" "Parent span ID" Nothing)
           , ("hashes", FieldInfo "array" "All relevant hashes for item identification" Nothing)
           , ("name", FieldInfo "string" "Name of the span or log" Nothing)
-          , ("kind", FieldInfo "string" "Type of telemetry data (logs, span, request)" (Just ["logs", "span", "request"]))
+          , ("kind", FieldInfo "string" "Log record or span kind" (Just ["log", "internal", "server", "client", "producer", "consumer", "unspecified"]))
           , ("status_code", FieldInfo "string" "Status code of the span" (Just ["OK", "ERROR", "UNSET"]))
           , ("status_message", FieldInfo "string" "Status message" Nothing)
           , ("level", FieldInfo "string" "Log level (uppercase)" (Just ["TRACE", "DEBUG", "INFO", "WARN", "ERROR", "FATAL"]))
@@ -235,11 +235,11 @@ popularOtelQueries =
     PopularOtelQuery "duration > 5s" "Slow requests (>5 seconds)"
   , PopularOtelQuery "duration > 1s" "Requests taking more than 1 second"
   , PopularOtelQuery "duration > 500ms" "Requests slower than 500ms"
-  , PopularOtelQuery "kind == \"span\" AND duration > 100ms" "Slow spans (>100ms)"
+  , PopularOtelQuery "kind != \"log\" AND duration > 100ms" "Slow spans (>100ms)"
   , -- Service and trace queries
     PopularOtelQuery "resource.service.name == \"api\"" "Logs from API service"
-  , PopularOtelQuery "kind == \"span\"" "All span data"
-  , PopularOtelQuery "kind == \"logs\"" "All log entries"
+  , PopularOtelQuery "kind != \"log\"" "All span data"
+  , PopularOtelQuery "kind == \"log\"" "All log entries"
   , PopularOtelQuery "parent_id != null" "Child spans with parent relationships"
   , PopularOtelQuery "context.trace_id != null" "Logs with trace correlation"
   , -- Text search operations using new operators
@@ -271,7 +271,7 @@ popularOtelQueries =
   , -- Complex multi-condition queries
     PopularOtelQuery "(level == \"ERROR\" OR duration > 5s) AND resource.service.name != null" "Errors or slow requests from known services"
   , PopularOtelQuery "attributes.http.response.status_code >= 500 AND attributes.user.id != null" "Server errors affecting users"
-  , PopularOtelQuery "kind == \"span\" AND (name contains \"database\" OR attributes.db.operation.name != null)" "Database-related spans"
+  , PopularOtelQuery "kind != \"log\" AND (name contains \"database\" OR attributes.db.operation.name != null)" "Database-related spans"
   ]
 
 


### PR DESCRIPTION
The telemetry schema advertises `logs`, `span`, and `request` as kind values, and four suggested queries use `span` or `logs`. Ingestion actually stores singular `log` and the six OpenTelemetry span kinds. Those suggestions therefore return empty results despite matching telemetry.

Advertise the stored values. Use `kind == "log"` for logs and `kind != "log"` for spans in the default logs-and-spans source. Existing filters for duration and database operations remain in each example.

Validation: extracted the four queries from the actual source, parsed and field-validated them with the application parser, and ran the generated SQL against a local PostgreSQL VALUES fixture containing all six span kinds, a log, and a null kind. All four original queries returned zero rows; corrected queries returned the expected 6/6/1/6 rows and excluded null kinds. HLint, Fourmolu, and diff checks passed. CI remains required before merge.
