### PR TITLE
Reduce metric UUID allocation without changing identifiers

### DIFF
--- a/monoscope.cabal
+++ b/monoscope.cabal
@@ -178,6 +178,8 @@ extra-source-files:
     static/migrations/0147_error_patterns_first_trace_at.sql
     static/migrations/0148_hosts_last_seen.sql
     static/migrations/0149_report_previews.sql
+    static/migrations/0150_background_job_notification_channel.sql
+    static/migrations/0151_background_job_updated_at.sql
 
 source-repository head
   type: git
@@ -285,6 +287,7 @@ library
       Pkg.TestClock
       Pkg.TestUtils
       Pkg.TraceSessionCache
+      Pkg.UUID
       ProcessMessage
       Start
       System.Config
@@ -892,6 +895,7 @@ test-suite test-dev
       Pkg.TestClock
       Pkg.TestUtils
       Pkg.TraceSessionCache
+      Pkg.UUID
       ProcessMessage
       Start
       System.Config

--- a/src/Models/Telemetry/Telemetry.hs
+++ b/src/Models/Telemetry/Telemetry.hs
@@ -142,6 +142,7 @@ import Pkg.DeriveUtils (AesonText (..), DB, UUIDId (..), WrappedEnum (..), Wrapp
 import Pkg.ErrorFingerprint qualified as EF
 import Pkg.ExtractionWorker qualified as EW
 import Pkg.Metrics qualified as Metrics
+import Pkg.UUID qualified as UUIDBytes
 import Relude hiding (ask)
 import Relude.Extra.Foldable1 (maximum1, minimum1)
 import System.IO (hPutStrLn)
@@ -2757,7 +2758,7 @@ metricIdNamespace = [uuid|5a5e99db-2f4d-58c6-9f8a-b9db1f6139aa|]
 
 -- | v5 id over 0x1F-joined key parts, in 'metricIdNamespace'.
 metricUuid :: [Text] -> UUID.UUID
-metricUuid = UUIDv5.generateNamed metricIdNamespace . BS.unpack . encodeUtf8 . T.intercalate "\x1f"
+metricUuid = UUIDBytes.generateNamedV5 metricIdNamespace . encodeUtf8 . T.intercalate "\x1f"
 
 
 metricSeriesId :: MetricRecord -> Text

--- a/src/Pkg/UUID.hs
+++ b/src/Pkg/UUID.hs
@@ -1,0 +1,28 @@
+module Pkg.UUID (generateNamedV5) where
+
+import Data.Bits (shiftL, (.&.), (.|.))
+import Data.ByteArray qualified as BA
+import Data.ByteString qualified as BS
+import Data.UUID qualified as UUID
+import Relude
+import "cryptonite" Crypto.Hash (Digest, SHA1, hash)
+
+
+-- | UUID v5 with a byte-string name. The uuid package's list API unpacks and
+-- repacks the entire name; metric series names can contain large JSON values.
+-- SHA1 supplies 20 bytes; UUID v5 uses the first 16, with its version and variant.
+--
+-- >>> import Data.UUID.V5 qualified as V5
+-- >>> import Data.ByteString qualified as BS
+-- >>> map (\s -> generateNamedV5 V5.namespaceDNS s == V5.generateNamed V5.namespaceDNS (BS.unpack s)) ["", "www.widgets.com", "a\NULb"]
+-- [True,True,True]
+generateNamedV5 :: UUID.UUID -> ByteString -> UUID.UUID
+generateNamedV5 namespace name =
+  UUID.fromWords
+    (wordAt 0)
+    ((wordAt 4 .&. 0xffff0fff) .|. 0x5000)
+    ((wordAt 8 .&. 0x3fffffff) .|. 0x80000000)
+    (wordAt 12)
+  where
+    digest = BA.convert (hash (toStrict (UUID.toByteString namespace) <> name) :: Digest SHA1)
+    wordAt offset = BS.foldl' (\word byte -> shiftL word 8 .|. fromIntegral byte) 0 (BS.take 4 $ BS.drop offset digest)


### PR DESCRIPTION
Metric series identifiers include encoded resource and attribute JSON. The UUID library accepts a byte list, so the current path unpacks each encoded name into `[Word8]` only for the library to pack it again. Production profiling attributed two large allocation paths to this conversion during point-ID minting and series-ID insertion.

Add a byte-string UUID-v5 helper using the existing SHA1 dependency, and use it for metric IDs. It hashes the same namespace bytes and unchanged UTF-8 name, reads the same first 128 digest bits, and sets the same version/variant bits. Other UUID generation calls remain unchanged. No dependency or storage-format changes.

Validation so far:
- Actual final helper matches the existing implementation across 10,000 varied namespaces and binary names, including empty names and lengths through 4,096 bytes.
- With inputs constructed before measurement, 20,000 UUIDs allocate 92,893,208 bytes versus 893,192,464; elapsed time is 44 ms versus 180 ms. These are local measurements.
- HLint, Fourmolu, and diff checks pass. The generated Cabal manifest registers the helper and includes the two existing recent migrations.
- Full application build, all 1,536 doctests, 308 unit tests, and the database-backed metric replay test passed. CI remains required before merge.
