### PR TITLE
Fix slow-span query in the query library

### DIFF
--- a/src/Pkg/Components/LogQueryBox.hs
+++ b/src/Pkg/Components/LogQueryBox.hs
@@ -434,7 +434,7 @@ popularQueries =
   , ("duration > 1000000000", "Slow requests (>1s)", Nothing)
   , ("attributes.exception.type != null", "Exceptions", Nothing)
   , ("attributes.error.type != null", "Error types", Nothing)
-  , ("kind == \"span\" and duration > 5000000000", "Slow spans (>5s)", Nothing)
+  , ("kind != \"log\" and duration > 5000000000", "Slow spans (>5s)", Nothing)
   , ("status_code == \"ERROR\" | summarize count(*) by bin_auto(timestamp), resource.service.name", "Errors by service", Just "Bar chart — error rate per service over time")
   , ("| summarize count(*) by bin_auto(timestamp), level", "Volume by level", Just "Bar chart — log volume breakdown")
   , ("| summarize percentiles(duration, 50, 90, 99) by bin_auto(timestamp)", "Latency percentiles", Just "Line chart — p50/p90/p99 over time")


### PR DESCRIPTION
The query library's “Slow spans (>5s)” entry filters on `kind == "span"`, which ingestion never stores. Change it to `kind != "log"`, matching the corrected editor suggestions while retaining the five-second threshold.

Validation: the extracted old/new query predicates were checked against a local PostgreSQL VALUES fixture. The old query selected nothing; the new query selected the two slow spans and excluded a fast span, a log, and a null kind. Both query forms also executed through the live API (no >5-second events in that 15-minute window); the corrected 100ms editor suggestion returned an internal span. HLint, Fourmolu and diff checks passed. CI remains required.
