### PR TITLE
Reduce allocation when scanning replay strings

### DIFF
--- a/src/Pages/Replay.hs
+++ b/src/Pages/Replay.hs
@@ -298,7 +298,8 @@ skipBracketed open close = AC.anyChar *> loop (1 :: Int)
 -- >>> AB.parseOnly (skipStringBody *> AC.takeByteString) "a\\\"b\",rest"
 -- Right ",rest"
 skipStringBody :: AC.Parser ()
-skipStringBody =
+skipStringBody = do
+  AB.skipWhile (\b -> b /= 0x22 && b /= 0x5c)
   AC.anyChar >>= \case
     '"' -> pass
     '\\' -> AC.anyChar *> skipStringBody

--- a/test/integration/ReplaySpec.hs
+++ b/test/integration/ReplaySpec.hs
@@ -313,6 +313,18 @@ spec = around withTestResources do
           events = AE.toJSON ([event] :: [AE.Value]) :: AE.Value
       roundTrip events `shouldBe` Right events
 
+    it "scans long event strings without allocating for each byte" $ \_ -> do
+      let events = AE.toJSON [T.replicate 1000000 "x"]
+          body = mkPayload events
+      bodySize <- evaluateWHNF (BS.length body)
+      allocated <- allocatedBy do
+        payload <- either fail pure (splitReplayPayload body)
+        evaluateWHNF (BS.length payload.eventsBytes)
+      -- Allow copies of the input and metadata overhead, but not the old
+      -- per-character parser chain (roughly 72 bytes per ordinary byte).
+      allocated `shouldSatisfy` (< fromIntegral bodySize * 8)
+      roundTrip events `shouldBe` Right events
+
   describe "processReplayEvents (e2e)" do
     -- End-to-end through the kafka batch entry point. Uses a nonexistent
     -- project_id so `saveReplayMinio` short-circuits in the project-lookup

--- a/test/integration/ReplaySpec.hs
+++ b/test/integration/ReplaySpec.hs
@@ -314,7 +314,7 @@ spec = around withTestResources do
       roundTrip events `shouldBe` Right events
 
     it "scans long event strings without allocating for each byte" $ \_ -> do
-      let events = AE.toJSON [T.replicate 1000000 "x"]
+      let events = AE.toJSON ([T.replicate 1000000 "x"] :: [Text])
           body = mkPayload events
       bodySize <- evaluateWHNF (BS.length body)
       allocated <- allocatedBy do

--- a/test/integration/ReplaySpec.hs
+++ b/test/integration/ReplaySpec.hs
@@ -313,16 +313,9 @@ spec = around withTestResources do
           events = AE.toJSON ([event] :: [AE.Value]) :: AE.Value
       roundTrip events `shouldBe` Right events
 
-    it "scans long event strings without allocating for each byte" $ \_ -> do
-      let events = AE.toJSON ([T.replicate 1000000 "x"] :: [Text])
-          body = mkPayload events
-      bodySize <- evaluateWHNF (BS.length body)
-      allocated <- allocatedBy do
-        payload <- either fail pure (splitReplayPayload body)
-        evaluateWHNF (BS.length payload.eventsBytes)
-      -- Allow copies of the input and metadata overhead, but not the old
-      -- per-character parser chain (roughly 72 bytes per ordinary byte).
-      allocated `shouldSatisfy` (< fromIntegral bodySize * 8)
+    it "round-trips long strings around escapes and UTF-8 characters" $ \_ -> do
+      let content = T.replicate 1000000 "x"
+          events = AE.toJSON ([content <> "\"\\é🙂" <> content, ""] :: [Text])
       roundTrip events `shouldBe` Right events
 
   describe "processReplayEvents (e2e)" do


### PR DESCRIPTION
Replay ingestion scans raw event strings one character at a time, allocating parser continuations for ordinary bytes. A production profile attributed 26.9 MB/s of allocation to this loop on one replica.

Skip ordinary byte runs with Attoparsec’s skipWhile primitive, retaining the existing handling of closing quotes and escapes. Add an integration case that round-trips two long byte runs separated by escapes and UTF-8 characters.

Validation: source-extracted old/new parser parity across 55,987 generated byte strings and every two-chunk split, including escapes and incomplete strings. With -O2, a 200 MB ordinary-string benchmark allocated 14,400,136,768 bytes before and 218,568 bytes after, taking 1.205 s and 0.129 s. These are local optimized measurements, not production percentages. CI deliberately compiles with -O0, where this compiler-dependent allocation improvement does not occur; CI checks functional behavior rather than asserting the optimized allocation limit. Formatting and source HLint pass. Final-head CI 34200197304 passed: application build, 1,536 doctests, 308 unit examples, 856 integration examples (24 existing pending), and end-to-end checks. All applicable PR checks passed; UI tests were excluded by the existing change gate. Production allocation profiling remains required after deployment.
