### PR TITLE
fix: reuse HTTP transport for replay object storage

### DIFF
--- a/monoscope.cabal
+++ b/monoscope.cabal
@@ -275,6 +275,7 @@ library
       Pkg.LiveTail
       Pkg.Mail
       Pkg.Metrics
+      Pkg.Minio
       Pkg.Parser
       Pkg.PatternMerge
       Pkg.Prometheus
@@ -641,6 +642,7 @@ test-suite integration-tests
       FacetsSpec
       Lifecycle.LogPatternIncidentSpec
       LiveTailSpec
+      MinioManagerSpec
       MonitoringSpec
       Opentelemetry.GrpcIngestionSpec
       Opentelemetry.StandardOtelSpansSpec
@@ -883,6 +885,7 @@ test-suite test-dev
       Pkg.LiveTail
       Pkg.Mail
       Pkg.Metrics
+      Pkg.Minio
       Pkg.Parser
       Pkg.PatternMerge
       Pkg.Prometheus
@@ -930,6 +933,7 @@ test-suite test-dev
       FacetsSpec
       Lifecycle.LogPatternIncidentSpec
       LiveTailSpec
+      MinioManagerSpec
       MonitoringSpec
       Opentelemetry.GrpcIngestionSpec
       Opentelemetry.StandardOtelSpansSpec

--- a/monoscope.cabal
+++ b/monoscope.cabal
@@ -749,6 +749,7 @@ test-suite integration-tests
     , hs-opentelemetry-instrumentation-auto
     , hspec
     , http-client
+    , http-client-tls
     , http-types
     , hw-kafka-client
     , kafka-effectful
@@ -795,6 +796,7 @@ test-suite integration-tests
     , vector
     , wai
     , wai-extra
+    , warp
     , wreq
     , zlib
   default-language: GHC2024

--- a/package.yaml
+++ b/package.yaml
@@ -251,6 +251,8 @@ tests:
       - grapesy
       - wreq
       - http-client
+      - http-client-tls
+      - warp
       - unliftio
       - bytestring
       - containers

--- a/src/Pages/Replay.hs
+++ b/src/Pages/Replay.hs
@@ -35,10 +35,12 @@ import Effectful.Time qualified as Time
 import Hasql.Interpolate qualified as HI
 import Models.Projects.Projects qualified as Projects
 import Models.Telemetry.Telemetry qualified as Telemetry
+import Network.HTTP.Client (Manager)
 import Network.Minio (MinioErr (..), ServiceErr (..))
 import Network.Minio qualified as Minio
 import OddJobs.Job (createJob)
 import Pkg.ErrorMetrics qualified as Metrics
+import Pkg.Minio qualified as Storage
 import Pkg.Queue (chunksByBytes, publishJSONToKafka, runSharedProducer)
 import Relude
 import Relude.Extra.Tuple (traverseToFst)
@@ -324,18 +326,18 @@ processReplayEvents msgs _attrs = do
       (oversized, valid) = partition (\(_, b) -> BS.length b > maxReplayMessageBytes) msgs
       oversizePoison = [(ackId, body, "replay:oversize_message") | (ackId, body) <- oversized]
   replicateM_ (length oversized) $ Metrics.bumpErrorCounter "replay:oversize_message"
-  (acks, decodePoison) <- foldMapM (handleChunk envCfg ctx.jobsPool) (chunksByBytes replayBatchByteBudget (BS.length . snd) valid)
+  (acks, decodePoison) <- foldMapM (handleChunk ctx.s3HttpManager envCfg ctx.jobsPool) (chunksByBytes replayBatchByteBudget (BS.length . snd) valid)
   pure $ Right (acks, oversizePoison <> decodePoison)
   where
     -- Returns @(acks, poison)@ for one chunk so the caller can DLQ poison and
     -- ack only the successfully-saved + DLQ'd ackIds.
-    handleChunk envCfg jobsPool = foldMapM \(!ackId, !body) ->
+    handleChunk manager envCfg jobsPool = foldMapM \(!ackId, !body) ->
       case splitReplayPayload (stripJsonNullEscapes body) of
         Left err -> do
           Metrics.bumpErrorCounter "replay:decode_error"
           pure ([], [(ackId, body, "replay:decode_error: " <> toText err)])
         Right payload ->
-          saveReplayMinio envCfg jobsPool ackId payload <&> (,[]) . maybeToList
+          saveReplayMinio manager envCfg jobsPool ackId payload <&> (,[]) . maybeToList
 
 
 -- | True if the Minio error represents a missing object (safe to treat as empty).
@@ -566,13 +568,14 @@ classifyFetches rs =
 -- that is `True` if any key was lost to a non-NoSuchKey error.
 fetchIndividualsRaw
   :: (IOE :> es, Log :> es)
-  => Minio.ConnectInfo
+  => Manager
+  -> Minio.ConnectInfo
   -> Minio.Bucket
   -> [Text]
   -> HashMap Text Text
   -> Eff es ([(Double, BL.ByteString)], Bool, Int)
-fetchIndividualsRaw conn bucket fileKeys logCtx = do
-  split <- classifyFetches <$> liftIO (forM fileKeys \k -> (k,) <$> Minio.runMinio conn (fetchRawForMerge bucket k False))
+fetchIndividualsRaw manager conn bucket fileKeys logCtx = do
+  split <- classifyFetches <$> liftIO (forM fileKeys \k -> (k,) <$> Storage.runMinio manager conn (fetchRawForMerge bucket k False))
   unless (null split.decodeErrs)
     $ Log.logAttention "Decode errors while reading replay event files" (HM.insert "errors" (toText $ show split.decodeErrs) logCtx)
   unless (null split.transportErrs)
@@ -588,8 +591,8 @@ fetchIndividualsRaw conn bucket fileKeys logCtx = do
 
 -- | Fetch events for a session. Returns `Left` with a user-facing message on
 -- unrecoverable failure, `Right` on success (including empty or partial results).
-getSessionEvents :: (DB es, Log :> es) => Minio.ConnectInfo -> Projects.ProjectId -> Minio.Bucket -> UUID.UUID -> Eff es (Either Text (BL.ByteString, Bool))
-getSessionEvents conn pid bucket sessionId = do
+getSessionEvents :: (DB es, Log :> es) => Manager -> Minio.ConnectInfo -> Projects.ProjectId -> Minio.Bucket -> UUID.UUID -> Eff es (Either Text (BL.ByteString, Bool))
+getSessionEvents manager conn pid bucket sessionId = do
   let sessionStr = UUID.toText sessionId
       logCtx = HM.fromList [("session", sessionStr), ("projectId", pid.toText)]
       transientMsg = "Storage is temporarily unreachable. Retry in a moment — your recording is safe." :: Text
@@ -602,7 +605,7 @@ getSessionEvents conn pid bucket sessionId = do
       -- Ancient single-object sessions (pre file_keys migration): fetch raw.
       legacy reason = do
         Log.logInfo "Falling back to legacy replay blob" (HM.insert "reason" reason logCtx)
-        liftIO (Minio.runMinio conn $ fetchRawForMerge bucket (sessionStr <> ".json") False) >>= \case
+        liftIO (Storage.runMinio manager conn $ fetchRawForMerge bucket (sessionStr <> ".json") False) >>= \case
           Left err
             | isNoSuchKey err -> noEvents "legacy_blob_missing"
             | otherwise -> legacyFailed (toText $ displayException err)
@@ -614,14 +617,14 @@ getSessionEvents conn pid bucket sessionId = do
   -- individual tail both come from the DB — never from listing S3 (minio-hs can't
   -- list R2). Fetch each key by getObject, gzip-decoding by suffix.
   (shardKeys, fileKeys) <- sessionKeys pid sessionId
-  shards <- classifyFetches <$> liftIO (forM shardKeys \sk -> (sk,) <$> Minio.runMinio conn (fetchRawForMerge bucket sk (".gz" `T.isSuffixOf` sk)))
+  shards <- classifyFetches <$> liftIO (forM shardKeys \sk -> (sk,) <$> Storage.runMinio manager conn (fetchRawForMerge bucket sk (".gz" `T.isSuffixOf` sk)))
   -- A corrupt shard is surfaced (not silently dropped); a transient fetch failure
   -- flags the recording partial, same contract as a missing individual file.
   let shardCorrupt = not (null shards.decodeErrs) -- data-integrity event
   unless (null shards.decodeErrs) $ Log.logError "Corrupt replay shard" (HM.insert "errors" (toText $ show shards.decodeErrs) logCtx)
   unless (null shards.transportErrs) $ Log.logAttention "Transient shard fetch failure; serving partial recording" (HM.insert "errors" (toText $ show shards.transportErrs) logCtx)
   (individuals, indivPartial, missingCount) <-
-    if null fileKeys then pure ([], False, 0) else fetchIndividualsRaw conn bucket fileKeys logCtx
+    if null fileKeys then pure ([], False, 0) else fetchIndividualsRaw manager conn bucket fileKeys logCtx
   let partial = indivPartial || not (null shards.transportErrs)
       -- Individuals collapse (sorted by first event) into one blob, ordered against
       -- the shards by first event. concatRawJsonArrays drops empty arrays.
@@ -741,8 +744,8 @@ maxFilesPerMerge = 25
 -- raw JSON bytes (already validated as a JSON value by the splitter) and
 -- streams them straight into MinIO with no AE.encode round-trip.
 {-# ANN saveReplayMinio ("HLint: ignore Use alternative" :: String) #-}
-saveReplayMinio :: (DB es, Log :> es, Time :> es) => EnvConfig -> Pool Connection -> Text -> ReplayPayload -> Eff es (Maybe Text)
-saveReplayMinio envCfg jobsPool ackId payload =
+saveReplayMinio :: (DB es, Log :> es, Time :> es) => Manager -> EnvConfig -> Pool Connection -> Text -> ReplayPayload -> Eff es (Maybe Text)
+saveReplayMinio manager envCfg jobsPool ackId payload =
   Projects.projectById payload.projectId >>= \case
     Nothing -> pure $ Just ackId
     Just p
@@ -754,7 +757,7 @@ saveReplayMinio envCfg jobsPool ackId payload =
               timeStr = toText $ formatTime defaultTimeLocale "%Y%m%dT%H%M%S%q" now
               objKeyText = replayObjectPrefix payload.projectId now payload.sessionId <> timeStr <> ".json"
               body = payload.eventsBytes
-          liftIO (Minio.runMinio conn $ Minio.putObject bucket objKeyText (CC.sourceLazy (BL.fromStrict body)) (Just $ fromIntegral $ BS.length body) Minio.defaultPutObjectOptions) >>= \case
+          liftIO (Storage.runMinio manager conn $ Minio.putObject bucket objKeyText (CC.sourceLazy (BL.fromStrict body)) (Just $ fromIntegral $ BS.length body) Minio.defaultPutObjectOptions) >>= \case
             Right _ -> do
               let ReplayPayload{sessionId, projectId, userId, userEmail, userName} = payload
               -- The object is durable BEFORE anything records its key, so a failure
@@ -824,7 +827,7 @@ fetchReplaySession p sessionId = do
       summaryCtx = HM.fromList [("session", sessionStr), ("projectId", pid.toText)]
   meta <- sessionMetadata pid sessionId summaryCtx
   let emptyResp userMsg = ReplaySessionResp{events = RawJson "[]", partial = Nothing, errorMsg = Just userMsg, meta}
-  tryAny (getSessionEvents conn pid bucket sessionId) >>= \case
+  tryAny (getSessionEvents ctx.s3HttpManager conn pid bucket sessionId) >>= \case
     Right (Right (replayEvents, partial)) -> do
       Log.logInfo
         "Replay session served"
@@ -900,7 +903,7 @@ fetchReplayShard p sessionId mkey = do
   let (conn, bucket) = projectMinioConn ctx.config p
   case mkey of
     Just k | replayKeyScoped p.id.toText (UUID.toText sessionId) k -> do
-      liftIO (Minio.runMinio conn $ fetchRawObject bucket k (".gz" `T.isSuffixOf` k)) >>= \case
+      liftIO (Storage.runMinio ctx.s3HttpManager conn $ fetchRawObject bucket k (".gz" `T.isSuffixOf` k)) >>= \case
         Right raw -> pure $ RawJson raw
         -- NoSuchKey = a concurrent seal/merge already removed this source; tolerate
         -- as empty (the sealed shard carries its events). Any other error
@@ -998,7 +1001,7 @@ mergeOneSessionByKeys pid sessionId logSuffix afterMerge =
           let startIdx = 1 + foldl' max 0 (mapMaybe (fmap fst . parseShardKey) existingShards)
           nowForKey <- Time.currentTime
           let shardPrefix = replayObjectPrefix pid nowForKey sessionId
-          liftIO (try @MergeError $ mergeOneSession s3Conn bucket shardPrefix startIdx fileKeys) >>= \case
+          liftIO (try @MergeError $ mergeOneSession ctx.s3HttpManager s3Conn bucket shardPrefix startIdx fileKeys) >>= \case
             Left merr -> do
               let ctxWithErr = Log.withError merr logCtx
               case merr of
@@ -1107,13 +1110,13 @@ parseShardKey key = do
 -- on any decode/transport failure so history is never dropped; NoSuchKey is
 -- tolerated (a source already removed by a crashed prior run). `startIdx` is the
 -- next append index (from the DB shard count) so shard keys stay unique.
-mergeOneSession :: Minio.ConnectInfo -> Minio.Bucket -> Text -> Int -> [Text] -> IO [Text]
-mergeOneSession conn bucket keyPrefix startIdx fileKeys = reverse <$> go startIdx (sort fileKeys) [] 0 []
+mergeOneSession :: Manager -> Minio.ConnectInfo -> Minio.Bucket -> Text -> Int -> [Text] -> IO [Text]
+mergeOneSession manager conn bucket keyPrefix startIdx fileKeys = reverse <$> go startIdx (sort fileKeys) [] 0 []
   where
     -- buf :: [(firstTs, raw, sourceKey)] for the current shard; sealed :: sealed keys (newest first)
     go idx [] buf _ sealed = seal idx buf sealed
     go idx (k : ks) buf !bufBytes sealed =
-      Minio.runMinio conn (fetchRawForMerge bucket k False) >>= \case
+      Storage.runMinio manager conn (fetchRawForMerge bucket k False) >>= \case
         Left me | isNoSuchKey me -> go idx ks buf bufBytes sealed
         Left me -> throwIO (MergeFetchFailed me)
         Right (Left de) -> throwIO (MergeDecodeFailed [(k, de)])
@@ -1130,7 +1133,7 @@ mergeOneSession conn bucket keyPrefix startIdx fileKeys = reverse <$> go startId
           !merged = concatRawJsonArrays [raw | (_, raw, _) <- sorted]
           !compressed = GZip.compress merged
           shardKey = shardKeyFor keyPrefix idx (round (firstTs :: Double))
-      putRes <- Minio.runMinio conn $ do
+      putRes <- Storage.runMinio manager conn $ do
         Minio.putObject bucket shardKey (CC.sourceLazy compressed) (Just (BL.length compressed)) Minio.defaultPutObjectOptions
         forM_ [k | (_, _, k) <- sorted] (Minio.removeObject bucket)
       whenLeft_ putRes (throwIO . MergePutFailed)
@@ -1181,7 +1184,7 @@ expireOldReplayData = do
       -- Separate `runMinio` per key so one transport error doesn't abort siblings;
       -- mirrors the `fetchIndividuals` pattern elsewhere in this module.
       perKey <- liftIO $ forM keyObjs $ \o ->
-        (o,) <$> Minio.runMinio conn (Minio.removeObject bucket o)
+        (o,) <$> Storage.runMinio ctx.s3HttpManager conn (Minio.removeObject bucket o)
       let fatal = [(o, e) | (o, Left e) <- perKey, not (isNoSuchKey e)]
       if null fatal
         then do

--- a/src/Pages/Replay.hs
+++ b/src/Pages/Replay.hs
@@ -44,7 +44,7 @@ import Pkg.Minio qualified as Storage
 import Pkg.Queue (chunksByBytes, publishJSONToKafka, runSharedProducer)
 import Relude
 import Relude.Extra.Tuple (traverseToFst)
-import System.Config (AuthContext (config, jobsPool), EnvConfig (..))
+import System.Config (AuthContext (config, jobsPool, s3HttpManager), EnvConfig (..))
 import System.Logging qualified as Log
 import System.Types (ATAuthCtx, ATBackgroundCtx, ATBaseCtx, DB, RespHeaders, addRespHeaders)
 import UnliftIO.Exception (finally, tryAny)

--- a/src/Pkg/Minio.hs
+++ b/src/Pkg/Minio.hs
@@ -1,0 +1,13 @@
+module Pkg.Minio (runMinio) where
+
+import Network.HTTP.Client (Manager)
+import Network.Minio qualified as Minio
+import Relude
+
+
+-- | Reuse the application transport while keeping credentials, endpoint,
+-- region and bucket-location cache local to this operation.
+runMinio :: Manager -> Minio.ConnectInfo -> Minio.Minio a -> IO (Either Minio.MinioErr a)
+runMinio manager config action = do
+  connection <- Minio.mkMinioConn config manager
+  Minio.runMinioWith connection action

--- a/src/Pkg/TestUtils.hs
+++ b/src/Pkg/TestUtils.hs
@@ -138,7 +138,9 @@ import Models.Telemetry.Schema qualified as Schema
 import Models.Telemetry.Telemetry qualified as Telemetry
 import Network.GRPC.Common.Protobuf (Proto (..))
 import Network.HTTP.Client (createCookieJar, defaultRequest)
+import Network.HTTP.Client qualified as HC
 import Network.HTTP.Client.Internal (Response (..), ResponseClose (..))
+import Network.HTTP.Client.TLS qualified as HCTLS
 import Network.HTTP.Types.Status (ok200)
 import Network.HTTP.Types.Version (http11)
 import Network.Minio qualified as Minio
@@ -846,9 +848,11 @@ withTestResources f = withSetup $ \pool cstr -> withSharedLogger \logger -> do
   liveTailBuffer <- LiveTail.newRelayBuffer
   let liveTail = LiveTail.Runtime{transport = LiveTail.PostgresRelay, cache = liveTailCache, hub = liveTailHub, relayBuffer = liveTailBuffer, emit = LiveTail.deliver liveTailHub}
 
+  s3HttpManager <- HC.newManager HCTLS.tlsManagerSettings
   let atAuthCtx =
         AuthContext
           envConfig
+          s3HttpManager
           pool
           pool
           pool

--- a/src/System/Config.hs
+++ b/src/System/Config.hs
@@ -26,6 +26,8 @@ import Models.Projects.Projects qualified as Projects
 import Models.Telemetry.ContainerTypes qualified as Containers
 import Models.Telemetry.RUM qualified as RUM
 import Models.Telemetry.Telemetry qualified as Telemetry
+import Network.HTTP.Client qualified as HC
+import Network.HTTP.Client.TLS qualified as HCTLS
 import OpenTelemetry.Instrumentation.Hasql qualified as OHasql
 import Pkg.DeriveUtils qualified as DeriveUtils
 import Pkg.ExtractionWorker qualified as ExtractionWorker
@@ -395,6 +397,7 @@ type CodeBlobKey = (Text, Text, Text, Text)
 
 data AuthContext = AuthContext
   { env :: EnvConfig
+  , s3HttpManager :: HC.Manager
   , pool :: Pool.Pool Connection
   , jobsPool :: Pool.Pool Connection
   , timefusionPgPool :: Pool.Pool Connection
@@ -465,6 +468,7 @@ instance Default DeploymentEnv where
 
 configToEnv :: IOE :> es => EnvConfig -> Eff es AuthContext
 configToEnv config = do
+  s3HttpManager <- liftIO $ HC.newManager HCTLS.tlsManagerSettings
   let createPgConnIO = PG.connectPostgreSQL $ DeriveUtils.addKeepaliveParams $ encodeUtf8 config.databaseUrl
       -- Raise TimescaleDB DML decompression limit for UPDATE queries on compressed hypertables
       tfParams =
@@ -562,6 +566,7 @@ configToEnv config = do
       , hasqlTimefusionPool
       , hasqlTimefusionUsesPgTypes = False -- prod TF is a real TimeFusion: bare text→Variant
       , env = config
+      , s3HttpManager
       , projectCache
       , projectKeyCache
       , logsPatternCache

--- a/test/integration/MinioManagerSpec.hs
+++ b/test/integration/MinioManagerSpec.hs
@@ -18,8 +18,8 @@ import Test.Hspec
 spec :: Spec
 spec = describe "shared object-storage transport" do
   it "reuses transport while honoring each operation's credentials, region and endpoint" do
-    first <- newIORef []
-    second <- newIORef []
+    firstRequests <- newIORef []
+    secondRequests <- newIORef []
     let server observed = pure $ \request respond -> do
           body <- Wai.strictRequestBody request
           atomicModifyIORef' observed $ \requests -> ((Wai.remoteHost request, List.lookup hAuthorization (Wai.requestHeaders request), body) : requests, ())
@@ -30,13 +30,13 @@ spec = describe "shared object-storage transport" do
               config = Minio.setCreds (Minio.CredentialValue access "test-secret" Nothing) (Minio.setRegion region info)
           result <- Storage.runMinio manager config $ Minio.putObject "test-bucket" "object" (CC.sourceLazy "body") (Just 4) Minio.defaultPutObjectOptions
           result `shouldSatisfy` isRight
-    Warp.testWithApplication (server first) $ \firstPort ->
-      Warp.testWithApplication (server second) $ \secondPort -> do
+    Warp.testWithApplication (server firstRequests) $ \firstPort ->
+      Warp.testWithApplication (server secondRequests) $ \secondPort -> do
         upload firstPort "first-key" "us-east-1"
         upload firstPort "second-key" "eu-west-1"
         upload secondPort "third-key" "us-east-1"
-    [(peer1, auth1, body1), (peer2, auth2, body2)] <- reverse <$> readIORef first
-    [(_, auth3, body3)] <- readIORef second
+    [(peer1, auth1, body1), (peer2, auth2, body2)] <- reverse <$> readIORef firstRequests
+    [(_, auth3, body3)] <- readIORef secondRequests
     peer1 `shouldBe` peer2
     forM_ [body1, body2, body3] $ \body -> case BL.lines body of
       [chunkHeader, payload, finalChunk, blank] -> do

--- a/test/integration/MinioManagerSpec.hs
+++ b/test/integration/MinioManagerSpec.hs
@@ -1,0 +1,50 @@
+module MinioManagerSpec (spec) where
+
+import Conduit qualified as CC
+import Data.ByteString qualified as BS
+import Data.ByteString.Lazy.Char8 qualified as BL
+import Data.List qualified as List
+import Network.HTTP.Client qualified as HC
+import Network.HTTP.Client.TLS qualified as HCTLS
+import Network.HTTP.Types (hAuthorization, status200)
+import Network.Minio qualified as Minio
+import Network.Wai qualified as Wai
+import Network.Wai.Handler.Warp qualified as Warp
+import Pkg.Minio qualified as Storage
+import Relude
+import Test.Hspec
+
+
+spec :: Spec
+spec = describe "shared object-storage transport" do
+  it "reuses transport while honoring each operation's credentials, region and endpoint" do
+    first <- newIORef []
+    second <- newIORef []
+    let server observed = pure $ \request respond -> do
+          body <- Wai.strictRequestBody request
+          atomicModifyIORef' observed $ \requests -> ((Wai.remoteHost request, List.lookup hAuthorization (Wai.requestHeaders request), body) : requests, ())
+          respond $ Wai.responseLBS status200 [("ETag", "\"etag\"")] ""
+    manager <- HC.newManager HCTLS.tlsManagerSettings
+    let upload port access region = do
+          let info = fromString $ "http://127.0.0.1:" <> show port
+              config = Minio.setCreds (Minio.CredentialValue access "test-secret" Nothing) (Minio.setRegion region info)
+          result <- Storage.runMinio manager config $ Minio.putObject "test-bucket" "object" (CC.sourceLazy "body") (Just 4) Minio.defaultPutObjectOptions
+          result `shouldSatisfy` isRight
+    Warp.testWithApplication (server first) $ \firstPort ->
+      Warp.testWithApplication (server second) $ \secondPort -> do
+        upload firstPort "first-key" "us-east-1"
+        upload firstPort "second-key" "eu-west-1"
+        upload secondPort "third-key" "us-east-1"
+    [(peer1, auth1, body1), (peer2, auth2, body2)] <- reverse <$> readIORef first
+    [(_, auth3, body3)] <- readIORef second
+    peer1 `shouldBe` peer2
+    forM_ [body1, body2, body3] $ \body -> case BL.lines body of
+      [chunkHeader, payload, finalChunk, blank] -> do
+        chunkHeader `shouldSatisfy` BL.isPrefixOf "4;chunk-signature="
+        payload `shouldBe` "body\r"
+        finalChunk `shouldSatisfy` BL.isPrefixOf "0;chunk-signature="
+        blank `shouldBe` "\r"
+      _ -> expectationFailure "expected one signed payload chunk and a final empty chunk"
+    auth1 `shouldSatisfy` maybe False (BS.isInfixOf "Credential=first-key/")
+    auth2 `shouldSatisfy` maybe False (\header -> BS.isInfixOf "Credential=second-key/" header && BS.isInfixOf "/eu-west-1/s3/aws4_request" header)
+    auth3 `shouldSatisfy` maybe False (BS.isInfixOf "Credential=third-key/")


### PR DESCRIPTION
Replay storage operations currently create a new HTTP manager for every upload, fetch, and merge operation. This repeatedly allocates TLS contexts and prevents connection reuse.

Create one TLS-capable manager in the application context and pass it through replay storage operations. Each operation still creates its own MinIO connection state from the current project credentials, endpoint, and region.

Validation:
- A real HTTP regression fails with the old adapter because two consecutive uploads use different TCP connections; it passes with the new implementation.
- The same test checks changed credentials and region, a second endpoint, and the signed upload payload.
- Fourmolu, hpack, diff checks, and current HLint pass.
- A 100-operation real-library benchmark measured 1,206,113,856 allocated bytes for fresh TLS managers versus 106,088 bytes for a shared manager with fresh per-operation MinIO state. This is a local allocation benchmark, not a production impact estimate.
- Full application CI is pending. Production profiling follows deployment.
