### PR TITLE
perf: retain unboxed centroid vectors across database loading

### DIFF
--- a/e2e/tests/metrics-catalog.spec.ts
+++ b/e2e/tests/metrics-catalog.spec.ts
@@ -164,6 +164,9 @@ test.describe('metrics catalog', () => {
     await page.setViewportSize({ width: 390, height: 844 });
     for (const colorScheme of ['light', 'dark'] as const) {
       await page.emulateMedia({ colorScheme });
+      await page.context().addCookies([{
+        name: 'theme', value: colorScheme, url: test.info().project.use.baseURL as string,
+      }]);
       await page.goto(url + '?q=uxcatalog');
       await expect(page.locator('body')).toHaveAttribute('data-theme', colorScheme);
       expect(await page.evaluate(() => document.body.scrollWidth)).toBeLessThanOrEqual(390);

--- a/src/BackgroundJobs.hs
+++ b/src/BackgroundJobs.hs
@@ -38,6 +38,7 @@ import Data.UUID qualified as UUID
 import Data.UUID.V4 qualified as UUIDV4
 import Data.Vector qualified as V
 import Data.Vector.Algorithms.Intro qualified as VA
+import Data.Vector.Unboxed qualified as VU
 import Database.PostgreSQL.Simple (FromRow)
 import Database.PostgreSQL.Simple qualified as SimplePG
 import Database.PostgreSQL.Simple.SqlQQ (sql)
@@ -3799,7 +3800,7 @@ data MergeConfig k a = MergeConfig
   , normalizeEmb :: Text -> Text -- normalize text before embedding (e.g. unify placeholders)
   , toId :: a -> k
   , updateEmbs :: [(k, [Float])] -> ATBackgroundCtx Int64
-  , getCentroids :: ATBackgroundCtx [(k, [Float])]
+  , getCentroids :: ATBackgroundCtx [(k, VU.Vector Float)]
   , assignCanonical :: [(k, k)] -> ATBackgroundCtx Int64
   , fetchTexts :: [k] -> ATBackgroundCtx (Map k Text)
   , canMerge :: Text -> Text -> Bool

--- a/src/Models/Apis/PatternMerge.hs
+++ b/src/Models/Apis/PatternMerge.hs
@@ -43,6 +43,7 @@ import Data.Effectful.Hasql qualified as Hasql
 import Data.Map.Strict qualified as Map
 import Data.Time (UTCTime)
 import Data.Vector qualified as V
+import Data.Vector.Unboxed qualified as VU
 import Effectful (Eff, (:>))
 import Effectful.Time qualified as Time
 import Hasql.Interpolate qualified as HI
@@ -75,9 +76,9 @@ updateErrorEmbeddings pairs =
     (ids, embs) = second (map showPGFloatArray) $ unzip pairs
 
 
-getCanonicalErrorPatterns :: DB es => Projects.ProjectId -> Eff es [(ErrorPatternId, [Float])]
+getCanonicalErrorPatterns :: DB es => Projects.ProjectId -> Eff es [(ErrorPatternId, VU.Vector Float)]
 getCanonicalErrorPatterns pid =
-  map (second V.toList)
+  map (second (V.convert :: V.Vector Float -> VU.Vector Float))
     <$> Hasql.interp
       [HI.sql| SELECT id, embedding FROM apis.error_patterns
         WHERE project_id = #{pid} AND canonical_id IS NULL
@@ -152,9 +153,9 @@ updateLogEmbeddings pairs =
     (ids, embs) = second (map showPGFloatArray) $ unzip pairs
 
 
-getCanonicalLogPatterns :: DB es => Projects.ProjectId -> Eff es [(LogPatternId, [Float])]
+getCanonicalLogPatterns :: DB es => Projects.ProjectId -> Eff es [(LogPatternId, VU.Vector Float)]
 getCanonicalLogPatterns pid =
-  map (second V.toList)
+  map (second (V.convert :: V.Vector Float -> VU.Vector Float))
     <$> Hasql.interp
       [HI.sql| SELECT id, embedding FROM apis.log_patterns
         WHERE project_id = #{pid} AND canonical_id IS NULL

--- a/src/Pkg/PatternMerge.hs
+++ b/src/Pkg/PatternMerge.hs
@@ -92,25 +92,25 @@ ambiguousThreshold = 0.75
 -- Patterns below ambiguousThreshold remain standalone (not returned).
 -- Pre-computes centroid norms and uses unboxed vectors for O(n*m) with low constant factor.
 --
--- >>> assignToCentroids [("c1", [1,0,0])] [("n1", [1,0,0])]
+-- >>> assignToCentroids [("c1", VU.fromList [1,0,0])] [("n1", [1,0,0])]
 -- ([("n1","c1")],[])
 --
--- >>> assignToCentroids [("c1", [1,0,0])] [("n1", [0,1,0])]
+-- >>> assignToCentroids [("c1", VU.fromList [1,0,0])] [("n1", [0,1,0])]
 -- ([],[])
 --
 -- Equal scores keep the last centroid, including scores tied by rounding.
--- >>> assignToCentroids [("first", [1,0]), ("last", [1,0])] [("new", [1,0])]
+-- >>> assignToCentroids [("first", VU.fromList [1,0]), ("last", VU.fromList [1,0])] [("new", [1,0])]
 -- ([("new","last")],[])
 --
--- >>> assignToCentroids [("zero", [0,0]), ("short", [1])] [("new", [1,0])]
+-- >>> assignToCentroids [("zero", VU.fromList [0,0]), ("short", VU.fromList [1])] [("new", [1,0])]
 -- ([],[])
 --
--- >>> assignToCentroids [("c", [1,0])] [("new", [0.8,0.6])]
+-- >>> assignToCentroids [("c", VU.fromList [1,0])] [("new", [0.8,0.6])]
 -- ([],[("new","c")])
-assignToCentroids :: [(a, [Float])] -> [(a, [Float])] -> ([(a, a)], [(a, a)])
+assignToCentroids :: [(a, VU.Vector Float)] -> [(a, [Float])] -> ([(a, a)], [(a, a)])
 assignToCentroids centroids = foldl' classify ([], [])
   where
-    centroidsU = map (\(cid, emb) -> let v = VU.fromList emb in (cid, v, vecNorm v)) centroids
+    centroidsU = map (\(cid, v) -> (cid, v, vecNorm v)) centroids
     classify (merges, ambiguous) (newId, newEmb) =
       let v = VU.fromList newEmb
           newNormed = (v, vecNorm v)


### PR DESCRIPTION
Loading canonical embeddings converts boxed database vectors to lists, then reconstructs unboxed vectors for similarity matching. This adds allocation to the profiled canonical-pattern loading path.

Keep canonical embeddings as unboxed vectors across the database, job configuration, and assignment function. Convert directly from the decoded boxed vector. Existing doctests continue checking merge thresholds, ties, zero vectors, and mismatched dimensions.

Validation: GHC9.12.2 -O2 -Wall -Werror parity harness extracted from the before/after functions produced identical assignments for901 centroid sets and450 pattern vectors. A conversion-only benchmark of1000 embeddings with1536 floats allocated102,761,368 bytes through lists versus6,281,176 bytes directly, with matching checksums. These are synthetic allocation measurements, not full-job speed claims. Fourmolu and git diff checks pass.

Local make ci-signoff CHECKS=hlint could not start because the Docker daemon is unavailable. Native scripts/ci/ci.sh run hlint passed with no hints and published its Darwin ARM64 attestation. Full build, doctests, unit, integration, and E2E checks remain for GitHub; the earlier session also lacked disk capacity (156 GiB is now free).


The metrics mobile-layout E2E fixture now sets the saved theme cookie for each light/dark case. The application's dark-default change means OS preference alone no longer selects light mode. All existing theme, overflow, and toolbar visibility assertions remain.

Resumed validation: run 34219568137 passed application build, doctests, 308 unit examples and integration shards 407+77+190+183 (24 pending). Browser tests had 70 passes, 5 skips and the one theme-fixture failure corrected here. Weeder findings remain informational under the existing workflow; no suppression was added. On commit 09a6c11f7, git diff --check and Playwright discovery of the affected test pass. make ci-signoff CHECKS=e2e exits 2 because Docker is unavailable; no new attestation published. Final status reuses existing passing build/doctest/unit/integration/frontend/CLI/UI/hlint results and leaves e2e and informational weeder for GitHub. Full browser execution is pending.
