### PR TITLE
Clear the hlint backlog, including ten hints no edit could satisfy

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -1742,17 +1742,14 @@
     name: "Use 'toException' from Relude"
     note: "'toException' is already exported from Relude"
     rhs: toException
-- warn:
-    lhs: Control.Exception.fromException
-    name: "Use 'fromException' from Relude"
-    note: "'fromException' is already exported from Relude"
-    rhs: fromException
-# NOTE: no `displayException` rule here. Relude re-exports
-# Control.Exception.displayException, so `lhs: Control.Exception.displayException`
-# also matches the already-correct unqualified use and suggests replacing the
-# symbol with itself — 10 unfixable hints, one per call site, which no edit can
-# satisfy. The sibling rules below are only safe while nothing uses those symbols
-# bare; if one starts self-suggesting, delete it for the same reason.
+# NOTE: no `displayException` or `fromException` rule here. Relude re-exports
+# both from Control.Exception, so `lhs: Control.Exception.<sym>` also matches the
+# already-correct unqualified use and suggests replacing the symbol with itself —
+# unfixable hints, one per call site, which no edit can satisfy. `fromException`
+# was deleted 2026-09-11 for exactly that, after the Slack retry paths started
+# using it bare (9 sites) alongside Data/Effectful/Hasql. The sibling rules below
+# are only safe while nothing uses those symbols bare; if one starts
+# self-suggesting, delete it for the same reason.
 - warn:
     lhs: Data.Foldable.asum
     name: "Use 'asum' from Relude"

--- a/src/BackgroundJobs.hs
+++ b/src/BackgroundJobs.hs
@@ -1841,8 +1841,8 @@ dispatchDueErrorNotifications
   -> UTCTime
   -> [ErrorSubscriptionDue]
   -> ATBackgroundCtx ()
-dispatchDueErrorNotifications ctx pid now dueErrors = unless (null dueErrors) do
-  whenJustM (Projects.projectById pid) \project -> when project.errorAlerts do
+dispatchDueErrorNotifications ctx pid now dueErrors = unless (null dueErrors)
+  $ whenJustM (Projects.projectById pid) \project -> when project.errorAlerts do
     teamM <- ProjectMembers.getEveryoneTeam pid
     case teamM of
       Just team | ProjectMembers.teamHasAnyEnabledChannel team -> do
@@ -3093,7 +3093,7 @@ commitQueryMonitorEvaluation monitor value status observedAt delivery commitStat
           pure True
 
 
-data IncidentCommitError = IncidentCommitError Incidents.RecordResult
+newtype IncidentCommitError = IncidentCommitError Incidents.RecordResult
   deriving stock (Show)
   deriving anyclass (CE.Exception)
 

--- a/src/Data/Effectful/Notify.hs
+++ b/src/Data/Effectful/Notify.hs
@@ -463,7 +463,7 @@ runNotifyTest ref = interpret \_ -> \case
           PagerdutyNotification pagerdutyData -> ("PagerDuty" :: Text, pagerdutyData.dedupKey, Just pagerdutyData.summary)
     Log.logTrace "Notification" notifInfo
     Log.logTrace "Notification payload" notification
-    liftIO $ atomicModifyIORef' ref (\notifications -> (notification : notifications, ()))
+    liftIO $ atomicModifyIORef'_ ref (notification :)
   SendNotificationWithReply notification -> do
     idx <- liftIO $ atomicModifyIORef' ref (\notifications -> (notification : notifications, length notifications + 1))
     pure $ case notification of

--- a/src/Models/Apis/Investigations.hs
+++ b/src/Models/Apis/Investigations.hs
@@ -478,7 +478,7 @@ commitProgress cursor scope checkpoint event
                   SELECT #{turnCursor.turn.projectId}, #{turnCursor.turn.conversationId}, 'user', #{followup.text}, #{followup.messageTs}, clock_timestamp()
                   WHERE EXISTS (SELECT 1 FROM accepted)
                   ON CONFLICT (project_id, conversation_id, slack_message_ts, role) WHERE slack_message_ts IS NOT NULL DO NOTHING|]
-            _ -> pure ()
+            _ -> pass
         pure updated
       either throwIO pure result
 

--- a/src/Models/Projects/CodeContext.hs
+++ b/src/Models/Projects/CodeContext.hs
@@ -278,7 +278,7 @@ readRunbook cfg pid query = runExceptT do
   (mapping, credential, connection) <- runbookRepository cfg pid query.mappingId query.revision
   blob <- ExceptT $ first RunbookProviderFailed <$> Git.fetchFile connection (Git.RepoRef mapping.owner mapping.repo query.revision) query.path
   when (BS.length blob > 1_048_576) $ throwE RunbookTooLarge
-  document <- hoistEither $ first (const RunbookNotText) $ TE.decodeUtf8' blob
+  document <- hoistEither $ first (const RunbookNotText) $ decodeUtf8' blob
   when (T.any (== '\0') document) $ throwE RunbookNotText
   let documentLines = lines document
       total = length documentLines

--- a/src/Pages/Bots/Slack.hs
+++ b/src/Pages/Bots/Slack.hs
@@ -37,6 +37,7 @@ import "cryptonite" Crypto.MAC.HMAC qualified as HMAC
 import Control.Concurrent (threadDelay)
 import Control.Exception (ErrorCall (..))
 import Control.Monad.Extra (whileM)
+import Data.Char (isDigit)
 import Data.Vector qualified as V
 import Deriving.Aeson qualified as DAE
 import Effectful (Eff, IOE, type (:>))
@@ -392,7 +393,7 @@ slackActionsH action = do
         selected <- maybe (throwError err400) (pure . (.value)) a.selected_option
         withWidget selected \_ dashboard title chartUrl ->
           updateModal context $ selectBlocks dashboard.widgets $ V.singleton $ imageBlock chartUrl title
-      _ -> pure ()
+      _ -> pass
     "view_submission" -> do
       selected <- maybe (throwError err400) pure $ slackAction.view.state >>= lookupSelectedValueByKey "widget-select"
       withWidget selected \did _ title chartUrl -> do
@@ -409,7 +410,7 @@ slackActionsH action = do
                       ]
                   )
             ]
-    _ -> pure ()
+    _ -> pass
   pure $ AE.object []
 
 
@@ -743,7 +744,7 @@ verifySlackSignature :: Text -> UTCTime -> Maybe Text -> Maybe Text -> ByteStrin
 verifySlackSignature secret now timestamp signature body = fromMaybe False do
   guard $ not $ T.null secret
   ts <- timestamp
-  guard $ not (T.null ts) && T.all (\c -> c >= '0' && c <= '9') ts
+  guard $ not (T.null ts) && T.all isDigit ts
   seconds <- readMaybe @Integer $ toString ts
   guard $ abs (utcTimeToPOSIXSeconds now - fromInteger seconds) <= 300
   digest <- signature >>= T.stripPrefix "v0=" >>= rightToMaybe . B16.decode . encodeUtf8
@@ -785,7 +786,7 @@ slackEventsPostH body timestamp signature = do
           SELECT now(), 'queued', #{job} FROM receipt|]
       case kind of
         AgentSessionStopped _ -> Integrations.recordSlackSessionEvent team_id event_id
-        _ -> pure ()
+        _ -> pass
       pure $ AE.object []
 
 
@@ -828,7 +829,7 @@ processSlackEvent receiptId =
           case kind of
             UserMessage message -> withThreadLock team_id message process
             AppMention message -> withThreadLock team_id message process
-            AppHomeOpened home -> withEventLock ("slack-onboarding:" <> decodeUtf8 (toStrict $ AE.encode ([team_id, home.channel, home.user] :: [Text]))) process
+            AppHomeOpened home -> withEventLock ("slack-onboarding:" <> decodeUtf8 (AE.encode ([team_id, home.channel, home.user] :: [Text]))) process
             _ -> process
     withThreadLock workspaceId message = withInvestigationLock workspaceId message.channel (fromMaybe message.ts message.thread_ts)
 
@@ -951,7 +952,7 @@ processSlackEvent receiptId =
 
 
 withInvestigationLock :: Text -> Text -> Text -> ATBackgroundCtx () -> ATBackgroundCtx ()
-withInvestigationLock workspace channel thread = withEventLock $ "slack-investigation:" <> decodeUtf8 (toStrict $ AE.encode ([workspace, channel, thread] :: [Text]))
+withInvestigationLock workspace channel thread = withEventLock $ "slack-investigation:" <> decodeUtf8 (AE.encode ([workspace, channel, thread] :: [Text]))
 
 
 -- | Keep the transaction-scoped lock on one checked-out connection and interrupt
@@ -1095,7 +1096,7 @@ reconcileProgressHistory target publicationId = do
     outcome <- searchPublicationHistory appId slackData "monoscope_investigation_progress" search
     AI.requireAgentAccess access target.projectId
     settlePublicationSearch (Investigations.confirmProgress publicationId) (Investigations.saveProgressSearchCursor search) outcome
-  join . fmap (.timestamp) <$> Investigations.loadProgress target
+  ((.timestamp) =<<) <$> Investigations.loadProgress target
 
 
 data PublicationHistory = PublicationFound Incidents.SlackTimestamp | PublicationCursor (Maybe Text)

--- a/src/Pages/Bots/Utils.hs
+++ b/src/Pages/Bots/Utils.hs
@@ -313,7 +313,7 @@ processAIQuery sourceConfig useTf access pid userQuery conversationId model apiK
   whenRight_ rawResult \answer -> whenJust conversationId \convId -> do
     AI.requireAgentAccess access pid
     case access of
-      AI.SlackInvestigationAccess{} -> pure () -- Saved atomically with the replayable answer.
+      AI.SlackInvestigationAccess{} -> pass -- Saved atomically with the replayable answer.
       _ -> Issues.insertChatMessage pid convId Issues.ChatAssistant answer.response Nothing Nothing
   let result = rawResult >>= AI.parseLLMResponse . (.response)
   whenLeft_ result \err -> Log.logAttention "processAIQuery failed" $ AE.object ["error" AE..= err, "userQuery" AE..= userQuery, "projectId" AE..= pid.toText]

--- a/src/Pkg/AI.hs
+++ b/src/Pkg/AI.hs
@@ -408,7 +408,7 @@ data AgentAccessDenied = AgentAccessDenied
 -- | ServiceAccess leaves authorization to its caller. Slack investigations
 -- retain the requesting identity and revalidate it at each data-use boundary.
 requireAgentAccess :: DB es => AgentAccess -> Projects.ProjectId -> Eff es ()
-requireAgentAccess ServiceAccess _ = pure ()
+requireAgentAccess ServiceAccess _ = pass
 requireAgentAccess (SlackAccess teamId slackUserId userId) projectId = do
   principal <- Integrations.resolveSlackPrincipal teamId slackUserId (Just projectId)
   unless (maybe False (\p -> p.userId == userId && p.projectId == projectId) principal) $ throwIO AgentAccessDenied
@@ -843,7 +843,7 @@ runAgenticLoopRaw turn journal config apiKey checkpoint = do
       _ -> pure Nothing
     record event = for_ journal (`Investigations.recordEvent` event)
     continue updated = runAgenticLoopRaw updated journal config apiKey
-    advance next = Investigations.commitProgress turn journal next Nothing >>= (\updated -> continue updated next)
+    advance next = Investigations.commitProgress turn journal next Nothing >>= (`continue` next)
 
 
 -- | Create ToolCallInfo from a tool call and its result
@@ -903,11 +903,12 @@ executeToolCall config tc = do
         _ -> pure "Repository evidence requires an authorized Slack investigation."
     "get_deployments" ->
       noRaw <$> case (config.access, config.sourceConfig) of
-        (SlackInvestigationAccess{}, Just cfg) -> withArg "get_deployments" "mapping_id" args \mapping ->
-          maybe
-            (pure "Invalid repository mapping ID.")
-            (\mappingId -> decodeUtf8 . AE.encode <$> CodeContext.fetchDeployments cfg config.projectId mappingId (getTextArg "environment" args))
-            (idFromText mapping)
+        (SlackInvestigationAccess{}, Just cfg) ->
+          withArg "get_deployments" "mapping_id" args
+            $ maybe
+              (pure "Invalid repository mapping ID.")
+              (\mappingId -> decodeUtf8 . AE.encode <$> CodeContext.fetchDeployments cfg config.projectId mappingId (getTextArg "environment" args))
+            . idFromText
         _ -> pure "Deployment evidence is unavailable for this conversation."
     "list_runbooks" ->
       noRaw <$> case (config.access, config.sourceConfig, parseMaybe AE.parseJSON $ AE.toJSON args) of

--- a/src/Pkg/Git.hs
+++ b/src/Pkg/Git.hs
@@ -574,7 +574,7 @@ data DeploymentEvidence = DeploymentEvidence
 
 
 getJson :: (AE.FromJSON a, IOE :> es, W.HTTP :> es) => GitConn -> Text -> Eff es (Either DeploymentReadError a)
-getJson conn endpoint = fmap (first DeploymentRequestFailed >=> first (InvalidDeploymentResponse . toText) . AE.eitherDecode) $ get_ conn endpoint
+getJson conn endpoint = (first DeploymentRequestFailed >=> first (InvalidDeploymentResponse . toText) . AE.eitherDecode) <$> get_ conn endpoint
 
 
 -- | GitHub deployment requests plus reported execution states. A status lookup

--- a/src/Pkg/Mail.hs
+++ b/src/Pkg/Mail.hs
@@ -356,8 +356,8 @@ errorIncidentMessages alertType err now episode projectUrl incidentUrl chart occ
         <> "\nObserved "
         <> atUtc now
         <> foldMap (" · " <>) occurrence
-        <> foldMap (" · " <>) (slackEscape <$> err.serviceName)
-        <> foldMap (" · " <>) (slackEscape <$> err.environment)
+        <> foldMap ((" · " <>) . slackEscape) err.serviceName
+        <> foldMap ((" · " <>) . slackEscape) err.environment
     current = slackSection text
     onset = tagged "incident_onset" $ slackContext ["Started " <> atUtc (maybe now (.startedAt) episode)]
     chartBlock = tagged "incident_chart" $ maybe (slackContext ["Chart unavailable. <" <> incidentUrl <> "|Open issue>"]) (slackImage ("Occurrences of " <> title) Nothing) chart

--- a/src/Web/Routes.hs
+++ b/src/Web/Routes.hs
@@ -1273,7 +1273,7 @@ widgetPngGetH pid widgetJsonM widgetZM sinceStr fromDStr toDStr widthM heightM s
             [ "echarts"
                 AE..= either
                   (const $ AE.object ["graphic" AE..= AE.object ["type" AE..= ("text" :: Text), "left" AE..= ("center" :: Text), "top" AE..= ("middle" :: Text), "style" AE..= AE.object ["text" AE..= ("Chart unavailable\nOpen the incident or monitor for details." :: Text), "fontSize" AE..= (18 :: Int), "fill" AE..= (bool "#334155" "#cbd5e1" darkMode :: Text), "textAlign" AE..= ("center" :: Text)]]])
-                  (Widget.widgetToECharts . (& #_staticRender ?~ True))
+                  (Widget.widgetToECharts . (#_staticRender ?~ True))
                   chart
             , "profile" AE..= fromMaybe Widget.PngStandard widget.pngProfile
             , "width" AE..= width

--- a/test/integration/Pages/IssuesSpec.hs
+++ b/test/integration/Pages/IssuesSpec.hs
@@ -204,24 +204,21 @@ spec = sequential $ aroundAll withTestResources do
       -- Reset state — earlier tests in this describe block may have acknowledged it.
       withResource tr.trPool \conn -> do
         void $ PGS.execute conn [sql| UPDATE apis.issues    SET acknowledged_at=NULL, acknowledged_by=NULL WHERE id=? |] (Only issueId)
-        void $ PGS.execute conn [sql| UPDATE apis.anomalies SET acknowledged_at=NULL, acknowledged_by=NULL WHERE project_id=? |] (Only testPid)
 
       _ <- testServant tr $ IssuesPage.issueBulkActionsPostH testPid IssuesPage.BAAcknowledge Nothing IssuesPage.IssueBulk{itemId = [DataUUID.toText issueId.unUUIDId]}
 
       countQ tr [sql| SELECT COUNT(*)::INT FROM apis.issues WHERE id=? AND acknowledged_at IS NOT NULL |] (Only issueId)
         >>= (`shouldBe` 1)
 
-    -- Regression: archive path posted to apis.anomalies by issue id (which is
-    -- never an anomaly id), so the cascade silently no-op'd and acknowledged_at
-    -- never propagated. Now archives apis.issues by id and cascades through
-    -- issue_data.anomaly_hashes; this test asserts both halves fire.
+    -- Regression: the archive path posted to apis.anomalies by *issue* id, which
+    -- is never an anomaly id, so it silently no-op'd. The mirror is gone now and
+    -- the issue row is the only state; this asserts it leaves the inbox.
     it "bulk archive removes the issue from the inbox" \tr -> do
       issueId <- pickApiChangeIssue tr
       let containsIssue = V.any \(IssuesPage.IssueVM _ _ issue) -> issue.base.id == issueId
 
       withResource tr.trPool \conn -> do
         void $ PGS.execute conn [sql| UPDATE apis.issues    SET archived_at=NULL, acknowledged_at=NULL, acknowledged_by=NULL WHERE id=? |] (Only issueId)
-        void $ PGS.execute conn [sql| UPDATE apis.anomalies SET archived_at=NULL, acknowledged_at=NULL, acknowledged_by=NULL WHERE project_id=? |] (Only testPid)
 
       inboxBefore <- listAnomalies tr Nothing
       containsIssue inboxBefore `shouldBe` True


### PR DESCRIPTION
`make lint` has been red long enough that nobody reads it, which makes it useless
as a gate. This takes `hlint src` to **no hints**.

## Ten of the thirty were unsatisfiable

The `Control.Exception.fromException` rule in `.hlint.yaml` also matches the
already-correct *unqualified* use — Relude re-exports the symbol — so it reported:

```
Found:   fromException
Perhaps: fromException
```

once per call site. No edit can satisfy that. The file **already documented this
exact trap** for `displayException`, and ended:

> The sibling rules below are only safe while nothing uses those symbols bare; if
> one starts self-suggesting, delete it for the same reason.

`fromException` started self-suggesting when the Slack retry paths began using it
bare (9 sites, plus `Data/Effectful/Hasql`). Deleted for the stated reason, and
the note updated to record it.

## The other twenty, applied by hand

`hlint --refactor` cannot run on this machine — it looks for a GHC 8.10.7 that
isn't installed — so each was applied and read individually:

| fix | n |
|---|---|
| `pure () -> pass` | 6 |
| redundant `toStrict` under `decodeUtf8` | 2 |
| `foldMap`/`<$>` fusion | 2 |
| explicit `'0'..'9'` range -> `isDigit` | 1 |
| redundant `&` on a section | 1 |
| `atomicModifyIORef'` -> `atomicModifyIORef'_` | 1 |
| `TE.decodeUtf8'` -> Relude's | 1 |
| `fmap f $ x` -> `f <$> x` | 1 |
| single-constructor `data` -> `newtype` | 1 |
| lambda eta-reductions | 2 |
| `do` wrapping a single statement | 1 |
| `join . fmap f` -> `(f =<<)` | 1 |

Also removes two test statements resetting `apis.anomalies.acknowledged_at` /
`archived_at` — nothing has written those columns since the mirror was retired in
#560, so they were resetting state no code produces.

## Verification

`hlint src` → no hints · builds clean under `-Werror` · 140 integration examples
across `Pages.Issues`, `IncidentDelivery` and `Pages.Bots` pass.

The changes touch live paths (Slack retry/rate-limit handling, the AI agent loop,
the notification recorder, error-alert dispatch), which is why the integration
specs for those were run rather than relying on the type-checker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)