### PR TITLE
Drop the anomaly ack/archive mirror now its writes are gone

### DIFF
--- a/static/migrations/0182_drop_anomaly_ack_mirror.sql
+++ b/static/migrations/0182_drop_anomaly_ack_mirror.sql
@@ -1,0 +1,24 @@
+-- Retire the acknowledged/archived mirror on apis.anomalies.
+--
+-- Issue lifecycle state lives on apis.issues alone. These columns were a second
+-- copy of it, kept in sync by a prefix sweep over 6.3M rows that no reader ever
+-- consulted — every read path (getAnomaliesVM, Endpoints' hash remap, the
+-- recently-active-projects probe) uses only target_hash and created_at.
+--
+-- ORDERING: the writes stopped in 23dafe4f6. This must not ship in the same
+-- deploy as that commit — while it rolls, replicas still running the previous
+-- image would be writing columns this removes. It is safe once every replica is
+-- on 23dafe4f6 or later, which is why it is a separate migration landing after
+-- that deploy rather than alongside it.
+--
+-- Dropping is safe to repeat and safe to run against a database where an earlier
+-- attempt half-applied; IF EXISTS covers both.
+--
+-- acknowledged_by carries anomalies_acknowledged_by_fkey (migration 0001).
+-- DROP COLUMN takes a column's own constraints with it, so that needs no
+-- separate statement — but it does mean this is not reversible by re-adding the
+-- columns alone.
+
+ALTER TABLE apis.anomalies DROP COLUMN IF EXISTS acknowledged_at;
+ALTER TABLE apis.anomalies DROP COLUMN IF EXISTS acknowledged_by;
+ALTER TABLE apis.anomalies DROP COLUMN IF EXISTS archived_at;


### PR DESCRIPTION
Final step of #560. Removes `acknowledged_at`, `acknowledged_by` and
`archived_at` from `apis.anomalies`.

## Why these were dead

Issue lifecycle state lives on `apis.issues` alone. These columns were a second
copy of it, kept in sync by a prefix sweep over a 6.3M-row table that **no reader
ever consulted** — audited in #560: `getAnomaliesVM`, the endpoint hash remap in
`Models/Apis/Endpoints.hs`, and the recently-active-projects probe in
`Models/Projects/Projects.hs` all read only `target_hash` and `created_at`.

## Why it is a separate deploy

#560 removed the writes. Shipping the drop in that same deploy would have taken
the columns out from under replicas still serving the previous image mid-rollout.

Production reports `monoscope:23dafe4f6` as of this PR, so nothing running writes
what this removes. Verified the remaining call sites in the previous image are
all HTTP handlers in `Pages/Anomalies.hs` — no background worker touches them, so
there is no queued work that could fail after the drop.

## Notes

- `acknowledged_by` carries `anomalies_acknowledged_by_fkey` from migration
  `0001`. `DROP COLUMN` takes a column's own constraints with it, so no separate
  statement is needed — but it also means this is **not reversible by re-adding
  the columns alone**.
- `IF EXISTS` on each, so a half-applied earlier attempt re-runs cleanly.

## Verification

The local test harness applies migrations when it builds its template database,
so this ran there before being pushed — which is how it surfaced two test
statements still resetting the mirror (removed in #561). 140 integration examples
pass with the columns gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)